### PR TITLE
Fix broken formatting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,11 +103,9 @@ module.exports = function( grunt ){
 					]
 				}
 			}
-		}
+		},
 
-	});
-
-	// Load NPM tasks to be used here
+		// Load NPM tasks to be used here
 		jshint: {
 			options: grunt.file.readJSON('.jshintrc'),
 			src: [


### PR DESCRIPTION
A rogue set of closing brackets caused the `jshint` and `wp_readme_to_markdown` npm tasks to not be part of Grunt's `initConfig`.