### PR TITLE
Job post form categories are now properly cached and displayed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,7 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 == Changelog ==
 
 = 1.25.1 =
+* Fix - Job post form categories are now properly cached and displayed per language when using WPML or Polylang. (https://github.com/Automattic/WP-Job-Manager/issues/692)
 * Fix - Refactored WPML workaround, which was causing no job listings on non-default languages. (https://github.com/Automattic/WP-Job-Manager/issues/617)
 
 = 1.25.0 =

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -546,6 +546,13 @@ function job_manager_dropdown_categories( $args = '' ) {
 		$r['pad_counts'] = true;
 	}
 
+	// WPML & Polylang caching per language
+	if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+		$r['lang'] = apply_filters( 'wpml_current_language', NULL );
+	} elseif ( function_exists( 'pll_current_language' ) ) {
+		$r['lang'] = pll_current_language();
+	}
+
 	extract( $r );
 
 	// Store in a transient to help sites with many cats


### PR DESCRIPTION
Job post form categories are now properly cached and displayed per language when using WPML or Polylang.

Fixes #692
