### PR TITLE
Reverts previous WPML fix and implements new fix

### DIFF
--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -9,11 +9,22 @@
  * @since 1.26.0
  */
 function wpml_wpjm_init() {
+	add_action( 'get_job_listings_init', 'wpml_wpjm_set_language' );
 	add_filter( 'wpjm_lang', 'wpml_wpjm_get_job_listings_lang' );
-	add_filter( 'wpjm_ajax_endpoint', 'wpml_wpjm_add_lang_to_ajax_endpoint' );
 	add_filter( 'wpjm_page_id', 'wpml_wpjm_page_id' );
 }
 add_action( 'wpml_loaded', 'wpml_wpjm_init' );
+
+/**
+ * Sets WPJM's language if it is sent in the Ajax request.
+ *
+ * @since 1.26.0
+ */
+function wpml_wpjm_set_language() {
+	if ( ( strstr( $_SERVER['REQUEST_URI'], '/jm-ajax/' ) || ! empty( $_GET['jm-ajax'] ) ) && isset( $_POST['lang'] ) ) {
+		do_action( 'wpml_switch_language', sanitize_text_field( $_POST['lang'] ) );
+	}
+}
 
 /**
  * Returns WPML's current language.
@@ -30,27 +41,9 @@ function wpml_wpjm_get_job_listings_lang( $lang ) {
 /**
  * Returns the page ID for the current language.
  *
- * @since 1.26.0
- *
  * @param int $page_id
  * @return int
  */
 function wpml_wpjm_page_id( $page_id ) {
 	return apply_filters( 'wpml_object_id', $page_id, 'page', true );
-}
-
-/**
- * Add language to ajax endpoint.
- *
- * @since 1.28.0
- *
- * @param string $endpoint
- * @return string
- */
-function wpml_wpjm_add_lang_to_ajax_endpoint( $endpoint ) {
-	$lang = apply_filters( 'wpml_current_language', null );
-	if ( ! empty( $lang ) ) {
-		$endpoint = add_query_arg( 'lang', $lang, $endpoint );
-	}
-	return $endpoint;
 }

--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -18,6 +18,10 @@ add_action( 'wpml_loaded', 'wpml_wpjm_set_language' );
 
 /**
  * Sets WPJM's language if it is sent in the Ajax request.
+ * Note: This is hooked into both `wpml_loaded` and `get_job_listings_init`. As of WPML 3.7.1, if it was hooked
+ * into just `wpml_loaded` the query doesn't get the correct language for job listings. If it is just hooked into
+ * `get_job_listings_init` the locale doesn't get set correctly and the string translations are only loaded from
+ * the default language.
  *
  * @since 1.26.0
  */

--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -14,6 +14,7 @@ function wpml_wpjm_init() {
 	add_filter( 'wpjm_page_id', 'wpml_wpjm_page_id' );
 }
 add_action( 'wpml_loaded', 'wpml_wpjm_init' );
+add_action( 'wpml_loaded', 'wpml_wpjm_set_language' );
 
 /**
  * Sets WPJM's language if it is sent in the Ajax request.

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -76,18 +76,7 @@ class WP_Job_Manager_Ajax {
 		} else {
 			$endpoint = add_query_arg( 'jm-ajax', $request, trailingslashit( home_url( '', 'relative' ) ) );
 		}
-
-		/**
-		 * Allows overriding of Ajax endpoint.
-		 *
-		 * @since 1.28.0
-		 *
-		 * @param string $endpoint
-		 */
-		$endpoint = apply_filters( 'wpjm_ajax_endpoint', $endpoint );
-
-		// URL may have been encoded above, but we need `%25%25endpoint%25%25` => `%%endpoint%%`
-		return esc_url_raw( strtr( $endpoint, array( '%25%25' => '%%' ) ) );
+		return esc_url_raw( $endpoint );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #973

#### Changes proposed in this Pull Request:

* Reverts #1123 
* Sets locale from `$_POST['lang']` further up call chain (`wpml_loaded`), fixing localization issue.

#### Testing instructions:

* `[jobs]` shortcode: Make sure the location and date locale match the language for the listings for both the default and a non-default language.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Improved support with WPML in the `[jobs]` shortcode.