### PR TITLE
New user notification action

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -332,7 +332,6 @@ if ( ! function_exists( 'wp_job_manager_notify_new_user' ) ) :
 		}
 	}
 endif;
-add_action( 'job_manager_new_user_notification', 'wp_job_manager_notify_new_user', 10, 2);
 
 if ( ! function_exists( 'job_manager_create_account' ) ) :
 /**
@@ -417,9 +416,8 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
     }
 
     // Notify
-	do_action( 'job_manager_new_user_notification', $user_id, $password, $new_user );
-
-	// Login
+    wp_job_manager_notify_new_user( $user_id, $password, $new_user );
+    // Login
     wp_set_auth_cookie( $user_id, true, is_ssl() );
     $current_user = get_user_by( 'id', $user_id );
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -317,6 +317,23 @@ function get_job_listing_rss_link( $args = array() ) {
 }
 endif;
 
+if ( ! function_exists( 'wp_job_manager_notify_new_user' ) ) :
+	/**
+	 * Handle account creation.
+	 *
+	 * @param  int $user_id 
+	 * @param  string $password
+	 */
+	function wp_job_manager_notify_new_user( $user_id, $password ) {
+		if ( version_compare( $wp_version, '4.3.1', '<' ) ) {
+			wp_new_user_notification( $user_id, $password );
+		} else {
+			wp_new_user_notification( $user_id, null, 'both' );
+		}
+	}
+endif;
+add_action( 'job_manager_new_user_notification', 'wp_job_manager_notify_new_user', 2);
+
 if ( ! function_exists( 'job_manager_create_account' ) ) :
 /**
  * Handle account creation.
@@ -400,11 +417,7 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
     }
 
     // Notify
-    if ( version_compare( $wp_version, '4.3.1', '<' ) ) {
-    	wp_new_user_notification( $user_id, $password );
-    } else {
-    	wp_new_user_notification( $user_id, null, 'both' );
-    }
+	do_action( 'job_manager_new_user_notification', $user_id, $password, $new_user );
 
 	// Login
     wp_set_auth_cookie( $user_id, true, is_ssl() );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -332,7 +332,7 @@ if ( ! function_exists( 'wp_job_manager_notify_new_user' ) ) :
 		}
 	}
 endif;
-add_action( 'job_manager_new_user_notification', 'wp_job_manager_notify_new_user', 2);
+add_action( 'job_manager_new_user_notification', 'wp_job_manager_notify_new_user', 10, 2);
 
 if ( ! function_exists( 'job_manager_create_account' ) ) :
 /**


### PR DESCRIPTION
Allows us to add our own new user notification in place of the default
one. This is by placing an action hook in wp_job_manager_create_account.
The default notification code is placed in it's own function and hooked
in.

I added this because on my site I'd rather use the WooCommerce mailer. I
imagine I wouldn't be the only one who would want a nice looking email
for the notification.
Same issue as this post:
https://wordpress.org/support/topic/new-user-email-notification-1

Now without indent change.