### PR TITLE
Add isset POST check when saving values

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -387,7 +387,9 @@ class WP_Job_Manager_Writepanels {
 						}
 					break;
 					default :
-						if ( is_array( $_POST[ $key ] ) ) {
+						if ( ! isset( $_POST[ $key ] ) ) {
+							continue;
+						} elseif ( is_array( $_POST[ $key ] ) ) {
 							update_post_meta( $post_id, $key, array_filter( array_map( 'sanitize_text_field', $_POST[ $key ] ) ) );
 						} else {
 							update_post_meta( $post_id, $key, sanitize_text_field( $_POST[ $key ] ) );


### PR DESCRIPTION
Hi Mike,

When using WP Job Manger I got an error when extending it by using a Chosen selector on the 'edit job' admin page. This only occurs when the Chosen selector is empty, it doesn't seem to post an empty value when so.  

Placed it so we don't interfere with the checkbox values.

Error:
`Notice: Undefined index: _products in /Applications/MAMP/htdocs/jobmanager/wp-content/plugins/wp-job-manager/includes/admin/class-wp-job-manager-writepanels.php on line 390`
