### PR TITLE
Add employment type meta field to job type terms

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -51,9 +51,17 @@ class WP_Job_Manager_Admin {
 
 		$this->settings_page = WP_Job_Manager_Settings::instance();
 
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'current_screen', array( $this, 'conditional_includes' ) );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+	}
+
+	/**
+	 * Set up actions during admin initialization.
+	 */
+	public function admin_init() {
+		include_once( 'class-wp-job-manager-taxonomy-meta.php' );
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-taxonomy-meta.php
+++ b/includes/admin/class-wp-job-manager-taxonomy-meta.php
@@ -1,0 +1,156 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles taxonomy meta custom fields. Just used for job type.
+ *
+ * @package wp-job-manager
+ * @since 1.28.0
+ */
+class WP_Job_Manager_Taxonomy_Meta {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var self
+	 * @since  1.28.0
+	 */
+	private static $_instance = null;
+
+	/**
+	 * Allows for accessing single instance of class. Class should only be constructed once per call.
+	 *
+	 * @since  1.28.0
+	 * @static
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * WP_Job_Manager_Taxonomy_Meta constructor.
+	 */
+	public function __construct() {
+		if ( wpjm_job_listing_employment_type_enabled() ) {
+			add_action( 'job_listing_type_edit_form_fields', array( $this, 'display_schema_org_employment_type_field' ), 10, 2 );
+			add_action( 'job_listing_type_add_form_fields', array( $this, 'add_form_display_schema_org_employment_type_field' ), 10 );
+			add_action( 'edited_job_listing_type', array( $this, 'set_schema_org_employment_type_field' ), 10, 2 );
+			add_action( 'created_job_listing_type', array( $this, 'set_schema_org_employment_type_field' ), 10, 2 );
+			add_filter( 'manage_edit-job_listing_type_columns', array( $this, 'add_employment_type_column' ) );
+			add_filter( 'manage_job_listing_type_custom_column', array( $this, 'add_employment_type_column_content' ), 10, 3 );
+			add_filter( 'manage_edit-job_listing_type_sortable_columns', array( $this, 'add_employment_type_column_sortable' ) );
+	    }
+	}
+
+	/**
+	 * Set the employment type field when creating/updating a job type item.
+	 *
+	 * @param int $term_id Term ID.
+	 * @param int $tt_id   Taxonomy type ID.
+	 */
+	public function set_schema_org_employment_type_field( $term_id, $tt_id ) {
+		$employment_types = wpjm_job_listing_employment_type_options();
+		if( isset( $_POST['employment_type'] ) && isset( $employment_types[ $_POST['employment_type'] ] ) ){
+			update_term_meta( $term_id, 'employment_type', $_POST['employment_type'] );
+		} elseif ( isset( $_POST['employment_type'] ) ) {
+			delete_term_meta( $term_id, 'employment_type' );
+		}
+	}
+
+	/**
+	 * Add the option to select schema.org employmentType for job type on the edit meta field form.
+	 *
+	 * @param WP_Term $term     Term object.
+	 * @param string  $taxonomy Taxonomy slug.
+	 */
+	public function display_schema_org_employment_type_field( $term, $taxonomy ) {
+		$employment_types = wpjm_job_listing_employment_type_options();
+		$current_employment_type = get_term_meta( $term->term_id, 'employment_type', true );
+
+		if ( ! empty( $employment_types ) ) {
+			?>
+			<tr class="form-field term-group-wrap">
+			<th scope="row"><label for="feature-group"><?php _e( 'Employment Type', 'wp-job-manager' ); ?></label></th>
+			<td><select class="postform" id="employment_type" name="employment_type">
+					<option value=""></option>
+					<?php foreach ( $employment_types as $key => $employment_type ) : ?>
+						<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $current_employment_type, $key ); ?>><?php echo esc_html( $employment_type ); ?></option>
+					<?php endforeach; ?>
+				</select></td>
+			</tr><?php
+		}
+	}
+
+	/**
+	 * Add the option to select schema.org employmentType for job type on the add meta field form.
+	 *
+	 * @param string       $taxonomy Taxonomy slug.
+	 */
+	public function add_form_display_schema_org_employment_type_field( $taxonomy ) {
+		$employment_types = wpjm_job_listing_employment_type_options();
+
+		if ( ! empty( $employment_types ) ) {
+			?>
+			<div class="form-field term-group">
+			<label for="feature-group"><?php _e( 'Employment Type', 'wp-job-manager' ); ?></label>
+			<select class="postform" id="employment_type" name="employment_type">
+					<option value=""></option>
+					<?php foreach ( $employment_types as $key => $employment_type ) : ?>
+						<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $employment_type ); ?></option>
+					<?php endforeach; ?>
+				</select>
+			</div><?php
+		}
+	}
+
+	/**
+	 * Adds the Employment Type column when listing job type terms in WP Admin.
+	 *
+	 * @param array $columns
+	 * @return array
+	 */
+	public function add_employment_type_column( $columns ) {
+		$columns['employment_type'] = __( 'Employment Type', 'wp-job-manager' );
+		return $columns;
+	}
+
+	/**
+	 * Adds the Employment Type column as a sortable column when listing job type terms in WP Admin.
+	 *
+	 * @param array $sortable
+	 * @return array
+	 */
+	public function add_employment_type_column_sortable( $sortable ) {
+		$sortable['employment_type'] = 'employment_type';
+		return $sortable;
+	}
+
+	/**
+	 * Adds the Employment Type column content when listing job type terms in WP Admin.
+	 *
+	 * @param string $content
+	 * @param string $column_name
+	 * @param int    $term_id
+	 * @return string
+	 */
+	public function add_employment_type_column_content( $content, $column_name, $term_id ) {
+		if( 'employment_type' !== $column_name ){
+			return $content;
+		}
+		$employment_types = wpjm_job_listing_employment_type_options();
+		$term_id = absint( $term_id );
+		$term_employment_type = get_term_meta( $term_id, 'employment_type', true );
+
+		if ( ! empty( $term_employment_type ) && isset( $employment_types[ $term_employment_type ] ) ) {
+			$content .= esc_attr( $employment_types[ $term_employment_type ] );
+		}
+		return $content;
+	}
+}
+
+WP_Job_Manager_Taxonomy_Meta::instance();

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -32,6 +32,11 @@ class WP_Job_Manager_Install {
 			$wpdb->query( "UPDATE {$wpdb->posts} p LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id SET p.menu_order = -1 WHERE pm.meta_key = '_featured' AND pm.meta_value='1' AND p.post_type='job_listing';" );
 		}
 
