### PR TITLE
Job feed will not load when a site has no posts

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -353,7 +353,8 @@ class WP_Job_Manager_Post_Types {
 			);
 		}
 
-		if ( $job_manager_keyword = sanitize_text_field( $_GET['search_keywords'] ) ) {
+		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( $_GET['search_keywords'] ) : '';
+		if ( !empty( $job_manager_keyword ) ) {
 			$query_args['_keyword'] = $job_manager_keyword; // Does nothing but needed for unique hash
 			add_filter( 'posts_clauses', 'get_job_listings_keyword_search' );
 		}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -38,6 +38,8 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'update_post_meta', array( $this, 'update_post_meta' ), 10, 4 );
 		add_action( 'wp_insert_post', array( $this, 'maybe_add_default_meta_data' ), 10, 2 );
 
+		add_action( 'parse_query', array( $this, 'add_feed_query_args' ) );
+
 		// WP ALL Import
 		add_action( 'pmxi_saved_post', array( $this, 'pmxi_saved_post' ), 10, 1 );
 
@@ -368,6 +370,31 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'rss2_ns', array( $this, 'job_feed_namespace' ) );
 		add_action( 'rss2_item', array( $this, 'job_feed_item' ) );
 		do_feed_rss2( false );
+	}
+
+	/**
+	 * In order to make sure that the feed properly queries the 'job_listing' type
+	 *
+	 * @param WP_Query $wp
+	 */
+	public function add_feed_query_args( $wp ) {
+
+		// Let's leave if not the job feed
+		if ( ! isset( $wp->query_vars['feed'] ) || 'job_feed' !== $wp->query_vars['feed'] ) {
+			return;
+		}
+
+		// Leave if not a feed.
+		if ( false === $wp->is_feed ) {
+			return;
+		}
+
+		// If the post_type was already set, let's get out of here.
+		if ( isset( $wp->query_vars['post_type'] ) && ! empty( $wp->query_vars['post_type'] ) ) {
+			return;
+		}
+
+		$wp->query_vars['post_type'] = 'job_listing';
 	}
 
 	/**


### PR DESCRIPTION
It appears that the way feeds are loaded has changed since WordPress 4.7 landed. Because of this, the `do_feed_job_feed` action is now loading AFTER an initial query for posts is done. This means that we need to add in some parameters for that initial query that tells it to look for posts of the `job_listing` type to make sure it even tries loading the feed.

This PR fixes #841 

### What you see now

This is the screen you currently see, before modification, when you load a feed without having any posts on the site.

<img width="931" alt="screen shot 2017-02-16 at 11 28 03 am" src="https://cloud.githubusercontent.com/assets/195095/23007432/4583a204-f43b-11e6-9116-2e1fdc72ca1f.png">

### How to test

1. In a WordPress 4.7.* instance, add WP-Job-Manager@`fix/feed-missing-post-type` and enable the plugin.
2. Delete all posts (clear trash too just to be sure)
3. Create at least one job listing
4. Go to https://{yousite.com}/?feed=job_feed
5. You should see your XML feed load properly.

### Other considerations

Because the query is now being loaded before the feed action occurs, there are some other optimizations we should do to how this query is being performed to prevent too many calls from occurring. I will be handling that as a separate issue though