### PR TITLE
Handed over size parameter to get company image.

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -311,7 +311,7 @@ function get_the_job_location( $post = null ) {
  * @return void
  */
 function the_company_logo( $size = 'thumbnail', $default = null, $post = null ) {
-	$logo = get_the_company_logo( $post );
+	$logo = get_the_company_logo( $post, $size );
 
 	if ( has_post_thumbnail( $post ) ) {
 		echo '<img class="company_logo" src="' . esc_attr( $logo ) . '" alt="' . esc_attr( get_the_company_name( $post ) ) . '" />';


### PR DESCRIPTION
The `$size` is missing as parameter when calling a company image for a job with a company logo as attachment (since 1.24.0).
Otherwise the default of `get_the_company_logo()` is used, which is _thumbnail_.
