### PR TITLE
cache post counts and fix counts not showing for custom menu labels

### DIFF
--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -23,6 +23,7 @@ class WP_Job_Manager_Cache_Helper {
 		add_action( 'create_term', array( __CLASS__, 'edited_term' ), 10, 3 );
 		add_action( 'delete_term', array( __CLASS__, 'edited_term' ), 10, 3 );
 		add_action( 'job_manager_clear_expired_transients', array( __CLASS__, 'clear_expired_transients' ), 10 );
+		add_action( 'transition_post_status', array( __CLASS__, 'maybe_clear_count_transients' ), 10, 3 );
 	}
 
 	/**
@@ -127,6 +128,105 @@ class WP_Job_Manager_Cache_Helper {
 				AND b.option_value < %s;";
 			$wpdb->query( $wpdb->prepare( $sql, $wpdb->esc_like( '_transient_jm_' ) . '%', $wpdb->esc_like( '_transient_timeout_jm_' ) . '%', time() ) );
 		}
+	}
+
+	/**
+	 * Maybe remove pending count transients
+	 *
+	 * When a supported post type status is updated, check if any cached count transients
+	 * need to be removed, and remove the
+	 *
+	 * @since 1.6.2
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public static function maybe_clear_count_transients( $new_status, $old_status, $post ) {
+		global $wpdb;
+
+		/**
+		 * Get supported post types for count caching
+		 *
+		 * @since 1.26.2
+		 *
+		 * @param string  $new_status New post status.
+		 * @param string  $old_status Old post status.
+		 * @param WP_Post $post       Post object.
+		 */
+		$post_types = apply_filters( 'job_manager_count_cache_supported_post_types', array( 'job_listing' ), $new_status, $old_status, $post );
+
+		// Only proceed when statuses do not match, and post type is supported post type
+		if ( $new_status === $old_status || ! in_array( $post->post_type, $post_types ) ) {
+			return;
+		}
+
+		/**
+		 * Get supported post statuses for count caching
+		 *
+		 * @since 1.26.2
+		 *
+		 * @param string  $new_status New post status.
+		 * @param string  $old_status Old post status.
+		 * @param WP_Post $post       Post object.
+		 */
+		$valid_statuses = apply_filters( 'job_manager_count_cache_supported_statuses', array( 'pending' ), $new_status, $old_status, $post );
+
+		$rlike = array();
+		// New status transient option name
+		if( in_array( $new_status, $valid_statuses ) ){
+			$rlike[] = "^_transient_jm_{$new_status}_{$post->post_type}_count_user_";
+		}
+		// Old status transient option name
+		if( in_array( $old_status, $valid_statuses ) ){
+			$rlike[] = "^_transient_jm_{$old_status}_{$post->post_type}_count_user_";
+		}
+
+		$sql        = $wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name RLIKE '%s'", implode('|', $rlike ) );
+		$transients = $wpdb->get_col( $sql );
+
+		// For each transient...
+		foreach ( $transients as $transient ) {
+			// Strip away the WordPress prefix in order to arrive at the transient key.
+			$key = str_replace( '_transient_', '', $transient );
+			// Now that we have the key, use WordPress core to the delete the transient.
+			delete_transient( $key );
+		}
+
+		// Sometimes transients are not in the DB, so we have to do this too:
+		wp_cache_flush();
+	}
+
+	/**
+	 * Get Listings Count from Cache
+	 *
+	 *
+	 * @since 1.26.2
+	 *
+	 * @param string $post_type
+	 * @param string $status
+	 * @param bool   $force Force update cache
+	 *
+	 * @return int
+	 */
+	public static function get_listings_count( $post_type = 'job_listing', $status = 'pending', $force = FALSE ) {
+
+		// Get user based cache transient
+		$user_id   = get_current_user_id();
+		$transient = "jm_{$status}_{$post_type}_count_user_{$user_id}";
+
+		// Set listings_count value from cache if exists, otherwise set to 0 as default
+		$status_count = ( $cached_count = get_transient( $transient ) ) ? $cached_count : 0;
+
+		// $cached_count will be false if transient does not exist
+		if ( $cached_count === FALSE || $force ) {
+			$count_posts = wp_count_posts( $post_type, 'readable' );
+			// Default to 0 $status if object does not have a value
+			$status_count = isset( $count_posts->$status ) ? $count_posts->$status : 0;
+			set_transient( $transient, $status_count );
+		}
+
+		return $status_count;
 	}
 }
 

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -136,7 +136,7 @@ class WP_Job_Manager_Cache_Helper {
 	 * When a supported post type status is updated, check if any cached count transients
 	 * need to be removed, and remove the
 	 *
-	 * @since 1.6.2
+	 * @since 1.26.3
 	 *
 	 * @param string  $new_status New post status.
 	 * @param string  $old_status Old post status.
@@ -148,13 +148,13 @@ class WP_Job_Manager_Cache_Helper {
 		/**
 		 * Get supported post types for count caching
 		 *
-		 * @since 1.26.2
+		 * @since 1.26.3
 		 *
 		 * @param string  $new_status New post status.
 		 * @param string  $old_status Old post status.
 		 * @param WP_Post $post       Post object.
 		 */
-		$post_types = apply_filters( 'job_manager_count_cache_supported_post_types', array( 'job_listing' ), $new_status, $old_status, $post );
+		$post_types = apply_filters( 'wpjm_count_cache_supported_post_types', array( 'job_listing' ), $new_status, $old_status, $post );
 
 		// Only proceed when statuses do not match, and post type is supported post type
 		if ( $new_status === $old_status || ! in_array( $post->post_type, $post_types ) ) {
@@ -164,13 +164,13 @@ class WP_Job_Manager_Cache_Helper {
 		/**
 		 * Get supported post statuses for count caching
 		 *
-		 * @since 1.26.2
+		 * @since 1.26.3
 		 *
 		 * @param string  $new_status New post status.
 		 * @param string  $old_status Old post status.
 		 * @param WP_Post $post       Post object.
 		 */
-		$valid_statuses = apply_filters( 'job_manager_count_cache_supported_statuses', array( 'pending' ), $new_status, $old_status, $post );
+		$valid_statuses = apply_filters( 'wpjm_count_cache_supported_statuses', array( 'pending' ), $new_status, $old_status, $post );
 
 		$rlike = array();
 		// New status transient option name
@@ -200,8 +200,7 @@ class WP_Job_Manager_Cache_Helper {
 	/**
 	 * Get Listings Count from Cache
 	 *
-	 *
-	 * @since 1.26.2
+	 * @since 1.26.3
 	 *
 	 * @param string $post_type
 	 * @param string $status
@@ -209,7 +208,7 @@ class WP_Job_Manager_Cache_Helper {
 	 *
 	 * @return int
 	 */
-	public static function get_listings_count( $post_type = 'job_listing', $status = 'pending', $force = FALSE ) {
+	public static function get_listings_count( $post_type = 'job_listing', $status = 'pending', $force = false ) {
 
 		// Get user based cache transient
 		$user_id   = get_current_user_id();
@@ -219,7 +218,7 @@ class WP_Job_Manager_Cache_Helper {
 		$status_count = ( $cached_count = get_transient( $transient ) ) ? $cached_count : 0;
 
 		// $cached_count will be false if transient does not exist
-		if ( $cached_count === FALSE || $force ) {
+		if ( $cached_count === false || $force ) {
 			$count_posts = wp_count_posts( $post_type, 'readable' );
 			// Default to 0 $status if object does not have a value
 			$status_count = isset( $count_posts->$status ) ? $count_posts->$status : 0;

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -277,17 +277,21 @@ class WP_Job_Manager_Post_Types {
 	public function admin_head() {
 		global $menu;
 
-		$plural     = __( 'Job Listings', 'wp-job-manager' );
-		$count_jobs = wp_count_posts( 'job_listing', 'readable' );
+		$pending_jobs = WP_Job_Manager_Cache_Helper::get_listings_count();
 
-		if ( ! empty( $menu ) && is_array( $menu ) ) {
-			foreach ( $menu as $key => $menu_item ) {
-				if ( strpos( $menu_item[0], $plural ) === 0 ) {
-					if ( $order_count = $count_jobs->pending ) {
-						$menu[ $key ][0] .= " <span class='awaiting-mod update-plugins count-$order_count'><span class='pending-count'>" . number_format_i18n( $count_jobs->pending ) . "</span></span>" ;
-					}
-					break;
-				}
+		// No need to go further if no pending jobs, menu is not set, or is not an array
+		if( empty( $pending_jobs ) || empty( $menu ) || ! is_array( $menu ) ){
+			return;
+		}
+
+		// Try to pull menu_name from post type object to support themes/plugins that change the menu string
+		$post_type = get_post_type_object( 'job_listing' );
+		$plural = isset( $post_type->labels, $post_type->labels->menu_name ) ? $post_type->labels->menu_name : __( 'Job Listings', 'wp-job-manager' );
+
+		foreach ( $menu as $key => $menu_item ) {
+			if ( strpos( $menu_item[0], $plural ) === 0 ) {
+				$menu[ $key ][0] .= " <span class='awaiting-mod update-plugins count-{$pending_jobs}'><span class='pending-count'>" . number_format_i18n( $pending_jobs ) . "</span></span>" ;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1023 Fixes #984 

Here's my first stab at caching the counts in transients to prevent unnecessary queries on every admin page load for counts.

#### Changes proposed in this Pull Request:

* For #1023 this PR uses the post type object to get the `menu_name` when looping through the menu to look for the correct one to update (with fallback to standard translation)

* For #984 this PR adds two static methods in cache helper class, one to return listing counts, with support for multiple post types, and statuses, and one to clear the transients when statuses are updated

So initially I was going to write this code to be specifically for Job Listings, but while doing so I realized that Resumes also uses counts (exactly the same as core), and it would prob be beneficial to write the code so caching could work with any other related post types or statuses as needed (ie, adding a count for say the Applications addon menu item)

Let me know what you guys think about this
