### PR TITLE
Improve support for Google Job Search with JobPosting structured data

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -44,6 +44,8 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'auto-draft_to_publish', array( $this, 'set_expiry' ) );
 		add_action( 'expired_to_publish', array( $this, 'set_expiry' ) );
 
+		add_action( 'wp_footer', array( $this, 'output_structured_data' ) );
+
 		add_filter( 'the_job_description', 'wptexturize'        );
 		add_filter( 'the_job_description', 'convert_smilies'    );
 		add_filter( 'the_job_description', 'convert_chars'      );
@@ -728,6 +730,22 @@ class WP_Job_Manager_Post_Types {
 		if ( empty( $post ) || 'job_listing' === $post->post_type ) {
 			add_post_meta( $post_id, '_filled', 0, true );
 			add_post_meta( $post_id, '_featured', 0, true );
+		}
+	}
+
+	public function output_structured_data() {
+		if ( ! is_single() ) {
+			return;
+		}
+
+		$post = get_post();
+		if ( ! $post || $post->post_type !== 'job_listing' ) {
+			return;
+		}
+
+		$structured_data = wpjm_get_job_listing_structured_data();
+		if ( ! empty( $structured_data ) ) {
+			echo '<script type="application/ld+json">' . wp_json_encode( $structured_data ) . '</script>';
 		}
 	}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -738,8 +738,7 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
-		$post = get_post();
-		if ( ! $post || $post->post_type !== 'job_listing' ) {
+		if ( ! wpjm_output_job_listing_structured_data() ) {
 			return;
 		}
 

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -31,7 +31,7 @@ global $post; ?>
 			<?php if ( get_option( 'job_manager_enable_types' ) ) { ?>
 				<?php $types = wpjm_get_the_job_types(); ?>
 				<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
-					<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
+					<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>"><?php echo esc_html( $type->name ); ?></li>
 				<?php endforeach; endif; ?>
 			<?php } ?>
 

--- a/templates/content-single-job_listing-company.php
+++ b/templates/content-single-job_listing-company.php
@@ -11,15 +11,15 @@ if ( ! get_the_company_name() ) {
 	return;
 }
 ?>
-<div class="company" itemscope itemtype="http://data-vocabulary.org/Organization">
+<div class="company">
 	<?php the_company_logo(); ?>
 
 	<p class="name">
 		<?php if ( $website = get_the_company_website() ) : ?>
-			<a class="website" href="<?php echo esc_url( $website ); ?>" itemprop="url" target="_blank" rel="nofollow"><?php _e( 'Website', 'wp-job-manager' ); ?></a>
+			<a class="website" href="<?php echo esc_url( $website ); ?>" target="_blank" rel="nofollow"><?php _e( 'Website', 'wp-job-manager' ); ?></a>
 		<?php endif; ?>
 		<?php the_company_twitter(); ?>
-		<?php the_company_name( '<strong itemprop="name">', '</strong>' ); ?>
+		<?php the_company_name( '<strong>', '</strong>' ); ?>
 	</p>
 	<?php the_company_tagline( '<p class="tagline">', '</p>' ); ?>
 	<?php the_company_video(); ?>

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -23,14 +23,14 @@ do_action( 'single_job_listing_meta_before' ); ?>
 		<?php $types = wpjm_get_the_job_types(); ?>
 		<?php if ( ! empty( $types ) ) : foreach ( $types as $type ) : ?>
 
-			<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>" itemprop="employmentType"><?php echo esc_html( $type->name ); ?></li>
+			<li class="job-type <?php echo esc_attr( sanitize_title( $type->slug ) ); ?>"><?php echo esc_html( $type->name ); ?></li>
 
 		<?php endforeach; endif; ?>
 	<?php } ?>
 
-	<li class="location" itemprop="jobLocation"><?php the_job_location(); ?></li>
+	<li class="location"><?php the_job_location(); ?></li>
 
-	<li class="date-posted" itemprop="datePosted"><?php the_job_publish_date(); ?></li>
+	<li class="date-posted"><?php the_job_publish_date(); ?></li>
 
 	<?php if ( is_position_filled() ) : ?>
 		<li class="position-filled"><?php _e( 'This position has been filled', 'wp-job-manager' ); ?></li>

--- a/templates/content-single-job_listing.php
+++ b/templates/content-single-job_listing.php
@@ -1,7 +1,5 @@
 <?php global $post; ?>
-<div class="single_job_listing" itemscope itemtype="http://schema.org/JobPosting">
-	<meta itemprop="title" content="<?php echo esc_attr( wpjm_get_the_job_title( $post ) ); ?>" />
-
+<div class="single_job_listing">
 	<?php if ( get_option( 'job_manager_hide_expired_content', 1 ) && 'expired' === $post->post_status ) : ?>
 		<div class="job-manager-info"><?php _e( 'This listing has expired.', 'wp-job-manager' ); ?></div>
 	<?php else : ?>
@@ -15,7 +13,7 @@
 			do_action( 'single_job_listing_start' );
 		?>
 
-		<div class="job_description" itemprop="description">
+		<div class="job_description">
 			<?php wpjm_the_job_description(); ?>
 		</div>
 

