### PR TITLE
Allow optional taxonomy term-select fields

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -241,7 +241,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					if ( is_array( $values[ $group_key ][ $key ] ) ) {
 						$check_value = $values[ $group_key ][ $key ];
 					} else {
-						$check_value = empty($values[ $group_key ][ $key ]) ? array() : array($values[ $group_key ][ $key ]);
+						$check_value = empty( $values[ $group_key ][ $key ] ) ? array() : array( $values[ $group_key ][ $key ] );
 					}
 					foreach ( $check_value as $term ) {
 						if ( ! term_exists( $term, $field['taxonomy'] ) ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -241,7 +241,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					if ( is_array( $values[ $group_key ][ $key ] ) ) {
 						$check_value = $values[ $group_key ][ $key ];
 					} else {
-						$check_value = array( $values[ $group_key ][ $key ] );
+						$check_value = empty($values[ $group_key ][ $key ]) ? array() : array($values[ $group_key ][ $key ]);
 					}
 					foreach ( $check_value as $term ) {
 						if ( ! term_exists( $term, $field['taxonomy'] ) ) {


### PR DESCRIPTION
Currently the way that taxonomy fields are validated is in a `foreach` loop through the array.  If the field is a `term-select` field the value will be either empty or an integer for the selected taxonomy. 

The problem is if a `term-select` field is set as optional, and the user does not select a value, when processing through validation the value is an empty string, and is placed into an array, creating an array with one member, that is empty.  

This causes the `term_exists()` to fail and returns a `WP_Error` saying the term is invalid.  

This PR adds an inline if statement to check if the value is empty, and if so, return an empty array, instead of an array with one member that is empty.

https://github.com/tripflex/wp-job-manager-field-editor/issues/289