### PR TITLE
Introduces `wpjm_the_job_title` filter and implements in WP admin and templates

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -162,10 +162,10 @@ class WP_Job_Manager_CPT {
 				$approved_jobs = array_map( 'absint', $approved_jobs );
 				$titles        = array();
 				foreach ( $approved_jobs as $job_id )
-					$titles[] = get_the_title( $job_id );
+					$titles[] = wpjm_get_the_job_title( $job_id );
 				echo '<div class="updated"><p>' . sprintf( __( '%s approved', 'wp-job-manager' ), '&quot;' . implode( '&quot;, &quot;', $titles ) . '&quot;' ) . '</p></div>';
 			} else {
-				echo '<div class="updated"><p>' . sprintf( __( '%s approved', 'wp-job-manager' ), '&quot;' . get_the_title( $approved_jobs ) . '&quot;' ) . '</p></div>';
+				echo '<div class="updated"><p>' . sprintf( __( '%s approved', 'wp-job-manager' ), '&quot;' . wpjm_get_the_job_title( $approved_jobs ) . '&quot;' ) . '</p></div>';
 			}
 		}
 	}
@@ -182,10 +182,10 @@ class WP_Job_Manager_CPT {
 				$expired_jobs = array_map( 'absint', $expired_jobs );
 				$titles        = array();
 				foreach ( $expired_jobs as $job_id )
-					$titles[] = get_the_title( $job_id );
+					$titles[] = wpjm_get_the_job_title( $job_id );
 				echo '<div class="updated"><p>' . sprintf( __( '%s expired', 'wp-job-manager' ), '&quot;' . implode( '&quot;, &quot;', $titles ) . '&quot;' ) . '</p></div>';
 			} else {
-				echo '<div class="updated"><p>' . sprintf( __( '%s expired', 'wp-job-manager' ), '&quot;' . get_the_title( $expired_jobs ) . '&quot;' ) . '</p></div>';
+				echo '<div class="updated"><p>' . sprintf( __( '%s expired', 'wp-job-manager' ), '&quot;' . wpjm_get_the_job_title( $expired_jobs ) . '&quot;' ) . '</p></div>';
 			}
 		}
 	}
