### PR TITLE
Only add the API key if available. 

### DIFF
--- a/includes/class-wp-job-manager-geocode.php
+++ b/includes/class-wp-job-manager-geocode.php
@@ -148,14 +148,13 @@ class WP_Job_Manager_Geocode {
 	 * @return string|bool
 	 */
 	public function add_geolocation_endpoint_query_args( $geocode_endpoint_url, $raw_address ) {
+		// Add an API key if available.
 		$api_key = apply_filters( 'job_manager_geolocation_api_key', '', $raw_address );
 
-		// Google Maps API no longer accepts requests without an API key
-		if ( '' === $api_key ) {
-			return false;
+		if ( '' !== $api_key ) {
+			$geocode_endpoint_url = add_query_arg( 'key', urlencode( $api_key ), $geocode_endpoint_url );
 		}
 
-		$geocode_endpoint_url = add_query_arg( 'key', urlencode( $api_key ), $geocode_endpoint_url );
 		$geocode_endpoint_url = add_query_arg( 'address', urlencode( $raw_address ), $geocode_endpoint_url );
 
 		$region = apply_filters( 'job_manager_geolocation_region_cctld', '', $raw_address );


### PR DESCRIPTION
Fixes #951

#### Changes proposed in this Pull Request:

* Only add the `key` parameter to geocode request if available.

#### Testing instructions:

* Add a location to a job listing and publish.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Fix: Do not automatically stop geocoding when no Google API key is available. Legacy sites still have no restrictions.