### PR TITLE
Add filters for file uploads (prepare and pre upload), update PHPDoc

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -693,14 +693,14 @@ function job_manager_prepare_uploaded_files( $file_data ) {
 		$files_to_upload[] = $file_data;
 	}
 
-	return $files_to_upload;
+	return apply_filters( 'job_manager_prepare_uploaded_files', $files_to_upload );
 }
 
 /**
  * Upload a file using WordPress file API.
  * @param  array $file_data Array of $_FILE data to upload.
  * @param  array $args Optional arguments
- * @return array|WP_Error Array of objects containing either file information or an error
+ * @return stdClass|WP_Error Object containing file information, or error
  */
 function job_manager_upload_file( $file, $args = array() ) {
 	global $job_manager_upload, $job_manager_uploading_file;
@@ -721,6 +721,10 @@ function job_manager_upload_file( $file, $args = array() ) {
 		$allowed_mime_types = job_manager_get_allowed_mime_types( $job_manager_uploading_file );
 	} else {
 		$allowed_mime_types = $args['allowed_mime_types'];
+	}
+
+	if( is_wp_error( $file = apply_filters( 'job_manager_upload_file_pre_upload', $file, $args, $allowed_mime_types ) ) ) {
+		return $file;
 	}
 
 	if ( ! in_array( $file['type'], $allowed_mime_types ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -723,7 +723,21 @@ function job_manager_upload_file( $file, $args = array() ) {
 		$allowed_mime_types = $args['allowed_mime_types'];
 	}
 
-	if( is_wp_error( $file = apply_filters( 'job_manager_upload_file_pre_upload', $file, $args, $allowed_mime_types ) ) ) {
+	/**
+	 * Filter file configuration before upload
+	 *
+	 * This filter can be used to modify the file arguments before being uploaded, or return a WP_Error
+	 * object to prevent the file from being uploaded, and return the error.
+	 *
+	 * @since 1.25.2
+	 *
+	 * @param array $file               Array of $_FILE data to upload.
+	 * @param array $args               Optional file arguments
+	 * @param array $allowed_mime_types Array of allowed mime types from field config or defaults
+	 */
+	$file = apply_filters( 'job_manager_upload_file_pre_upload', $file, $args, $allowed_mime_types );
+
+	if ( is_wp_error( $file ) ) {
 		return $file;
 	}
 


### PR DESCRIPTION
This PR adds two new filters in the file upload handling process.

The first filter `job_manager_prepare_uploaded_files` is added to the return value from the core function `job_manager_prepare_uploaded_files` (this I added so it's available if needed later)

**_The second filter and the most important one is the `job_manager_upload_file_pre_upload` filter added before the core `wp_handle_upload` function is called._**  

This allows us to check the file for certain conditions (file size, dimensions, etc), or anything else that may be required before actually uploading the file, and return our own `WP_Error` that would then be output on the frontend (in error notice, or message box for Ajax uploads).

The most important part of this is that it prevents the file from actually being uploaded to the server, as the only method I can use right now is in the validation process and return an error, but by that point the file has already been uploaded to the server.
