### PR TITLE
Show expired content on the job listings page if required.

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -23,9 +23,15 @@ function get_job_listings( $args = array() ) {
 		'fields'            => 'all'
 	) );
 
+	if ( false == get_option( 'job_manager_hide_expired_content', 1 ) ) {
+		$post_status = array( 'publish', 'expired' );
+	} else {
+		$post_status = 'publish';
+	}
+
 	$query_args = array(
 		'post_type'              => 'job_listing',
-		'post_status'            => 'publish',
+		'post_status'            => $post_status,
 		'ignore_sticky_posts'    => 1,
 		'offset'                 => absint( $args['offset'] ),
 		'posts_per_page'         => intval( $args['posts_per_page'] ),


### PR DESCRIPTION
Fixes #703
The function that displays the job listings didn't account for post_status = expired so they never showed up even when that option was unchecked in the settings.