### PR TITLE
Simplify the search message some more. Just the number of records

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -186,7 +186,7 @@ class WP_Job_Manager_Ajax {
 		}
 
 		if ( $jobs->post_count && ( $search_location || $search_keywords || $search_categories ) ) {
-			$message = sprintf( __( '%1$s search completed. Found %2$d matching records.', 'wp-job-manager' ), __( $post_type_label, 'wp-job-manager' ), $jobs->post_count );
+			$message = sprintf( _n( 'Search completed. Found %d matching record.', 'Search completed. Found %d matching records.', $jobs->post_count, 'wp-job-manager' ), $jobs->post_count );
 			$result['showing_all'] = true;
 		} else {
 			$message = "";


### PR DESCRIPTION
Fixes #647 (again)
My previous patch didn't account for plurals - for multiple records vs 1 record found.
Also dropping the post_type_label in like I did might not work in some languages. Props @akirk