### PR TITLE
$id unused, no need to expect both params passed

### DIFF
--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -171,10 +171,10 @@ class WP_Job_Manager {
 	}
 }
 
-function job_manager_add_post_types( $types, $id ) {
+function job_manager_add_post_types( $types ) {
 	$types[] = 'job_listing';
 	return $types;
 }
-add_filter( 'post_types_to_delete_with_user', 'job_manager_add_post_types', 10, 2 );
+add_filter( 'post_types_to_delete_with_user', 'job_manager_add_post_types', 10 );
 
 $GLOBALS['job_manager'] = new WP_Job_Manager();


### PR DESCRIPTION
This is related to this support request:
https://wordpress.org/support/topic/error-on-user-deletion/#post-8818607

Since `$id` is not even used, no need to expect both args