### PR TITLE
Allow linking to specific settings tab via hash in URL

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -431,7 +431,17 @@ class WP_Job_Manager_Settings {
 				jQuery(this).addClass('nav-tab-active');
 				return false;
 			});
-			jQuery('.nav-tab-wrapper a:first').click();
+			var goto_hash = window.location.hash;
+			if ( goto_hash ) {
+				var the_tab = jQuery( 'a[href="' + goto_hash + '"]' );
+				if ( the_tab ) {
+					the_tab.click();
+				} else {
+					jQuery( '.nav-tab-wrapper a:first' ).click();
+				}
+			} else {
+				jQuery( '.nav-tab-wrapper a:first' ).click();
+			}
 			jQuery('#setting-job_manager_enable_registration').change(function(){
 				if ( jQuery( this ).is(':checked') ) {
 					jQuery('#setting-job_manager_registration_role').closest('tr').show();

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -434,7 +434,7 @@ class WP_Job_Manager_Settings {
 			var goto_hash = window.location.hash;
 			if ( goto_hash ) {
 				var the_tab = jQuery( 'a[href="' + goto_hash + '"]' );
-				if ( the_tab ) {
+				if ( the_tab.length > 0 ) {
 					the_tab.click();
 				} else {
 					jQuery( '.nav-tab-wrapper a:first' ).click();


### PR DESCRIPTION
Fixes #993 

#### Changes proposed in this Pull Request:

* Allow linking to specific settings tab via hash in URL

#### Testing instructions:

* Goto settings page, copy URL from one of the tabs, go to some other non-settings page, enter the URL with the hash, voila!
