### PR TITLE
697 translation of datepicker

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -45,7 +45,7 @@ class WP_Job_Manager_Admin {
 			wp_enqueue_script( 'job_manager_admin_js', JOB_MANAGER_PLUGIN_URL. '/assets/js/admin.min.js', array( 'jquery', 'jquery-tiptip', 'jquery-ui-datepicker' ), JOB_MANAGER_VERSION, true );
 
 			wp_localize_script( 'job_manager_admin_js', 'job_manager_admin', array(
-				'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker', 'wp-job-manager' )
+				'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker. See http://api.jqueryui.com/datepicker/#utility-formatDate', 'wp-job-manager' )
 			) );
 		}
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -45,7 +45,8 @@ class WP_Job_Manager_Admin {
 			wp_enqueue_script( 'job_manager_admin_js', JOB_MANAGER_PLUGIN_URL. '/assets/js/admin.min.js', array( 'jquery', 'jquery-tiptip', 'jquery-ui-datepicker' ), JOB_MANAGER_VERSION, true );
 
 			wp_localize_script( 'job_manager_admin_js', 'job_manager_admin', array(
-				'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker. See http://api.jqueryui.com/datepicker/#utility-formatDate', 'wp-job-manager' )
+				/* translators: jQuery date format, see http://api.jqueryui.com/datepicker/#utility-formatDate */
+				'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker.', 'wp-job-manager' )
 			) );
 		}
 

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -84,7 +84,8 @@ class WP_Job_Manager_Writepanels {
 				'label'       => __( 'Listing Expiry Date', 'wp-job-manager' ),
 				'priority'    => 11,
 				'classes'     => array( 'job-manager-datepicker' ),
-				'placeholder' => _x( 'yyyy-mm-dd', 'Date format placeholder. http://php.net/manual/en/function.date.php', 'wp-job-manager' ),
+				/* translators: date format placeholder, see https://secure.php.net/date */
+				'placeholder' => _x( 'yyyy-mm-dd', 'Date format placeholder.', 'wp-job-manager' ),
 				'value'       => metadata_exists( 'post', $post->ID, '_job_expires' ) ? get_post_meta( $post->ID, '_job_expires', true ) : calculate_job_expiry( $post->ID ),
 			);
 		}

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -84,7 +84,7 @@ class WP_Job_Manager_Writepanels {
 				'label'       => __( 'Listing Expiry Date', 'wp-job-manager' ),
 				'priority'    => 11,
 				'classes'     => array( 'job-manager-datepicker' ),
-				'placeholder' => _x( 'yyyy-mm-dd', 'Date format placeholder', 'wp-job-manager' ),
+				'placeholder' => _x( 'yyyy-mm-dd', 'Date format placeholder. http://php.net/manual/en/function.date.php', 'wp-job-manager' ),
 				'value'       => metadata_exists( 'post', $post->ID, '_job_expires' ) ? get_post_meta( $post->ID, '_job_expires', true ) : calculate_job_expiry( $post->ID ),
 			);
 		}


### PR DESCRIPTION
Fixes #697
The Italian and French translations are incorrect as the translators changed the date format from "yyyy" and "dd" to the first letter of the words in those languages. I'm adding a link to the official documentation for the date format in PHP and Javascript respectively for each of these to help translation.
