### PR TITLE
Add noindex to expired/filled job listings

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -44,6 +44,7 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'auto-draft_to_publish', array( $this, 'set_expiry' ) );
 		add_action( 'expired_to_publish', array( $this, 'set_expiry' ) );
 
+		add_action( 'wp_head', array( $this, 'noindex_expired_filled_job_listings' ) );
 		add_action( 'wp_footer', array( $this, 'output_structured_data' ) );
 
 		add_filter( 'the_job_description', 'wptexturize'        );
@@ -733,6 +734,29 @@ class WP_Job_Manager_Post_Types {
 		}
 	}
 
+	/**
+	 * Add noindex for expired and filled job listings.
+	 */
+	public function noindex_expired_filled_job_listings() {
+		if ( ! is_single() ) {
+			return;
+		}
+
+		$post = get_post();
+		if ( ! $post || 'job_listing' !== $post->post_type ) {
+			return;
+		}
+
+		if ( wpjm_allow_indexing_job_listing() ) {
+			return;
+		}
+
+		wp_no_robots();
+	}
+
+	/**
+	 * Add structured data to the footer of job listing pages.
+	 */
 	public function output_structured_data() {
 		if ( ! is_single() ) {
 			return;

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -281,6 +281,33 @@ function wpjm_get_job_employment_types( $post = null) {
 }
 
 /**
+ * Returns if we allow indexing of a job listing.
+ *
+ * @since 1.28.0
+ *
+ * @param WP_Post|int|null $post
+ * @return bool
+ */
+function wpjm_allow_indexing_job_listing( $post = null ) {
+	$post = get_post( $post );
+
+	if ( $post && $post->post_type !== 'job_listing' ) {
+		return true;
+	}
+
+	// Only index job listings that are un-filled and published.
+	$index_job_listing = ! is_position_filled( $post ) && 'publish' === $post->post_status;
+
+	/**
+	 * Filter if we should allow indexing of job listing.
+	 *
+	 * @since 1.28.0
+	 * @param bool $index_job_listing True if we should allow indexing of job listing.
+	 */
+	return apply_filters( 'wpjm_allow_indexing_job_listing', $index_job_listing );
+}
+
+/**
  * Returns if we output job listing structured data for a post.
  *
  * @since 1.28.0


### PR DESCRIPTION
Further Fixes #1117 ;)

#### Changes proposed in this Pull Request:

* Adds `noindex` meta tag to expired and filled job listings to make Google happy (might be flagged as spam if we don't).
* Adds `wpjm_allow_indexing_job_listing` filter to override this.

#### Testing instructions:

* Make sure expired and filled job postings have the `noindex` value for the `robots` meta field in their single page header.
* Make sure non-expired/filled job postings do _not_ have this tag.
* Also make sure non-job listings don't have this tag.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Instructs search engines not to index expired and filled job listings.