### PR TITLE
removed faulty string concatenation in email application template

### DIFF
--- a/templates/job-application-email.php
+++ b/templates/job-application-email.php
@@ -5,10 +5,10 @@
 
 	<a href="https://mail.google.com/mail/?view=cm&fs=1&to=<?php echo $apply->email; ?>&su=<?php echo urlencode( $apply->subject ); ?>" target="_blank" class="job_application_email">Gmail</a> / 
 	
-	<a href="' . 'http://webmail.aol.com/Mail/ComposeMessage.aspx?to=<?php echo $apply->email; ?>&subject=<?php echo urlencode( $apply->subject ); ?>" target="_blank" class="job_application_email">AOL</a> / 
+	<a href="http://webmail.aol.com/Mail/ComposeMessage.aspx?to=<?php echo $apply->email; ?>&subject=<?php echo urlencode( $apply->subject ); ?>" target="_blank" class="job_application_email">AOL</a> / 
 	
-	<a href="' . 'http://compose.mail.yahoo.com/?to=<?php echo $apply->email; ?>&subject=<?php echo urlencode( $apply->subject ); ?>" target="_blank" class="job_application_email">Yahoo</a> / 
+	<a href="http://compose.mail.yahoo.com/?to=<?php echo $apply->email; ?>&subject=<?php echo urlencode( $apply->subject ); ?>" target="_blank" class="job_application_email">Yahoo</a> / 
 	
-	<a href="' . 'http://mail.live.com/mail/EditMessageLight.aspx?n=&to=<?php echo $apply->email; ?>&subject=<?php echo urlencode( $apply->subject ); ?>" target="_blank" class="job_application_email">Outlook</a>
+	<a href="http://mail.live.com/mail/EditMessageLight.aspx?n=&to=<?php echo $apply->email; ?>&subject=<?php echo urlencode( $apply->subject ); ?>" target="_blank" class="job_application_email">Outlook</a>
 
 </p>


### PR DESCRIPTION
Apply by webmail links for AOL, Yahoo and Outlook were all rendering mangled URLs. There were attempts at string concatenation outside of a PHP block. Also, this needs fixing in WP Job Manager Resumes template as well, but that isn't public on GitHub. Please fix it there as well.
