### PR TITLE
Account password wording support for WordPress >= 4.3

### DIFF
--- a/templates/account-signin.php
+++ b/templates/account-signin.php
@@ -13,7 +13,7 @@
 	</fieldset>
 
 <?php else :
-
+	global $wp_version;
 	$account_required             = job_manager_user_requires_account();
 	$registration_enabled         = job_manager_enable_registration();
 	$generate_username_from_email = job_manager_generate_username_from_email();
@@ -25,7 +25,7 @@
 
 			<?php if ( $registration_enabled ) : ?>
 
-				<?php printf( __( 'If you don&rsquo;t have an account you can %screate one below by entering your email address/username. A password will be automatically emailed to you.', 'wp-job-manager' ), $account_required ? '' : __( 'optionally', 'wp-job-manager' ) . ' ' ); ?>
+				<?php printf( __( 'If you don&rsquo;t have an account you can %1$screate one below by entering your email address/username. %2$s will be automatically emailed to you.', 'wp-job-manager' ), $account_required ? '' : __( 'optionally', 'wp-job-manager' ) . ' ', version_compare( $wp_version, '4.3', '>=' ) ? __( 'A link to set a password', 'wp-job-manager' ) : __( 'A password', 'wp-job-manager' ) ); ?>
 
 			<?php elseif ( $account_required ) : ?>
 


### PR DESCRIPTION
With the release of WordPress 4.3 passwords are no longer sent via the `wp_new_user_notification` function, instead a link to set a password is sent.

This commit just updates the wording in the `account-signin.php` to output

`A link to set a password will be automatically emailed to you.`
instead of
`A password will be automatically emailed to you.`

If the WordPress install is version greater than or equal to 4.3, otherwise it will still show the standard wording.