### PR TITLE
Fix jobs shortcode so the random orderby is actually random. #714

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -143,6 +143,11 @@ function get_job_listings( $args = array() ) {
 			set_transient( $query_args_hash, $result, DAY_IN_SECONDS * 30 );
 		}
 
+		// random order is cached so shuffle them
+		if ( $query_args[ 'orderby' ] == 'rand' ) {
+			shuffle( $result->posts );
+		}
+
 	}
 	else {
 		$result = new WP_Query( $query_args );


### PR DESCRIPTION
This fixes #714 by shuffling the posts returned from WP_Query, which may have been cached.