### PR TITLE
Hide page query results when adding links from job submission WP editor

### DIFF
--- a/assets/css/job-submission.css
+++ b/assets/css/job-submission.css
@@ -1,0 +1,11 @@
+#wp-link #search-panel,
+#wp-link #wplink-link-existing-content {
+  display: none;
+}
+div#wp-link-wrap.wp-core-ui {
+  height: 300px;
+}
+.wplink-autocomplete.ui-autocomplete {
+  display: none;
+  visibility: hidden;
+}

--- a/assets/css/job-submission.less
+++ b/assets/css/job-submission.less
@@ -1,0 +1,14 @@
+#wp-link {
+  #search-panel, #wplink-link-existing-content {
+	display: none;
+  }
+}
+
+div#wp-link-wrap.wp-core-ui {
+  height: 300px;
+}
+
+.wplink-autocomplete.ui-autocomplete {
+  display: none;
+  visibility: hidden;
+}

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -111,6 +111,8 @@ class WP_Job_Manager {
 	 * Register and enqueue scripts and css
 	 */
 	public function frontend_scripts() {
+		global $post;
+
 		$ajax_url         = WP_Job_Manager_Ajax::get_endpoint();
 		$ajax_filter_deps = array( 'jquery', 'jquery-deserialize' );
 		$ajax_data 		  = array(
@@ -167,7 +169,10 @@ class WP_Job_Manager {
 			'i18n_confirm_delete' => __( 'Are you sure you want to delete this listing?', 'wp-job-manager' )
 		) );
 
-		wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css' );
+		wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css', array(), JOB_MANAGER_VERSION );
+		if( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'submit_job_form') ) {
+			wp_enqueue_style( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-submission.css', array(), JOB_MANAGER_VERSION );
+		}
 	}
 }
 


### PR DESCRIPTION
This is a hack-y fix to hide page/post query results when adding links in the `[submit_job_form]` shortcode's form. Right now WordPress core's `wplink` TinyMCE editor has limited options for customizing the display. 

Fixes: #920

