### PR TITLE
Don't Show Job Type Drop Down if There Are No Job Types.

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -116,7 +116,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			break;
 		}
 
-		$this->fields = apply_filters( 'submit_job_form_fields', array(
+		$job_form_fields = array(
 			'job' => array(
 				'job_title' => array(
 					'label'       => __( 'Job Title', 'wp-job-manager' ),
@@ -132,15 +132,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					'required'    => false,
 					'placeholder' => __( 'e.g. "London"', 'wp-job-manager' ),
 					'priority'    => 2
-				),
-				'job_type' => array(
-					'label'       => __( 'Job type', 'wp-job-manager' ),
-					'type'        => 'term-select',
-					'required'    => true,
-					'placeholder' => '',
-					'priority'    => 3,
-					'default'     => 'full-time',
-					'taxonomy'    => 'job_listing_type'
 				),
 				'job_category' => array(
 					'label'       => __( 'Job category', 'wp-job-manager' ),
@@ -219,7 +210,25 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					)
 				)
 			)
-		) );
+		);
+		if(wp_count_terms('job_listing_type')>0){
+			$job_type_field = array(
+				'job' => array(
+					'job_type' => array(
+						'label'       => __( 'Job type', 'wp-job-manager' ),
+						'type'        => 'term-select',
+						'required'    => true,
+						'placeholder' => '',
+						'priority'    => 3,
+						'default'     => 'full-time',
+						'taxonomy'    => 'job_listing_type'
+					)
+				)
+			);
+			$job_form_fields = array_merge_recursive($job_form_fields,$job_type_field);
+		}
+
+		$this->fields = apply_filters( 'submit_job_form_fields', $job_form_fields );
 
 		if ( ! get_option( 'job_manager_enable_categories' ) || wp_count_terms( 'job_listing_category' ) == 0 ) {
 			unset( $this->fields['job']['job_category'] );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -116,7 +116,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			break;
 		}
 
-		$job_form_fields = array(
+		$this->fields = apply_filters( 'submit_job_form_fields', array(
 			'job' => array(
 				'job_title' => array(
 					'label'       => __( 'Job Title', 'wp-job-manager' ),
@@ -132,6 +132,15 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					'required'    => false,
 					'placeholder' => __( 'e.g. "London"', 'wp-job-manager' ),
 					'priority'    => 2
+				),
+				'job_type' => array(
+					'label'       => __( 'Job type', 'wp-job-manager' ),
+					'type'        => 'term-select',
+					'required'    => true,
+					'placeholder' => '',
+					'priority'    => 3,
+					'default'     => 'full-time',
+					'taxonomy'    => 'job_listing_type'
 				),
 				'job_category' => array(
 					'label'       => __( 'Job category', 'wp-job-manager' ),
@@ -210,28 +219,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					)
 				)
 			)
-		);
-		if(wp_count_terms('job_listing_type')>0){
-			$job_type_field = array(
-				'job' => array(
-					'job_type' => array(
-						'label'       => __( 'Job type', 'wp-job-manager' ),
-						'type'        => 'term-select',
-						'required'    => true,
-						'placeholder' => '',
-						'priority'    => 3,
-						'default'     => 'full-time',
-						'taxonomy'    => 'job_listing_type'
-					)
-				)
-			);
-			$job_form_fields = array_merge_recursive($job_form_fields,$job_type_field);
-		}
-
-		$this->fields = apply_filters( 'submit_job_form_fields', $job_form_fields );
+		) );
 
 		if ( ! get_option( 'job_manager_enable_categories' ) || wp_count_terms( 'job_listing_category' ) == 0 ) {
 			unset( $this->fields['job']['job_category'] );
+		}
+		if ( wp_count_terms( 'job_listing_type' ) < 1 ) {
+			unset( $this->fields['job']['job_type'] );
 		}
 	}
 


### PR DESCRIPTION
I have a site which doesn't use Job Types, but they want to use the front-end submission form. Unfortunately, the current code forces the job type field to be required even if there aren't any job types to choose from!

_The Fix:_ I've made this edit to the form field code so it only includes the job type field if there's job types to choose from. The job type field remains required, but only if there are job types to be shown.

I'd love to see this included in a future version of the plugin since I'm sure there's plenty of people out there who share the need for this use case, and I want them to be able to use this great plugin. Thanks!
