### PR TITLE
Move WPML and Polylang code into separate files

### DIFF
--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Load 3rd party compatibility tweaks.
+ */
+require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wpml.php' );
+require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/polylang.php' );

--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Only load these if Polylang plugin is installed and active.
+ */
+
+/**
+ * Load routines only if Polylang is loaded.
+ *
+ * @since 1.26.0
+ */
+function polylang_wpjm_init() {
+	add_filter( 'wpjm_lang', 'polylang_wpjm_get_job_listings_lang' );
+	add_filter( 'wpjm_page_id', 'polylang_wpjm_page_id' );
+}
+add_action( 'pll_init', 'polylang_wpjm_init' );
+
+/**
+ * Returns Polylang's current language.
+ *
+ * @since 1.26.0
+ *
+ * @param string $lang
+ * @return string
+ */
+function polylang_wpjm_get_job_listings_lang( $lang ) {
+	if ( function_exists( 'pll_current_language' ) ) {
+		return pll_current_language();
+	}
+	return $lang;
+}
+
+/**
+ * Returns the page ID for the current language.
+ *
+ * @since 1.26.0
+ *
+ * @param int $page_id
+ * @return int
+ */
+function polylang_wpjm_page_id( $page_id ) {
+	if ( function_exists( 'pll_get_post' ) ) {
+		$page_id = pll_get_post( $page_id );
+	}
+	return absint( $page_id );
+}
+

--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Only load these if WPML plugin is installed and active.
+ */
+
+/**
+ * Load routines only if WPML is loaded.
+ *
+ * @since 1.26.0
+ */
+function wpml_wpjm_init() {
+	add_action( 'get_job_listings_init', 'wpml_wpjm_set_language' );
+	add_filter( 'wpjm_lang', 'wpml_wpjm_get_job_listings_lang' );
+	add_filter( 'wpjm_page_id', 'wpml_wpjm_page_id' );
+}
+add_action( 'wpml_loaded', 'wpml_wpjm_init' );
+
+/**
+ * Sets WPJM's language if it is sent in the Ajax request.
+ *
+ * @since 1.26.0
+ */
+function wpml_wpjm_set_language() {
+	if ( ( strstr( $_SERVER['REQUEST_URI'], '/jm-ajax/' ) || ! empty( $_GET['jm-ajax'] ) ) && isset( $_POST['lang'] ) ) {
+		do_action( 'wpml_switch_language', sanitize_text_field( $_POST['lang'] ) );
+	}
+}
+
+/**
+ * Returns WPML's current language.
+ *
+ * @since 1.26.0
+ *
+ * @param string $lang
+ * @return string
+ */
+function wpml_wpjm_get_job_listings_lang( $lang ) {
+	return apply_filters( 'wpml_current_language', $lang );
+}
+
+/**
+ * Returns the page ID for the current language.
+ *
+ * @param int $page_id
+ * @return int
+ */
+function wpml_wpjm_page_id( $page_id ) {
+	return apply_filters( 'wpml_object_id', $page_id, 'page', true );
+}

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -71,6 +71,9 @@ class WP_Job_Manager {
 			include( 'includes/admin/class-wp-job-manager-admin.php' );
 		}
 
+		// Load 3rd party customizations
+		require_once( 'includes/3rd-party/3rd-party.php' );
+
 		// Init classes
 		$this->forms      = WP_Job_Manager_Forms::instance();
 		$this->post_types = WP_Job_Manager_Post_Types::instance();
@@ -150,10 +153,14 @@ class WP_Job_Manager {
 			'i18n_load_prev_listings' => __( 'Load previous listings', 'wp-job-manager' ),
 		);
 
-		// WPML workaround
-		if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
-			$ajax_data['lang'] = apply_filters( 'wpml_current_language', null );
-		}
+		/**
+		 * Retrieves the current language for use when caching requests.
+		 *
+		 * @since 1.26.0
+		 *
+		 * @param string|null $lang
+		 */
+		$ajax_data['lang'] = apply_filters( 'wpjm_lang', null );
 
 		if ( apply_filters( 'job_manager_chosen_enabled', true ) ) {
 			wp_register_script( 'chosen', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-chosen/chosen.jquery.min.js', array( 'jquery' ), '1.1.0', true );


### PR DESCRIPTION
Clean up code by moving tweaks for WPML and Polylang to separate files.
Used Jetpack for inspiration.

Added the filter `wpjm_lang` for retrieving the current language. This is used when creating cache key signatures.

Added the action `get_job_listings_init` which fires at the start of the `get_job_listings()` function. Used for updating WPML's language when it is an Ajax request.

Fixes #962

@vukvukovich If you wouldn't mind, please review the code changes related to WPML. Thank you!

#### Testing instructions:

* Separately for WPML and Polylang:
1) Create job listings and pages with WPJM shortcodes in two languages.
2) View job listing in one language and then switch language. Verify correct job listing language shows up on page refresh.
3) View list of job listings (`[jobs]`) in one language, switch language, refresh to verify you're given correct content.
4) View other WPJM shortcode pages. Verify the correct version shows up for different languages.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Moved third-party multi-language (WPML and Polylang) tweaks into separate files.