### PR TITLE
Update class-wp-job-manager-post-types.php

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -220,7 +220,7 @@ class WP_Job_Manager_Post_Types {
 		 */
 		register_post_status( 'expired', array(
 			'label'                     => _x( 'Expired', 'post status', 'wp-job-manager' ),
-			'public'                    => false,
+			'public'                    => true,
 			'protected'                 => true,
 			'exclude_from_search'       => true,
 			'show_in_admin_all_list'    => true,


### PR DESCRIPTION
If public is set to false non logged in users will get a 404 for expired jobs, its better for seo if they can see the jobs, even if they are expired, and will stop google bots from flagging 404s on your website.