### PR TITLE
Move new permalink function to `WP_Job_Manager_Post_Types`

### DIFF
--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -46,7 +46,7 @@ class WP_Job_Manager_Permalink_Settings {
 	public function __construct() {
 		$this->setup_fields();
 		$this->settings_save();
-		$this->permalinks = wpjm_get_permalink_structure();
+		$this->permalinks = WP_Job_Manager_Post_Types::get_permalink_structure();
 	}
 
 	public function setup_fields() {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -86,7 +86,8 @@ class WP_Job_Manager_Post_Types {
 
 		$admin_capability = 'manage_job_listings';
 
-		$permalink_structure = wpjm_get_permalink_structure();
+		$permalink_structure = WP_Job_Manager_Post_Types::get_permalink_structure();
+
 		/**
 		 * Taxonomies
 		 */
@@ -604,6 +605,37 @@ class WP_Job_Manager_Post_Types {
 				$data['post_name'] = $postarr['post_name'];
 		 }
 		 return $data;
+	}
+
+	/**
+	 * Retrieves permalink settings.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/blob/3.0.8/includes/wc-core-functions.php#L1573
+	 * @since 1.27.1
+	 * @return array
+	 */
+	public static function get_permalink_structure() {
+		// Switch to the site's default locale, bypassing the active user's locale.
+		if ( function_exists( 'switch_to_locale' ) && did_action( 'admin_init' ) ) {
+			switch_to_locale( get_locale() );
+		}
+
+		$permalinks = wp_parse_args( (array) get_option( 'wpjm_permalinks', array() ), array(
+			'job_base'           => '',
+			'category_base'          => '',
+			'type_base'               => '',
+		) );
+
+		// Ensure rewrite slugs are set.
+		$permalinks['job_rewrite_slug']      = untrailingslashit( empty( $permalinks['job_base'] ) ? _x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' )                   : $permalinks['job_base'] );
+		$permalinks['category_rewrite_slug'] = untrailingslashit( empty( $permalinks['category_base'] ) ? _x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['category_base'] );
+		$permalinks['type_rewrite_slug']     = untrailingslashit( empty( $permalinks['type_base'] ) ? _x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' )             : $permalinks['type_base'] );
+
+		// Restore the original locale.
+		if ( function_exists( 'restore_current_locale' ) && did_action( 'admin_init' ) ) {
+			restore_current_locale();
+		}
+		return $permalinks;
 	}
 
 	/**

--- a/wp-job-manager-deprecated.php
+++ b/wp-job-manager-deprecated.php
@@ -71,3 +71,16 @@ function get_the_job_type( $post = null ) {
 	return apply_filters( 'the_job_type', $type, $post );
 }
 endif;
+
+if ( ! function_exists( 'wpjm_get_permalink_structure' ) ) :
+/**
+ * Retrieves permalink settings. Moved to `WP_Job_Manager_Post_Types` class in 1.27.1.
+ *
+ * @since 1.27.0
+ * @deprecated 1.27.1
+ * @return array
+ */
+function wpjm_get_permalink_structure() {
+	return WP_Job_Manager_Post_Types::get_permalink_structure();
+}
+endif;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -521,38 +521,6 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
 }
 endif;
 
-
-/**
- * Retrieves permalink settings.
- *
- * @see https://github.com/woocommerce/woocommerce/blob/3.0.8/includes/wc-core-functions.php#L1573
- * @since 2.7.3
- * @return array
- */
-function wpjm_get_permalink_structure() {
-	// Switch to the site's default locale, bypassing the active user's locale.
-	if ( function_exists( 'switch_to_locale' ) && did_action( 'admin_init' ) ) {
-		switch_to_locale( get_locale() );
-	}
-
-	$permalinks = wp_parse_args( (array) get_option( 'wpjm_permalinks', array() ), array(
-		'job_base'           => '',
-		'category_base'          => '',
-		'type_base'               => '',
-	) );
-
-	// Ensure rewrite slugs are set.
-	$permalinks['job_rewrite_slug']      = untrailingslashit( empty( $permalinks['job_base'] ) ? _x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' )                   : $permalinks['job_base'] );
-	$permalinks['category_rewrite_slug'] = untrailingslashit( empty( $permalinks['category_base'] ) ? _x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['category_base'] );
-	$permalinks['type_rewrite_slug']     = untrailingslashit( empty( $permalinks['type_base'] ) ? _x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' )             : $permalinks['type_base'] );
-
-	// Restore the original locale.
-	if ( function_exists( 'restore_current_locale' ) && did_action( 'admin_init' ) ) {
-		restore_current_locale();
-	}
-	return $permalinks;
-}
-
 /**
  * Checks if the user can upload a file via the Ajax endpoint.
  *

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -58,8 +58,6 @@ class WP_Job_Manager {
 		define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 
 		// Includes
-		include_once( 'wp-job-manager-functions.php' );
-		include_once( 'wp-job-manager-deprecated.php' );
 		include_once( 'includes/class-wp-job-manager-install.php' );
 		include_once( 'includes/class-wp-job-manager-post-types.php' );
 		include_once( 'includes/class-wp-job-manager-ajax.php' );
@@ -132,6 +130,8 @@ class WP_Job_Manager {
 	 * Loads plugin's core helper template functions.
 	 */
 	public function include_template_functions() {
+		include_once( 'wp-job-manager-deprecated.php' );
+		include_once( 'wp-job-manager-functions.php' );
 		include_once( 'wp-job-manager-template.php' );
 	}
 


### PR DESCRIPTION
Fixes #1103 

#### Changes proposed in this Pull Request:

* As `wpjm_get_permalink_structure()` was the only function used in `init`, I'm moving it to a static method in `WP_Job_Manager_Post_Types`. 
* With that gone, I'm restoring the inclusion of the functions file to the `after_setup_theme` action. 

#### Testing instructions:

* Go through the process of updating permalinks in WP Admin > Settings > Permalinks. Verify you are able to view job listings/categories/tags still.