### PR TITLE
Escape job listing title in admin and templates

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -346,7 +346,7 @@ class WP_Job_Manager_CPT {
 			break;
 			case "job_position" :
 				echo '<div class="job_position">';
-				echo '<a href="' . admin_url('post.php?post=' . $post->ID . '&action=edit') . '" class="tips job_title" data-tip="' . sprintf( __( 'ID: %d', 'wp-job-manager' ), $post->ID ) . '">' . $post->post_title . '</a>';
+				echo '<a href="' . admin_url('post.php?post=' . $post->ID . '&action=edit') . '" class="tips job_title" data-tip="' . sprintf( __( 'ID: %d', 'wp-job-manager' ), $post->ID ) . '">' . esc_html( $post->post_title ) . '</a>';
 
 				echo '<div class="company">';
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -106,7 +106,7 @@ class WP_Job_Manager_Shortcodes {
 						update_post_meta( $job_id, '_filled', 1 );
 
 						// Message
-						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been filled', 'wp-job-manager' ), $job->post_title ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been filled', 'wp-job-manager' ), esc_html( $job->post_title ) ) . '</div>';
 						break;
 					case 'mark_not_filled' :
 						// Check status
@@ -118,14 +118,14 @@ class WP_Job_Manager_Shortcodes {
 						update_post_meta( $job_id, '_filled', 0 );
 
 						// Message
-						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been marked as not filled', 'wp-job-manager' ), $job->post_title ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been marked as not filled', 'wp-job-manager' ), esc_html( $job->post_title ) ) . '</div>';
 						break;
 					case 'delete' :
 						// Trash it
 						wp_trash_post( $job_id );
 
 						// Message
-						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been deleted', 'wp-job-manager' ), $job->post_title ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been deleted', 'wp-job-manager' ), esc_html( $job->post_title ) ) . '</div>';
 
 						break;
 					case 'duplicate' :
@@ -450,7 +450,7 @@ class WP_Job_Manager_Shortcodes {
 
 			<?php while ( $jobs->have_posts() ) : $jobs->the_post(); ?>
 
-				<h1><?php the_title(); ?></h1>
+				<h1><?php echo esc_html( get_the_title() ); ?></h1>
 
 				<?php get_job_manager_template_part( 'content-single', 'job_listing' ); ?>
 

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -3,7 +3,7 @@
 	<a href="<?php the_job_permalink(); ?>">
 		<?php the_company_logo(); ?>
 		<div class="position">
-			<h3><?php the_title(); ?></h3>
+			<h3><?php echo esc_html( get_the_title() ); ?></h3>
 			<div class="company">
 				<?php the_company_name( '<strong>', '</strong> ' ); ?>
 				<?php the_company_tagline( '<span class="tagline">', '</span>' ); ?>

--- a/templates/content-summary-job_listing.php
+++ b/templates/content-summary-job_listing.php
@@ -11,7 +11,7 @@
 
 	<div class="job_summary_content">
 
-		<h1><?php the_title(); ?></h1>
+		<h1><?php echo esc_html( get_the_title() ); ?></h1>
 
 		<p class="meta"><?php the_job_location( false ); ?> &mdash; <?php the_job_publish_date(); ?></p>
 

--- a/templates/content-widget-job_listing.php
+++ b/templates/content-widget-job_listing.php
@@ -1,7 +1,7 @@
 <li <?php job_listing_class(); ?>>
 	<a href="<?php the_job_permalink(); ?>">
 		<div class="position">
-			<h3><?php the_title(); ?></h3>
+			<h3><?php echo esc_html( get_the_title() ); ?></h3>
 		</div>
 		<ul class="meta">
 			<li class="location"><?php the_job_location( false ); ?></li>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -20,9 +20,9 @@
 							<td class="<?php echo esc_attr( $key ); ?>">
 								<?php if ('job_title' === $key ) : ?>
 									<?php if ( $job->post_status == 'publish' ) : ?>
-										<a href="<?php echo get_permalink( $job->ID ); ?>"><?php echo $job->post_title; ?></a>
+										<a href="<?php echo get_permalink( $job->ID ); ?>"><?php echo esc_html( $job->post_title ); ?></a>
 									<?php else : ?>
-										<?php echo $job->post_title; ?> <small>(<?php the_job_status( $job ); ?>)</small>
+										<?php echo esc_html( $job->post_title ); ?> <small>(<?php the_job_status( $job ); ?>)</small>
 									<?php endif; ?>
 									<ul class="job-dashboard-actions">
 										<?php

--- a/templates/job-preview.php
+++ b/templates/job-preview.php
@@ -5,7 +5,7 @@
 		<h2><?php _e( 'Preview', 'wp-job-manager' ); ?></h2>
 	</div>
 	<div class="job_listing_preview single_job_listing">
-		<h1><?php the_title(); ?></h1>
+		<h1><?php echo esc_html( get_the_title() ); ?></h1>
 
 		<?php get_job_manager_template_part( 'content-single', 'job_listing' ); ?>
 


### PR DESCRIPTION
Main fix is in the `class-wp-job-manager-cpt.php`. It appears standard for the post title to be escaped on WP admin contexts. I've also escaped it when used in templates. Many themes don't seem escape `post_title`, but this should help out with those that do.

p6r3EZ-mL-p2