### PR TITLE
Updates docblocks to PHP Documentation specs

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -1,14 +1,16 @@
 <?php
 
 /**
- * Abstract WP_Job_Manager_Form class.
+ * Parent abstract class for form classes.
  *
  * @abstract
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 abstract class WP_Job_Manager_Form {
 
 	/**
-	 * Form fields
+	 * Form fields.
 	 *
 	 * @access protected
 	 * @var array
@@ -16,7 +18,7 @@ abstract class WP_Job_Manager_Form {
 	protected $fields = array();
 
 	/**
-	 * Form action
+	 * Form action.
 	 *
 	 * @access protected
 	 * @var string
@@ -24,7 +26,7 @@ abstract class WP_Job_Manager_Form {
 	protected $action = '';
 
 	/**
-	 * Form errors
+	 * Form errors.
 	 *
 	 * @access protected
 	 * @var array
@@ -32,7 +34,7 @@ abstract class WP_Job_Manager_Form {
 	protected $errors = array();
 
 	/**
-	 * Form steps
+	 * Form steps.
 	 *
 	 * @access protected
 	 * @var array
@@ -40,7 +42,7 @@ abstract class WP_Job_Manager_Form {
 	protected $steps = array();
 
 	/**
-	 * Form step
+	 * Current form step.
 	 *
 	 * @access protected
 	 * @var int
@@ -48,7 +50,7 @@ abstract class WP_Job_Manager_Form {
 	protected $step = 0;
 
 	/**
-	 * Form fields
+	 * Form name.
 	 *
 	 * @access protected
 	 * @var string
@@ -63,14 +65,14 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Unserializing instances of this class is forbidden.
+	 * Unserializes instances of this class is forbidden.
 	 */
 	public function __wakeup() {
 		_doing_it_wrong( __FUNCTION__ );
 	}
 
 	/**
-	 * Process function. all processing code if needed - can also change view if step is complete
+	 * Processes the form result and can also change view if step is complete.
 	 */
 	public function process() {
 
@@ -102,7 +104,9 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Call the view handler if set, otherwise call the next handler.
+	 * Calls the view handler if set, otherwise call the next handler.
+	 *
+	 * @param array $atts Attributes to use in the view handler.
 	 */
 	public function output( $atts = array() ) {
 		$step_key = $this->get_step_key( $this->step );
@@ -114,16 +118,16 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Add an error
+	 * Adds an error.
 	 *
-	 * @param string $error
+	 * @param string $error The error message.
 	 */
 	public function add_error( $error ) {
 		$this->errors[] = $error;
 	}
 
 	/**
-	 * Show errors
+	 * Displays errors.
 	 */
 	public function show_errors() {
 		foreach ( $this->errors as $error ) {
@@ -132,7 +136,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get action (URL for forms to post to).
+	 * Gets the action (URL for forms to post to).
 	 * As of 1.22.2 this defaults to the current page permalink.
 	 *
 	 * @return string
@@ -142,7 +146,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get formn name.
+	 * Gets form name.
 	 *
 	 * @since 1.24.0
 	 * @return string
@@ -152,7 +156,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get steps from outside of the class
+	 * Gets steps from outside of the class.
 	 *
 	 * @since 1.24.0
 	 */
@@ -161,16 +165,18 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get step from outside of the class
+	 * Gets step from outside of the class.
 	 */
 	public function get_step() {
 		return $this->step;
 	}
 
 	/**
-	 * Get step key from outside of the class
+	 * Gets step key from outside of the class.
 	 *
 	 * @since 1.24.0
+	 * @param string|int $step
+	 * @return string
 	 */
 	public function get_step_key( $step = '' ) {
 		if ( ! $step ) {
@@ -181,30 +187,31 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get step from outside of the class
+	 * Sets step from outside of the class.
 	 *
 	 * @since 1.24.0
+	 * @param int $step
 	 */
 	public function set_step( $step ) {
 		$this->step = absint( $step );
 	}
 
 	/**
-	 * Increase step from outside of the class
+	 * Increases step from outside of the class.
 	 */
 	public function next_step() {
 		$this->step ++;
 	}
 
 	/**
-	 * Decrease step from outside of the class
+	 * Decreases step from outside of the class.
 	 */
 	public function previous_step() {
 		$this->step --;
 	}
 
 	/**
-	 * get_fields function.
+	 * Gets fields for form.
 	 *
 	 * @param string $key
 	 * @return array
@@ -222,7 +229,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Sort array by priority value
+	 * Sorts array by priority value.
 	 *
 	 * @param array $a
 	 * @param array $b
@@ -236,14 +243,14 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Init form fields
+	 * Initializes form fields.
 	 */
 	protected function init_fields() {
 		$this->fields = array();
 	}
 
 	/**
-	 * Get post data for fields
+	 * Gets post data for fields.
 	 *
 	 * @return array of data
 	 */
@@ -287,7 +294,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get the value of a posted field
+	 * Gets the value of a posted field.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -298,7 +305,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get the value of a posted multiselect field
+	 * Gets the value of a posted multiselect field.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -309,7 +316,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get the value of a posted file field
+	 * Gets the value of a posted file field.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -328,7 +335,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get the value of a posted textarea field
+	 * Gets the value of a posted textarea field.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -339,7 +346,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get the value of a posted textarea field
+	 * Gets the value of a posted textarea field.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -350,7 +357,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get posted terms for the taxonomy
+	 * Gets posted terms for the taxonomy.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -365,7 +372,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get posted terms for the taxonomy
+	 * Gets posted terms for the taxonomy.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -376,7 +383,7 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get posted terms for the taxonomy
+	 * Gets posted terms for the taxonomy.
 	 *
 	 * @param  string $key
 	 * @param  array  $field
@@ -387,9 +394,12 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Upload a file
+	 * Handles the uploading of files.
 	 *
-	 * @return  string or array
+	 * @param string $field_key
+	 * @param array  $field
+	 * @throws Exception When file upload failed
+	 * @return  string|array
 	 */
 	protected function upload_file( $field_key, $field ) {
 		if ( isset( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ]['name'] ) ) {

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -8,7 +8,10 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 if ( ! class_exists( 'WP_Job_Manager_Addons' ) ) :
 
 /**
- * WP_Job_Manager_Addons Class
+ * Handles the admin add-ons page.
+ *
+ * @package wp-job-manager
+ * @since 1.1.0
  */
 class WP_Job_Manager_Addons {
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -3,15 +3,15 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_Admin class.
+ * Handles front admin page for WP Job Manager.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Admin {
 
 	/**
-	 * __construct function.
-	 *
-	 * @access public
-	 * @return void
+	 * Constructor.
 	 */
 	public function __construct() {
 		include_once( 'class-wp-job-manager-cpt.php' );
@@ -26,10 +26,7 @@ class WP_Job_Manager_Admin {
 	}
 
 	/**
-	 * admin_enqueue_scripts function.
-	 *
-	 * @access public
-	 * @return void
+	 * Enqueues CSS and JS assets.
 	 */
 	public function admin_enqueue_scripts() {
 		global $wp_scripts;
@@ -54,10 +51,7 @@ class WP_Job_Manager_Admin {
 	}
 
 	/**
-	 * admin_menu function.
-	 *
-	 * @access public
-	 * @return void
+	 * Adds pages to admin menu.
 	 */
 	public function admin_menu() {
 		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), __( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', array( $this->settings_page, 'output' ) );
@@ -67,7 +61,7 @@ class WP_Job_Manager_Admin {
 	}
 
 	/**
-	 * Output addons page
+	 * Displays addons page.
 	 */
 	public function addons_page() {
 		$addons = include( 'class-wp-job-manager-addons.php' );

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -3,15 +3,15 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_CPT class.
+ * Handles actions and filters specific to the custom post type for Job Listings.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_CPT {
 
 	/**
-	 * __construct function.
-	 *
-	 * @access public
-	 * @return void
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_filter( 'enter_title_here', array( $this, 'enter_title_here' ), 1, 2 );
@@ -38,7 +38,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Edit bulk actions
+	 * Adds bulk actions to drop downs on Job Listing admin page.
 	 */
 	public function add_bulk_actions() {
 		global $post_type, $wp_post_types;;
@@ -59,7 +59,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Do custom bulk actions
+	 * Performs bulk actions on Job Listing admin page.
 	 */
 	public function do_bulk_actions() {
 		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' );
@@ -111,7 +111,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Approve a single job
+	 * Approves a single job.
 	 */
 	public function approve_job() {
 		if ( ! empty( $_GET['approve_job'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'approve_job' ) && current_user_can( 'publish_post', $_GET['approve_job'] ) ) {
@@ -127,7 +127,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Show a notice if we did a bulk action or approval
+	 * Shows a notice if we did a bulk approval action.
 	 */
 	public function approved_notice() {
 		 global $post_type, $pagenow;
@@ -147,7 +147,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Show a notice if we did a bulk action or approval
+	 * Shows a notice if we did a bulk expired action.
 	 */
 	public function expired_notice() {
 		 global $post_type, $pagenow;
@@ -167,7 +167,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Show category dropdown
+	 * Shows category dropdown.
 	 */
 	public function jobs_by_category() {
 		global $typenow, $wp_query;
@@ -201,10 +201,11 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * enter_title_here function.
+	 * Filters page title placeholder text to show custom label.
 	 *
-	 * @access public
-	 * @return void
+	 * @param string      $text
+	 * @param WP_Post|int $post
+	 * @return string
 	 */
 	public function enter_title_here( $text, $post ) {
 		if ( $post->post_type == 'job_listing' )
@@ -213,11 +214,10 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * post_updated_messages function.
+	 * Filters the post updated message array to add custom post type's messages.
 	 *
-	 * @access public
-	 * @param mixed $messages
-	 * @return void
+	 * @param array $messages
+	 * @return array
 	 */
 	public function post_updated_messages( $messages ) {
 		global $post, $post_ID, $wp_post_types;
@@ -241,7 +241,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * columns function.
+	 * Adds columns to admin listing of Job Listings.
 	 *
 	 * @param array $columns
 	 * @return array
@@ -276,11 +276,9 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * custom_columns function.
+	 * Displays the content for each custom column on the admin list for Job Listings.
 	 *
-	 * @access public
 	 * @param mixed $column
-	 * @return void
 	 */
 	public function custom_columns( $column ) {
 		global $post;
@@ -385,11 +383,10 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * sortable_columns function.
+	 * Filters the list table sortable columns for the admin list of Job Listings.
 	 *
-	 * @access public
 	 * @param mixed $columns
-	 * @return void
+	 * @return array
 	 */
 	public function sortable_columns( $columns ) {
 		$custom = array(
@@ -402,11 +399,10 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * sort_columns function.
+	 * Sorts the admin listing of Job Listings by updating the main query in the request.
 	 *
-	 * @access public
 	 * @param mixed $vars
-	 * @return void
+	 * @return array
 	 */
 	public function sort_columns( $vars ) {
 		if ( isset( $vars['orderby'] ) ) {
@@ -426,7 +422,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Search custom fields as well as content.
+	 * Searches custom fields as well as content.
 	 *
 	 * @param WP_Query $wp
 	 */
@@ -463,7 +459,7 @@ class WP_Job_Manager_CPT {
 	}
 
 	/**
-	 * Change the label when searching meta.
+	 * Changes the label when searching meta.
 	 *
 	 * @param string $query
 	 * @return string
@@ -480,8 +476,6 @@ class WP_Job_Manager_CPT {
 
 	/**
 	 * Adds post status to the "submitdiv" Meta Box and post type WP List Table screens. Based on https://gist.github.com/franz-josef-kaiser/2930190
-	 *
-	 * @return void
 	 */
 	public function extend_submitdiv_post_status() {
 		global $post, $post_type;

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -3,15 +3,15 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_Settings class.
+ * Handles the management of plugin settings.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Settings {
 
 	/**
-	 * __construct function.
-	 *
-	 * @access public
-	 * @return void
+	 * Constructor.
 	 */
 	public function __construct() {
 		$this->settings_group = 'job_manager';
@@ -19,10 +19,9 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
-	 * init_settings function.
+	 * Initializes the configuration for the plugin's setting fields.
 	 *
 	 * @access protected
-	 * @return void
 	 */
 	protected function init_settings() {
 		// Prepare roles option
@@ -242,10 +241,7 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
-	 * register_settings function.
-	 *
-	 * @access public
-	 * @return void
+	 * Registers the plugin's settings with WordPress's Settings API.
 	 */
 	public function register_settings() {
 		$this->init_settings();
@@ -260,10 +256,7 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
-	 * output function.
-	 *
-	 * @access public
-	 * @return void
+	 * Shows the plugin's settings page.
 	 */
 	public function output() {
 		$this->init_settings();

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -4,15 +4,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * WP_Job_Manager_Setup class.
+ * Handles initial environment setup after plugin is first activated.
+ *
+ * @package wp-job-manager
+ * @since 1.16.0
  */
 class WP_Job_Manager_Setup {
 
 	/**
-	 * __construct function.
-	 *
-	 * @access public
-	 * @return void
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
@@ -23,27 +23,21 @@ class WP_Job_Manager_Setup {
 	}
 
 	/**
-	 * admin_menu function.
-	 *
-	 * @access public
-	 * @return void
+	 * Adds setup link to admin dashboard menu briefly so the page callback is registered.
 	 */
 	public function admin_menu() {
 		add_dashboard_page( __( 'Setup', 'wp-job-manager' ), __( 'Setup', 'wp-job-manager' ), 'manage_options', 'job-manager-setup', array( $this, 'output' ) );
 	}
 
 	/**
-	 * Add styles just for this page, and remove dashboard page links.
-	 *
-	 * @access public
-	 * @return void
+	 * Removes the setup link from admin dashboard menu so just the handler callback is registered.
 	 */
 	public function admin_head() {
 		remove_submenu_page( 'index.php', 'job-manager-setup' );
 	}
 
 	/**
-	 * Sends user to the setup page on first activation
+	 * Sends user to the setup page on first activation.
 	 */
 	public function redirect() {
 		// Bail if no activation redirect transient is set
@@ -72,14 +66,14 @@ class WP_Job_Manager_Setup {
 	}
 
 	/**
-	 * Enqueue scripts for setup page
+	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
 		wp_enqueue_style( 'job_manager_setup_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/setup.css', array( 'dashicons' ) );
 	}
 
 	/**
-	 * Create a page.
+	 * Creates a page.
 	 *
 	 * @param  string $title
 	 * @param  string $content
@@ -104,7 +98,7 @@ class WP_Job_Manager_Setup {
 	}
 
 	/**
-	 * Output addons page
+	 * Displays setup page.
 	 */
 	public function output() {
 		$step = ! empty( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -1,13 +1,16 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
+/**
+ * Handles the management of Job Listing meta fields.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
+ */
 class WP_Job_Manager_Writepanels {
 
 	/**
-	 * __construct function.
-	 *
-	 * @access public
-	 * @return void
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
@@ -16,10 +19,9 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * job_listing_fields function.
+	 * Returns configuration for custom fields on Job Listing posts.
 	 *
-	 * @access public
-	 * @return void
+	 * @return array
 	 */
 	public function job_listing_fields() {
 		global $post;
@@ -105,7 +107,11 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * Sort array by priority value
+	 * Sorts array of custom fields by priority value.
+	 *
+	 * @param array $a
+	 * @param array $b
+	 * @return int
 	 */
 	protected function sort_by_priority( $a, $b ) {
 	    if ( ! isset( $a['priority'] ) || ! isset( $b['priority'] ) || $a['priority'] === $b['priority'] ) {
@@ -115,10 +121,7 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * add_meta_boxes function.
-	 *
-	 * @access public
-	 * @return void
+	 * Handles the hooks to add custom field meta boxes.
 	 */
 	public function add_meta_boxes() {
 		global $wp_post_types;
@@ -133,7 +136,12 @@ class WP_Job_Manager_Writepanels {
 		}
 	}
 
-	function job_listing_metabox( $post ) {
+	/**
+	 * Displays job listing metabox.
+	 *
+	 * @param int|WP_Post $post
+	 */
+	public function job_listing_metabox( $post ) {
 		// Set up the taxonomy object and get terms
 		$taxonomy = 'job_listing_type';
 		$tax = get_taxonomy( $taxonomy );// This is the taxonomy object
@@ -190,10 +198,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * input_file function.
+	 * Displays label and file input field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_file( $key, $field ) {
 		global $thepostid;
@@ -229,10 +237,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * input_text function.
+	 * Displays label and text input field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_text( $key, $field ) {
 		global $thepostid;
@@ -259,10 +267,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * input_text function.
+	 * Displays label and textarea input field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_textarea( $key, $field ) {
 		global $thepostid;
@@ -284,10 +292,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * input_select function.
+	 * Displays label and select input field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_select( $key, $field ) {
 		global $thepostid;
@@ -313,10 +321,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * input_select function.
+	 * Displays label and multi-select input field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_multiselect( $key, $field ) {
 		global $thepostid;
@@ -342,10 +350,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * input_checkbox function.
+	 * Displays label and checkbox input field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_checkbox( $key, $field ) {
 		global $thepostid;
@@ -368,10 +376,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * Box to choose who posted the job
+	 * Displays label and author select field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_author( $key, $field ) {
 		global $thepostid, $post;
@@ -407,10 +415,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * input_radio function.
+	 * Displays label and radio input field.
 	 *
-	 * @param mixed $key
-	 * @param mixed $field
+	 * @param string $key
+	 * @param array  $field
 	 */
 	public static function input_radio( $key, $field ) {
 		global $thepostid;
@@ -435,11 +443,9 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * job_listing_data function.
+	 * Displays metadata fields for Job Listings.
 	 *
-	 * @access public
-	 * @param mixed $post
-	 * @return void
+	 * @param int|WP_Post $post
 	 */
 	public function job_listing_data( $post ) {
 		global $post, $thepostid;
@@ -468,12 +474,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * save_post function.
+	 * Handles `save_post` action.
 	 *
-	 * @access public
-	 * @param mixed $post_id
-	 * @param mixed $post
-	 * @return void
+	 * @param int     $post_id
+	 * @param WP_Post $post
 	 */
 	public function save_post( $post_id, $post ) {
 		if ( empty( $post_id ) || empty( $post ) || empty( $_POST ) ) return;
@@ -488,12 +492,10 @@ class WP_Job_Manager_Writepanels {
 	}
 
 	/**
-	 * save_job_listing_data function.
+	 * Handles the actual saving of job listing data fields.
 	 *
-	 * @access public
-	 * @param mixed $post_id
-	 * @param mixed $post
-	 * @return void
+	 * @param int     $post_id
+	 * @param WP_Post $post (Unused)
 	 */
 	public function save_job_listing_data( $post_id, $post ) {
 		global $wpdb;

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -3,12 +3,15 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_Ajax class.
+ * Handles Job Manager's Ajax endpoints.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Ajax {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'init', array( __CLASS__, 'add_endpoint') );
@@ -26,7 +29,7 @@ class WP_Job_Manager_Ajax {
 	}
 
 	/**
-	 * Add our endpoint for frontend ajax requests
+	 * Adds endpoint for frontend Ajax requests.
 	 */
 	public static function add_endpoint() {
 		add_rewrite_tag( '%jm-ajax%', '([^/]*)' );
@@ -35,10 +38,10 @@ class WP_Job_Manager_Ajax {
 	}
 
 	/**
-	 * Get JM Ajax Endpoint
+	 * Gets Job Manager's Ajax Endpoint.
 	 *
-	 * @param  string $request Optional
-	 * @param  string $ssl     Optional
+	 * @param  string $request      Optional
+	 * @param  string $ssl (Unused) Optional
 	 * @return string
 	 */
 	public static function get_endpoint( $request = '%%endpoint%%', $ssl = null ) {
@@ -53,7 +56,7 @@ class WP_Job_Manager_Ajax {
 	}
 
 	/**
-	 * Check for WC Ajax request and fire action
+	 * Ferforms Job Manager's Ajax actions.
 	 */
 	public static function do_jm_ajax() {
 		global $wp_query;
@@ -76,7 +79,7 @@ class WP_Job_Manager_Ajax {
 	}
 
 	/**
-	 * Get listings via ajax
+	 * Returns Job Listings for Ajax endpoint.
 	 */
 	public function get_listings() {
 		global $wp_post_types;
@@ -219,7 +222,7 @@ class WP_Job_Manager_Ajax {
 	}
 
 	/**
-	 * Upload file via ajax
+	 * Uploads file from an Ajax request.
 	 *
 	 * No nonce field since the form may be statically cached.
 	 */

--- a/includes/class-wp-job-manager-api.php
+++ b/includes/class-wp-job-manager-api.php
@@ -3,17 +3,15 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_API API
+ * Handles API requests for WP Job Manager.
  *
- * This API class handles API requests.
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_API {
 
 	/**
-	 * __construct function.
-	 *
-	 * @access public
-	 * @return void
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_filter( 'query_vars', array( $this, 'add_query_vars'), 0 );
@@ -21,9 +19,8 @@ class WP_Job_Manager_API {
 	}
 
 	/**
-	 * add_query_vars function.
+	 * Adds query vars used in API calls.
 	 *
-	 * @access public
 	 * @param array $vars the query vars
 	 * @return array
 	 */
@@ -33,10 +30,7 @@ class WP_Job_Manager_API {
 	}
 
 	/**
-	 * add_endpoint function.
-	 *
-	 * @access public
-	 * @return void
+	 * Adds endpoint for API requests.
 	 */
 	public function add_endpoint() {
 		add_rewrite_endpoint( 'job-manager-api', EP_ALL );
@@ -44,9 +38,6 @@ class WP_Job_Manager_API {
 
 	/**
 	 * API request - Trigger any API requests (handy for third party plugins/gateways).
-	 *
-	 * @access public
-	 * @return void
 	 */
 	public function api_requests() {
 		global $wp;

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -5,10 +5,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * WP_Job_Manager_Cache_Helper class.
+ * Assists in cache management for WP Job Management posts and terms.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Cache_Helper {
 
+	/**
+	 * Initializes cache hooks.
+	 */
 	public static function init() {
 		add_action( 'save_post', array( __CLASS__, 'flush_get_job_listings_cache' ) );
 		add_action( 'job_manager_my_job_do_action', array( __CLASS__, 'job_manager_my_job_do_action' ) );
@@ -20,7 +26,9 @@ class WP_Job_Manager_Cache_Helper {
 	}
 
 	/**
-	 * Flush the cache
+	 * Flushes the cache.
+	 *
+	 * @param int|WP_Post $post_id
 	 */
 	public static function flush_get_job_listings_cache( $post_id ) {
 		if ( 'job_listing' === get_post_type( $post_id ) ) {
@@ -29,7 +37,9 @@ class WP_Job_Manager_Cache_Helper {
 	}
 
 	/**
-	 * Flush the cache
+	 * Refreshes the Job Listing cache when performing actions on it.
+	 *
+	 * @param string $action
 	 */
 	public static function job_manager_my_job_do_action( $action ) {
 		if ( 'mark_filled' === $action || 'mark_not_filled' === $action ) {
@@ -38,21 +48,30 @@ class WP_Job_Manager_Cache_Helper {
 	}
 
 	/**
-	 * When any post has a term set
+	 * Refreshes the Job Listing cache when terms are updated.
+	 *
+	 * @param string|int $object_id
+	 * @param string     $terms
+	 * @param string     $tt_ids
+	 * @param string     $taxonomy
 	 */
 	public static function set_term( $object_id = '', $terms = '', $tt_ids = '', $taxonomy = '' ) {
 		self::get_transient_version( 'jm_get_' . sanitize_text_field( $taxonomy ), true );
 	}
 
 	/**
-	 * When any term is edited
+	 * Refreshes the Job Listing cache when terms are updated.
+	 *
+	 * @param string|int $term_id
+	 * @param string|int $tt_id
+	 * @param string     $taxonomy
 	 */
 	public static function edited_term( $term_id = '', $tt_id = '', $taxonomy = '' ) {
 		self::get_transient_version( 'jm_get_' . sanitize_text_field( $taxonomy ), true );
 	}
 
 	/**
-	 * Get transient version
+	 * Gets transient version.
 	 *
 	 * When using transients with unpredictable names, e.g. those containing an md5
 	 * hash in the name, we need a way to invalidate them all at once.
@@ -64,9 +83,9 @@ class WP_Job_Manager_Cache_Helper {
 	 * to append a unique string (based on time()) to each transient. When transients
 	 * are invalidated, the transient version will increment and data will be regenerated.
 	 *
-	 * @param  string  $group   Name for the group of transients we need to invalidate
-	 * @param  boolean $refresh true to force a new version
-	 * @return string transient version based on time(), 10 digits
+	 * @param  string  $group   Name for the group of transients we need to invalidate.
+	 * @param  boolean $refresh True to force a new version (Default: false).
+	 * @return string Transient version based on time(), 10 digits.
 	 */
 	public static function get_transient_version( $group, $refresh = false ) {
 		$transient_name  = $group . '-transient-version';
@@ -83,6 +102,8 @@ class WP_Job_Manager_Cache_Helper {
 	 * When the transient version increases, this is used to remove all past transients to avoid filling the DB.
 	 *
 	 * Note; this only works on transients appended with the transient version, and when object caching is not being used.
+	 *
+	 * @param string $version
 	 */
 	private static function delete_version_transients( $version ) {
 		if ( ! wp_using_ext_object_cache() && ! empty( $version ) ) {
@@ -92,7 +113,7 @@ class WP_Job_Manager_Cache_Helper {
 	}
 
 	/**
-	 * Clear expired transients
+	 * Clear expired transients.
 	 */
 	public static function clear_expired_transients() {
 		global $wpdb;

--- a/includes/class-wp-job-manager-category-walker.php
+++ b/includes/class-wp-job-manager-category-walker.php
@@ -2,24 +2,24 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_Category_Walker class.
+ * Walks through categories.
  *
  * @extends Walker
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Category_Walker extends Walker {
 
 	/**
-	 * Tree type
+	 * Tree type that the class handles.
 	 *
-	 * @access public
 	 * @var string
 	 */
 	public $tree_type = 'category';
 
 	/**
-	 * Database fields
+	 * Database fields to use.
 	 *
-	 * @access public
 	 * @var array
 	 */
 	public $db_fields = array ('parent' => 'parent', 'id' => 'term_id', 'slug' => 'slug' );
@@ -29,9 +29,10 @@ class WP_Job_Manager_Category_Walker extends Walker {
 	 * @since 2.1.0
 	 *
 	 * @param string $output Passed by reference. Used to append additional content.
-	 * @param object $category Category data object.
+	 * @param object $object Category data object.
 	 * @param int    $depth Depth of category in reference to parents.
 	 * @param array  $args
+	 * @param int    $current_object_id
 	 */
 	public function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 

--- a/includes/class-wp-job-manager-forms.php
+++ b/includes/class-wp-job-manager-forms.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * WP_Job_Manager_Forms class.
+ * Base class for all WP Job Manager forms.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Forms {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'load_posted_form' ) );
@@ -52,11 +55,11 @@ class WP_Job_Manager_Forms {
 	}
 
 	/**
-	 * get_form function.
+	 * Returns the form content.
 	 *
 	 * @param string $form_name
-	 * @param  array  $atts Optional passed attributes
-	 * @return string
+	 * @param array  $atts Optional passed attributes
+	 * @return string|null
 	 */
 	public function get_form( $form_name, $atts = array() ) {
 		if ( $form = $this->load_form_class( $form_name ) ) {

--- a/includes/class-wp-job-manager-geocode.php
+++ b/includes/class-wp-job-manager-geocode.php
@@ -3,16 +3,17 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_Geocode
- *
  * Obtains Geolocation data for posted jobs from Google.
+ *
+ * @package wp-job-manager
+ * @since 1.6.1
  */
 class WP_Job_Manager_Geocode {
 
 	const GOOGLE_MAPS_GEOCODE_API_URL = 'https://maps.googleapis.com/maps/api/geocode/json';
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_filter( 'job_manager_geolocation_endpoint', array( $this, 'add_geolocation_endpoint_query_args' ), 0, 2 );
@@ -22,7 +23,10 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Update location data - when submitting a job
+	 * Updates location data when submitting a job.
+	 *
+	 * @param int   $job_id
+	 * @param array $values
 	 */
 	public function update_location_data( $job_id, $values ) {
 		if ( apply_filters( 'job_manager_geolocation_enabled', true ) && isset( $values['job']['job_location'] ) ) {
@@ -32,7 +36,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Change a jobs location data upon editing
+	 * Changes a jobs location data upon editing.
 	 *
 	 * @param  int    $job_id
 	 * @param  string $new_location
@@ -46,7 +50,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Checks if a job has location data or not
+	 * Checks if a job has location data or not.
 	 *
 	 * @param  int $job_id
 	 * @return boolean
@@ -56,7 +60,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Called manually to generate location data and save to a post
+	 * Generates location data and saves to a post.
 	 *
 	 * @param  int    $job_id
 	 * @param  string $location
@@ -67,7 +71,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Delete a job's location data
+	 * Deletes a job's location data.
 	 *
 	 * @param  int $job_id
 	 */
@@ -88,7 +92,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Save any returned data to post meta
+	 * Saves any returned data to post meta.
 	 *
 	 * @param  int   $job_id
 	 * @param  array $address_data
@@ -105,7 +109,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Retrieves the Google Maps API key from the plugin's settings
+	 * Retrieves the Google Maps API key from the plugin's settings.
 	 *
 	 * @param  string $key
 	 * @return string
@@ -115,7 +119,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Adds the necessary query arguments for a Google Maps Geocode API request
+	 * Adds the necessary query arguments for a Google Maps Geocode API request.
 	 *
 	 * @param  string $geocode_endpoint_url
 	 * @param  string $raw_address
@@ -141,7 +145,7 @@ class WP_Job_Manager_Geocode {
 	}
 
 	/**
-	 * Get Location Data from Google
+	 * Gets Location Data from Google.
 	 *
 	 * Based on code by Eyal Fitoussi.
 	 *

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -5,12 +5,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * WP_Job_Manager_Install
+ * Handles the installation of the WP Job Manager plugin.s
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Install {
 
 	/**
-	 * Install WP Job Manager
+	 * Installs WP Job Manager.
 	 */
 	public static function install() {
 		global $wpdb;
@@ -45,7 +48,7 @@ class WP_Job_Manager_Install {
 	}
 
 	/**
-	 * Init user roles
+	 * Initializes user roles.
 	 */
 	private static function init_user_roles() {
 		global $wp_roles;
@@ -72,7 +75,7 @@ class WP_Job_Manager_Install {
 	}
 
 	/**
-	 * Get capabilities
+	 * Returns capabilities.
 	 *
 	 * @return array
 	 */
@@ -104,7 +107,7 @@ class WP_Job_Manager_Install {
 	}
 
 	/**
-	 * default_terms function.
+	 * Returns the default Job Manager terms.
 	 */
 	private static function default_terms() {
 		if ( get_option( 'job_manager_installed_terms' ) == 1 ) {
@@ -133,7 +136,7 @@ class WP_Job_Manager_Install {
 	}
 
 	/**
-	 * Setup cron jobs
+	 * Setup cron jobs.
 	 */
 	private static function schedule_cron() {
 		wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * WP_Job_Manager_Content class.
+ * Handles displays and hooks for the Job Listing custom post type.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Post_Types {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_post_types' ), 0 );
@@ -53,10 +56,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * register_post_types function.
-	 *
-	 * @access public
-	 * @return void
+	 * Registers the custom post type and taxonomies.
 	 */
 	public function register_post_types() {
 		if ( post_type_exists( "job_listing" ) )
@@ -250,7 +250,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Change label
+	 * Change label for admin menu item to show number of Job Listing items pending approval.
 	 */
 	public function admin_head() {
 		global $menu;
@@ -271,7 +271,9 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Toggle filter on and off
+	 * Toggles content filter on and off.
+	 *
+	 * @param bool $enable
 	 */
 	private function job_content_filter( $enable ) {
 		if ( ! $enable ) {
@@ -282,7 +284,10 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Add extra content before/after the post for single job listings.
+	 * Adds extra content before/after the post for single job listings.
+	 *
+	 * @param string $content
+	 * @return string
 	 */
 	public function job_content( $content ) {
 		global $post;
@@ -307,7 +312,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Job listing feeds
+	 * Generates the RSS feed for Job Listings.
 	 */
 	public function job_feed() {
 		$query_args = array(
@@ -374,7 +379,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * In order to make sure that the feed properly queries the 'job_listing' type
+	 * Adds query arguments in order to make sure that the feed properly queries the 'job_listing' type.
 	 *
 	 * @param WP_Query $wp
 	 */
@@ -399,14 +404,14 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Add a custom namespace to the job feed
+	 * Adds a custom namespace to the job feed.
 	 */
 	public function job_feed_namespace() {
 		echo 'xmlns:job_listing="' .  site_url() . '"' . "\n";
 	}
 
 	/**
-	 * Add custom data to the job feed
+	 * Adds custom data to the job feed.
 	 */
 	public function job_feed_item() {
 		$post_id  = get_the_ID();
@@ -423,7 +428,7 @@ class WP_Job_Manager_Post_Types {
 		if ( $company ) {
 			echo "<job_listing:company><![CDATA[" . esc_html( $company ) . "]]></job_listing:company>\n";
 		}
-		
+
 		/**
 		 * Fires at the end of each job RSS feed item.
 		 *
@@ -433,7 +438,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Expire jobs
+	 * Maintenance task to expire jobs.
 	 */
 	public function check_for_expired_jobs() {
 		global $wpdb;
@@ -476,7 +481,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Delete old previewed jobs after 30 days to keep the DB clean
+	 * Deletes old previewed jobs after 30 days to keep the DB clean.
 	 */
 	public function delete_old_previews() {
 		global $wpdb;
@@ -497,14 +502,19 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Typo -.-
+	 * Typo wrapper for `set_expiry` method.
+	 *
+	 * @param WP_Post $post
+	 * @deprecated
 	 */
 	public function set_expirey( $post ) {
 		$this->set_expiry( $post );
 	}
 
 	/**
-	 * Set expirey date when job status changes
+	 * Sets expiry date when job status changes.
+	 *
+	 * @param WP_Post $post
 	 */
 	public function set_expiry( $post ) {
 		if ( $post->post_type !== 'job_listing' ) {
@@ -536,23 +546,28 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * The application content when the application method is an email
+	 * Displays the application content when the application method is an email.
+	 *
+	 * @param stdClass $apply
 	 */
 	public function application_details_email( $apply ) {
 		get_job_manager_template( 'job-application-email.php', array( 'apply' => $apply ) );
 	}
 
 	/**
-	 * The application content when the application method is a url
+	 * Displays the application content when the application method is a url.
+	 *
+	 * @param stdClass $apply
 	 */
 	public function application_details_url( $apply ) {
 		get_job_manager_template( 'job-application-url.php', array( 'apply' => $apply ) );
 	}
 
 	/**
-	 * Fix post name when wp_update_post changes it
+	 * Fixes post name when wp_update_post changes it.
 	 *
-	 * @param  array $data
+	 * @param array $data
+	 * @param array $postarr
 	 * @return array
 	 */
 	public function fix_post_name( $data, $postarr ) {
@@ -563,10 +578,11 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Generate location data if a post is added
+	 * Generates location data if a post is added.
 	 *
-	 * @param  int   $post_id
-	 * @param  array $post
+	 * @param int    $object_id
+	 * @param string $meta_key
+	 * @param mixed  $meta_value
 	 */
 	public function maybe_add_geolocation_data( $object_id, $meta_key, $meta_value ) {
 		if ( '_job_location' !== $meta_key || 'job_listing' !== get_post_type( $object_id ) ) {
@@ -576,7 +592,12 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Triggered when updating meta on a job listing
+	 * Triggered when updating meta on a job listing.
+	 *
+	 * @param int    $meta_id
+	 * @param int    $object_id
+	 * @param string $meta_key
+	 * @param mixed  $meta_value
 	 */
 	public function update_post_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
 		if ( 'job_listing' === get_post_type( $object_id ) ) {
@@ -592,14 +613,24 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Generate location data if a post is updated
+	 * Generates location data if a post is updated.
+	 *
+	 * @param int    $meta_id (Unused)
+	 * @param int    $object_id
+	 * @param string $meta_key (Unused)
+	 * @param mixed  $meta_value
 	 */
 	public function maybe_update_geolocation_data( $meta_id, $object_id, $meta_key, $meta_value ) {
 		do_action( 'job_manager_job_location_edited', $object_id, $meta_value );
 	}
 
 	/**
-	 * Maybe set menu_order if the featured status of a job is changed
+	 * Maybe sets menu_order if the featured status of a job is changed.
+	 *
+	 * @param int    $meta_id (Unused)
+	 * @param int    $object_id
+	 * @param string $meta_key (Unused)
+	 * @param mixed  $meta_value
 	 */
 	public function maybe_update_menu_order( $meta_id, $object_id, $meta_key, $meta_value ) {
 		global $wpdb;
@@ -614,8 +645,12 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Legacy
+	 * Legacy.
 	 *
+	 * @param int    $meta_id
+	 * @param int    $object_id
+	 * @param string $meta_key
+	 * @param mixed  $meta_value
 	 * @deprecated 1.19.1
 	 */
 	public function maybe_generate_geolocation_data( $meta_id, $object_id, $meta_key, $meta_value ) {
@@ -623,10 +658,10 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Maybe set default meta data for job listings
+	 * Maybe sets default meta data for job listings.
 	 *
-	 * @param  int     $post_id
-	 * @param  WP_Post $post
+	 * @param  int            $post_id
+	 * @param  WP_Post|string $post
 	 */
 	public function maybe_add_default_meta_data( $post_id, $post = '' ) {
 		if ( empty( $post ) || 'job_listing' === $post->post_type ) {
@@ -636,7 +671,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * After importing via WP ALL Import, add default meta data
+	 * After importing via WP All Import, adds default meta data.
 	 *
 	 * @param  int $post_id
 	 */
@@ -650,7 +685,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Replace RP4WP template with the template from Job Manager
+	 * Replaces RP4WP template with the template from Job Manager.
 	 *
 	 * @param  string $located
 	 * @param  string $template_name
@@ -665,7 +700,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Add meta fields for RP4WP to relate jobs by
+	 * Adds meta fields for RP4WP to relate jobs by.
 	 *
 	 * @param  array   $meta_fields
 	 * @param  int     $post_id
@@ -681,7 +716,7 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Add meta fields for RP4WP to relate jobs by
+	 * Adds meta fields for RP4WP to relate jobs by.
 	 *
 	 * @param  int     $weight
 	 * @param  WP_Post $post

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -3,12 +3,15 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * WP_Job_Manager_Shortcodes class.
+ * Handles the shortcodes for WP Job Manager.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Shortcodes {
 
 	/**
-	 * Dashboard message
+	 * Dashboard message.
 	 *
 	 * @access private
 	 * @var string
@@ -16,7 +19,7 @@ class WP_Job_Manager_Shortcodes {
 	private $job_dashboard_message = '';
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'wp', array( $this, 'shortcode_action_handler' ) );
@@ -33,7 +36,7 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Handle actions which need to be run before the shortcode e.g. post actions
+	 * Handles actions which need to be run before the shortcode e.g. post actions.
 	 */
 	public function shortcode_action_handler() {
 		global $post;
@@ -44,14 +47,17 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Show the job submission form
+	 * Shows the job submission form.
+	 *
+	 * @param array $atts
+	 * @return string|null
 	 */
 	public function submit_job_form( $atts = array() ) {
 		return $GLOBALS['job_manager']->forms->get_form( 'submit-job', $atts );
 	}
 
 	/**
-	 * Handles actions on job dashboard
+	 * Handles actions on job dashboard.
 	 */
 	public function job_dashboard_handler() {
 		if ( ! empty( $_REQUEST['action'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'job_manager_my_job_actions' ) ) {
@@ -137,7 +143,10 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Shortcode which lists the logged in user's jobs
+	 * Handles shortcode which lists the logged in user's jobs.
+	 *
+	 * @param array $atts
+	 * @return string
 	 */
 	public function job_dashboard( $atts ) {
 		if ( ! is_user_logged_in() ) {
@@ -195,7 +204,7 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Edit job form
+	 * Displays edit job form.
 	 */
 	public function edit_job() {
 		global $job_manager;
@@ -204,11 +213,10 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * output_jobs function.
+	 * Lists all job listings.
 	 *
-	 * @access public
-	 * @param mixed $args
-	 * @return void
+	 * @param array $atts
+	 * @return string
 	 */
 	public function output_jobs( $atts ) {
 		ob_start();
@@ -354,14 +362,14 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Output some content when no results were found
+	 * Displays some content when no results were found.
 	 */
 	public function output_no_results() {
 		get_job_manager_template( 'content-no-jobs-found.php' );
 	}
 
 	/**
-	 * Get string as a bool
+	 * Gets string as a bool.
 	 *
 	 * @param  string $value
 	 * @return bool
@@ -371,7 +379,7 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Show job types
+	 * Shows job types.
 	 *
 	 * @param  array $atts
 	 */
@@ -385,26 +393,26 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Show results div
+	 * Shows results div.
 	 */
 	public function job_filter_results() {
 		echo '<div class="showing_jobs"></div>';
 	}
 
 	/**
-	 * output_job function.
+	 * Shows a single job.
 	 *
-	 * @access public
-	 * @param array $args
-	 * @return string
+	 * @param array $atts
+	 * @return string|null
 	 */
 	public function output_job( $atts ) {
 		extract( shortcode_atts( array(
 			'id' => '',
 		), $atts ) );
 
-		if ( ! $id )
+		if ( ! $id ) {
 			return;
+		}
 
 		ob_start();
 
@@ -434,10 +442,9 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Job Summary shortcode
+	 * Handles the Job Summary shortcode.
 	 *
-	 * @access public
-	 * @param array $args
+	 * @param array $atts
 	 * @return string
 	 */
 	public function output_job_summary( $atts ) {
@@ -492,7 +499,10 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
-	 * Show the application area
+	 * Shows the application area.
+	 *
+	 * @param array $atts
+	 * @return string
 	 */
 	public function output_job_apply( $atts ) {
 		extract( shortcode_atts( array(

--- a/includes/class-wp-job-manager-widgets.php
+++ b/includes/class-wp-job-manager-widgets.php
@@ -3,59 +3,57 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 /**
- * Job Manager Widget base
+ * Job Manager Widget base.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Widget extends WP_Widget {
 
 	/**
-	 * Widget CSS class
+	 * Widget CSS class.
 	 *
-	 * @access public
 	 * @var string
 	 */
 	public $widget_cssclass;
 
 	/**
-	 * Widget description
+	 * Widget description.
 	 *
-	 * @access public
 	 * @var string
 	 */
 	public $widget_description;
 
 	/**
-	 * Widget id
+	 * Widget id.
 	 *
-	 * @access public
 	 * @var string
 	 */
 	public $widget_id;
 
 	/**
-	 * Widget name
+	 * Widget name.
 	 *
-	 * @access public
 	 * @var string
 	 */
 	public $widget_name;
 
 	/**
-	 * Widget settings
+	 * Widget settings.
 	 *
-	 * @access public
 	 * @var array
 	 */
 	public $settings;
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		$this->register();
 	}
 
 	/**
-	 * Register Widget
+	 * Registers widget.
 	 */
 	public function register() {
 		$widget_ops = array(
@@ -71,7 +69,10 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	}
 
 	/**
-	 * get_cached_widget function.
+	 * Checks for cached version of widget and outputs it if found.
+	 *
+	 * @param array $args
+	 * @return bool
 	 */
 	public function get_cached_widget( $args ) {
 		$cache = wp_cache_get( $this->widget_id, 'widget' );
@@ -88,7 +89,10 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Cache the widget
+	 * Caches the widget.
+	 *
+	 * @param array  $args
+	 * @param string $content
 	 */
 	public function cache_widget( $args, $content ) {
 		$cache[ $args['widget_id'] ] = $content;
@@ -97,19 +101,16 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Flush the cache
-	 *
-	 * @return [type]
+	 * Flushes the cache for a widget.
 	 */
 	public function flush_widget_cache() {
 		wp_cache_delete( $this->widget_id, 'widget' );
 	}
 
 	/**
-	 * update function.
+	 * Updates a widget instance settings.
 	 *
 	 * @see WP_Widget->update
-	 * @access public
 	 * @param array $new_instance
 	 * @param array $old_instance
 	 * @return array
@@ -130,14 +131,13 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	}
 
 	/**
-	 * form function.
+	 * Displays widget setup form.
 	 *
 	 * @see WP_Widget->form
-	 * @access public
 	 * @param array $instance
 	 * @return void
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 
 		if ( ! $this->settings )
 			return;
@@ -168,26 +168,26 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	}
 
 	/**
-	 * widget function.
+	 * Echoes the widget content.
 	 *
 	 * @see    WP_Widget
-	 * @access public
 	 *
 	 * @param array $args
 	 * @param array $instance
-	 *
-	 * @return void
 	 */
 	public function widget( $args, $instance ) {}
 }
 
 /**
- * Recent Jobs Widget
+ * Recent Jobs widget.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		global $wp_post_types;
@@ -225,13 +225,11 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 	}
 
 	/**
-	 * widget function.
+	 * Echoes the widget content.
 	 *
 	 * @see WP_Widget
-	 * @access public
 	 * @param array $args
 	 * @param array $instance
-	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		if ( $this->get_cached_widget( $args ) ) {
@@ -287,12 +285,15 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 }
 
 /**
- * Featured Jobs Widget
+ * Featured Jobs widget.
+ *
+ * @package wp-job-manager
+ * @since 1.21.0
  */
 class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	public function __construct() {
 		global $wp_post_types;
@@ -320,13 +321,11 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 	}
 
 	/**
-	 * widget function.
+	 * Echoes the widget content.
 	 *
 	 * @see WP_Widget
-	 * @access public
 	 * @param array $args
 	 * @param array $instance
-	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		if ( $this->get_cached_widget( $args ) ) {

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -3,14 +3,17 @@
 include_once( 'class-wp-job-manager-form-submit-job.php' );
 
 /**
- * WP_Job_Manager_Form_Edit_Job class.
+ * Handles the editing of Job Listings from the public facing frontend (from within `[job_dashboard]` shortcode).
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
+ * @extends WP_Job_Manager_Form_Submit_Job
  */
 class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 
 	/**
 	 * Form name
 	 *
-	 * @access public
 	 * @var string
 	 */
 	public $form_name = 'edit-job';
@@ -46,6 +49,8 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 
 	/**
 	 * output function.
+	 *
+	 * @param array $atts
 	 */
 	public function output( $atts = array() ) {
 		$this->submit_handler();

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1,20 +1,23 @@
 <?php
 
 /**
- * WP_Job_Manager_Form_Submit_Job class.
+ * Handles the editing of Job Listings from the public facing frontend (from within `[submit_job_form]` shortcode).
+ *
+ * @package wp-job-manager
+ * @extends WP_Job_Manager_Form
+ * @since 1.0.0
  */
 class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 	/**
-	 * Form name
+	 * Form name.
 	 *
-	 * @access public
 	 * @var string
 	 */
 	public $form_name = 'submit-job';
 
 	/**
-	 * Job id
+	 * Job listing ID.
 	 *
 	 * @access protected
 	 * @var int
@@ -22,7 +25,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	protected $job_id;
 
 	/**
-	 * Preview job
+	 * Preview job (unused)
 	 *
 	 * @access protected
 	 * @var string
@@ -30,7 +33,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	protected $preview_job;
 
 	/**
-	 * Instance
+	 * Stores static instance of class.
 	 *
 	 * @access protected
 	 * @var WP_Job_Manager_Form_Submit_Job The single instance of the class
@@ -38,7 +41,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	protected static $_instance = null;
 
 	/**
-	 * Main Instance
+	 * Returns static instance of class.
+	 *
+	 * @return self
 	 */
 	public static function instance() {
 		if ( is_null( self::$_instance ) ) {
@@ -116,7 +121,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Get the submitted job ID
+	 * Gets the submitted job ID.
 	 *
 	 * @return int
 	 */
@@ -125,7 +130,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * init_fields function.
+	 * Initializes the fields used in the form.
 	 */
 	public function init_fields() {
 		if ( $this->fields ) {
@@ -267,9 +272,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Validate the posted fields
+	 * Validates the posted fields.
 	 *
-	 * @return bool on success, WP_ERROR on failure
+	 * @param array $values
+	 * @throws Exception Uploaded file is not a valid mime-type or other validation error
+	 * @return bool|WP_Error True on success, WP_Error on failure
 	 */
 	protected function validate_fields( $values ) {
 		foreach ( $this->fields as $group_key => $group_fields ) {
@@ -346,7 +353,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * job_types function.
+	 * Returns an array of the job types indexed by slug. (Unused)
+	 *
+	 * @return array
 	 */
 	private function job_types() {
 		$options = array();
@@ -358,7 +367,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Submit Step
+	 * Displays the form.
 	 */
 	public function submit() {
 		$this->init_fields();
@@ -425,7 +434,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Submit Step is posted
+	 * Handles the submission of form data.
 	 */
 	public function submit_handler() {
 		try {
@@ -489,7 +498,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Update or create a job listing from posted data
+	 * Updates or creates a job listing from posted data.
 	 *
 	 * @param  string $post_title
 	 * @param  string $post_content
@@ -551,7 +560,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Create an attachment
+	 * Creates a file attachment.
 	 *
 	 * @param  string $attachment_url
 	 * @return int attachment id
@@ -590,7 +599,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Set job meta + terms based on posted values
+	 * Sets job meta and terms based on posted values.
 	 *
 	 * @param  array $values
 	 */
@@ -669,7 +678,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Preview Step
+	 * Displays preview of Job Listing.
 	 */
 	public function preview() {
 		global $post, $job_preview;
@@ -690,7 +699,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Preview Step Form handler
+	 * Handles the preview step form response.
 	 */
 	public function preview_handler() {
 		if ( ! $_POST ) {
@@ -726,7 +735,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Done Step
+	 * Displays the final screen after a job listing has been submitted.
 	 */
 	public function done() {
 		do_action( 'job_manager_job_submitted', $this->job_id );

--- a/templates/form-fields/radio-field.php
+++ b/templates/form-fields/radio-field.php
@@ -14,6 +14,7 @@
  * 		)
  * 	)
  */
+
 $field['default'] = empty( $field['default'] ) ? current( array_keys( $field['options'] ) ) : $field['default'];
 $default          = ! empty( $field['value'] ) ? $field['value'] : $field['default'];
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1,10 +1,11 @@
 <?php
 if ( ! function_exists( 'get_job_listings' ) ) :
 /**
- * Queries job listings with certain criteria and returns them
+ * Queries job listings with certain criteria and returns them.
  *
- * @access public
- * @return void
+ * @since 1.0.5
+ * @param array $args
+ * @return array
  */
 function get_job_listings( $args = array() ) {
 	global $wpdb, $job_manager_keyword;
@@ -169,8 +170,9 @@ endif;
 
 if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 	/**
-	 * Join and where query for keywords
+	 * Adds join and where query for keywords.
 	 *
+	 * @since 1.21.0
 	 * @param array $args
 	 * @return array
 	 */
@@ -211,9 +213,9 @@ endif;
 
 if ( ! function_exists( 'get_job_listing_post_statuses' ) ) :
 /**
- * Get post statuses used for jobs
+ * Gets post statuses used for jobs.
  *
- * @access public
+ * @since 1.12.0
  * @return array
  */
 function get_job_listing_post_statuses() {
@@ -232,7 +234,7 @@ if ( ! function_exists( 'get_featured_job_ids' ) ) :
 /**
  * Gets the ids of featured jobs.
  *
- * @access public
+ * @since 1.0.4
  * @return array
  */
 function get_featured_job_ids() {
@@ -249,9 +251,10 @@ endif;
 
 if ( ! function_exists( 'get_job_listing_types' ) ) :
 /**
- * Get job listing types
+ * Gets job listing types.
  *
- * @access public
+ * @since 1.0.0
+ * @param string|array $fields
  * @return array
  */
 function get_job_listing_types( $fields = 'all' ) {
@@ -277,9 +280,9 @@ endif;
 
 if ( ! function_exists( 'get_job_listing_categories' ) ) :
 /**
- * Get job categories
+ * Gets job categories.
  *
- * @access public
+ * @since 1.0.0
  * @return array
  */
 function get_job_listing_categories() {
@@ -298,6 +301,10 @@ endif;
 if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 /**
  * Shows links after filtering jobs
+ *
+ * @since 1.0.6
+ * @param array $args
+ * @return string
  */
 function job_manager_get_filtered_links( $args = array() ) {
 	$job_categories = array();
@@ -351,6 +358,8 @@ if ( ! function_exists( 'get_job_listing_rss_link' ) ) :
 /**
  * Get the Job Listing RSS link
  *
+ * @since 1.0.0
+ * @param array $args
  * @return string
  */
 function get_job_listing_rss_link( $args = array() ) {
@@ -361,8 +370,9 @@ endif;
 
 if ( ! function_exists( 'wp_job_manager_notify_new_user' ) ) :
 	/**
-	 * Handle account creation.
+	 * Handles notification of new users.
 	 *
+	 * @since 1.23.10
 	 * @param  int    $user_id
 	 * @param  string $password
 	 */
@@ -379,11 +389,12 @@ endif;
 
 if ( ! function_exists( 'job_manager_create_account' ) ) :
 /**
- * Handle account creation.
+ * Handles account creation.
  *
- * @param  array  $args containing username, email, role
- * @param  string $deprecated role string
- * @return WP_error | bool was an account created?
+ * @since 1.0.0
+ * @param  string|array|object $args containing username, email, role
+ * @param  string              $deprecated role string
+ * @return WP_Error|bool was an account created?
  */
 function wp_job_manager_create_account( $args, $deprecated = '' ) {
 	global $current_user;
@@ -469,8 +480,9 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
 endif;
 
 /**
- * True if an the user can post a job. If accounts are required, and reg is enabled, users can post (they signup at the same time).
+ * Checks if an the user can post a job. If accounts are required, and reg is enabled, users can post (they signup at the same time).
  *
+ * @since 1.5.1
  * @return bool
  */
 function job_manager_user_can_post_job() {
@@ -486,8 +498,10 @@ function job_manager_user_can_post_job() {
 }
 
 /**
- * True if an the user can edit a job.
+ * Checks if the user can edit a job.
  *
+ * @since 1.5.1
+ * @param int|WP_Post $job_id
  * @return bool
  */
 function job_manager_user_can_edit_job( $job_id ) {
@@ -507,8 +521,9 @@ function job_manager_user_can_edit_job( $job_id ) {
 }
 
 /**
- * True if only one type allowed per job
+ * Checks if only one type allowed per job.
  *
+ * @since 1.25.2
  * @return bool
  */
 function job_manager_multi_job_type() {
@@ -516,8 +531,9 @@ function job_manager_multi_job_type() {
 }
 
 /**
- * True if registration is enabled.
+ * Checks if registration is enabled.
  *
+ * @since 1.5.1
  * @return bool
  */
 function job_manager_enable_registration() {
@@ -525,8 +541,9 @@ function job_manager_enable_registration() {
 }
 
 /**
- * True if usernames are generated from email addresses.
+ * Checks if usernames are generated from email addresses.
  *
+ * @since 1.20.0
  * @return bool
  */
 function job_manager_generate_username_from_email() {
@@ -534,8 +551,9 @@ function job_manager_generate_username_from_email() {
 }
 
 /**
- * True if an account is required to post a job.
+ * Checks if an account is required to post a job.
  *
+ * @since 1.5.1
  * @return bool
  */
 function job_manager_user_requires_account() {
@@ -543,8 +561,9 @@ function job_manager_user_requires_account() {
 }
 
 /**
- * True if users are allowed to edit submissions that are pending approval.
+ * Checks if users are allowed to edit submissions that are pending approval.
  *
+ * @since 1.16.1
  * @return bool
  */
 function job_manager_user_can_edit_pending_submissions() {
@@ -552,9 +571,14 @@ function job_manager_user_can_edit_pending_submissions() {
 }
 
 /**
+ * Displays category select dropdown.
+ *
  * Based on wp_dropdown_categories, with the exception of supporting multiple selected categories.
  *
+ * @since 1.14.0
  * @see  wp_dropdown_categories
+ * @param string|array|object $args
+ * @return string
  */
 function job_manager_dropdown_categories( $args = '' ) {
 	$defaults = array(
@@ -645,8 +669,9 @@ function job_manager_dropdown_categories( $args = '' ) {
 }
 
 /**
- * Get the page ID of a page if set, with PolyLang compat.
+ * Gets the page ID of a page if set, with PolyLang compat.
  *
+ * @since 1.23.12
  * @param  string $page e.g. job_dashboard, submit_job_form, jobs
  * @return int
  */
@@ -660,8 +685,9 @@ function job_manager_get_page_id( $page ) {
 }
 
 /**
- * Get the permalink of a page if set
+ * Gets the permalink of a page if set.
  *
+ * @since 1.16.0
  * @param  string $page e.g. job_dashboard, submit_job_form, jobs
  * @return string|bool
  */
@@ -674,8 +700,9 @@ function job_manager_get_permalink( $page ) {
 }
 
 /**
- * Filters the upload dir when $job_manager_upload is true
+ * Filters the upload dir when $job_manager_upload is true.
  *
+ * @since 1.21.0
  * @param  array $pathdata
  * @return array
  */
@@ -702,8 +729,9 @@ function job_manager_upload_dir( $pathdata ) {
 add_filter( 'upload_dir', 'job_manager_upload_dir' );
 
 /**
- * Prepare files for upload by standardizing them into an array. This adds support for multiple file upload fields.
+ * Prepares files for upload by standardizing them into an array. This adds support for multiple file upload fields.
  *
+ * @since 1.21.0
  * @param  array $file_data
  * @return array
  */
@@ -733,10 +761,11 @@ function job_manager_prepare_uploaded_files( $file_data ) {
 }
 
 /**
- * Upload a file using WordPress file API.
+ * Uploads a file using WordPress file API.
  *
- * @param  array $file_data Array of $_FILE data to upload.
- * @param  array $args Optional arguments
+ * @since 1.21.0
+ * @param  array|WP_Error      $file Array of $_FILE data to upload.
+ * @param  string|array|object $args Optional arguments
  * @return stdClass|WP_Error Object containing file information, or error
  */
 function job_manager_upload_file( $file, $args = array() ) {
@@ -805,8 +834,9 @@ function job_manager_upload_file( $file, $args = array() ) {
 }
 
 /**
- * Allowed Mime types specifically for WPJM.
+ * Returns mime types specifically for WPJM.
  *
+ * @since 1.25.1
  * @param   string $field Field used.
  * @return  array  Array of allowed mime types
  */
@@ -845,8 +875,9 @@ function job_manager_get_allowed_mime_types( $field = '' ){
 }
 
 /**
- * Calculate and return the job expiry date
+ * Calculates and returns the job expiry date.
  *
+ * @since 1.22.0
  * @param  int $job_id
  * @return string
  */
@@ -867,8 +898,9 @@ function calculate_job_expiry( $job_id ) {
 }
 
 /**
- * Duplicate a listing.
+ * Duplicates a listing.
  *
+ * @since 1.25.0
  * @param  int $post_id
  * @return int 0 on fail or the post ID.
  */

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -11,13 +11,13 @@
  */
 
 /**
- * Get and include template files.
+ * Gets and includes template files.
  *
+ * @since 1.0.0
  * @param mixed  $template_name
  * @param array  $args (default: array())
  * @param string $template_path (default: '')
  * @param string $default_path (default: '')
- * @return void
  */
 function get_job_manager_template( $template_name, $args = array(), $template_path = 'job_manager', $default_path = '' ) {
 	if ( $args && is_array( $args ) ) {
@@ -27,7 +27,7 @@ function get_job_manager_template( $template_name, $args = array(), $template_pa
 }
 
 /**
- * Locate a template and return the path for inclusion.
+ * Locates a template and return the path for inclusion.
  *
  * This is the load order:
  *
@@ -35,6 +35,7 @@ function get_job_manager_template( $template_name, $args = array(), $template_pa
  *		yourtheme		/	$template_name
  *		$default_path	/	$template_name
  *
+ * @since 1.0.0
  * @param string      $template_name
  * @param string      $template_path (default: 'job_manager')
  * @param string|bool $default_path (default: '') False to not load a default
@@ -62,8 +63,9 @@ function locate_job_manager_template( $template_name, $template_path = 'job_mana
 }
 
 /**
- * Get template part (for templates in loops).
+ * Gets template part (for templates in loops).
  *
+ * @since 1.0.0
  * @param string      $slug
  * @param string      $name (default: '')
  * @param string      $template_path (default: 'job_manager')
@@ -87,8 +89,9 @@ function get_job_manager_template_part( $slug, $name = '', $template_path = 'job
 }
 
 /**
- * Add custom body classes
+ * Adds custom body classes.
  *
+ * @since 1.16.0
  * @param  array $classes
  * @return array
  */
@@ -102,9 +105,12 @@ function job_manager_body_class( $classes ) {
 add_filter( 'body_class', 'job_manager_body_class' );
 
 /**
- * Get jobs pagination for [jobs] shortcode
+ * Get jobs pagination for [jobs] shortcode.
  *
- * @return [type] [description]
+ * @since 1.13.0
+ * @param int $max_num_pages
+ * @param int $current_page
+ * @return string
  */
 function get_job_listing_pagination( $max_num_pages, $current_page = 1 ) {
 	ob_start();
@@ -113,17 +119,20 @@ function get_job_listing_pagination( $max_num_pages, $current_page = 1 ) {
 }
 
 /**
- * Outputs the jobs status
+ * Displays the jobs status.
  *
- * @return void
+ * @since 1.0.0
+ * @param int|WP_Post $post
  */
 function the_job_status( $post = null ) {
 	echo get_the_job_status( $post );
 }
 
 /**
- * Gets the jobs status
+ * Gets the jobs status.
  *
+ * @since 1.
+ * @param int|WP_Post $post
  * @return string
  */
 function get_the_job_status( $post = null ) {
@@ -141,9 +150,10 @@ function get_the_job_status( $post = null ) {
 }
 
 /**
- * Return whether or not the position has been marked as filled
+ * Checks whether or not the position has been marked as filled.
  *
- * @param  object $post
+ * @since 1.0.0
+ * @param  WP_Post|int $post
  * @return boolean
  */
 function is_position_filled( $post = null ) {
@@ -152,9 +162,10 @@ function is_position_filled( $post = null ) {
 }
 
 /**
- * Return whether or not the position has been featured
+ * Checks whether or not the position has been featured.
  *
- * @param  object $post
+ * @since 1.2.0
+ * @param  WP_Post|int $post
  * @return boolean
  */
 function is_position_featured( $post = null ) {
@@ -163,9 +174,10 @@ function is_position_featured( $post = null ) {
 }
 
 /**
- * Return whether or not applications are allowed
+ * Checks whether or not applications are allowed.
  *
- * @param  object $post
+ * @since 1.21.0
+ * @param  WP_Post|int $post
  * @return boolean
  */
 function candidates_can_apply( $post = null ) {
@@ -174,9 +186,10 @@ function candidates_can_apply( $post = null ) {
 }
 
 /**
- * the_job_permalink function.
+ * Displays the permalink for the job listing post.
  *
- * @access public
+ * @since 1.0.0
+ * @param int|WP_Post $post (default: null)
  * @return void
  */
 function the_job_permalink( $post = null ) {
@@ -184,10 +197,10 @@ function the_job_permalink( $post = null ) {
 }
 
 /**
- * get_the_job_permalink function.
+ * Gets the permalink for a job listing.
  *
- * @access public
- * @param mixed $post (default: null)
+ * @since 1.0.0
+ * @param int|WP_Post $post (default: null)
  * @return string
  */
 function get_the_job_permalink( $post = null ) {
@@ -198,11 +211,11 @@ function get_the_job_permalink( $post = null ) {
 }
 
 /**
- * get_the_job_application_method function.
+ * Gets the application method for the job listing.
  *
- * @access public
- * @param mixed $post (default: null)
- * @return object
+ * @since 1.0.0
+ * @param int|WP_Post $post (default: null)
+ * @return stdClass|bool|null
  */
 function get_the_job_application_method( $post = null ) {
 	$post = get_post( $post );
@@ -232,10 +245,11 @@ function get_the_job_application_method( $post = null ) {
 	return apply_filters( 'the_job_application_method', $method, $post );
 }
 /**
- * the_job_type function.
+ * Displays the job type for the listing.
  *
- * @access public
- * @return void
+ * @since 1.0.0
+ * @param int|WP_Post $post
+ * @return string
  */
 function the_job_type( $post = null ) {
 	if ( ! get_option( 'job_manager_enable_types' ) ) {
@@ -247,11 +261,11 @@ function the_job_type( $post = null ) {
 }
 
 /**
- * get_the_job_type function.
+ * Gets the job type for the listing.
  *
- * @access public
- * @param mixed $post (default: null)
- * @return void
+ * @since 1.0.0
+ * @param int|WP_Post $post (default: null)
+ * @return string|bool|null
  */
 function get_the_job_type( $post = null ) {
 	$post = get_post( $post );
@@ -272,10 +286,10 @@ function get_the_job_type( $post = null ) {
 
 
 /**
- * the_job_publish_date function.
+ * Displays the published date of the job listing.
  *
- * @param mixed $post (default: null)
- * @return [type]
+ * @since 1.25.3
+ * @param int|WP_Post $post (default: null)
  */
 function the_job_publish_date( $post = null ) {
 	$date_format = get_option( 'job_manager_date_format' );
@@ -291,10 +305,11 @@ function the_job_publish_date( $post = null ) {
 
 
 /**
- * get_the_job_publish_date function.
+ * Gets the published date of the job listing.
  *
- * @param mixed $post (default: null)
- * @return [type]
+ * @since 1.25.3
+ * @param int|WP_Post $post (default: null)
+ * @return string|int|false
  */
 function get_the_job_publish_date( $post = null ) {
 	$date_format = get_option( 'job_manager_date_format' );
@@ -308,10 +323,11 @@ function get_the_job_publish_date( $post = null ) {
 
 
 /**
- * the_job_location function.
+ * Displays the location for the job listing.
  *
- * @param  boolean $map_link whether or not to link to google maps
- * @return [type]
+ * @since 1.0.0
+ * @param  bool        $map_link whether or not to link to Google Maps
+ * @param int|WP_Post $post
  */
 function the_job_location( $map_link = true, $post = null ) {
 	$location = get_the_job_location( $post );
@@ -329,11 +345,11 @@ function the_job_location( $map_link = true, $post = null ) {
 }
 
 /**
- * get_the_job_location function.
+ * Gets the location for the job listing.
  *
- * @access public
- * @param mixed $post (default: null)
- * @return void
+ * @since 1.0.0
+ * @param int|WP_Post $post (default: null)
+ * @return string|null
  */
 function get_the_job_location( $post = null ) {
 	$post = get_post( $post );
@@ -345,12 +361,12 @@ function get_the_job_location( $post = null ) {
 }
 
 /**
- * the_company_logo function.
+ * Displays the company logo.
  *
- * @access public
- * @param string $size (default: 'full')
- * @param mixed  $default (default: null)
- * @return void
+ * @since 1.0.0
+ * @param string      $size (default: 'full')
+ * @param mixed       $default (default: null)
+ * @param int|WP_Post $post (default: null)
  */
 function the_company_logo( $size = 'thumbnail', $default = null, $post = null ) {
 	$logo = get_the_company_logo( $post, $size );
@@ -372,10 +388,11 @@ function the_company_logo( $size = 'thumbnail', $default = null, $post = null ) 
 }
 
 /**
- * get_the_company_logo function.
+ * Gets the company logo.
  *
- * @access public
- * @param mixed $post (default: null)
+ * @since 1.0.0
+ * @param int|WP_Post $post (default: null)
+ * @param string      $size
  * @return string Image SRC
  */
 function get_the_company_logo( $post = null, $size = 'thumbnail' ) {
@@ -393,8 +410,9 @@ function get_the_company_logo( $post = null, $size = 'thumbnail' ) {
 }
 
 /**
- * Resize and get url of the image
+ * Resizes and returns the url of an image.
  *
+ * @since 1.5.1
  * @param  string $logo
  * @param  string $size
  * @return string
@@ -453,7 +471,10 @@ function job_manager_get_resized_image( $logo, $size ) {
 }
 
 /**
- * Output the company video
+ * Displays the company video.
+ *
+ * @since 1.14.0
+ * @param int|WP_Post $post
  */
 function the_company_video( $post = null ) {
 	$video_embed = false;
@@ -479,10 +500,11 @@ function the_company_video( $post = null ) {
 }
 
 /**
- * Get the company video URL
+ * Gets the company video URL.
  *
- * @param mixed $post (default: null)
- * @return string
+ * @since 1.14.0
+ * @param int|WP_Post $post (default: null)
+ * @return string|null
  */
 function get_the_company_video( $post = null ) {
 	$post = get_post( $post );
@@ -493,11 +515,15 @@ function get_the_company_video( $post = null ) {
 }
 
 /**
- * Display or retrieve the current company name with optional content.
+ * Displays or retrieves the current company name with optional content.
  *
- * @access public
- * @param mixed $id (default: null)
- * @return void
+ * @since 1.0.0
+ * @since 1.0.1 Add the `$post` argument.
+ * @param string           $before (default: '')
+ * @param string           $after (default: '')
+ * @param bool             $echo (default: true)
+ * @param int|WP_Post|null $post (default: null)
+ * @return string|void
  */
 function the_company_name( $before = '', $after = '', $echo = true, $post = null ) {
 	$company_name = get_the_company_name( $post );
@@ -515,9 +541,9 @@ function the_company_name( $before = '', $after = '', $echo = true, $post = null
 }
 
 /**
- * get_the_company_name function.
+ * Gets the company name.
  *
- * @access public
+ * @since 1.0.0
  * @param int $post (default: null)
  * @return string
  */
@@ -531,11 +557,11 @@ function get_the_company_name( $post = null ) {
 }
 
 /**
- * get_the_company_website function.
+ * Gets the company website.
  *
- * @access public
+ * @since 1.0.0
  * @param int $post (default: null)
- * @return void
+ * @return null|string
  */
 function get_the_company_website( $post = null ) {
 	$post = get_post( $post );
@@ -553,11 +579,14 @@ function get_the_company_website( $post = null ) {
 }
 
 /**
- * Display or retrieve the current company tagline with optional content.
+ * Displays or retrieves the current company tagline with optional content.
  *
- * @access public
- * @param mixed $id (default: null)
- * @return void
+ * @since 1.0.0
+ * @param string           $before (default: '')
+ * @param string           $after (default: '')
+ * @param bool             $echo (default: true)
+ * @param int|WP_Post|null $post (default: null)
+ * @return string|void
  */
 function the_company_tagline( $before = '', $after = '', $echo = true, $post = null ) {
 	$company_tagline = get_the_company_tagline( $post );
@@ -575,11 +604,11 @@ function the_company_tagline( $before = '', $after = '', $echo = true, $post = n
 }
 
 /**
- * get_the_company_tagline function.
+ * Gets the company tagline.
  *
- * @access public
- * @param int $post (default: 0)
- * @return void
+ * @since 1.0.0
+ * @param int|WP_Post|null $post (default: null)
+ * @return string|null
  */
 function get_the_company_tagline( $post = null ) {
 	$post = get_post( $post );
@@ -591,11 +620,14 @@ function get_the_company_tagline( $post = null ) {
 }
 
 /**
- * Display or retrieve the current company twitter link with optional content.
+ * Displays or retrieves the current company Twitter link with optional content.
  *
- * @access public
- * @param mixed $id (default: null)
- * @return void
+ * @since 1.0.0
+ * @param string           $before (default: '')
+ * @param string           $after (default: '')
+ * @param bool             $echo (default: true)
+ * @param int|WP_Post|null $post (default: null)
+ * @return string|void
  */
 function the_company_twitter( $before = '', $after = '', $echo = true, $post = null ) {
 	$company_twitter = get_the_company_twitter( $post );
@@ -613,11 +645,11 @@ function the_company_twitter( $before = '', $after = '', $echo = true, $post = n
 }
 
 /**
- * get_the_company_twitter function.
+ * Gets the company Twitter link.
  *
- * @access public
- * @param int $post (default: 0)
- * @return void
+ * @since 1.0.0
+ * @param int|WP_Post|null $post (default: null)
+ * @return string|null
  */
 function get_the_company_twitter( $post = null ) {
 	$post = get_post( $post );
@@ -636,12 +668,11 @@ function get_the_company_twitter( $post = null ) {
 }
 
 /**
- * job_listing_class function.
+ * Outputs the job listing class.
  *
- * @access public
- * @param string $class (default: '')
- * @param mixed  $post_id (default: null)
- * @return void
+ * @since 1.0.0
+ * @param string      $class (default: '')
+ * @param int|WP_Post $post_id (default: null)
  */
 function job_listing_class( $class = '', $post_id = null ) {
 	// Separates classes with a single space, collates classes for post DIV
@@ -649,9 +680,11 @@ function job_listing_class( $class = '', $post_id = null ) {
 }
 
 /**
- * get_job_listing_class function.
+ * Gets the job listing class.
  *
- * @access public
+ * @since 1.0.0
+ * @param string      $class
+ * @param int|WP_Post $post_id (default: null)
  * @return array
  */
 function get_job_listing_class( $class = '', $post_id = null ) {
@@ -695,7 +728,9 @@ function get_job_listing_class( $class = '', $post_id = null ) {
 }
 
 /**
- * Displays job meta data on the single job page
+ * Displays job meta data on the single job page.
+ *
+ * @since 1.14.0
  */
 function job_listing_meta_display() {
 	get_job_manager_template( 'content-single-job_listing-meta.php', array() );
@@ -703,7 +738,9 @@ function job_listing_meta_display() {
 add_action( 'single_job_listing_start', 'job_listing_meta_display', 20 );
 
 /**
- * Displays job company data on the single job page
+ * Displays job company data on the single job page.
+ *
+ * @since 1.14.0
  */
 function job_listing_company_display() {
 	get_job_manager_template( 'content-single-job_listing-company.php', array() );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -17,12 +17,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * WP_Job_Manager class.
+ * Handles core plugin hooks and action setup.
+ *
+ * @package wp-job-manager
+ * @since 1.0.0
  */
 class WP_Job_Manager {
 
 	/**
-	 * Constructor - get the plugin hooked in and ready
+	 * Constructor.
 	 */
 	public function __construct() {
 		// Define constants
@@ -65,7 +68,7 @@ class WP_Job_Manager {
 	}
 
 	/**
-	 * Called on plugin activation
+	 * Performs plugin activation steps.
 	 */
 	public function activate() {
 		WP_Job_Manager_Ajax::add_endpoint();
@@ -75,7 +78,7 @@ class WP_Job_Manager {
 	}
 
 	/**
-	 * Handle Updates
+	 * Handles tasks after plugin is updated.
 	 */
 	public function updater() {
 		if ( version_compare( JOB_MANAGER_VERSION, get_option( 'wp_job_manager_version' ), '>' ) ) {
@@ -85,7 +88,7 @@ class WP_Job_Manager {
 	}
 
 	/**
-	 * Localisation
+	 * Loads textdomain for plugin.
 	 */
 	public function load_plugin_textdomain() {
 		load_textdomain( 'wp-job-manager', WP_LANG_DIR . "/wp-job-manager/wp-job-manager-" . apply_filters( 'plugin_locale', get_locale(), 'wp-job-manager' ) . ".mo" );
@@ -93,7 +96,7 @@ class WP_Job_Manager {
 	}
 
 	/**
-	 * Load functions
+	 * Loads plugin's core helper functions.
 	 */
 	public function include_template_functions() {
 		include( 'wp-job-manager-functions.php' );
@@ -101,14 +104,14 @@ class WP_Job_Manager {
 	}
 
 	/**
-	 * Widgets init
+	 * Loads plugin's widgets.
 	 */
 	public function widgets_init() {
 		include_once( 'includes/class-wp-job-manager-widgets.php' );
 	}
 
 	/**
-	 * Register and enqueue scripts and css
+	 * Registers and enqueues scripts and CSS.
 	 */
 	public function frontend_scripts() {
 		global $post;
@@ -176,6 +179,12 @@ class WP_Job_Manager {
 	}
 }
 
+/**
+ * Add post type for Job Manager.
+ *
+ * @param array $types
+ * @return array
+ */
 function job_manager_add_post_types( $types ) {
 	$types[] = 'job_listing';
 	return $types;


### PR DESCRIPTION
This large PR contains no change to code, just documentation fixes. Sorry for its size. I wanted to get this out of the way before writing tests as it will help with that process considerably. This is the initial housekeeping of docblocks according to WordPress standards:
https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/

Still to do in smaller PRs:
- Add documentation for action hooks and filters.
- Add description to method arguments where missing.

Notes:
- Following WordPress standards, I omitted "@return void" in most places. I added "@return null" only when returning the value 'null' was meaningful (not, for example, just prematurely execution of function).
