### PR TITLE
Update class-wp-job-manager-post-types.php

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -224,10 +224,12 @@ class WP_Job_Manager_Post_Types {
 			'label_count'               => _n_noop( 'Expired <span class="count">(%s)</span>', 'Expired <span class="count">(%s)</span>', 'wp-job-manager' ),
 		) );
 		register_post_status( 'preview', array(
+			'label'                     => _x( 'Preview', 'post status', 'wp-job-manager' ),
 			'public'                    => false,
 			'exclude_from_search'       => true,
-			'show_in_admin_all_list'    => false,
-			'show_in_admin_status_list' => false,
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+			'label_count'               => _n_noop( 'Preview <span class="count">(%s)</span>', 'Preview <span class="count">(%s)</span>', 'wp-job-manager' ),
 		) );
 	}
 


### PR DESCRIPTION
It is beneficial to see the preview post types, as often people do not complete the posts, and they may contact the admin requesting the job be approved, etc. Makes it easier in terms of customer service.