@@ -346,7 +346,7 @@ class WP_Job_Manager_CPT {
 			break;
 			case "job_position" :
 				echo '<div class="job_position">';
-				echo '<a href="' . admin_url('post.php?post=' . $post->ID . '&action=edit') . '" class="tips job_title" data-tip="' . sprintf( __( 'ID: %d', 'wp-job-manager' ), $post->ID ) . '">' . esc_html( $post->post_title ) . '</a>';
+				echo '<a href="' . admin_url('post.php?post=' . $post->ID . '&action=edit') . '" class="tips job_title" data-tip="' . sprintf( __( 'ID: %d', 'wp-job-manager' ), $post->ID ) . '">' . wpjm_get_the_job_title() . '</a>';
 
 				echo '<div class="company">';
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -106,7 +106,7 @@ class WP_Job_Manager_Shortcodes {
 						update_post_meta( $job_id, '_filled', 1 );
 
 						// Message
-						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been filled', 'wp-job-manager' ), esc_html( $job->post_title ) ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been filled', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) . '</div>';
 						break;
 					case 'mark_not_filled' :
 						// Check status
@@ -118,14 +118,14 @@ class WP_Job_Manager_Shortcodes {
 						update_post_meta( $job_id, '_filled', 0 );
 
 						// Message
-						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been marked as not filled', 'wp-job-manager' ), esc_html( $job->post_title ) ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been marked as not filled', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) . '</div>';
 						break;
 					case 'delete' :
 						// Trash it
 						wp_trash_post( $job_id );
 
 						// Message
-						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been deleted', 'wp-job-manager' ), esc_html( $job->post_title ) ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . sprintf( __( '%s has been deleted', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) . '</div>';
 
 						break;
 					case 'duplicate' :
@@ -450,7 +450,7 @@ class WP_Job_Manager_Shortcodes {
 
 			<?php while ( $jobs->have_posts() ) : $jobs->the_post(); ?>
 
-				<h1><?php echo esc_html( get_the_title() ); ?></h1>
+				<h1><?php wpjm_the_job_title(); ?></h1>
 
 				<?php get_job_manager_template_part( 'content-single', 'job_listing' ); ?>
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -577,7 +577,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		$attachment     = array(
-			'post_title'   => get_the_title( $this->job_id ),
+			'post_title'   => wpjm_get_the_job_title( $this->job_id ),
 			'post_content' => '',
 			'post_status'  => 'inherit',
 			'post_parent'  => $this->job_id,

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -3,7 +3,7 @@
 	<a href="<?php the_job_permalink(); ?>">
 		<?php the_company_logo(); ?>
 		<div class="position">
-			<h3><?php echo esc_html( get_the_title() ); ?></h3>
+			<h3><?php wpjm_the_job_title(); ?></h3>
 			<div class="company">
 				<?php the_company_name( '<strong>', '</strong> ' ); ?>
 				<?php the_company_tagline( '<span class="tagline">', '</span>' ); ?>

--- a/templates/content-single-job_listing.php
+++ b/templates/content-single-job_listing.php
@@ -1,6 +1,6 @@
 <?php global $post; ?>
 <div class="single_job_listing" itemscope itemtype="http://schema.org/JobPosting">
-	<meta itemprop="title" content="<?php echo esc_attr( $post->post_title ); ?>" />
+	<meta itemprop="title" content="<?php echo esc_attr( wpjm_get_the_job_title( $post ) ); ?>" />
 
 	<?php if ( get_option( 'job_manager_hide_expired_content', 1 ) && 'expired' === $post->post_status ) : ?>
 		<div class="job-manager-info"><?php _e( 'This listing has expired.', 'wp-job-manager' ); ?></div>

--- a/templates/content-summary-job_listing.php
+++ b/templates/content-summary-job_listing.php
@@ -11,7 +11,7 @@
 
 	<div class="job_summary_content">
 
-		<h1><?php echo esc_html( get_the_title() ); ?></h1>
+		<h1><?php wpjm_the_job_title(); ?></h1>
 
 		<p class="meta"><?php the_job_location( false ); ?> &mdash; <?php the_job_publish_date(); ?></p>
 

--- a/templates/content-widget-job_listing.php
+++ b/templates/content-widget-job_listing.php
@@ -1,7 +1,7 @@
 <li <?php job_listing_class(); ?>>
 	<a href="<?php the_job_permalink(); ?>">
 		<div class="position">
-			<h3><?php echo esc_html( get_the_title() ); ?></h3>
+			<h3><?php wpjm_the_job_title(); ?></h3>
 		</div>
 		<ul class="meta">
 			<li class="location"><?php the_job_location( false ); ?></li>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -20,9 +20,9 @@
 							<td class="<?php echo esc_attr( $key ); ?>">
 								<?php if ('job_title' === $key ) : ?>
 									<?php if ( $job->post_status == 'publish' ) : ?>
-										<a href="<?php echo get_permalink( $job->ID ); ?>"><?php echo esc_html( $job->post_title ); ?></a>
+										<a href="<?php echo get_permalink( $job->ID ); ?>"><?php wpjm_the_job_title( $job ); ?></a>
 									<?php else : ?>
-										<?php echo esc_html( $job->post_title ); ?> <small>(<?php the_job_status( $job ); ?>)</small>
+										<?php wpjm_the_job_title( $job ); ?> <small>(<?php the_job_status( $job ); ?>)</small>
 									<?php endif; ?>
 									<ul class="job-dashboard-actions">
 										<?php

--- a/templates/job-preview.php
+++ b/templates/job-preview.php
@@ -5,7 +5,7 @@
 		<h2><?php _e( 'Preview', 'wp-job-manager' ); ?></h2>
 	</div>
 	<div class="job_listing_preview single_job_listing">
-		<h1><?php echo esc_html( get_the_title() ); ?></h1>
+		<h1><?php wpjm_the_job_title(); ?></h1>
 
 		<?php get_job_manager_template_part( 'content-single', 'job_listing' ); ?>
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -244,6 +244,45 @@ function get_the_job_application_method( $post = null ) {
 
 	return apply_filters( 'the_job_application_method', $method, $post );
 }
+
+/**
+ * Displays the job title for the listing.
+ *
+ * @since 1.26.3
+ * @param int|WP_Post $post
+ * @return string
+ */
+function wpjm_the_job_title( $post = null ) {
+	if ( $job_title = wpjm_get_the_job_title( $post ) ) {
+		echo $job_title;
+	}
+}
+
+/**
+ * Gets the job title for the listing.
+ *
+ * @since 1.26.3
+ * @param int|WP_Post $post (default: null)
+ * @return string|bool|null
+ */
+function wpjm_get_the_job_title( $post = null ) {
+	$post = get_post( $post );
+	if ( $post->post_type !== 'job_listing' ) {
+		return;
+	}
+
+	$title = esc_html( get_the_title( $post ) );
+
+	/**
+	 * Filter for the job title.
+	 *
+	 * @since 1.26.3
+	 * @param string      $title Title to be filtered.
+	 * @param int|WP_Post $post
+	 */
+	return apply_filters( 'wpjm_the_job_title', $title, $post );
+}
+
 /**
  * Displays the job type for the listing.
  *


### PR DESCRIPTION
Now that we're escaping `post_title` in WPJM, I wanted to add this filter to allow for plugins / themes to change the title in certain contexts. Our Applications plugin was affected by this. 

I'm using this filter in most places, including WP Admin. Be sure to check the context before changing the title.