### PR TITLE
Adds support for custom upload URLs

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -327,7 +327,8 @@ function job_manager_get_resized_image( $logo, $size ) {
 		$img_width  = $_wp_additional_image_sizes[ $size ]['width'];
 		$img_height = $_wp_additional_image_sizes[ $size ]['height'];
 
-		$logo_path         = str_replace( home_url('/'), ABSPATH, $logo );
+		$upload_dir        = wp_upload_dir();
+		$logo_path         = str_replace( $upload_dir['baseurl'], $upload_dir['basedir'], $logo );
 		$path_parts        = pathinfo( $logo_path );
 		$resized_logo_path = str_replace( '.' . $path_parts['extension'], '-' . $size . '.' . $path_parts['extension'], $logo_path );
 


### PR DESCRIPTION
Uses the baseurl and basedir variables returned from `wp_upload_dir` to generate the resized logo path. Fixes an issue where `job_manager_get_resized_image` will not be able to save the generated image, when the home URL is different from the domain of the uploads URL. 

Currently something like http://example.com/uploads/image.jpg works but  http://uploads.example.com/image.jpg does not because it is assumed that home_url is contained in the URL of the uploaded image and can be replaced by ABSPATH.

There are various ways to alter the uploads directory/url that `wp_upload_dir` supports (see [codex page](https://codex.wordpress.org/Function_Reference/wp_upload_dir))
