### PR TITLE
Allow custom settings field types

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -269,7 +269,7 @@ class WP_Job_Manager_Settings {
 								break;
 								default :
 
-									do_action( 'wp_job_manager_admin_field_' . $option['type'], $option );
+									do_action( 'wp_job_manager_admin_field_' . $option['type'], $option, $attributes, $value, $placeholder );
 									
 								break;
 


### PR DESCRIPTION
Allows custom settings fields types + has backward compatibility for settings fields without defined 'type' which falls back to text input.
