### PR TITLE
Adding WordPress function has_shortcode() instead of strstr

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -38,7 +38,7 @@ class WP_Job_Manager_Shortcodes {
 	public function shortcode_action_handler() {
 		global $post;
 
-		if ( is_page() && strstr( $post->post_content, '[job_dashboard' ) ) {
+		if ( is_page() && has_shortcode($post->post_content, 'job_dashboard' ) ) {
 			$this->job_dashboard_handler();
 		}
 	}


### PR DESCRIPTION
The php function strstr() provided small check which could be easily skipped by adding the string ['job_dashboard'  to the post content. By adding the function has_shortcode() it does a more strict search using regex for searching the shortcode in post content and it couldn't be skipped.