### PR TITLE
Add the wpml_object_id filter to aid multi language use of the plugin.

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -640,7 +640,7 @@ function job_manager_dropdown_categories( $args = '' ) {
 function job_manager_get_page_id( $page ) {
 	$page_id = get_option( 'job_manager_' . $page . '_page_id', false );
 	if ( $page_id ) {
-		return absint( function_exists( 'pll_get_post' ) ? pll_get_post( $page_id ) : $page_id );
+		return apply_filters( 'wpml_object_id', absint( function_exists( 'pll_get_post' ) ? pll_get_post( $page_id ) : $page_id ), 'page', TRUE );
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
See #786. If the site owner has WPML installed this filter should help redirect the visitor to the translated page they need. Props @spencerfinnell
