### PR TITLE
Removes job posting resume ID and key cookies at logout

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -84,8 +84,8 @@ abstract class WP_Job_Manager_Form {
 			get_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key', true ) == $_COOKIE['wp-job-manager-submitting-job-key']
 		) {
 			delete_post_meta( $_COOKIE[ 'wp-job-manager-submitting-job-id' ], '_submitting_key' );
-			setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-			setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+			setcookie( 'wp-job-manager-submitting-job-id', '', 0, COOKIEPATH, COOKIE_DOMAIN, false );
+			setcookie( 'wp-job-manager-submitting-job-key', '', 0, COOKIEPATH, COOKIE_DOMAIN, false );
 			wp_redirect( remove_query_arg( array( 'new', 'key' ), $_SERVER[ 'REQUEST_URI' ] ) );
 		}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -563,8 +563,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			if ( ! headers_sent() ) {
 				$submitting_key = uniqid();
 
-				setcookie( 'wp-job-manager-submitting-job-id', $this->job_id, false, COOKIEPATH, COOKIE_DOMAIN, false );
-				setcookie( 'wp-job-manager-submitting-job-key', $submitting_key, false, COOKIEPATH, COOKIE_DOMAIN, false );
+				setcookie( 'wp-job-manager-submitting-job-id', $this->job_id, 0, COOKIEPATH, COOKIE_DOMAIN, false );
+				setcookie( 'wp-job-manager-submitting-job-key', $submitting_key, 0, COOKIEPATH, COOKIE_DOMAIN, false );
 
 				update_post_meta( $this->job_id, '_submitting_key', $submitting_key );
 			}

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -97,6 +97,7 @@ class WP_Job_Manager {
 		add_action( 'widgets_init', array( $this, 'widgets_init' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
 		add_action( 'admin_init', array( $this, 'updater' ) );
+		add_action( 'wp_logout', array( $this, 'cleanup_job_posting_cookies' ) );
 	}
 
 	/**
@@ -155,6 +156,18 @@ class WP_Job_Manager {
 		}
 		if ( ! wp_next_scheduled( 'job_manager_clear_expired_transients' ) ) {
 			wp_schedule_event( time(), 'twicedaily', 'job_manager_clear_expired_transients' );
+		}
+	}
+
+	/**
+	 * Cleanup job posting cookies.
+	 */
+	public function cleanup_job_posting_cookies() {
+		if ( isset( $_COOKIE['wp-job-manager-submitting-job-id'] ) ) {
+			setcookie( 'wp-job-manager-submitting-job-id', '', 0, COOKIEPATH, COOKIE_DOMAIN, false );
+		}
+		if ( isset( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
+			setcookie( 'wp-job-manager-submitting-job-key', '', 0, COOKIEPATH, COOKIE_DOMAIN, false );
 		}
 	}
 


### PR DESCRIPTION
Fixes #826

#### Changes proposed in this Pull Request:

* Always treat these cookies as session cookies.
* Remove them on WordPress logout.

#### Testing instructions:

* Start a job listing but don't go past preview step.
* Logout and go back to job posting page. Verify you aren't resuming the previous listing.