### PR TITLE
Improves 3rd party support for sitemaps

### DIFF
--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -5,3 +5,4 @@
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/jetpack.php' );
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wpml.php' );
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/polylang.php' );
+require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/yoast.php' );

--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -6,3 +6,4 @@ require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/jetpack.php' );
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wpml.php' );
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/polylang.php' );
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/yoast.php' );
+require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/all_in_one_seo_pack.php' );

--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -2,5 +2,6 @@
 /**
  * Load 3rd party compatibility tweaks.
  */
+require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/jetpack.php' );
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wpml.php' );
 require_once( JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/polylang.php' );

--- a/includes/3rd-party/all_in_one_seo_pack.php
+++ b/includes/3rd-party/all_in_one_seo_pack.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Adds additional compatibility with All in One SEO Pack.
+ */
+
+/**
+ * Skip filled job listings.
+ *
+ * @param WP_Post[] $posts
+ * @return WP_Post[]
+ */
+function wpjm_aiosp_sitemap_filter_filled_jobs( $posts ) {
+	foreach ( $posts as $index => $post ) {
+		if ( $post instanceof WP_Post && 'job_listing' !== $post->post_type ) {
+			continue;
+		}
+		if ( is_position_filled( $post ) ) {
+			unset( $posts[ $index ] );
+		}
+	}
+	return $posts;
+}
+add_action( 'aiosp_sitemap_post_filter', 'wpjm_aiosp_sitemap_filter_filled_jobs', 10, 3 );

--- a/includes/3rd-party/jetpack.php
+++ b/includes/3rd-party/jetpack.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Adds additional compatibility with Jetpack.
+ */
+
+/**
+ * Skip filled job listings.
+ *
+ * @param bool    $skip_post
+ * @param WP_Post $post
+ * @return bool
+ */
+function wpjm_jetpack_skip_filled_job_listings( $skip_post, $post ) {
+	if ( 'job_listing' !== $post->post_type ) {
+		return $skip_post;
+	}
+
+	if ( is_position_filled( $post ) ) {
+		return true;
+	}
+
+	return $skip_post;
+}
+add_action( 'jetpack_sitemap_skip_post', 'wpjm_jetpack_skip_filled_job_listings', 10, 2 );
+
+/**
+ * Add `job_listing` post type to sitemap.
+ *
+ * @param array $post_types
+ * @return array
+ */
+function wpjm_jetpack_add_post_type( $post_types ) {
+	$post_types[] = 'job_listing';
+	return $post_types;
+}
+add_filter( 'jetpack_sitemap_post_types', 'wpjm_jetpack_add_post_type' );

--- a/includes/3rd-party/yoast.php
+++ b/includes/3rd-party/yoast.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Adds additional compatibility with Yoast SEO.
+ */
+
+// Yoast SEO will by default include the `job_listing` post type because it is flagged as public.
+
+/**
+ * Skip filled job listings.
+ *
+ * @param array  $url  Array of URL parts.
+ * @param string $type URL type.
+ * @param object $user Data object for the URL.
+ * @return string|bool False if we're skipping
+ */
+function wpjm_yoast_skip_filled_job_listings( $url, $type, $post ) {
+	if ( 'job_listing' !== $post->post_type ) {
+		return $url;
+	}
+
+	if ( is_position_filled( $post ) ) {
+		return false;
+	}
+
+	return $url;
+}
+add_action( 'wpseo_sitemap_entry', 'wpjm_yoast_skip_filled_job_listings', 10, 3 );


### PR DESCRIPTION
Fixes #1117 

#### Changes proposed in this Pull Request:

* Adds support for Jetpack Sitemaps
* Adds support for Yoast SEO Sitemaps
* Adds support for All in One SEO Sitemaps

**Note**: The popular [Google XML Sitemaps](https://en-gb.wordpress.org/plugins/google-sitemap-generator/) is not extendable. No filters of any use in the entire plugin. We should *not* recommend this plugin to our users as it will not filter out filled jobs.

#### Testing instructions:

* With each of these plugins, verify the sitemaps are generated for job listings and do not include expired or filled job listings.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Improved support for Jetpack Sitemaps, Yoast SEO Sitemaps, and All in One SEO Sitemaps.