### PR TITLE
Adds some tests for WP_Job_Manager_API

### DIFF
--- a/includes/class-wp-job-manager-api.php
+++ b/includes/class-wp-job-manager-api.php
@@ -1,6 +1,8 @@
 <?php
 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
 
 /**
  * Handles API requests for WP Job Manager.
@@ -36,8 +38,8 @@ class WP_Job_Manager_API {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'query_vars', array( $this, 'add_query_vars'), 0 );
-		add_action( 'parse_request', array( $this, 'api_requests'), 0 );
+		add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
+		add_action( 'parse_request', array( $this, 'api_requests' ), 0 );
 	}
 
 	/**
@@ -64,8 +66,9 @@ class WP_Job_Manager_API {
 	public function api_requests() {
 		global $wp;
 
-		if ( ! empty( $_GET['job-manager-api'] ) )
+		if ( ! empty( $_GET['job-manager-api'] ) ) {
 			$wp->query_vars['job-manager-api'] = $_GET['job-manager-api'];
+		}
 
 		if ( ! empty( $wp->query_vars['job-manager-api'] ) ) {
 			// Buffer, we won't want any output here
@@ -75,15 +78,21 @@ class WP_Job_Manager_API {
 			$api = strtolower( esc_attr( $wp->query_vars['job-manager-api'] ) );
 
 			// Load class if exists
-			if ( has_action( 'job_manager_api_' . $api ) && class_exists( $api ) )
+			if ( has_action( 'job_manager_api_' . $api ) && class_exists( $api ) ) {
 				$api_class = new $api();
+			}
 
-			// Trigger actions
+			/**
+			 * Performs an API action.
+			 * The dynamic part of the action, $api, is the API action.
+			 *
+			 * @since 1.0.0
+			 */
 			do_action( 'job_manager_api_' . $api );
 
 			// Done, clear buffer and exit
 			ob_end_clean();
-			die('1');
+			wp_die();
 		}
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -30,7 +30,7 @@ class WPJM_Unit_Tests_Bootstrap {
 		error_reporting( E_ALL );
 		$this->tests_dir    = dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'tests';
 		$this->includes_dir    = dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'includes';
-		$this->plugin_dir   = dirname( dirname ( dirname( $this->tests_dir ) ) );
+		$this->plugin_dir   = dirname( dirname( dirname( $this->tests_dir ) ) );
 		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
 
 		// load test function so tests_add_filter() is available

--- a/tests/php/includes/stubs/class-wpjm-api-handler-stub.php
+++ b/tests/php/includes/stubs/class-wpjm-api-handler-stub.php
@@ -1,0 +1,13 @@
+<?php
+
+class WPJM_Api_Handler_Stub {
+	public $fired = false;
+
+	public function __construct() {
+		add_action( 'job_manager_api_' . strtolower( get_class( $this ) ), array( $this, 'api_handler' ) );
+	}
+
+	public function api_handler() {
+		$this->fired = true;
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-api.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-api.php
@@ -1,0 +1,69 @@
+<?php
+
+class WP_Test_WP_Job_Manager_API extends WPJM_BaseTest {
+	/**
+	 * Tests the WP_Job_Manager_API::instance() always returns the same `WP_Job_Manager_API` instance.
+	 *
+	 * @since 1.26
+	 * @covers WP_Job_Manager_API::instance
+	 */
+	public function test_wp_job_manager_api_instance() {
+		$instance = WP_Job_Manager_API::instance();
+		// check the class
+		$this->assertInstanceOf( 'WP_Job_Manager_API', $instance, 'Job Manager API object is instance of WP_Job_Manager_API class' );
+
+		// check it always returns the same object
+		$this->assertSame( WP_Job_Manager_API::instance(), $instance, 'WP_Job_Manager_API::instance() must always return the same object' );
+	}
+
+	/**
+	 * @since 1.26
+	 * @covers WP_Job_Manager_API::add_query_vars
+	 */
+	public function test_add_query_vars() {
+		$instance = WP_Job_Manager_API::instance();
+		$vars = array( 'existing-var' );
+		$new_vars = $instance->add_query_vars( $vars );
+		$this->assertCount( 2, $new_vars );
+		$this->assertContains( 'job-manager-api', $new_vars );
+		$this->assertContains( 'existing-var', $new_vars );
+	}
+
+	/**
+	 * @since 1.26
+	 * @covers WP_Job_Manager_API::api_requests
+	 */
+	public function test_valid_api_requests() {
+		global $wp;
+		$instance = WP_Job_Manager_API::instance();
+		$bootstrap = WPJM_Unit_Tests_Bootstrap::instance();
+		include_once( $bootstrap->includes_dir . '/stubs/class-wpjm-api-handler-stub.php' );
+		$this->assertTrue( class_exists( 'WPJM_Api_Handler_Stub' ) );
+		$handler = new WPJM_Api_Handler_Stub();
+		$handler_tag = strtolower( get_class( $handler ) );
+		add_action( 'wp_die_handler', array( $this, 'return_do_not_die' ) );
+		$wp->query_vars['job-manager-api'] = $handler_tag;
+		$this->assertFalse( $handler->fired );
+		$instance->api_requests();
+		$this->assertTrue( $handler->fired );
+	}
+
+	/**
+	 * Helps to prevent `wp_die()` from ending execution during API call.
+	 *
+	 * @since 1.26
+	 * @return array
+	 */
+	public function return_do_not_die() {
+		return array( $this, 'do_not_die' );
+	}
+
+	/**
+	 * Does nothing.
+	 *
+	 * @since 1.26
+	 */
+	public function do_not_die() {
+		return;
+	}
+}


### PR DESCRIPTION
Adds test and fixes some code formatting issues for `WP_Job_Manager_API`.

One code change is replacing `die()` with `wp_die()` in the API handler to allow for proper testing. `wp_die()` doesn't return anything when it is an Ajax request. Seems to only be used (in our plugins) in the simple paid listings plugin for Paypal callback.