### PR TITLE
Remove reference to WP Editor placeholder

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -197,7 +197,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					'label'       => __( 'Description', 'wp-job-manager' ),
 					'type'        => 'wp-editor',
 					'required'    => true,
-					'placeholder' => '',
 					'priority'    => 5
 				),
 				'application' => array(


### PR DESCRIPTION
Don’t want to give false hope

Fixes: #1003 