### PR TITLE
Remove Grunt POT

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,18 +77,6 @@ module.exports = function( grunt ){
 			}
 		},
 
-		shell: {
-			options: {
-				stdout: true,
-				stderr: true
-			},
-			generatepot: {
-				command: [
-					'makepot'
-				].join( '&&' )
-			}
-		},
-
 		jshint: {
 			options: grunt.file.readJSON('.jshintrc'),
 			src: [
@@ -112,7 +100,6 @@ module.exports = function( grunt ){
 	});
 
 	// Load NPM tasks to be used here
-	grunt.loadNpmTasks( 'grunt-shell' );
 	grunt.loadNpmTasks( 'grunt-contrib-less' );
 	grunt.loadNpmTasks( 'grunt-contrib-cssmin' );
 	grunt.loadNpmTasks( 'grunt-contrib-uglify' );
@@ -126,11 +113,6 @@ module.exports = function( grunt ){
 		'cssmin',
 		'uglify',
 		'wp_readme_to_markdown'
-	]);
-
-	// Just an alias for pot file generation
-	grunt.registerTask( 'pot', [
-		'shell:generatepot'
 	]);
 
 	grunt.registerTask( 'dev', [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-job-manager",
   "title": "WP Job Manager",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "homepage": "http://wordpress.org/plugins/wp-job-manager/",
   "license": "GPL-2.0+",
   "repository": "automattic/wp-job-manager",
@@ -13,7 +13,6 @@
     "grunt-contrib-less": "~1.2.0",
     "grunt-contrib-uglify": "~0.9.2",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-shell": "~0.6.4",
     "grunt-wp-readme-to-markdown": "^2.0.0"
   },
   "engines": {


### PR DESCRIPTION
Instead of self-generating, let's direct folks to the w.org one.

Until we determine if there's a place we can actually send people, let's manually grab the pot down.