### PR TITLE
Adds permalink settings for job post type and category/job type taxonomies

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -43,8 +43,23 @@ class WP_Job_Manager_Admin {
 
 		$this->settings_page = WP_Job_Manager_Settings::instance();
 
+		add_action( 'current_screen', array( $this, 'conditional_includes' ) );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+	}
+
+	/**
+	 * Include admin files conditionally.
+	 */
+	public function conditional_includes() {
+		if ( ! $screen = get_current_screen() ) {
+			return;
+		}
+		switch ( $screen->id ) {
+			case 'options-permalink' :
+				include( 'class-wp-job-manager-permalink-settings.php' );
+				break;
+		}
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -1,0 +1,130 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+/**
+ * Handles front admin page for WP Job Manager.
+ *
+ * @package wp-job-manager
+ * @see https://github.com/woocommerce/woocommerce/blob/3.0.8/includes/admin/class-wc-admin-permalink-settings.php  Based on WooCommerce's implementation.
+ * @since 1.26.3
+ */
+class WP_Job_Manager_Permalink_Settings {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var self
+	 * @since  1.26.3
+	 */
+	private static $_instance = null;
+
+	/**
+	 * Permalink settings.
+	 *
+	 * @var array
+	 * @since 1.26.3
+	 */
+	private $permalinks = array();
+
+	/**
+	 * Allows for accessing single instance of class. Class should only be constructed once per call.
+	 *
+	 * @since  1.26.3
+	 * @static
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->setup_fields();
+		$this->settings_save();
+		$this->permalinks = wpjm_get_permalink_structure();
+	}
+
+	public function setup_fields() {
+		add_settings_field(
+			'wpjm_job_base_slug',
+			__( 'Job base', 'wp-job-manager' ),
+			array( $this, 'job_base_slug_input' ),
+			'permalink',
+			'optional'
+		);
+		add_settings_field(
+			'wpjm_job_category_slug',
+			__( 'Job category base', 'wp-job-manager' ),
+			array( $this, 'job_category_slug_input' ),
+			'permalink',
+			'optional'
+		);
+		add_settings_field(
+			'wpjm_job_type_slug',
+			__( 'Job type base', 'wp-job-manager' ),
+			array( $this, 'job_type_slug_input' ),
+			'permalink',
+			'optional'
+		);
+	}
+
+	/**
+	 * Show a slug input box for job post type slug.
+	 */
+	public function job_base_slug_input() {
+		?>
+		<input name="wpjm_job_base_slug" type="text" class="regular-text code" value="<?php echo esc_attr( $this->permalinks['job_base'] ); ?>" placeholder="<?php echo esc_attr_x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' ) ?>" />
+		<?php
+	}
+
+	/**
+	 * Show a slug input box for job category slug.
+	 */
+	public function job_category_slug_input() {
+		?>
+		<input name="wpjm_job_category_slug" type="text" class="regular-text code" value="<?php echo esc_attr( $this->permalinks['category_base'] ); ?>" placeholder="<?php echo esc_attr_x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ) ?>" />
+		<?php
+	}
+
+	/**
+	 * Show a slug input box for job type slug.
+	 */
+	public function job_type_slug_input() {
+		?>
+		<input name="wpjm_job_type_slug" type="text" class="regular-text code" value="<?php echo esc_attr( $this->permalinks['type_base'] ); ?>" placeholder="<?php echo esc_attr_x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' ) ?>" />
+		<?php
+	}
+
+	/**
+	 * Save the settings.
+	 */
+	public function settings_save() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( isset( $_POST['permalink_structure'] ) ) {
+			if ( function_exists( 'switch_to_locale' ) ) {
+				switch_to_locale( get_locale() );
+			}
+
+			$permalinks                   = (array) get_option( 'wpjm_permalinks', array() );
+			$permalinks['job_base']       = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );
+			$permalinks['category_base']  = sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] );
+			$permalinks['type_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] );
+
+			update_option( 'wpjm_permalinks', $permalinks );
+
+			if ( function_exists( 'restore_current_locale' ) ) {
+				restore_current_locale();
+			}
+		}
+	}
+}
+
+WP_Job_Manager_Permalink_Settings::instance();

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -86,6 +86,7 @@ class WP_Job_Manager_Post_Types {
 
 		$admin_capability = 'manage_job_listings';
 
+		$permalink_structure = wpjm_get_permalink_structure();
 		/**
 		 * Taxonomies
 		 */
@@ -95,7 +96,7 @@ class WP_Job_Manager_Post_Types {
 
 			if ( current_theme_supports( 'job-manager-templates' ) ) {
 				$rewrite   = array(
-					'slug'         => _x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ),
+					'slug'         => $permalink_structure['category_rewrite_slug'],
 					'with_front'   => false,
 					'hierarchical' => false
 				);
@@ -144,7 +145,7 @@ class WP_Job_Manager_Post_Types {
 
 			if ( current_theme_supports( 'job-manager-templates' ) ) {
 				$rewrite   = array(
-					'slug'         => _x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' ),
+					'slug'         => $permalink_structure['type_rewrite_slug'],
 					'with_front'   => false,
 					'hierarchical' => false
 				);
@@ -199,7 +200,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		$rewrite     = array(
-			'slug'       => _x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' ),
+			'slug'       => $permalink_structure['job_rewrite_slug'],
 			'with_front' => false,
 			'feeds'      => true,
 			'pages'      => false

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -523,6 +523,38 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
 }
 endif;
 
+
+/**
+ * Retrieves permalink settings.
+ *
+ * @see https://github.com/woocommerce/woocommerce/blob/3.0.8/includes/wc-core-functions.php#L1573
+ * @since 2.7.3
+ * @return array
+ */
+function wpjm_get_permalink_structure() {
+	// Switch to the site's default locale, bypassing the active user's locale.
+	if ( function_exists( 'switch_to_locale' ) && did_action( 'admin_init' ) ) {
+		switch_to_locale( get_locale() );
+	}
+
+	$permalinks = wp_parse_args( (array) get_option( 'wpjm_permalinks', array() ), array(
+		'job_base'           => '',
+		'category_base'          => '',
+		'type_base'               => '',
+	) );
+
+	// Ensure rewrite slugs are set.
+	$permalinks['job_rewrite_slug']      = untrailingslashit( empty( $permalinks['job_base'] ) ? _x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' )                   : $permalinks['job_base'] );
+	$permalinks['category_rewrite_slug'] = untrailingslashit( empty( $permalinks['category_base'] ) ? _x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['category_base'] );
+	$permalinks['type_rewrite_slug']     = untrailingslashit( empty( $permalinks['type_base'] ) ? _x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' )             : $permalinks['tag_base'] );
+
+	// Restore the original locale.
+	if ( function_exists( 'restore_current_locale' ) && did_action( 'admin_init' ) ) {
+		restore_current_locale();
+	}
+	return $permalinks;
+}
+
 /**
  * Checks if the user can upload a file via the Ajax endpoint.
  *


### PR DESCRIPTION
Fixes #688; Fixes: #1018

#### Changes proposed in this Pull Request:

* Follows WooCommerce's implementation by adding custom permalink slug base settings for job types, job categories, and job post type. Eventually, it'd be nice to allow for full custom syntax like WC does for product posts.

#### Testing instructions:

* From WP Admin > Settings > Permalinks, change the slugs for job types, job categories, and the job post type. Verify those new permalinks work.