--- a/templates/content-single-job_listing.php
+++ b/templates/content-single-job_listing.php
@@ -16,7 +16,7 @@
 		?>
 
 		<div class="job_description" itemprop="description">
-			<?php echo apply_filters( 'the_job_description', get_the_content() ); ?>
+			<?php wpjm_the_job_description(); ?>
 		</div>
 
 		<?php if ( candidates_can_apply() ) : ?>

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -287,7 +287,7 @@ if ( ! function_exists( 'get_job_listing_types' ) ) :
  *
  * @since 1.0.0
  * @param string|array $fields
- * @return array
+ * @return WP_Term[]
  */
 function get_job_listing_types( $fields = 'all' ) {
 	if ( ! get_option( 'job_manager_enable_types' ) ) {

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -281,6 +281,33 @@ function wpjm_get_job_employment_types( $post = null) {
 }
 
 /**
+ * Returns if we output job listing structured data for a post.
+ *
+ * @since 1.28.0
+ *
+ * @param WP_Post|int|null $post
+ * @return bool
+ */
+function wpjm_output_job_listing_structured_data( $post = null ) {
+	$post = get_post( $post );
+
+	if ( $post && $post->post_type !== 'job_listing' ) {
+		return false;
+	}
+
+	// Only show structured data for un-filled and published job listings.
+	$output_structured_data = ! is_position_filled( $post ) && 'publish' === $post->post_status;
+
+	/**
+	 * Filter if we should output structured data.
+	 *
+	 * @since 1.28.0
+	 * @param bool $output_structured_data True if we should show structured data for post.
+	 */
+	return apply_filters( 'wpjm_output_job_listing_structured_data', $output_structured_data );
+}
+
+/**
  * Gets the structured data for the job listing.
  *
  * @since 1.28.0

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -246,6 +246,167 @@ function get_the_job_application_method( $post = null ) {
 }
 
 /**
+ * Get the employment types for the job listing.
+ *
+ * @since 1.28.0
+ *
+ * @param WP_Post|int|null $post
+ * @return bool|array
+ */
+function wpjm_get_job_employment_types( $post = null) {
+	if ( ! wpjm_job_listing_employment_type_enabled() ) {
+		return false;
+	}
+	$employment_types = array();
+	$job_types = wpjm_get_the_job_types( $post );
+
+	if ( ! empty( $job_types ) ) {
+		foreach ( $job_types as $job_type ) {
+			$employment_type = get_term_meta( $job_type->term_id, 'employment_type', true );
+			if ( ! empty( $employment_type ) ) {
+				$employment_types[] = $employment_type;
+			}
+		}
+	}
+
+	/**
+	 * Filter the employment types for a job listing.
+	 *
+	 * @since 1.28.0
+	 *
+	 * @param array            $employment_types Employment types.
+	 * @param WP_Post|int|null $post
+	 */
+	return apply_filters( 'wpjm_get_job_employment_types', array_unique( $employment_types ), $post );
+}
+
+/**
+ * Gets the structured data for the job listing.
+ *
+ * @since 1.28.0
+ * @see https://developers.google.com/search/docs/data-types/job-postings
+ *
+ * @param WP_Post|int|null $post
+ * @return bool|array False if functionality is disabled; otherwise array of structured data.
+ */
+function wpjm_get_job_listing_structured_data( $post = null ) {
+	$post = get_post( $post );
+
+	if ( $post && $post->post_type !== 'job_listing' ) {
+		return false;
+	}
+
+	$data = array();
+	$data['@context'] = 'http://schema.org/';
+	$data['@type'] = 'JobPosting';
+	$data['datePosted'] = get_post_time( 'c', false, $post );
+
+	$job_expires = get_post_meta( $post->ID, '_job_expires', true );
+	if ( ! empty( $job_expires ) ) {
+		$data[ 'validThrough' ] = date( 'c', strtotime( $job_expires ) );
+	}
+
+	$data['title'] = strip_tags( wpjm_get_the_job_title( $post ) );
+	$data['description'] = wpjm_get_the_job_description( $post );
+
+	$employmentTypes = wpjm_get_job_employment_types();
+	if ( ! empty( $employmentTypes ) ) {
+		$data['employmentType'] = $employmentTypes;
+	}
+
+	$data['hiringOrganization'] = array();
+	$data['hiringOrganization']['@type'] = 'Organization';
+	$data['hiringOrganization']['name'] = get_the_company_name( $post );
+	if ( $company_website = get_the_company_website( $post ) ) {
+		$data['hiringOrganization']['sameAs'] = $company_website;
+		$data['hiringOrganization']['url'] = $company_website;
+	}
+
+	$data['identifier'] = array();
+	$data['identifier']['@type'] = 'PropertyValue';
+	$data['identifier']['name'] = get_the_company_name( $post );
+	$data['identifier']['value'] = get_the_guid( $post );
+
+	$location = get_the_job_location( $post );
+	if ( ! empty( $location ) ) {
+		$data['jobLocation'] = array();
+		$data['jobLocation']['@type'] = 'Place';
+		$data['jobLocation']['address'] = wpjm_get_job_listing_location_structured_data( $post );
+		if ( empty( $data['jobLocation']['address'] ) ) {
+			$data['jobLocation']['address'] = $location;
+		}
+	}
+
+	/**
+	 * Filter the structured data for a job listing.
+	 *
+	 * @since 1.28.0
+	 *
+	 * @param bool|array $structured_data False if functionality is disabled; otherwise array of structured data.
+	 * @param WP_Post    $post
+	 */
+	return apply_filters( 'wpjm_get_job_listing_structured_data', $data, $post );
+}
+
+/**
+ * Gets the job listing location data.
+ *
+ * @see http://schema.org/PostalAddress
+ *
+ * @param WP_Post $post
+ * @return array|bool
+ */
+function wpjm_get_job_listing_location_structured_data( $post ) {
+	$post = get_post( $post );
+
+	if ( $post && $post->post_type !== 'job_listing' ) {
+		return false;
+	}
+
+	$mapping = array();
+	$mapping['streetAddress'] = array( 'street_number', 'street' );
+	$mapping['addressLocality'] = 'city';
+	$mapping['addressRegion'] = 'state_short';
+	$mapping['postalCode'] = 'postcode';
+	$mapping['addressCountry'] = 'country_short';
+
+	$address = array();
+	$address['@type'] = 'PostalAddress';
+	foreach ( $mapping as $schema_key => $geolocation_key ) {
+		if ( is_array( $geolocation_key ) ) {
+			$values = array();
+			foreach ( $geolocation_key as $sub_geo_key ) {
+				$geo_value = get_post_meta( $post->ID, 'geolocation_' . $sub_geo_key, true );
+				if ( ! empty( $geo_value ) ) {
+					$values[] = $geo_value;
+				}
+			}
+			$value = implode( ' ', $values );
+		} else {
+			$value = get_post_meta( $post->ID, 'geolocation_' . $geolocation_key, true );
+		}
+		if ( ! empty( $value ) ) {
+			$address[ $schema_key ] = $value;
+		}
+	}
+
+	// No address parts were found
+	if ( 1 === count( $address ) ) {
+		$address = false;
+	}
+
+	/**
+	 * Gets the job listing location structured data.
+	 *
+	 * @since 1.28.0
+	 *
+	 * @param array|bool $address Array of address data.
+	 * @param WP_Post    $post
+	 */
+	return apply_filters( 'wpjm_get_job_listing_location_structured_data', $address, $post );
+}
+
+/**
  * Displays the job title for the listing.
  *
  * @since 1.27.0
@@ -281,6 +442,44 @@ function wpjm_get_the_job_title( $post = null ) {
 	 * @param int|WP_Post $post
 	 */
 	return apply_filters( 'wpjm_the_job_title', $title, $post );
+}
+
+/**
+ * Displays the job description for the listing.
+ *
+ * @since 1.28.0
+ * @param int|WP_Post $post
+ * @return string
+ */
+function wpjm_the_job_description( $post = null ) {
+	if ( $job_description = wpjm_get_the_job_description( $post ) ) {
+		echo $job_description;
+	}
+}
+
+/**
+ * Gets the job description for the listing.
+ *
+ * @since 1.28.0
+ * @param int|WP_Post $post (default: null)
+ * @return string|bool|null
+ */
+function wpjm_get_the_job_description( $post = null ) {
+	$post = get_post( $post );
+	if ( $post->post_type !== 'job_listing' ) {
+		return;
+	}
+
+	$description = apply_filters( 'the_job_description', get_the_content( $post ) );
+
+	/**
+	 * Filter for the job description.
+	 *
+	 * @since 1.28.0
+	 * @param string      $title Title to be filtered.
+	 * @param int|WP_Post $post
+	 */
+	return apply_filters( 'wpjm_the_job_description', $description, $post );
 }
 
 /**


### PR DESCRIPTION
Fixes #1046 

Base is `add/employment-type#1052` (requires #1112 to be merged first; for review, I would look at each commit individually skipping the first few)
 
#### Changes proposed in this Pull Request:

* Improves support for Google Job Search by putting structured data (JSON-LD) in page footer for single job listings.
* Removes existing microdata from default templates
* Adds `wpjm_get_job_listing_structured_data` filter for overriding auto-generated structured data. Return false to disable the behavior. 
* Minor: Added `wpjm_[get_]the_job_description()` and implemented in templates. 

See: https://developers.google.com/search/docs/data-types/job-postings

#### Testing instructions:

* Google has a [snazzy testing tool](https://search.google.com/structured-data/testing-tool). Paste in published job listing URLs and verify the content is accurate.

**Note for theme devs:** I'm using `wp_footer` to add this to the job listing pages. Structured data can be placed anywhere, but I found a few more examples of folks including it in the footer. I'm flexible and open to changing this and just adding it to the standard job listing content (which would allow theme developers to do the same eventually), but this will at least give a valid `JobListing` object for all users by default. Using JSON-LD will require theme developers to remove the microdata from their overridden templates. Not doing so won't cause huge issues, but may cause Google to think two different job listings are appearing on a page.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes: 
* Improves support for Google Job Search by providing a complete `JobListing` record.