+		// Update default term meta with employment types
+		if ( version_compare( get_option( 'wp_job_manager_version', JOB_MANAGER_VERSION ), '1.28.0', '<' ) ) {
+			self::add_employment_types();
+		}
+
 		// Update legacy options
 		if ( false === get_option( 'job_manager_submit_job_form_page_id', false ) && get_option( 'job_manager_submit_page_slug' ) ) {
 			$page_id = get_page_by_path( get_option( 'job_manager_submit_page_slug' ) )->ID;
@@ -106,31 +111,73 @@ class WP_Job_Manager_Install {
 	}
 
 	/**
-	 * Returns the default Job Manager terms.
+	 * Sets up the default WP Job Manager terms.
 	 */
 	private static function default_terms() {
 		if ( get_option( 'job_manager_installed_terms' ) == 1 ) {
 			return;
 		}
 
-		$taxonomies = array(
-			'job_listing_type' => array(
-				'Full Time',
-				'Part Time',
-				'Temporary',
-				'Freelance',
-				'Internship'
-			)
-		);
-
+		$taxonomies = self::get_default_taxonomy_terms();
 		foreach ( $taxonomies as $taxonomy => $terms ) {
-			foreach ( $terms as $term ) {
+			foreach ( $terms as $term => $meta ) {
 				if ( ! get_term_by( 'slug', sanitize_title( $term ), $taxonomy ) ) {
-					wp_insert_term( $term, $taxonomy );
+					$tt_package = wp_insert_term( $term, $taxonomy );
+					if ( is_array( $tt_package ) && isset( $tt_package['term_id'] ) && ! empty( $meta ) ) {
+						foreach ( $meta as $meta_key => $meta_value ) {
+							add_term_meta( $tt_package['term_id'], $meta_key, $meta_value );
+						}
+					}
 				}
 			}
 		}
 
 		update_option( 'job_manager_installed_terms', 1 );
+	}
+
+	/**
+	 * Default taxonomy terms to set up in WP Job Manager.
+	 *
+	 * @return array Default taxonomy terms.
+	 */
+	private static function get_default_taxonomy_terms() {
+		return array(
+			'job_listing_type' => array(
+				'Full Time' => array(
+					'employment_type' => 'FULL_TIME',
+				),
+				'Part Time' => array(
+					'employment_type' => 'PART_TIME',
+				),
+				'Temporary' => array(
+					'employment_type' => 'TEMPORARY',
+				),
+				'Freelance' => array(
+					'employment_type' => 'CONTRACTOR',
+				),
+				'Internship' => array(
+					'employment_type' => 'INTERN',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Adds the employment type to default job types when updating from a previous WP Job Manager version.
+	 */
+	private static function add_employment_types() {
+		$taxonomies = self::get_default_taxonomy_terms();
+		$terms = $taxonomies['job_listing_type'];
+
+		foreach ( $terms as $term => $meta ) {
+			$term = get_term_by( 'slug', sanitize_title( $term ), 'job_listing_type' );
+			if ( $term ) {
+				foreach ( $meta as $meta_key => $meta_value ) {
+					if ( ! get_term_meta( (int) $term->term_id, $meta_key, true ) ) {
+						add_term_meta( (int) $term->term_id, $meta_key, $meta_value );
+					}
+				}
+			}
+		}
 	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -650,7 +650,7 @@ function wpjm_job_listing_employment_type_enabled() {
 	 *
 	 * @param bool True if employment type meta field is enabled on job type terms.
 	 */
-	return apply_filters( 'wpjm_job_listing_employment_type_enabled', true );
+	return apply_filters( 'wpjm_job_listing_employment_type_enabled', get_option( 'job_manager_enable_types' ) ? true : false );
 }
 
 /**

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -606,6 +606,54 @@ function wpjm_use_standard_password_setup_email() {
 }
 
 /**
+ * Returns the list of employment types from Google's modification of schema.org's employmentType.
+ *
+ * @since 1.28.0
+ * @see https://developers.google.com/search/docs/data-types/job-postings#definitions
+ *
+ * @return array
+ */
+function wpjm_job_listing_employment_type_options() {
+	$employment_types = array();
+	$employment_types['FULL_TIME'] = __( 'Full Time', 'wp-job-manager' );
+	$employment_types['PART_TIME'] = __( 'Part Time', 'wp-job-manager' );
+	$employment_types['CONTRACTOR'] = __( 'Contractor', 'wp-job-manager' );
+	$employment_types['TEMPORARY'] = __( 'Temporary', 'wp-job-manager' );
+	$employment_types['INTERN'] = __( 'Intern', 'wp-job-manager' );
+	$employment_types['VOLUNTEER'] = __( 'Volunteer', 'wp-job-manager' );
+	$employment_types['PER_DIEM'] = __( 'Per Diem', 'wp-job-manager' );
+	$employment_types['OTHER'] = __( 'Other', 'wp-job-manager' );
+
+	/**
+	 * Filter the list of employment types.
+	 *
+	 * @since 1.28.0
+	 *
+	 * @param array List of employment types { string $key => string $label }.
+	 */
+	return apply_filters( 'wpjm_job_listing_employment_type_options', $employment_types );
+}
+
+
+/**
+ * Check if employment type meta fields are enabled on job type terms.
+ *
+ * @since 1.28.0
+ *
+ * @return bool
+ */
+function wpjm_job_listing_employment_type_enabled() {
+	/**
+	 * Filter whether employment types are enabled for job type terms.
+	 *
+	 * @since 1.28.0
+	 *
+	 * @param bool True if employment type meta field is enabled on job type terms.
+	 */
+	return apply_filters( 'wpjm_job_listing_employment_type_enabled', true );
+}
+
+/**
  * Checks if a password should be auto-generated for new users.
  *
  * @since 1.27.0


### PR DESCRIPTION
Fixes #1052 

#### Changes proposed in this Pull Request:

* In preparation for #1046, this PR adds Google's preset definitions for employment types. Admins can map job type taxonomy terms to Google's defined employment types.
* Will attempt to map terms that were set up using WPJM's defaults on update.

See: `employmentType` in [Google's Job Posting definition
](https://developers.google.com/search/docs/data-types/job-postings#definitions)

#### Testing instructions:

* Create a new job type set to an employment type. Edit the new employment type and verify the new setting was saved.
* Edit an existing job type and verify the employment type was updated.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Allows job types to be mapped to an employment type as defined for Google Job Search.

![screen shot 2017-07-25 at 7 13 21 pm](https://user-images.githubusercontent.com/68693/28586964-67b9a350-716d-11e7-9816-b8e62b55613f.png)
<img width="146" alt="screen shot 2017-07-25 at 7 14 25 pm" src="https://user-images.githubusercontent.com/68693/28586999-8475db44-716d-11e7-87c2-bc1872340543.png">
