### PR TITLE
Move event scheduling to main class

### DIFF
--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -20,7 +20,6 @@ class WP_Job_Manager_Install {
 
 		self::init_user_roles();
 		self::default_terms();
-		self::schedule_cron();
 
 		// Redirect to setup screen for new installs
 		if ( ! get_option( 'wp_job_manager_version' ) ) {
@@ -133,17 +132,5 @@ class WP_Job_Manager_Install {
 		}
 
 		update_option( 'job_manager_installed_terms', 1 );
-	}
-
-	/**
-	 * Setup cron jobs.
-	 */
-	private static function schedule_cron() {
-		wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
-		wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
-		wp_clear_scheduled_hook( 'job_manager_clear_expired_transients' );
-		wp_schedule_event( time(), 'hourly', 'job_manager_check_for_expired_jobs' );
-		wp_schedule_event( time(), 'daily', 'job_manager_delete_old_previews' );
-		wp_schedule_event( time(), 'twicedaily', 'job_manager_clear_expired_transients' );
 	}
 }

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -78,6 +78,9 @@ class WP_Job_Manager {
 		$this->forms      = WP_Job_Manager_Forms::instance();
 		$this->post_types = WP_Job_Manager_Post_Types::instance();
 
+		// Schedule cron jobs
+		self::maybe_schedule_cron_jobs();
+
 		// Activation - works with symlinks
 		register_activation_hook( basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ ), array( $this, 'activate' ) );
 
@@ -138,6 +141,21 @@ class WP_Job_Manager {
 		include_once( 'includes/class-wp-job-manager-widget.php' );
 		include_once( 'includes/widgets/class-wp-job-manager-widget-recent-jobs.php' );
 		include_once( 'includes/widgets/class-wp-job-manager-widget-featured-jobs.php' );
+	}
+
+	/**
+	 * Schedule cron jobs for WPJM events.
+	 */
+	public static function maybe_schedule_cron_jobs() {
+		if ( ! wp_next_scheduled( 'job_manager_check_for_expired_jobs' ) ) {
+			wp_schedule_event( time(), 'hourly', 'job_manager_check_for_expired_jobs' );
+		}
+		if ( ! wp_next_scheduled( 'job_manager_delete_old_previews' ) ) {
+			wp_schedule_event( time(), 'daily', 'job_manager_delete_old_previews' );
+		}
+		if ( ! wp_next_scheduled( 'job_manager_clear_expired_transients' ) ) {
+			wp_schedule_event( time(), 'twicedaily', 'job_manager_clear_expired_transients' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Looking for other issues with expirations.

Fixes #983 

#### Changes proposed in this Pull Request (so far):

* Move schedule setting to main `WP_Job_Manager` class. It seems like it was dropping off and never getting reset.
