### PR TITLE
Allow people to force the job application details to remain open

### DIFF
--- a/assets/js/job-application.js
+++ b/assets/js/job-application.js
@@ -1,6 +1,8 @@
 jQuery(document).ready(function($) {
 	// Slide toggle
-	$( '.application_details' ).hide();
+	if ( ! $( 'body' ).hasClass( 'job-application-details-keep-open' ) ) {
+		$('.application_details').hide();
+	}
 	$( '.application_button' ).click(function() {
 		$( '.application_details' ).slideToggle();
 	});

--- a/assets/js/job-application.min.js
+++ b/assets/js/job-application.min.js
@@ -1,1 +1,1 @@
-jQuery(document).ready(function(a){a(".application_details").hide(),a(".application_button").click(function(){a(".application_details").slideToggle()})});
+jQuery(document).ready(function(a){a("body").hasClass("job-application-details-keep-open")||a(".application_details").hide(),a(".application_button").click(function(){a(".application_details").slideToggle()})});


### PR DESCRIPTION
Fixes: #816 

As this issue only occurs with custom templates, I’ve just made it easier for folks to keep it open if necessary.

```
add_filter( 'body_class', function( $body_class ) {
	$body_class[] = 'job-application-details-keep-open';
	return $body_class;
} );
```