### PR TITLE
Allow for editing multiple job types during job listing submission

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -385,7 +385,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 							$this->fields[ $group_key ][ $key ]['value'] = $job->post_content;
 						break;
 						case 'job_type' :
-							$this->fields[ $group_key ][ $key ]['value'] = current( wp_get_object_terms( $job->ID, 'job_listing_type', array( 'fields' => 'ids' ) ) );
+							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_type', array( 'fields' => 'ids' ) );
+							if ( ! job_manager_multi_job_type() ) {
+								$this->fields[ $group_key ][ $key ]['value'] = current( $this->fields[ $group_key ][ $key ]['value'] );
+							}
 						break;
 						case 'job_category' :
 							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_category', array( 'fields' => 'ids' ) );


### PR DESCRIPTION
Fixes: #1097

Fixes a bug where if a user went to edit a listing from the Preview step all but the first selected job type would remain selected.

Steps to test:
1) On the job submission form, select two or more job types.
2) Continue to preview the submission.
3) Click “Edit Listing” from the Preview step.
4) Verify the originally selected job type values remain selected.