### PR TITLE
Update docblock of WP_Job_Manager_API::add_query_vars

### DIFF
--- a/includes/class-wp-job-manager-api.php
+++ b/includes/class-wp-job-manager-api.php
@@ -24,7 +24,8 @@ class WP_Job_Manager_API {
 	 * add_query_vars function.
 	 *
 	 * @access public
-	 * @return void
+	 * @param array $vars the query vars
+	 * @return array
 	 */
 	public function add_query_vars( $vars ) {
 		$vars[] = 'job-manager-api';


### PR DESCRIPTION
It now correctly states the return type and args