### PR TITLE
Added proper backend management that honours capabilities of users

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -26,7 +26,7 @@ class WP_Job_Manager_Writepanels {
 
 		$current_user = wp_get_current_user();
 
-		return apply_filters( 'job_manager_job_listing_data_fields', array(
+		$fields = array(
 			'_job_location' => array(
 				'label' => __( 'Location', 'wp-job-manager' ),
 				'placeholder' => __( 'e.g. "London"', 'wp-job-manager' ),
@@ -67,21 +67,27 @@ class WP_Job_Manager_Writepanels {
 			'_filled' => array(
 				'label' => __( 'Position filled?', 'wp-job-manager' ),
 				'type'  => 'checkbox'
-			),
-			'_featured' => array(
+			)
+		);
+		if ( $current_user->has_cap( 'manage_job_listings' ) ) {
+			$fields['_featured'] = array(
 				'label' => __( 'Feature this listing?', 'wp-job-manager' ),
 				'type'  => 'checkbox',
 				'description' => __( 'Featured listings will be sticky during searches, and can be styled differently.', 'wp-job-manager' )
-			),
-			'_job_expires' => array(
+			);
+			$fields['_job_expires'] = array(
 				'label'       => __( 'Expires', 'wp-job-manager' ),
 				'placeholder' => __( 'yyyy-mm-dd', 'wp-job-manager' )
-			),
-			'_job_author' => array(
+			);
+		}
+		if ( $current_user->has_cap( 'edit_others_job_listings' ) ) {
+			$fields['_job_author'] = array(
 				'label' => __( 'Posted by', 'wp-job-manager' ),
 				'type'  => 'author'
-			)
-		) );
+			);
+		}
+
+		return apply_filters( 'job_manager_job_listing_data_fields', $fields );
 	}
 
 	/**


### PR DESCRIPTION
This code solves issue mikejolley/WP-Job-Manager#328
It changes the visibility / executability of the following fields / actions:
Fields:
- _job_featured and _job_exipires are only available with manage_job_listings capability
- _job_author is only available with edit_others_job_listings capability

Actions:
- Jobs can be approved (bulk action and action icon) with the publish_job_listings capability
- Jobs can be expired (bulk action) with the manage_job_listings capability
- Jobs can be edited when the user has the capability corresponding to the current post state, i.e. edit_job_listings, edit_others_job_listings or edit_published_job_listings
- Jobs can be deleted when the user has the capability corresponding to the current post state, i.e. delete_job_listings, delete_others_job_listings or delete_published_job_listings

The standard behaviour of WP Job Manager can be achieved with the following capabilities: delete_job_listings, delete_published_job_listings, edit_job_listings, edit_published_job_listings. However, the WordPress capability system does not allow to prohibit modifications when waiting for review, which is an option of WP Job Manager.

BTW: The patch also corrects the missing notification after a bulk approval.
