### PR TITLE
Fix typo in add_filter missing required parameters

### DIFF
--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -175,6 +175,6 @@ function job_manager_add_post_types( $types, $id ) {
 	$types[] = 'job_listing';
 	return $types;
 }
-add_filter( 'post_types_to_delete_with_user', 'job_manager_add_post_types' );
+add_filter( 'post_types_to_delete_with_user', 'job_manager_add_post_types', 10, 2 );
 
 $GLOBALS['job_manager'] = new WP_Job_Manager();


### PR DESCRIPTION
Fixes #675 

The add_filter command was missing parameters to tell it to accept two parameters.