### PR TITLE
Types metabox should say Job Types not Job Listings

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -128,7 +128,8 @@ class WP_Job_Manager_Writepanels {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side');
 		} elseif ( false == job_manager_multi_job_type() ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side');
-			add_meta_box( 'job_listing_type', __( 'Job Types', 'wp-job-manager' ), array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
+			$job_listing_type = get_taxonomy( 'job_listing_type' );
+			add_meta_box( 'job_listing_type', $job_listing_type->label, array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -129,7 +129,7 @@ class WP_Job_Manager_Writepanels {
 		} elseif ( false == job_manager_multi_job_type() ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side');
 			$job_listing_type = get_taxonomy( 'job_listing_type' );
-			add_meta_box( 'job_listing_type', $job_listing_type->label, array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
+			add_meta_box( 'job_listing_type', $job_listing_type->labels->menu_name, array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -128,7 +128,7 @@ class WP_Job_Manager_Writepanels {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side');
 		} elseif ( false == job_manager_multi_job_type() ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side');
-			add_meta_box( 'job_listing_type', __( 'Job Listings', 'wp-job-manager' ), array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
+			add_meta_box( 'job_listing_type', __( 'Job Types', 'wp-job-manager' ), array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
 		}
 	}
 


### PR DESCRIPTION
Job Types metabox title should not say Job Listings, it should say Job Types to match the appropriate taxonomy (this has confused users who are opening support tickets with me about it)