### PR TITLE
Only add `lang` for Polylang when enabled for job_listing post type

### DIFF
--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -23,7 +23,9 @@ add_action( 'pll_init', 'polylang_wpjm_init' );
  * @return string
  */
 function polylang_wpjm_get_job_listings_lang( $lang ) {
-	if ( function_exists( 'pll_current_language' ) ) {
+	if ( function_exists( 'pll_current_language' )
+	     && function_exists( 'pll_is_translated_post_type' )
+	     && pll_is_translated_post_type( 'job_listing' ) ) {
 		return pll_current_language();
 	}
 	return $lang;


### PR DESCRIPTION
Fixes #832

#### Changes proposed in this Pull Request:

* Only uses Polylang's current language if Polylang is set to translate `job_listing` post types.

#### Testing instructions:

* See issue #832 
