### PR TITLE
Adds static instance access for WP_Job_Manager class

### DIFF
--- a/tests/php/test_class.wp-job-manager.php
+++ b/tests/php/test_class.wp-job-manager.php
@@ -6,14 +6,41 @@ class WP_Test_WP_Job_Manager extends WP_UnitTestCase {
 	 *
 	 * @since 1.26
 	 */
-	function test_job_manager_global_var() {
+	public function test_wp_job_manager_global_object() {
 		// setup the test
 		global $job_manager;
 
 		// test if the global job manager object is loaded
-		$this->assertTrue( isset( $job_manager ), 'Job Manager global object loaded ' );
+		$this->assertTrue( isset( $job_manager ), 'Job Manager global object loaded' );
 
 		// check the class
-		$this->assertTrue( $job_manager instanceof WP_Job_Manager, 'Job Manager object is instance of WP_Job_Manager class' );
+		$this->assertInstanceOf( 'WP_Job_Manager', $job_manager, 'Job Manager object is instance of WP_Job_Manager class' );
+
+		// check it matches result of global function
+		$this->assertSame( WPJM(), $job_manager, 'Job Manager global must be equal to result of WPJM()' );
+	}
+
+	/**
+	 * Tests the WPJM() always returns the same `WP_Job_Manager` instance.
+	 *
+	 * @since 1.26
+	 * @covers ::WPJM
+	 */
+	public function test_wp_job_manager_global_function() {
+		$job_manager_instance = WPJM();
+		$this->assertSame( WPJM(), $job_manager_instance, 'WPJM() must always provide the same instance of WP_Job_Manager' );
+		$this->assertTrue( $job_manager_instance instanceof WP_Job_Manager, 'Job Manager object is instance of WP_Job_Manager class' );
+	}
+
+	/**
+	 * Tests the WP_Job_Manager::instance() always returns the same `WP_Job_Manager` instance.
+	 *
+	 * @since 1.26
+	 * @covers WP_Job_Manager::instance
+	 */
+	public function test_wp_job_manager_instance() {
+		$job_manager_instance = WP_Job_Manager::instance();
+		$this->assertSame( WP_Job_Manager::instance(), $job_manager_instance, 'WP_Job_Manager::instance() must always provide the same instance of WP_Job_Manager' );
+		$this->assertInstanceOf( 'WP_Job_Manager', $job_manager_instance, 'WP_Job_Manager::instance() must always provide the same instance of WP_Job_Manager' );
 	}
 }

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -23,6 +23,30 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class WP_Job_Manager {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var self
+	 * @since  1.26
+	 */
+	private static $_instance = null;
+
+	/**
+	 * Main WP Job Manager Instance.
+	 *
+	 * Ensures only one instance of WP Job Manager is loaded or can be loaded.
+	 *
+	 * @since  1.26
+	 * @static
+	 * @see WPJM()
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
 
 	/**
 	 * Constructor.
@@ -191,4 +215,16 @@ function job_manager_add_post_types( $types ) {
 }
 add_filter( 'post_types_to_delete_with_user', 'job_manager_add_post_types', 10 );
 
-$GLOBALS['job_manager'] = new WP_Job_Manager();
+/**
+ * Main instance of WP Job Manager.
+ *
+ * Returns the main instance of WP Job Manager to prevent the need to use globals.
+ *
+ * @since  1.26
+ * @return WP_Job_Manager
+ */
+function WPJM() {
+	return WP_Job_Manager::instance();
+}
+
+$GLOBALS['job_manager'] = WPJM();

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -115,7 +115,7 @@ class WP_Job_Manager {
 	 * Loads textdomain for plugin.
 	 */
 	public function load_plugin_textdomain() {
-		load_textdomain( 'wp-job-manager', WP_LANG_DIR . "/wp-job-manager/wp-job-manager-" . apply_filters( 'plugin_locale', get_locale(), 'wp-job-manager' ) . ".mo" );
+		load_textdomain( 'wp-job-manager', WP_LANG_DIR . '/wp-job-manager/wp-job-manager-' . apply_filters( 'plugin_locale', get_locale(), 'wp-job-manager' ) . '.mo' );
 		load_plugin_textdomain( 'wp-job-manager', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 	}
 
@@ -150,7 +150,7 @@ class WP_Job_Manager {
 
 		// WPML workaround
 		if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
-			$ajax_data['lang'] = apply_filters( 'wpml_current_language', NULL );
+			$ajax_data['lang'] = apply_filters( 'wpml_current_language', null );
 		}
 
 		if ( apply_filters( 'job_manager_chosen_enabled', true ) ) {
@@ -161,7 +161,9 @@ class WP_Job_Manager {
 			$ajax_filter_deps[] = 'chosen';
 
 			wp_localize_script( 'chosen', 'job_manager_chosen_multiselect_args',
-				apply_filters( 'job_manager_chosen_multiselect_args', array( 'search_contains' => true ) )
+				apply_filters( 'job_manager_chosen_multiselect_args', array(
+					'search_contains' => true,
+				) )
 			);
 		}
 
@@ -171,18 +173,26 @@ class WP_Job_Manager {
 			wp_register_script( 'wp-job-manager-ajax-file-upload', JOB_MANAGER_PLUGIN_URL . '/assets/js/ajax-file-upload.min.js', array( 'jquery', 'jquery-fileupload' ), JOB_MANAGER_VERSION, true );
 
 			ob_start();
-			get_job_manager_template( 'form-fields/uploaded-file-html.php', array( 'name' => '', 'value' => '', 'extension' => 'jpg' ) );
+			get_job_manager_template( 'form-fields/uploaded-file-html.php', array(
+				'name' => '',
+				'value' => '',
+				'extension' => 'jpg',
+			) );
 			$js_field_html_img = ob_get_clean();
 
 			ob_start();
-			get_job_manager_template( 'form-fields/uploaded-file-html.php', array( 'name' => '', 'value' => '', 'extension' => 'zip' ) );
+			get_job_manager_template( 'form-fields/uploaded-file-html.php', array(
+				'name' => '',
+				'value' => '',
+				'extension' => 'zip',
+			) );
 			$js_field_html = ob_get_clean();
 
 			wp_localize_script( 'wp-job-manager-ajax-file-upload', 'job_manager_ajax_file_upload', array(
 				'ajax_url'               => $ajax_url,
-				'js_field_html_img'      => esc_js( str_replace( "\n", "", $js_field_html_img ) ),
-				'js_field_html'          => esc_js( str_replace( "\n", "", $js_field_html ) ),
-				'i18n_invalid_file_type' => __( 'Invalid file type. Accepted types:', 'wp-job-manager' )
+				'js_field_html_img'      => esc_js( str_replace( "\n", '', $js_field_html_img ) ),
+				'js_field_html'          => esc_js( str_replace( "\n", '', $js_field_html ) ),
+				'i18n_invalid_file_type' => __( 'Invalid file type. Accepted types:', 'wp-job-manager' ),
 			) );
 		}
 
@@ -193,11 +203,11 @@ class WP_Job_Manager {
 		wp_register_script( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-submission.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
 		wp_localize_script( 'wp-job-manager-ajax-filters', 'job_manager_ajax_filters', $ajax_data );
 		wp_localize_script( 'wp-job-manager-job-dashboard', 'job_manager_job_dashboard', array(
-			'i18n_confirm_delete' => __( 'Are you sure you want to delete this listing?', 'wp-job-manager' )
+			'i18n_confirm_delete' => __( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
 		) );
 
 		wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css', array(), JOB_MANAGER_VERSION );
-		if( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'submit_job_form') ) {
+		if ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'submit_job_form' ) ) {
 			wp_enqueue_style( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-submission.css', array(), JOB_MANAGER_VERSION );
 		}
 	}


### PR DESCRIPTION
Get this in now to ease future cleanup of plugins.

PR is split between two commits. One is just formatting fixes to `wp-job-manager.php` since I touched the file. It seems like the large formatting fix PR wasn't working for folks.