### PR TITLE
Adds support for custom classes parameter to get_job_listing_class

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -515,6 +515,8 @@ function get_job_listing_class( $class = '', $post_id = null ) {
 	$post = get_post( $post_id );
 	if ( $post->post_type !== 'job_listing' )
 		return array();
+	
+	$classes = array();
 
 	if ( empty( $post ) )
 		return $classes;


### PR DESCRIPTION
Self-explanatory. Right now the parameter doesn't do anything. 

I copied from the internal get_post_class function so arrays can be passed-in as well.
