### PR TITLE
Add filterable search-able meta keys 

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -177,7 +177,7 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 	function get_job_listings_keyword_search( $args ) {
 		global $wpdb, $job_manager_keyword;
 
-		/* Searchable Meta Keys: set to empty to search all meta keys */
+		// Searchable Meta Keys: set to empty to search all meta keys
 		$searchable_meta_keys = array(
 			'_job_location',
 			'_company_name',
@@ -189,26 +189,25 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 		);
 		$searchable_meta_keys = apply_filters( 'job_listing_searchable_meta_keys', $searchable_meta_keys );
 
-		/* Set Search DB Conditions */
+		// Set Search DB Conditions
 		$conditions   = array();
 
-		/* Search Post Title  */
+		// Search Post Title
 		$conditions[] = "{$wpdb->posts}.post_title LIKE '%" . esc_sql( $job_manager_keyword ) . "%'";
 
-		/* Search Post Meta */
-		if( apply_filters( 'job_listing_search_post_meta', true ) ){
+		// Search Post Meta
+		if( apply_filters( 'job_listing_search_post_meta', true ) ) {
 
-			/* Only selected meta keys */
-			if( $searchable_meta_keys ){
-				$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key IN ( '" . implode( "','", $searchable_meta_keys ) . "' ) AND meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
-			}
-			/* No meta keys defined, search all post meta value */
-			else{
+			// Only selected meta keys
+			if( $searchable_meta_keys ) {
+				$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key IN ( '" . implode( "','", array_map( 'esc_sql', $searchable_meta_keys ) ) . "' ) AND meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
+			} else {
+			    // No meta keys defined, search all post meta value
 				$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
 			}
 		}
 
-		/* Search taxonomy */
+		// Search taxonomy
 		$conditions[] = "{$wpdb->posts}.ID IN ( SELECT object_id FROM {$wpdb->term_relationships} AS tr LEFT JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id LEFT JOIN {$wpdb->terms} AS t ON tt.term_id = t.term_id WHERE t.name LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
 
 		if ( ctype_alnum( $job_manager_keyword ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -177,9 +177,38 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 	function get_job_listings_keyword_search( $args ) {
 		global $wpdb, $job_manager_keyword;
 
+		/* Searchable Meta Keys: set to empty to search all meta keys */
+		$searchable_meta_keys = array(
+			'_job_location',
+			'_company_name',
+			'_application',
+			'_company_name',
+			'_company_tagline',
+			'_company_website',
+			'_company_twitter',
+		);
+		$searchable_meta_keys = apply_filters( 'job_listing_searchable_meta_keys', $searchable_meta_keys );
+
+		/* Set Search DB Conditions */
 		$conditions   = array();
+
+		/* Search Post Title  */
 		$conditions[] = "{$wpdb->posts}.post_title LIKE '%" . esc_sql( $job_manager_keyword ) . "%'";
-		$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
+
+		/* Search Post Meta */
+		if( apply_filters( 'job_listing_search_post_meta', true ) ){
+
+			/* Only selected meta keys */
+			if( $searchable_meta_keys ){
+				$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key IN ( '" . implode( "','", $searchable_meta_keys ) . "' ) AND meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
+			}
+			/* No meta keys defined, search all post meta value */
+			else{
+				$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
+			}
+		}
+
+		/* Search taxonomy */
 		$conditions[] = "{$wpdb->posts}.ID IN ( SELECT object_id FROM {$wpdb->term_relationships} AS tr LEFT JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id LEFT JOIN {$wpdb->terms} AS t ON tt.term_id = t.term_id WHERE t.name LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
 
 		if ( ctype_alnum( $job_manager_keyword ) ) {


### PR DESCRIPTION
Currently WPJM search all meta value,
This will cause issue explained in https://github.com/Automattic/WP-Job-Manager/issues/900

> When searched for keywords wp-content, tent, wp, content, uploads,etc all listings are displayed