### PR TITLE
update/fix visibility declarations

### DIFF
--- a/includes/class-wp-job-manager-category-walker.php
+++ b/includes/class-wp-job-manager-category-walker.php
@@ -8,8 +8,8 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 class WP_Job_Manager_Category_Walker extends Walker {
 
-	var $tree_type = 'category';
-	var $db_fields = array ('parent' => 'parent', 'id' => 'term_id', 'slug' => 'slug' );
+	public $tree_type = 'category';
+	public $db_fields = array ('parent' => 'parent', 'id' => 'term_id', 'slug' => 'slug' );
 
 	/**
 	 * @see Walker::start_el()
@@ -20,7 +20,7 @@ class WP_Job_Manager_Category_Walker extends Walker {
 	 * @param int $depth Depth of category in reference to parents.
 	 * @param array $args
 	 */
-	function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
+	public function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 
 		if ( ! empty( $args['hierarchical'] ) )
 			$pad = str_repeat('&nbsp;', $depth * 3);

--- a/includes/class-wp-job-manager-widgets.php
+++ b/includes/class-wp-job-manager-widgets.php
@@ -39,7 +39,7 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	/**
 	 * get_cached_widget function.
 	 */
-	function get_cached_widget( $args ) {
+	public function get_cached_widget( $args ) {
 		$cache = wp_cache_get( $this->widget_id, 'widget' );
 
 		if ( ! is_array( $cache ) )
@@ -79,7 +79,7 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	 * @param array $old_instance
 	 * @return array
 	 */
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 
 		if ( ! $this->settings )


### PR DESCRIPTION
Make property and method visibility declarations more clear and explicit.

Per http://docs.php.net/manual/en/language.oop5.visibility.php: 

"Class properties must be defined as public, private, or protected. If declared using var, the property will be defined as public. ... The PHP 4 method of declaring a variable with the var keyword is still supported for compatibility reasons (as a synonym for the public keyword).  ... Class methods may be defined as public, private, or protected. Methods declared without any explicit visibility keyword are defined as public."
