### PR TITLE
Properly set jQuery as a dependency

### DIFF
--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -78,9 +78,9 @@ class WP_Job_Manager {
 	 * @return void
 	 */
 	public function frontend_scripts() {
-		wp_register_script( 'wp-job-manager-ajax-filters', JOB_MANAGER_PLUGIN_URL . '/assets/js/ajax-filters.min.js', 'jquery', JOB_MANAGER_VERSION, true );
-		wp_register_script( 'wp-job-manager-job-dashboard', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-dashboard.min.js', 'jquery', JOB_MANAGER_VERSION, true );
-		wp_register_script( 'wp-job-manager-job-application', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-application.min.js', 'jquery', JOB_MANAGER_VERSION, true );
+		wp_register_script( 'wp-job-manager-ajax-filters', JOB_MANAGER_PLUGIN_URL . '/assets/js/ajax-filters.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
+		wp_register_script( 'wp-job-manager-job-dashboard', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-dashboard.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
+		wp_register_script( 'wp-job-manager-job-application', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-application.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
 
 		wp_localize_script( 'wp-job-manager-ajax-filters', 'job_manager_ajax_filters', array(
 			'ajax_url' => admin_url('admin-ajax.php')


### PR DESCRIPTION
When registering the scripts, jQuery is supposed to be set as a dependency, but it's passed as a string instead of an array. It must be an array: http://core.trac.wordpress.org/ticket/21520#comment:8

Because of this, using a theme like Twenty Twelve where jQuery isn't enqueued by the theme specifically, a few things break (including outputting the jobs).
