### PR TITLE
Remove `grunt package-unsafe`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -256,8 +256,7 @@ module.exports = function( grunt ){
 	grunt.registerTask( 'deploy', [ 'checkbranch:master', 'checkrepo', 'build', 'wp_deploy' ] );
 	grunt.registerTask( 'deploy-unsafe', [ 'build', 'wp_deploy' ] );
 
-	grunt.registerTask( 'package', [ 'checkbranch:master', 'checkrepo', 'build', 'zip' ] );
-	grunt.registerTask( 'package-unsafe', [ 'build', 'zip' ] );
+	grunt.registerTask( 'package', [ 'build', 'zip' ] );
 
 	// Register tasks
 	grunt.registerTask( 'default', [


### PR DESCRIPTION
It will always be run in unsafe, so just make that default.