### PR TITLE
Serialize Data Issue on Duplication

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -910,7 +910,7 @@ function job_manager_duplicate_listing( $post_id ) {
 			if ( in_array( $meta_key, apply_filters( 'job_manager_duplicate_listing_ignore_keys', array( '_filled', '_featured', '_job_expires', '_job_duration', '_package_id', '_user_package_id' ) ) ) ) {
 				continue;
 			}
-			update_post_meta( $new_post_id, $meta_key, $meta_value );
+			update_post_meta( $new_post_id, $meta_key, maybe_unserialize( $meta_value ) );
 		}
 	}
 


### PR DESCRIPTION
Problem with multiple fields: https://github.com/Automattic/WP-Job-Manager/issues/732
Because multiple is serialize data. So, we need to unserialize it before duplicating the data.

Note: I think it's a bug in WP that it try to serialize serialized data using `maybe_serialize()` (?)

#### CMIIW:
The duplicate functionality (job dashboard shortcode) works well for string data,
But if the data is already serialize `update_metadata` will perform `maybe_serialize` that cause the data fail to be unserialized correctly.
https://github.com/WordPress/WordPress/blob/4.7.3/wp-includes/meta.php#L212

#### Example Code:
```
$data = array(
	'1' => 'one',
	'2' => 'two',
	'3' => 'three',
);
$data = serialize( $data ); // a:3:{i:1;s:3:"one";i:2;s:3:"two";i:3;s:5:"three";}
$data = maybe_serialize( $data ); // s:50:"a:3:{i:1;s:3:"one";i:2;s:3:"two";i:3;s:5:"three";}";
$data = maybe_unserialize( $data ); // a:3:{i:1;s:3:"one";i:2;s:3:"two";i:3;s:5:"three";}
```

The correct procedure:
```
$data = array(
	'1' => 'one',
	'2' => 'two',
	'3' => 'three',
);
$data = serialize( $data ); // a:3:{i:1;s:3:"one";i:2;s:3:"two";i:3;s:5:"three";}
$data = maybe_unserialize( $data ); // THIS STEP MISSING! back to array()
$data = maybe_serialize( $data ); // a:3:{i:1;s:3:"one";i:2;s:3:"two";i:3;s:5:"three";}
$data = maybe_unserialize( $data ); // back to array()
```
