### PR TITLE
Fix the_company_video unnecessary call to wp_oembed_get causing additional site load time

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -413,15 +413,16 @@ function job_manager_get_resized_image( $logo, $size ) {
  * Output the company video
  */
 function the_company_video( $post = null ) {
-	$video    = get_the_company_video( $post );
-	$filetype = wp_check_filetype( $video );
+	$video_embed = false;
+	$video       = get_the_company_video( $post );
+	$filetype    = wp_check_filetype( $video );
 
 	// FV Wordpress Flowplayer Support for advanced video formats
 	if ( shortcode_exists( 'flowplayer' ) ) {
 		$video_embed = '[flowplayer src="' . esc_attr( $video ) . '"]';
 	} elseif ( ! empty( $filetype['ext'] ) ) {
 		$video_embed = wp_video_shortcode( array( 'src' => $video ) );
-	} else {
+	} elseif( ! empty( $video ) ) {
 		$video_embed = wp_oembed_get( $video );
 	}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -417,13 +417,15 @@ function the_company_video( $post = null ) {
 	$video       = get_the_company_video( $post );
 	$filetype    = wp_check_filetype( $video );
 
-	// FV Wordpress Flowplayer Support for advanced video formats
-	if ( shortcode_exists( 'flowplayer' ) ) {
-		$video_embed = '[flowplayer src="' . esc_attr( $video ) . '"]';
-	} elseif ( ! empty( $filetype['ext'] ) ) {
-		$video_embed = wp_video_shortcode( array( 'src' => $video ) );
-	} elseif( ! empty( $video ) ) {
-		$video_embed = wp_oembed_get( $video );
+	if( ! empty( $video ) ){
+		// FV Wordpress Flowplayer Support for advanced video formats
+		if ( shortcode_exists( 'flowplayer' ) ) {
+			$video_embed = '[flowplayer src="' . esc_attr( $video ) . '"]';
+		} elseif ( ! empty( $filetype[ 'ext' ] ) ) {
+			$video_embed = wp_video_shortcode( array( 'src' => $video ) );
+		} else {
+			$video_embed = wp_oembed_get( $video );
+		}
 	}
 
 	$video_embed = apply_filters( 'the_company_video_embed', $video_embed, $post );


### PR DESCRIPTION
Even though the `the_company_video` field is not a required field, the core code base still assumes that a value will be returned each time for this field, causing an unnecessary call to `wp_oembed_get` causing a call to `wp_safe_remote_get` which ends up in a GET timeout, adding additional load time to the site.

This PR fixes this issue by only calling `wp_oembed_get` if `$video_embed` has a value, while still maintaining the ability to use the filter and still have the video output.

![](https://smyl.es/img/Screenshot_2016-09-29_03-12-53_PM.png)
