### PR TITLE
Use the default WordPress upload files for resized images.

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -375,7 +375,8 @@ function job_manager_get_resized_image( $logo, $size ) {
 		$upload_dir        = wp_upload_dir();
 		$logo_path         = str_replace( array( $upload_dir['baseurl'], $upload_dir['url'], WP_CONTENT_URL ), array( $upload_dir['basedir'], $upload_dir['path'], WP_CONTENT_DIR ), $logo );
 		$path_parts        = pathinfo( $logo_path );
-		$resized_logo_path = str_replace( '.' . $path_parts['extension'], '-' . $size . '.' . $path_parts['extension'], $logo_path );
+		$dims              = $img_width . 'x' . $img_height;
+		$resized_logo_path = str_replace( '.' . $path_parts['extension'], '-' . $dims . '.' . $path_parts['extension'], $logo_path );
 
 		if ( strstr( $resized_logo_path, 'http:' ) || strstr( $resized_logo_path, 'https:' ) ) {
 			return $logo;


### PR DESCRIPTION
Fixes #706

The function job_manager_get_resized_image() creates images that
use the strings, 'thumbnail', 'medium', 'large' rather than the
dimensions that WordPress uses. This fixes that and the plugin
will use files that might already have been generated by
WordPress. Props @spencerfinnell.