### PR TITLE
Simplify the search message on the job listing page.

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -185,7 +185,13 @@ class WP_Job_Manager_Ajax {
 			$result['showing_all'] = true;
 		}
 
-		$result['showing'] = apply_filters( 'job_manager_get_listings_custom_filter_text', sprintf( __( 'Showing all %s', 'wp-job-manager' ), implode( ' ', $result['showing'] ) ) );
+		if ( $jobs->post_count && ( $search_location || $search_keywords || $search_categories ) ) {
+			$message = sprintf( __( '%1$s search completed. Found %2$d matching records.', 'wp-job-manager' ), __( $post_type_label, 'wp-job-manager' ), $jobs->post_count );
+			$result['showing_all'] = true;
+		} else {
+			$message = "";
+		}
+		$result['showing'] = apply_filters( 'job_manager_get_listings_custom_filter_text', $message );
 
 		// Generate RSS link
 		$result['showing_links'] = job_manager_get_filtered_links( array(


### PR DESCRIPTION
Fixes #647
The original string was translated incorrectly to French but because of the way it was constructed it couldn't be easily translated correctly anyway. Since the search terms are already on the page I modified the string so it would display how many records had been found.