### PR TITLE
Expiration meta field logic fixes.

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -597,10 +597,14 @@ class WP_Job_Manager_Writepanels {
 
 			// Expirey date
 			if ( '_job_expires' === $key ) {
-				if ( ! empty( $_POST[ $key ] ) ) {
-					update_post_meta( $post_id, $key, date( 'Y-m-d', strtotime( sanitize_text_field( $_POST[ $key ] ) ) ) );
+				if ( empty( $_POST[ $key ] ) ) {
+					if ( get_option( 'job_manager_submission_duration' ) ) {
+						update_post_meta( $post_id, $key, calculate_job_expiry( $post_id ) );
+					} else {
+						delete_post_meta( $post_id, $key );
+					}
 				} else {
-					update_post_meta( $post_id, $key, calculate_job_expiry( $post_id ) );
+					update_post_meta( $post_id, $key, date( 'Y-m-d', strtotime( sanitize_text_field( $_POST[ $key ] ) ) ) );
 				}
 			}
 


### PR DESCRIPTION
Fixes #1075 

#### Changes proposed in this Pull Request:

* If the "Expiration" field is blank allow an expiration to be deleted (if no global setting is entered).
* If the "Expiration" field is using a set value allow it to continue to be saved.

#### Testing instructions:

1. Create a new listing with no expiration date.
2. Save the listing.

-

1. Create a new listing with an expiration date.
2. Clear the expiration date.
3. Save the listing.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Fix: If the "Expiration" field is blank allow an expiration to be deleted (if no global setting is entered).
* Fix: If the "Expiration" field is using a set value allow it to continue to be saved.