### PR TITLE
Guest AJAX upload error alerts and handling

### DIFF
--- a/assets/js/ajax-file-upload.js
+++ b/assets/js/ajax-file-upload.js
@@ -41,7 +41,7 @@ jQuery(function($) {
 			fail: function (e, data) {
 				var $file_field     = $( this );
 				var $form           = $file_field.closest( 'form' );
-
+				
 				if ( data.errorThrown ) {
 					window.alert( data.errorThrown );
 				}
@@ -58,6 +58,11 @@ jQuery(function($) {
 				var image_types     = [ 'jpg', 'gif', 'png', 'jpeg', 'jpe' ];
 
 				data.context.remove();
+
+				// Handle JSON errors when success is false
+				if( typeof data.result.success !== 'undefined' && ! data.result.success ){
+					window.alert( data.result.data );
+				}
 
 				$.each(data.result.files, function(index, file) {
 					if ( file.error ) {

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -264,7 +264,7 @@ class WP_Job_Manager_Ajax {
 	 */
 	public function upload_file() {
 		if ( ! job_manager_user_can_upload_file_via_ajax() ) {
-			wp_send_json_error( new WP_Error( 'upload', __( 'You must be logged in to upload files using this method.', 'wp-job-manager' ) ) );
+			wp_send_json_error( __( 'You must be logged in to upload files using this method.', 'wp-job-manager' ) );
 			return;
 		}
 		$data = array(


### PR DESCRIPTION
#1043 

#### Changes proposed in this Pull Request:

* Return standard string error instead of `WP_Error` in `wp_send_json_error`
* Show alert window when `success` is false

This doesn't exactly solve the entire problem (which could be through template files or filter on fields), but at least gives the user some type of feedback instead of failing silently in the background.

Because the entire core WP Job Manager never actually calls `wp_send_json_success` the JS for file uploads doesn't have any handling for when `success` is false, which is what is returned by `wp_send_json_error`

When sending a `WP_Error` response it then responds with an array of errors, even though ours is only a single error, and as such, I remove it from using `WP_Error` to send just a simple string so we can alert the user with the error (without a bunch of code to handle arrays)

