### PR TITLE
Stop setup.css loading except on the setup page

### DIFF
--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -18,7 +18,8 @@ class WP_Job_Manager_Setup {
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
 		add_action( 'admin_head', array( $this, 'admin_head' ) );
 		add_action( 'admin_init', array( $this, 'redirect' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 12 );
+		if ( isset( $_GET[ 'page' ] ) && $_GET[ 'page' ] == 'job-manager-setup' )
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 12 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #728
The file setup.css was enqueued on every Job Manager admin page
but this checks that the setup page is loaded before enqueuing it.