### PR TITLE
Filter args before queries are being made

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -44,7 +44,7 @@ class WP_Job_Manager_Ajax {
 			'posts_per_page'    => absint( $_POST['per_page'] )
 		);
 
-		$jobs = get_job_listings( $args );
+		$jobs = get_job_listings( apply_filters( 'job_manager_ajax_output_jobs_args', $args ) );
 
 		$result['found_jobs'] = false;
 


### PR DESCRIPTION
I need to create a location based custom query using the posts_clauses
filter and I need to prevent WP Job Manager from doing its own location
query.
The only way I can do it is using this filter and
set$args[‘search_location’] to false
