### PR TITLE
Warn the user if they're editing an existing job.

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -73,6 +73,20 @@ abstract class WP_Job_Manager_Form {
 	 * Process function. all processing code if needed - can also change view if step is complete
 	 */
 	public function process() {
+
+		// reset cookie
+		if (
+			isset( $_GET[ 'new' ] ) &&
+			isset( $_COOKIE[ 'wp-job-manager-submitting-job-id' ] ) &&
+			isset( $_COOKIE[ 'wp-job-manager-submitting-job-key' ] ) &&
+			get_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key', true ) == $_COOKIE['wp-job-manager-submitting-job-key']
+		) {
+			delete_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key' );
+			setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+			setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+			wp_redirect( remove_query_arg( array( 'new', 'key' ), $_SERVER[ 'REQUEST_URI' ] ) );
+		}
+
 		$step_key = $this->get_step_key( $this->step );
 
 		if ( $step_key && is_callable( $this->steps[ $step_key ]['handler'] ) ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -89,12 +89,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		// Allow resuming from cookie.
-		if ( ! $this->job_id && ! empty( $_COOKIE['wp-job-manager-submitting-job-id'] ) && ! empty( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
+		$this->resume_edit = false;
+		if ( ! isset( $_GET[ 'new' ] ) && ! $this->job_id && ! empty( $_COOKIE['wp-job-manager-submitting-job-id'] ) && ! empty( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
 			$job_id     = absint( $_COOKIE['wp-job-manager-submitting-job-id'] );
 			$job_status = get_post_status( $job_id );
 
 			if ( ( 'preview' === $job_status || 'pending_payment' === $job_status ) && get_post_meta( $job_id, '_submitting_key', true ) === $_COOKIE['wp-job-manager-submitting-job-key'] ) {
 				$this->job_id = $job_id;
+				$this->resume_edit = get_post_meta( $job_id, '_submitting_key', true );
 			}
 		}
 
@@ -412,6 +414,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		get_job_manager_template( 'job-submit.php', array(
 			'form'               => $this->form_name,
 			'job_id'             => $this->get_job_id(),
+			'resume_edit'        => $this->resume_edit,
 			'action'             => $this->get_action(),
 			'job_fields'         => $this->get_fields( 'job' ),
 			'company_fields'     => $this->get_fields( 'company' ),

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -90,7 +90,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		// Allow resuming from cookie.
 		$this->resume_edit = false;
-		if ( ! isset( $_GET[ 'new' ] ) && ! $this->job_id && ! empty( $_COOKIE['wp-job-manager-submitting-job-id'] ) && ! empty( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
+		if ( ! isset( $_GET[ 'new' ] ) && ( 'before' === get_option( 'job_manager_paid_listings_flow' ) || ! $this->job_id ) && ! empty( $_COOKIE['wp-job-manager-submitting-job-id'] ) && ! empty( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
 			$job_id     = absint( $_COOKIE['wp-job-manager-submitting-job-id'] );
 			$job_status = get_post_status( $job_id );
 

--- a/templates/job-submit.php
+++ b/templates/job-submit.php
@@ -8,6 +8,12 @@ global $job_manager;
 ?>
 <form action="<?php echo esc_url( $action ); ?>" method="post" id="submit-job-form" class="job-manager-form" enctype="multipart/form-data">
 
+	<?php
+	if ( isset( $resume_edit ) && $resume_edit ) {
+		printf( '<p><strong>' . __( "You are editing an existing job. %s" ) . '</strong></p>', '<a href="?new=1&key=' . $resume_edit . '">' . __( 'Create A New Job' ) . '</a>' );
+	}
+	?>
+
 	<?php do_action( 'submit_job_form_start' ); ?>
 
 	<?php if ( apply_filters( 'submit_job_form_show_signin', true ) ) : ?>

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -913,15 +913,3 @@ function job_manager_duplicate_listing( $post_id ) {
 	return $new_post_id;
 }
 
-// reset cookie
-if (
-	isset( $_GET[ 'new' ] ) &&
-	isset( $_COOKIE[ 'wp-job-manager-submitting-job-id' ] ) &&
-	isset( $_COOKIE[ 'wp-job-manager-submitting-job-key' ] ) &&
-	get_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key', true ) == $_COOKIE['wp-job-manager-submitting-job-key']
-) {
-	delete_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key' );
-	setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-	setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-	wp_redirect( remove_query_arg( array( 'new', 'key' ), $_SERVER[ 'REQUEST_URI' ] ) );
-}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -912,3 +912,16 @@ function job_manager_duplicate_listing( $post_id ) {
 
 	return $new_post_id;
 }
+
+// reset cookie
+if (
+	isset( $_GET[ 'new' ] ) &&
+	isset( $_COOKIE[ 'wp-job-manager-submitting-job-id' ] ) &&
+	isset( $_COOKIE[ 'wp-job-manager-submitting-job-key' ] ) &&
+	get_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key', true ) == $_COOKIE['wp-job-manager-submitting-job-key']
+) {
+	delete_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key' );
+	setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+	setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+	wp_redirect( remove_query_arg( array( 'new', 'key' ), $_SERVER[ 'REQUEST_URI' ] ) );
+}


### PR DESCRIPTION
See #835

The plugin allows the user to edit jobs before they're published, but if the paid listings plugin is installed a new job may be in "pending_payment" status even after the user has submitted it. This patch warns the user and displays a link   to delete the cookie. The link will allow users to start a new job submission even without the paid listing plugin installed.