### PR TITLE
Fix job_manager_user_can_edit_job()

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -449,7 +449,7 @@ function job_manager_user_can_edit_job( $job_id ) {
 	} else {
 		$job      = get_post( $job_id );
 
-		if ( ! $job || ( $job->post_author !== get_current_user_id() && ! current_user_can( 'edit_post', $job_id ) ) ) {
+		if ( ! $job || ( $job->post_author != get_current_user_id() && ! current_user_can( 'edit_post', $job_id ) ) ) {
 			$can_edit = false;
 		}
 	}


### PR DESCRIPTION
Users who have created job listings are unable to make changes (edit, mark filled, delete) from the page with the [job_dashboard] shortcode after the most recent update (1.23.10).  

Changing $job->post_author !== get_current_user_id()  to $job->post_author != get_current_user_id() solved the problem.  There may be a better fix if the variable data types need to match by using !== but it seems like it should be fine.