### PR TITLE
Dashboard actions use permissions

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -60,7 +60,7 @@ class WP_Job_Manager_Shortcodes {
 				$job    = get_post( $job_id );
 
 				// Check ownership
-				if ( $job->post_author != get_current_user_id() ) {
+				if (!job_manager_user_can_edit_job($job_id)) {
 					throw new Exception( __( 'Invalid ID', 'wp-job-manager' ) );
 				}
 


### PR DESCRIPTION
Instead of checking permissions directly, dashboard actions use the
same permission check function as what displays jobs, more consistent
and allows filters to be used for permissions.
