### PR TITLE
Stop using jQuery.live

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -34,7 +34,7 @@ jQuery(document).ready(function($) {
 	var file_target_input;
 	var file_target_wrapper;
 
-	$('.wp_job_manager_add_another_file_button').live('click', function( event ){
+	$(document).on('click', '.wp_job_manager_add_another_file_button', function( event ){
 		event.preventDefault();
 
 		var field_name        = $( this ).data( 'field_name' );
@@ -45,7 +45,7 @@ jQuery(document).ready(function($) {
 		$( this ).before('<span class="file_url"><input type="text" name="' + field_name + '[]" placeholder="' + field_placeholder + '" /><button class="button button-small wp_job_manager_upload_file_button" data-uploader_button_text="' + button_text + '">' + button + '</button></span>');
 	});
 
-	$('.wp_job_manager_upload_file_button').live('click', function( event ){
+	$(document).on('click', '.wp_job_manager_upload_file_button', function( event ){
 		event.preventDefault();
 
 		file_target_wrapper = $( this ).closest('.file_url');


### PR DESCRIPTION
By changing over to $(document).on('click', 'selector', function(){});
we maintain the same functionality without .live

Mentioned in #650
