### PR TITLE
Fix/rename mixtape prefix

### DIFF
--- a/.mixtapefile
+++ b/.mixtapefile
@@ -1,3 +1,3 @@
 sha=da21513ec58babe6f8ada1b8ccf21e39003e04b0
-prefix=WPJM_REST
+prefix=WP_Job_Manager_REST
 destination=lib/wpjm_rest

--- a/includes/rest-api/class-wp-job-manager-controllers-status.php
+++ b/includes/rest-api/class-wp-job-manager-controllers-status.php
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class WP_Job_Manager_Controllers_Status
  */
-class WP_Job_Manager_Controllers_Status extends WPJM_REST_Controller_Model
-	implements WPJM_REST_Interfaces_Controller {
+class WP_Job_Manager_Controllers_Status extends WP_Job_Manager_REST_Controller_Model
+	implements WP_Job_Manager_REST_Interfaces_Controller {
 
 
 	/**

--- a/includes/rest-api/class-wp-job-manager-data-stores-status.php
+++ b/includes/rest-api/class-wp-job-manager-data-stores-status.php
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class WP_Job_Manager_Data_Stores_Status
  */
-class WP_Job_Manager_Data_Stores_Status extends WPJM_REST_Data_Store_Abstract
-	implements WPJM_REST_Interfaces_Data_Store {
+class WP_Job_Manager_Data_Stores_Status extends WP_Job_Manager_REST_Data_Store_Abstract
+	implements WP_Job_Manager_REST_Interfaces_Data_Store {
 
 	/**
 	 * Get all the models (taking into account any filtering)
@@ -22,7 +22,7 @@ class WP_Job_Manager_Data_Stores_Status extends WPJM_REST_Data_Store_Abstract
 	 * @return WPJM_REST_Model_Collection
 	 */
 	public function get_entities( $filter = null ) {
-		return new WPJM_REST_Model_Collection( array( $this->get_entity( null ) ) );
+		return new WP_Job_Manager_REST_Model_Collection( array( $this->get_entity( null ) ) );
 	}
 
 	/**

--- a/includes/rest-api/class-wp-job-manager-filters-status.php
+++ b/includes/rest-api/class-wp-job-manager-filters-status.php
@@ -12,14 +12,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class WP_Job_Manager_Filters_Status
  */
-class WP_Job_Manager_Filters_Status extends WPJM_REST_Model_Declaration {
+class WP_Job_Manager_Filters_Status extends WP_Job_Manager_REST_Model_Declaration {
 
 	/**
 	 * Declare our fields
 	 *
-	 * @param  WPJM_REST_Model_Field_Declaration_Collection_Builder $def Def.
+	 * @param  WP_Job_Manager_REST_Model_Field_Declaration_Collection_Builder $def Def.
 	 * @return array
-	 * @throws WPJM_REST_Exception Exc.
+	 * @throws WP_Job_Manager_REST_Exception Exc.
 	 */
 	public function declare_fields( $def ) {
 		return array(
@@ -33,8 +33,8 @@ class WP_Job_Manager_Filters_Status extends WPJM_REST_Model_Declaration {
 	/**
 	 * Explode keys
 	 *
-	 * @param  WPJM_REST_Interfaces_Model $model Model.
-	 * @param  mixed                      $keys  The keys.
+	 * @param  WP_Job_Manager_REST_Interfaces_Model $model Model.
+	 * @param  mixed                                $keys  The keys.
 	 * @return array
 	 */
 	public function explode_keys( $model, $keys ) {

--- a/includes/rest-api/class-wp-job-manager-models-settings.php
+++ b/includes/rest-api/class-wp-job-manager-models-settings.php
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class WP_Job_Manager_Models_Settings
  */
-class WP_Job_Manager_Models_Settings extends WPJM_REST_Model_Declaration_Settings
-	implements WPJM_REST_Interfaces_Permissions_Provider {
+class WP_Job_Manager_Models_Settings extends WP_Job_Manager_REST_Model_Declaration_Settings
+	implements WP_Job_Manager_REST_Interfaces_Permissions_Provider {
 
 
 	/**
@@ -44,10 +44,10 @@ class WP_Job_Manager_Models_Settings extends WPJM_REST_Model_Declaration_Setting
 	/**
 	 * Adds validations to fields requiring page ids.
 	 *
-	 * @param string                                               $field_name    The fields name.
-	 * @param WPJM_REST_Model_Field_Declaration_Builder            $field_builder The field builder.
-	 * @param array                                                $field_data    The field data.
-	 * @param WPJM_REST_Model_Field_Declaration_Collection_Builder $def           The definition.
+	 * @param string                                                         $field_name    The fields name.
+	 * @param WP_Job_Manager_REST_Model_Field_Declaration_Builder            $field_builder The field builder.
+	 * @param array                                                          $field_data    The field data.
+	 * @param WP_Job_Manager_REST_Model_Field_Declaration_Collection_Builder $def           The definition.
 	 */
 	protected function on_field_setup( $field_name, $field_builder, $field_data, $def ) {
 		if ( in_array( $field_name, $this->get_fields_requiring_page_id_validation(), true ) ) {
@@ -59,7 +59,7 @@ class WP_Job_Manager_Models_Settings extends WPJM_REST_Model_Declaration_Setting
 	/**
 	 * Validates that a page_id points to a valid page.
 	 *
-	 * @param  WPJM_REST_Model_ValidationData $validation_data The data.
+	 * @param  WP_Job_Manager_REST_Model_ValidationData $validation_data The data.
 	 * @return bool|WP_Error
 	 */
 	public function validate_page_id_belongs_to_valid_page( $validation_data ) {

--- a/includes/rest-api/class-wp-job-manager-models-status.php
+++ b/includes/rest-api/class-wp-job-manager-models-status.php
@@ -12,14 +12,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class WP_Job_Manager_Models_Status
  */
-class WP_Job_Manager_Models_Status extends WPJM_REST_Model_Declaration
-	implements WPJM_REST_Interfaces_Permissions_Provider {
+class WP_Job_Manager_Models_Status extends WP_Job_Manager_REST_Model_Declaration
+	implements WP_Job_Manager_REST_Interfaces_Permissions_Provider {
 
 
 	/**
 	 * Declare our fields
 	 *
-	 * @param  WPJM_REST_Model_Field_Declaration_Collection_Builder $def Def.
+	 * @param  WP_Job_Manager_REST_Model_Field_Declaration_Collection_Builder $def Def.
 	 * @return array
 	 * @throws WPJM_REST_Exception Exc.
 	 */

--- a/includes/rest-api/class-wp-job-manager-permissions-any.php
+++ b/includes/rest-api/class-wp-job-manager-permissions-any.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class WP_Job_Manager_Permissions_Any
  */
-class WP_Job_Manager_Permissions_Any implements WPJM_REST_Interfaces_Permissions_Provider {
+class WP_Job_Manager_Permissions_Any implements WP_Job_Manager_REST_Interfaces_Permissions_Provider {
 
 	/**
 	 * Handle Permissions for a REST Controller Action

--- a/includes/rest-api/class-wp-job-manager-rest-api.php
+++ b/includes/rest-api/class-wp-job-manager-rest-api.php
@@ -23,7 +23,7 @@ class WP_Job_Manager_REST_API {
 	/**
 	 * Our bootstrap
 	 *
-	 * @var WPJM_REST_Bootstrap
+	 * @var WP_Job_Manager_REST_Bootstrap
 	 */
 	private $wpjm_rest_api;
 	/**
@@ -47,9 +47,9 @@ class WP_Job_Manager_REST_API {
 	 * Bootstrap our REST Api
 	 */
 	private function bootstrap() {
-		include_once $this->base_dir . 'lib/wpjm_rest/class-wpjm-rest-bootstrap.php';
+		include_once $this->base_dir . 'lib/wpjm_rest/class-wp-job-manager-rest-bootstrap.php';
 
-		$this->wpjm_rest_api = WPJM_REST_Bootstrap::create()->load();
+		$this->wpjm_rest_api = WP_Job_Manager_REST_Bootstrap::create()->load();
 
 		include_once 'class-wp-job-manager-models-settings.php';
 		include_once 'class-wp-job-manager-models-status.php';
@@ -60,9 +60,9 @@ class WP_Job_Manager_REST_API {
 	}
 
 	/**
-	 * Get WPJM_REST_Bootstrap
+	 * Get WP_Job_Manager_REST_Bootstrap
 	 *
-	 * @return WPJM_REST_Bootstrap
+	 * @return WP_Job_Manager_REST_Bootstrap
 	 */
 	public function get_bootstrap() {
 		return $this->wpjm_rest_api;
@@ -87,12 +87,12 @@ class WP_Job_Manager_REST_API {
 	/**
 	 * Define our REST API Models and Controllers
 	 *
-	 * @param WPJM_REST_Environment $env The Environment.
+	 * @param WP_Job_Manager_REST_Environment $env The Environment.
 	 */
 	public function define_api( $env ) {
 		// Models.
 		$env->define_model( 'WP_Job_Manager_Models_Settings' )
-			->with_data_store( $env->data_store( 'WPJM_REST_Data_Store_Option' ) );
+			->with_data_store( $env->data_store( 'WP_Job_Manager_REST_Data_Store_Option' ) );
 		$env->define_model( 'WP_Job_Manager_Models_Status' )
 			->with_data_store( $env->data_store( 'WP_Job_Manager_Data_Stores_Status' ) );
 		$env->define_model( 'WP_Job_Manager_Filters_Status' )
@@ -103,7 +103,7 @@ class WP_Job_Manager_REST_API {
 		$wpjm_v1->endpoint()
 			->for_model( $env->model( 'WP_Job_Manager_Models_Settings' ) )
 			->with_base( '/settings' )
-			->with_class( 'WPJM_REST_Controller_Settings' );
+			->with_class( 'WP_Job_Manager_REST_Controller_Settings' );
 		$wpjm_v1->endpoint()
 			->for_model( $env->model( 'WP_Job_Manager_Models_Status' ) )
 			->with_base( '/status' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

No logic changes, only renames and include file renames.

* Rename mixtape `WPJM_REST` prefix to `WP_Job_Manager_REST` as discussed in #1036 

#### Testing instructions:

* pull this repo and run `./scripts/build_mixtape.sh`
* No fatals, wpjm rest api works
