### PR TITLE
Make notification for new users an action

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -510,8 +510,23 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
 		return $user_id;
 	}
 
-	// Notify
-	wp_job_manager_notify_new_user( $user_id, $password, $new_user );
+	/**
+	 * Send notification to new users.
+	 *
+	 * @since 1.28.0
+	 *
+	 * @param  int         $user_id
+	 * @param  string|bool $password
+	 * @param  array       $new_user {
+	 *     Information about the new user.
+	 *
+	 *     @type string $user_login Username for the user.
+	 *     @type string $user_pass  Password for the user (may be blank).
+	 *     @type string $user_email Email for the new user account.
+	 *     @type string $role       New user's role.
+	 * }
+	 */
+	do_action( 'wpjm_notify_new_user', $user_id, $password, $new_user );
 
 	// Login
 	wp_set_auth_cookie( $user_id, true, is_ssl() );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -103,6 +103,9 @@ class WP_Job_Manager {
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
 		add_action( 'admin_init', array( $this, 'updater' ) );
 		add_action( 'wp_logout', array( $this, 'cleanup_job_posting_cookies' ) );
+
+		// Defaults for WPJM core actions
+		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
Adds new action `wpjm_notify_new_user` which defaults to `wp_job_manager_notify_new_user()`.

Fixes: #1105 