### PR TITLE
Better Support for Multiple Job Types

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -418,9 +418,13 @@ class WP_Job_Manager_CPT {
 
 		switch ( $column ) {
 			case "job_listing_type" :
-				$type = get_the_job_type( $post );
-				if ( $type )
-					echo '<span class="job-type ' . $type->slug . '">' . $type->name . '</span>';
+				$types = get_the_job_types( $post );
+
+				if ( $types && ! empty( $types ) ) {
+					foreach ( $types as $type ) {
+						echo '<span class="job-type ' . $type->slug . '">' . $type->name . '</span>';
+					}
+				}
 			break;
 			case "job_position" :
 				echo '<div class="job_position">';

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -418,7 +418,7 @@ class WP_Job_Manager_CPT {
 
 		switch ( $column ) {
 			case "job_listing_type" :
-				$types = get_the_job_types( $post );
+				$types = wpjm_get_the_job_types( $post );
 
 				if ( $types && ! empty( $types ) ) {
 					foreach ( $types as $type ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -437,16 +437,17 @@ class WP_Job_Manager_Post_Types {
 	 * Adds custom data to the job feed.
 	 */
 	public function job_feed_item() {
-		$post_id  = get_the_ID();
-		$location = get_the_job_location( $post_id );
-		$job_type = get_the_job_type( $post_id );
-		$company  = get_the_company_name( $post_id );
+		$post_id         = get_the_ID();
+		$location        = get_the_job_location( $post_id );
+		$company         = get_the_company_name( $post_id );
+		$job_types       = wpjm_get_the_job_types( $post_id );
 
 		if ( $location ) {
 			echo "<job_listing:location><![CDATA[" . esc_html( $location ) . "]]></job_listing:location>\n";
 		}
-		if ( $job_type ) {
-			echo "<job_listing:job_type><![CDATA[" . esc_html( $job_type->name ) . "]]></job_listing:job_type>\n";
+		if ( ! empty( $job_types ) ) {
+			$job_types_names = implode( ', ', wp_list_pluck( $job_types, 'name' ) );
+			echo "<job_listing:job_type><![CDATA[" . esc_html( $job_types_names ) . "]]></job_listing:job_type>\n";
 		}
 		if ( $company ) {
 			echo "<job_listing:company><![CDATA[" . esc_html( $company ) . "]]></job_listing:company>\n";

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -529,7 +529,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 			// Prepend with job type
 			if ( apply_filters( 'submit_job_form_prefix_post_name_with_job_type', true ) && ! empty( $values['job']['job_type'] ) ) {
-				if ( ! get_option( 'job_manager_multi_job_type', false ) ) {
+				if ( ! job_manager_multi_job_type() ) {
 					$job_slug[] = $values['job']['job_type'];
 				} else {
 					$terms = $values['job']['job_type'];

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -529,7 +529,19 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 			// Prepend with job type
 			if ( apply_filters( 'submit_job_form_prefix_post_name_with_job_type', true ) && ! empty( $values['job']['job_type'] ) ) {
-				$job_slug[] = $values['job']['job_type'];
+				if ( ! get_option( 'job_manager_multi_job_type', false ) ) {
+					$job_slug[] = $values['job']['job_type'];
+				} else {
+					$terms = $values['job']['job_type'];
+
+					foreach ( $terms as $term ) {
+						$term = get_term_by( 'id', intval( $term ), 'job_listing_type' );
+
+						if ( $term ) {
+							$job_slug[] = $term->slug;
+						}
+					}
+				}
 			}
 
 			$job_slug[]            = $post_title;

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -29,19 +29,10 @@ global $post; ?>
 			<?php do_action( 'job_listing_meta_start' ); ?>
 
 			<?php if ( get_option( 'job_manager_enable_types' ) ) { ?>
-				<?php if ( ! get_option( 'job_manager_multi_job_type', false ) ) : ?>
-
-					<li class="job-type <?php echo get_the_job_type() ? esc_attr( sanitize_title( get_the_job_type()->slug ) ) : ''; ?>" itemprop="employmentType"><?php the_job_type(); ?></li>
-
-				<?php else : $types = wpjm_get_the_job_types(); ?>
-
-					<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
-
-						<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
-
-					<?php endforeach; endif; ?>
-
-				<?php endif; ?>
+				<?php $types = wpjm_get_the_job_types(); ?>
+				<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
+					<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
+				<?php endforeach; endif; ?>
 			<?php } ?>
 
 			<li class="date"><?php the_job_publish_date(); ?></li>

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -1,4 +1,17 @@
-<?php global $post; ?>
+<?php
+/**
+ * Job listing in the loop.
+ *
+ * @since 1.0.0
+ * @version 1.26.2
+ *
+ * @package WP Job Manager
+ * @category Template
+ * @author Automattic
+ */
+
+global $post; ?>
+
 <li <?php job_listing_class(); ?> data-longitude="<?php echo esc_attr( $post->geolocation_lat ); ?>" data-latitude="<?php echo esc_attr( $post->geolocation_long ); ?>">
 	<a href="<?php the_job_permalink(); ?>">
 		<?php the_company_logo(); ?>
@@ -16,8 +29,21 @@
 			<?php do_action( 'job_listing_meta_start' ); ?>
 
 			<?php if ( get_option( 'job_manager_enable_types' ) ) { ?>
-			<li class="job-type <?php echo get_the_job_type() ? sanitize_title( get_the_job_type()->slug ) : ''; ?>"><?php the_job_type(); ?></li>
+				<?php if ( ! get_option( 'job_manager_multi_job_type', false ) ) : ?>
+
+					<li class="job-type <?php echo get_the_job_type() ? esc_attr( sanitize_title( get_the_job_type()->slug ) ) : ''; ?>" itemprop="employmentType"><?php the_job_type(); ?></li>
+
+				<?php else : $types = get_the_job_types(); ?>
+
+					<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
+
+						<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
+
+					<?php endforeach; endif; ?>
+
+				<?php endif; ?>
 			<?php } ?>
+
 			<li class="date"><?php the_job_publish_date(); ?></li>
 
 			<?php do_action( 'job_listing_meta_end' ); ?>

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -3,7 +3,7 @@
  * Job listing in the loop.
  *
  * @since 1.0.0
- * @version 1.26.2
+ * @version 1.26.3
  *
  * @package WP Job Manager
  * @category Template

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -33,7 +33,7 @@ global $post; ?>
 
 					<li class="job-type <?php echo get_the_job_type() ? esc_attr( sanitize_title( get_the_job_type()->slug ) ) : ''; ?>" itemprop="employmentType"><?php the_job_type(); ?></li>
 
-				<?php else : $types = get_the_job_types(); ?>
+				<?php else : $types = wpjm_get_the_job_types(); ?>
 
 					<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
 

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -20,19 +20,12 @@ do_action( 'single_job_listing_meta_before' ); ?>
 	<?php do_action( 'single_job_listing_meta_start' ); ?>
 
 	<?php if ( get_option( 'job_manager_enable_types' ) ) { ?>
-		<?php if ( ! get_option( 'job_manager_multi_job_type', false ) ) : ?>
+		<?php $types = wpjm_get_the_job_types(); ?>
+		<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
 
-			<li class="job-type <?php echo get_the_job_type() ? esc_attr( sanitize_title( get_the_job_type()->slug ) ) : ''; ?>" itemprop="employmentType"><?php the_job_type(); ?></li>
+			<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
 
-		<?php else : $types = wpjm_get_the_job_types(); ?>
-
-			<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
-
-				<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
-
-			<?php endforeach; endif; ?>
-
-		<?php endif; ?>
+		<?php endforeach; endif; ?>
 	<?php } ?>
 
 	<li class="location" itemprop="jobLocation"><?php the_job_location(); ?></li>

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -5,7 +5,7 @@
  * Hooked into single_job_listing_start priority 20
  *
  * @since 1.14.0
- * @version 1.26.2
+ * @version 1.26.3
  *
  * @package WP Job Manager
  * @category Template

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -24,7 +24,7 @@ do_action( 'single_job_listing_meta_before' ); ?>
 
 			<li class="job-type <?php echo get_the_job_type() ? esc_attr( sanitize_title( get_the_job_type()->slug ) ) : ''; ?>" itemprop="employmentType"><?php the_job_type(); ?></li>
 
-		<?php else : $types = get_the_job_types(); ?>
+		<?php else : $types = wpjm_get_the_job_types(); ?>
 
 			<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
 

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -4,8 +4,14 @@
  *
  * Hooked into single_job_listing_start priority 20
  *
- * @since  1.14.0
+ * @since 1.14.0
+ * @version 1.26.2
+ *
+ * @package WP Job Manager
+ * @category Template
+ * @author Automattic
  */
+
 global $post;
 
 do_action( 'single_job_listing_meta_before' ); ?>
@@ -14,7 +20,19 @@ do_action( 'single_job_listing_meta_before' ); ?>
 	<?php do_action( 'single_job_listing_meta_start' ); ?>
 
 	<?php if ( get_option( 'job_manager_enable_types' ) ) { ?>
-	<li class="job-type <?php echo get_the_job_type() ? sanitize_title( get_the_job_type()->slug ) : ''; ?>" itemprop="employmentType"><?php the_job_type(); ?></li>
+		<?php if ( ! get_option( 'job_manager_multi_job_type', false ) ) : ?>
+
+			<li class="job-type <?php echo get_the_job_type() ? esc_attr( sanitize_title( get_the_job_type()->slug ) ) : ''; ?>" itemprop="employmentType"><?php the_job_type(); ?></li>
+
+		<?php else : $types = get_the_job_types(); ?>
+
+			<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
+
+				<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
+
+			<?php endforeach; endif; ?>
+
+		<?php endif; ?>
 	<?php } ?>
 
 	<li class="location" itemprop="jobLocation"><?php the_job_location(); ?></li>

--- a/templates/content-summary-job_listing.php
+++ b/templates/content-summary-job_listing.php
@@ -2,7 +2,12 @@
 
 <a href="<?php the_permalink(); ?>">
 	<?php if ( get_option( 'job_manager_enable_types' ) ) { ?>
-	<div class="job-type <?php echo get_the_job_type() ? sanitize_title( get_the_job_type()->slug ) : ''; ?>"><?php the_job_type(); ?></div>
+		<?php $types = wpjm_get_the_job_types(); ?>
+		<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
+
+			<div class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>"><?php echo esc_html( $type->name ); ?></div>
+
+		<?php endforeach; endif; ?>
 	<?php } ?>
 
 	<?php if ( $logo = get_the_company_logo() ) : ?>

--- a/templates/content-widget-job_listing.php
+++ b/templates/content-widget-job_listing.php
@@ -7,7 +7,10 @@
 			<li class="location"><?php the_job_location( false ); ?></li>
 			<li class="company"><?php the_company_name(); ?></li>
 			<?php if ( get_option( 'job_manager_enable_types' ) ) { ?>
-			<li class="job-type <?php echo get_the_job_type() ? sanitize_title( get_the_job_type()->slug ) : ''; ?>"><?php the_job_type(); ?></li>
+				<?php $types = wpjm_get_the_job_types(); ?>
+				<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
+					<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>"><?php echo esc_html( $type->name ); ?></li>
+				<?php endforeach; endif; ?>
 			<?php } ?>
 		</ul>
 	</a>

--- a/wp-job-manager-deprecated.php
+++ b/wp-job-manager-deprecated.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Deprecated functions. Do not use these.
+ */
+
+if ( ! function_exists( 'order_featured_job_listing' ) ) :
+/**
+* Was used for sorting.
+*
+* @deprecated 1.22.4
+* @param array $args
+* @return array
+*/
+function order_featured_job_listing( $args ) {
+	global $wpdb;
+	$args['orderby'] = "$wpdb->posts.menu_order ASC, $wpdb->posts.post_date DESC";
+	return $args;
+}
+endif;
+
+
+
+if ( ! function_exists( 'the_job_type' ) ) :
+/**
+ * Displays the job type for the listing.
+ *
+ * @since 1.0.0
+ * @deprecated 1.26.3 Use `wpjm_the_job_types()` instead.
+ *
+ * @param int|WP_Post $post
+ * @return string
+ */
+function the_job_type( $post = null ) {
+	_deprecated_function( __FUNCTION__, '1.26.3', 'wpjm_the_job_types' );
+
+	if ( ! get_option( 'job_manager_enable_types' ) ) {
+		return '';
+	}
+	if ( $job_type = get_the_job_type( $post ) ) {
+		echo $job_type->name;
+	}
+}
+endif;
+
+if ( ! function_exists( 'get_the_job_type' ) ) :
+/**
+ * Gets the job type for the listing.
+ *
+ * @since 1.0.0
+ * @deprecated 1.26.3 Use `wpjm_get_the_job_types()` instead.
+ *
+ * @param int|WP_Post $post (default: null)
+ * @return string|bool|null
+ */
+function get_the_job_type( $post = null ) {
+	_deprecated_function( __FUNCTION__, '1.26.3', 'wpjm_get_the_job_types' );
+
+	$post = get_post( $post );
+	if ( $post->post_type !== 'job_listing' ) {
+		return;
+	}
+
+	$types = wp_get_post_terms( $post->ID, 'job_listing_type' );
+
+	if ( $types ) {
+		$type = current( $types );
+	} else {
+		$type = false;
+	}
+
+	return apply_filters( 'the_job_type', $type, $post );
+}
+endif;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -243,21 +243,6 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 	}
 endif;
 
-if ( ! function_exists( 'order_featured_job_listing' ) ) :
-	/**
-	 * Was used for sorting.
-	 *
-	 * @deprecated 1.22.4
-	 * @param array $args
-	 * @return array
-	 */
-	function order_featured_job_listing( $args ) {
-		global $wpdb;
-		$args['orderby'] = "$wpdb->posts.menu_order ASC, $wpdb->posts.post_date DESC";
-		return $args;
-	}
-endif;
-
 if ( ! function_exists( 'get_job_listing_post_statuses' ) ) :
 /**
  * Gets post statuses used for jobs.

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -326,15 +326,14 @@ function get_the_job_type( $post = null ) {
 /**
  * Displays multiple job types for the listing.
  *
- * @since 1.26.2
+ * @since 1.26.3
  *
  * @param int|WP_Post $post Current post object.
  * @param string      $separator String to join the term names with.
- * @return string
  */
-function the_job_types( $post = null, $separator = ', ' ) {
+function wpjm_the_job_types( $post = null, $separator = ', ' ) {
 	if ( ! get_option( 'job_manager_enable_types' ) ) {
-		return '';
+		return;
 	}
 
 	// Return single if not enabled.
@@ -342,7 +341,7 @@ function the_job_types( $post = null, $separator = ', ' ) {
 		return the_job_type( $post );
 	}
 
-	$job_types = get_the_job_types( $post );
+	$job_types = wpjm_get_the_job_types( $post );
 
 	if ( $job_types ) {
 		$names = wp_list_pluck( $job_types, 'name' );
@@ -354,12 +353,12 @@ function the_job_types( $post = null, $separator = ', ' ) {
 /**
  * Gets the job type for the listing.
  *
- * @since 1.26.2
+ * @since 1.26.3
  *
  * @param int|WP_Post $post (default: null).
- * @return false|array
+ * @return bool|array
  */
-function get_the_job_types( $post = null ) {
+function wpjm_get_the_job_types( $post = null ) {
 	$post = get_post( $post );
 
 	if ( 'job_listing' !== $post->post_type ) {

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -363,7 +363,7 @@ function wpjm_get_the_job_types( $post = null ) {
 	$types = get_the_terms( $post->ID, 'job_listing_type' );
 
 	// Return single if not enabled.
-	if ( ! empty( $types ) && ! get_option( 'job_manager_multi_job_type', false ) ) {
+	if ( ! empty( $types ) && ! job_manager_multi_job_type() ) {
 		$types = array( current( $types ) );
 	}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -323,6 +323,53 @@ function get_the_job_type( $post = null ) {
 	return apply_filters( 'the_job_type', $type, $post );
 }
 
+/**
+ * Displays multiple job types for the listing.
+ *
+ * @since 1.26.2
+ *
+ * @param int|WP_Post $post Current post object.
+ * @param string      $separator String to join the term names with.
+ * @return string
+ */
+function the_job_types( $post = null, $separator = ', ' ) {
+	if ( ! get_option( 'job_manager_enable_types' ) ) {
+		return '';
+	}
+
+	// Return single if not enabled.
+	if ( ! get_option( 'job_manager_multi_job_type', false ) ) {
+		return the_job_type( $post );
+	}
+
+	$job_types = get_the_job_types( $post );
+
+	if ( $job_types ) {
+		$names = wp_list_pluck( $job_types, 'name' );
+
+		echo esc_html( implode( $separator, $names ) );
+	}
+}
+
+/**
+ * Gets the job type for the listing.
+ *
+ * @since 1.26.2
+ *
+ * @param int|WP_Post $post (default: null).
+ * @return false|array
+ */
+function get_the_job_types( $post = null ) {
+	$post = get_post( $post );
+
+	if ( 'job_listing' !== $post->post_type ) {
+		return;
+	}
+
+	$types = get_the_terms( $post->ID, 'job_listing_type' );
+
+	return apply_filters( 'the_job_types', $types, $post );
+}
 
 /**
  * Displays the published date of the job listing.

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -287,10 +287,14 @@ function wpjm_get_the_job_title( $post = null ) {
  * Displays the job type for the listing.
  *
  * @since 1.0.0
+ * @deprecated 1.26.3 Use `wpjm_the_job_types()` instead.
+ *
  * @param int|WP_Post $post
  * @return string
  */
 function the_job_type( $post = null ) {
+	_deprecated_function( __FUNCTION__, '1.26.3', 'wpjm_the_job_types' );
+
 	if ( ! get_option( 'job_manager_enable_types' ) ) {
 		return '';
 	}
@@ -303,10 +307,14 @@ function the_job_type( $post = null ) {
  * Gets the job type for the listing.
  *
  * @since 1.0.0
+ * @deprecated 1.26.3 Use `wpjm_get_the_job_types()` instead.
+ *
  * @param int|WP_Post $post (default: null)
  * @return string|bool|null
  */
 function get_the_job_type( $post = null ) {
+	_deprecated_function( __FUNCTION__, '1.26.3', 'wpjm_get_the_job_types' );
+
 	$post = get_post( $post );
 	if ( $post->post_type !== 'job_listing' ) {
 		return;

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -357,7 +357,7 @@ function wpjm_get_the_job_types( $post = null ) {
 	$post = get_post( $post );
 
 	if ( 'job_listing' !== $post->post_type ) {
-		return;
+		return false;
 	}
 
 	$types = get_the_terms( $post->ID, 'job_listing_type' );
@@ -367,7 +367,15 @@ function wpjm_get_the_job_types( $post = null ) {
 		$types = array( current( $types ) );
 	}
 
-	return apply_filters( 'the_job_types', $types, $post );
+	/**
+	 * Filter the returned job types for a post.
+	 *
+	 * @since 1.26.3
+	 *
+	 * @param array   $types
+	 * @param WP_Post $post
+	 */
+	return apply_filters( 'wpjm_the_job_types', $types, $post );
 }
 
 /**

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -818,8 +818,13 @@ function wpjm_add_post_class( $classes, $class, $post_id ) {
 
 	$classes[] = 'job_listing';
 
-	if ( get_option( 'job_manager_enable_types' ) && ( $job_type = get_the_job_type( $post ) ) ) {
-		$classes[] = 'job-type-' . sanitize_title( $job_type->name );
+	if ( get_option( 'job_manager_enable_types' ) ) {
+		$job_types = wpjm_get_the_job_types( $post );
+		if ( ! empty( $job_types ) ) {
+			foreach ( $job_types as $job_type ) {
+				$classes[] = 'job-type-' . sanitize_title( $job_type->name );
+			}
+		}
 	}
 
 	if ( is_position_filled( $post ) ) {

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -284,54 +284,6 @@ function wpjm_get_the_job_title( $post = null ) {
 }
 
 /**
- * Displays the job type for the listing.
- *
- * @since 1.0.0
- * @deprecated 1.26.3 Use `wpjm_the_job_types()` instead.
- *
- * @param int|WP_Post $post
- * @return string
- */
-function the_job_type( $post = null ) {
-	_deprecated_function( __FUNCTION__, '1.26.3', 'wpjm_the_job_types' );
-
-	if ( ! get_option( 'job_manager_enable_types' ) ) {
-		return '';
-	}
-	if ( $job_type = get_the_job_type( $post ) ) {
-		echo $job_type->name;
-	}
-}
-
-/**
- * Gets the job type for the listing.
- *
- * @since 1.0.0
- * @deprecated 1.26.3 Use `wpjm_get_the_job_types()` instead.
- *
- * @param int|WP_Post $post (default: null)
- * @return string|bool|null
- */
-function get_the_job_type( $post = null ) {
-	_deprecated_function( __FUNCTION__, '1.26.3', 'wpjm_get_the_job_types' );
-
-	$post = get_post( $post );
-	if ( $post->post_type !== 'job_listing' ) {
-		return;
-	}
-
-	$types = wp_get_post_terms( $post->ID, 'job_listing_type' );
-
-	if ( $types ) {
-		$type = current( $types );
-	} else {
-		$type = false;
-	}
-
-	return apply_filters( 'the_job_type', $type, $post );
-}
-
-/**
  * Displays multiple job types for the listing.
  *
  * @since 1.26.3

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -363,7 +363,7 @@ function wpjm_get_the_job_types( $post = null ) {
 	$types = get_the_terms( $post->ID, 'job_listing_type' );
 
 	// Return single if not enabled.
-	if ( ! get_option( 'job_manager_multi_job_type', false ) ) {
+	if ( ! empty( $types ) && ! get_option( 'job_manager_multi_job_type', false ) ) {
 		$types = array( current( $types ) );
 	}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -336,11 +336,6 @@ function wpjm_the_job_types( $post = null, $separator = ', ' ) {
 		return;
 	}
 
-	// Return single if not enabled.
-	if ( ! get_option( 'job_manager_multi_job_type', false ) ) {
-		return the_job_type( $post );
-	}
-
 	$job_types = wpjm_get_the_job_types( $post );
 
 	if ( $job_types ) {
@@ -366,6 +361,11 @@ function wpjm_get_the_job_types( $post = null ) {
 	}
 
 	$types = get_the_terms( $post->ID, 'job_listing_type' );
+
+	// Return single if not enabled.
+	if ( ! get_option( 'job_manager_multi_job_type', false ) ) {
+		$types = array( current( $types ) );
+	}
 
 	return apply_filters( 'the_job_types', $types, $post );
 }

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -128,6 +128,7 @@ class WP_Job_Manager {
 	public function include_template_functions() {
 		include( 'wp-job-manager-functions.php' );
 		include( 'wp-job-manager-template.php' );
+		include( 'wp-job-manager-deprecated.php' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #854 
Fixes #928

#### Changes proposed in this Pull Request:

* Add the ability to output and fetch all job types for a listing.
* Output multiple job types in template files (if enabled).
* Output multiple job slugs in job listing URL (if enabled).
* Output multiple job types in WordPress admin view.

#### Testing instructions:

* Enable multiple job types in Job Listings > Settings
* Create a listing with multiple job types.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Fix: Full support for job listings with multiple job types.