### PR TITLE
Implicit whitelisting for API requests

### DIFF
--- a/includes/class-wp-job-manager-api.php
+++ b/includes/class-wp-job-manager-api.php
@@ -61,7 +61,7 @@ class WP_Job_Manager_API {
 			$api = strtolower( esc_attr( $wp->query_vars['job-manager-api'] ) );
 
 			// Load class if exists
-			if ( class_exists( $api ) )
+			if ( has_action( 'job_manager_api_' . $api ) && class_exists( $api ) )
 				$api_class = new $api();
 
 			// Trigger actions


### PR DESCRIPTION
To mitigate the security risk of exposing arbitrary class construction methods to execution via a GET request, the `api_requests()` method now only instantiates those classes for which an `job_manager_api_$api` action hook has been registered.