### PR TITLE
Add license helper to WPJM core for premium add-ons

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,1 +1,666 @@
-.clearfix{zoom:1}.clearfix:after,.clearfix:before{content:"";display:table}.clearfix:after{clear:both}@font-face{font-family:job-manager;src:url(../font/job-manager.eot?4963673);src:url(../font/job-manager.eot?4963673#iefix) format('embedded-opentype'),url(../font/job-manager.woff?4963673) format('woff'),url(../font/job-manager.ttf?4963673) format('truetype'),url(../font/job-manager.svg?4963673#job-manager) format('svg');font-weight:400;font-style:normal}@font-face{font-family:jm-logo;src:url(../font/jm-logo/jm.eot?ycsbky);src:url(../font/jm-logo/jm.eot?#iefixycsbky) format('embedded-opentype'),url(../font/jm-logo/jm.woff?ycsbky) format('woff'),url(../font/jm-logo/jm.ttf?ycsbky) format('truetype'),url(../font/jm-logo/jm.svg?ycsbky#icomoon) format('svg');font-weight:400;font-style:normal}.jm-icon{font-family:job-manager!important;font-style:normal;font-weight:400;speak:none;display:inline-block;text-decoration:inherit;width:1em;text-align:center;font-variant:normal;text-transform:none;line-height:1em}.job-manager-settings-wrap .updated{display:none}.job-manager-settings-wrap .job-manager-updated{display:block;margin:1em 0 0}.widefat td.column-featured_job,.widefat td.column-filled,.widefat td.column-job_status{width:46px;text-align:left;padding-left:11px}.widefat th.column-featured_job,.widefat th.column-filled,.widefat th.column-job_status{width:1em}.widefat th.column-featured_job span,.widefat th.column-filled span,.widefat th.column-job_status span{display:block;width:1em;height:1em;line-height:1em;padding:1px 0 0;overflow:hidden}.widefat th.column-featured_job span:before,.widefat th.column-filled span:before,.widefat th.column-job_status span:before{content:'\e803';font-family:job-manager!important;font-style:normal;font-weight:400;speak:none;display:inline-block;text-decoration:inherit;width:1em;text-align:center;font-variant:normal;text-transform:none;line-height:1em}.widefat th.column-filled span:before{content:'\e807'}.widefat th.column-job_status span:before{content:'\e828'}.widefat .column-job_posted strong{display:block;margin-bottom:.2em}.widefat td.column-job_status span{position:relative;font-size:1em;line-height:1.5em;width:1em;height:0;padding:2em 0 0;overflow:hidden;display:block}.widefat td.column-job_status span:before{font-family:job-manager!important;font-style:normal;font-weight:400;speak:none;display:inline-block;text-decoration:inherit;width:1em;text-align:center;font-variant:normal;text-transform:none;position:absolute;top:0;left:0;line-height:1.5em;vertical-align:middle;color:#999;content:'\e829'}.widefat td.column-job_status .status-trash:before{content:'\e82b';color:#a00}.widefat td.column-job_status .status-pending:before{content:'\e82c';color:#ffba00}.widefat td.column-job_status .status-publish:before{content:'\e82f';color:#73a724}.widefat td.column-job_status .status-expired:before{content:'\e82e';color:#a00}.widefat .column-job_listing_type{text-align:left;width:6em;word-wrap:normal!important}.widefat .column-job_listing_type .job-type{color:#fff;padding:4px;font-size:11px;-webkit-border-radius:2px;border-radius:2px;display:block;background-color:#f08d3c;text-align:center}.widefat .column-job_listing_type .full-time{background-color:#90da36}.widefat .column-job_listing_type .part-time{background-color:#f08d3c}.widefat .column-job_listing_type .temporary{background-color:#d93674}.widefat .column-job_listing_type .freelance{background-color:#39c}.widefat .column-job_listing_type .internship{background-color:#6033cc}.widefat th.column-job_position{width:20%}.widefat td.column-job_position{width:20%;height:34px}.widefat td.column-job_position .job_position{position:relative;padding-right:50px!important}.widefat td.column-job_position a.job_title{font-weight:700}.widefat td.column-job_position img{width:32px;height:32px;position:absolute;right:7px;top:0;-webkit-border-radius:50%;border-radius:50%;box-shadow:0 1px 0 1px rgba(0,0,0,.1);-webkit-box-shadow:0 1px 0 1px rgba(0,0,0,.1);-moz-box-shadow:0 1px 0 1px rgba(0,0,0,.1);border:1px solid #fff}.widefat td.column-job_position .company{margin-top:.2em;display:block;padding-top:2px;color:#bbb}.widefat .column-job_location{width:10%}.widefat .column-job_actions{text-align:right;width:128px}.widefat .column-job_actions strong{display:block;margin-bottom:.2em}.widefat .column-job_actions .actions{padding-top:2px}.widefat .column-job_actions a.button{display:inline-block;margin:0 0 2px 4px;cursor:pointer;padding:0 6px!important;font-size:1em!important;line-height:2em!important;overflow:hidden}.widefat .column-job_actions a.button-icon{width:2em!important;padding:0!important}.widefat .column-job_actions a.button-icon:before{font-family:job-manager!important;font-style:normal;font-weight:400;speak:none;display:inline-block;text-decoration:inherit;text-align:center;font-variant:normal;text-transform:none;float:left;width:2em!important;line-height:2em}.widefat .column-job_actions .icon-view:before{content:'\e805'}.widefat .column-job_actions .icon-edit:before{content:'\e804'}.widefat .column-job_actions .icon-delete:before{content:'\e82b'}.widefat .column-job_actions .icon-approve:before{content:'\e802'}.wp_job_manager_meta_data{zoom:1}.wp_job_manager_meta_data:after,.wp_job_manager_meta_data:before{content:"";display:table}.wp_job_manager_meta_data:after{clear:both}.wp_job_manager_meta_data .form-field{width:50%;line-height:2em;float:left;box-sizing:border-box;padding:0 12px 0 0;margin:0 0 12px;clear:both}.wp_job_manager_meta_data .form-field:nth-child(even){float:right;padding:0 0 0 12px;clear:right}.wp_job_manager_meta_data .form-field:nth-last-child(-n+2){margin-bottom:0;padding-bottom:0;border-bottom:0}.wp_job_manager_meta_data .form-field label{vertical-align:middle;display:block;font-weight:700;margin:0}.wp_job_manager_meta_data .form-field .tips{cursor:help;float:right;font-weight:400;color:#999}.wp_job_manager_meta_data .form-field input{width:100%;margin:1px 0;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;vertical-align:middle}.wp_job_manager_meta_data .form-field input.checkbox,.wp_job_manager_meta_data .form-field input.radio{width:auto;margin:4px 2px;display:inline-block}.wp_job_manager_meta_data .form-field .description{display:block;color:#999}.wp_job_manager_meta_data .form-field.form-field-checkbox .description{display:inline}.wp_job_manager_meta_data .form-field .file_url input{width:75%}.wp_job_manager_meta_data .form-field .button{margin-left:4px}.wp_job_manager_meta_data .form-field .file_no_url{-o-animation:flash .3s linear infinite alternate;-webkit-animation:flash .3s linear infinite alternate;-moz-animation:flash .3s linear infinite alternate;animation:flash .3s linear infinite alternate}@-o-keyframes flash{from{background-color:unset}to{background-color:#dc3232}}@-ms-keyframes flash{from{background-color:unset}to{background-color:#dc3232}}@-moz-keyframes flash{from{background-color:unset}to{background-color:#dc3232}}@-webkit-keyframes flash{from{background-color:unset}to{background-color:#dc3232}}@keyframes flash{from{background-color:unset}to{background-color:#dc3232}}#tiptip_holder{display:none;position:absolute;top:0;left:0;z-index:99999}#tiptip_holder.tip_top{padding-bottom:5px}#tiptip_holder.tip_bottom{padding-top:5px}#tiptip_holder.tip_right{padding-left:5px}#tiptip_holder.tip_left{padding-right:5px}#tiptip_content{font-size:11px;color:#fff;padding:4px 8px;background:#464646;border-radius:3px;-webkit-border-radius:3px;-moz-border-radius:3px;box-shadow:1px 1px 3px rgba(0,0,0,.1);-webkit-box-shadow:1px 1px 3px rgba(0,0,0,.1);-moz-box-shadow:1px 1px 3px rgba(0,0,0,.1);text-align:center}#tiptip_content code{background:#999;padding:1px}#tiptip_arrow,#tiptip_arrow_inner{position:absolute;border-color:transparent;border-style:solid;border-width:6px;height:0;width:0}#tiptip_holder.tip_top #tiptip_arrow_inner{margin-top:-7px;margin-left:-6px;border-top-color:#464646}#tiptip_holder.tip_bottom #tiptip_arrow_inner{margin-top:-5px;margin-left:-6px;border-bottom-color:#464646}#tiptip_holder.tip_right #tiptip_arrow_inner{margin-top:-6px;margin-left:-5px;border-right-color:#464646}#tiptip_holder.tip_left #tiptip_arrow_inner{margin-top:-6px;margin-left:-7px;border-left-color:#464646}.wp_job_manager_addons_wrap #job-manager-addons-banner{position:relative;background:#d85677;padding:0 2em 0 5em;color:#fff;margin:10px .25% 20px 0;border-color:rgba(0,0,0,.1);overflow:hidden}.wp_job_manager_addons_wrap #job-manager-addons-banner strong{font-size:1.25em;line-height:.8em;text-shadow:0 2px 0 rgba(0,0,0,.1);font-weight:400;float:left;padding:1.6em 0}.wp_job_manager_addons_wrap #job-manager-addons-banner a.button{color:#fff;text-decoration:none;font-weight:700;float:right;background:#d85677;border:1px solid #fff;line-height:1em;padding:1em;margin:1em 0;text-shadow:0 2px 0 rgba(0,0,0,.1);box-shadow:0 2px 0 rgba(0,0,0,.1);height:auto;position:relative}.wp_job_manager_addons_wrap #job-manager-addons-banner:before{display:inline-block;-webkit-font-smoothing:antialiased;vertical-align:top;font-family:jm-logo;content:"\e600";top:.02em;left:0;position:absolute;text-shadow:0 2px 0 rgba(0,0,0,.1);font-size:5em;font-weight:400;text-align:center;width:1em;height:1em;line-height:1em}.wp_job_manager_addons_wrap .products{overflow:hidden}.wp_job_manager_addons_wrap .products li{display:inline-block;margin:0 1% 10px 0!important;padding:0;vertical-align:top;width:24%;min-width:250px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;border:1px solid #ddd;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,.2),inset 0 -1px 0 rgba(0,0,0,.1);box-shadow:inset 0 1px 0 rgba(255,255,255,.2),inset 0 -1px 0 rgba(0,0,0,.1);overflow:hidden;position:relative;opacity:.8}.wp_job_manager_addons_wrap .products li:nth-child(4n+0){margin-right:0!important}.wp_job_manager_addons_wrap .products li a{color:inherit;text-decoration:none}.wp_job_manager_addons_wrap .products li img{width:100%;height:auto;display:block;padding:0;margin:0;background:#fff;border-bottom:1px solid rgba(0,0,0,.1)}.wp_job_manager_addons_wrap .products li h2{margin:0!important;padding:10px 0!important;line-height:1;background:rgba(255,255,255,.6);border-bottom:1px solid rgba(0,0,0,.1);color:#000;text-align:center;position:absolute;width:100%;top:0;left:0;font-size:16px;text-shadow:none;display:none}.wp_job_manager_addons_wrap .products li:focus,.wp_job_manager_addons_wrap .products li:hover{opacity:1}.wp_job_manager_addons_wrap .products li:focus h2,.wp_job_manager_addons_wrap .products li:hover h2{display:block}.wp_job_manager_addons_wrap .products li .third_party{display:none}.wp_job_manager_addons_wrap .products li p{padding:20px!important;margin:0!important;border-top:1px solid #f1f1f1}.wp_job_manager_addons_wrap .products li .price{display:none}.rtl .widefat .column-job_actions a.button-icon:before{float:right}.rtl .wp_job_manager_meta_data p{padding:0 20% 0 0}.rtl .wp_job_manager_meta_data label{left:auto;right:0}@media only screen and (max-width:782px){.widefat .job_position.column-primary{display:table-cell!important}.widefat .toggle-row:before{top:5px}.widefat .column-job_actions{text-align:left}.widefat .column-job_actions a.button-icon:before{float:left}.rtl .widefat .column-job_actions{text-align:right}.rtl .widefat .column-job_actions a.button-icon:before{float:right}.wp_job_manager_meta_data .form-field{width:100%;padding:0}.wp_job_manager_meta_data .form-field:nth-child(even),.wp_job_manager_meta_data .form-field:nth-last-child(-n+2){float:none;padding:0;margin-bottom:12px;clear:both}}
+.clearfix {
+  zoom: 1;
+  /* For IE 6/7 (trigger hasLayout) */
+}
+.clearfix:before,
+.clearfix:after {
+  content: "";
+  display: table;
+}
+.clearfix:after {
+  clear: both;
+}
+@font-face {
+  font-family: 'job-manager';
+  src: url('../font/job-manager.eot?4963673');
+  src: url('../font/job-manager.eot?4963673#iefix') format('embedded-opentype'), url('../font/job-manager.woff?4963673') format('woff'), url('../font/job-manager.ttf?4963673') format('truetype'), url('../font/job-manager.svg?4963673#job-manager') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'jm-logo';
+  src: url('../font/jm-logo/jm.eot?ycsbky');
+  src: url('../font/jm-logo/jm.eot?#iefixycsbky') format('embedded-opentype'), url('../font/jm-logo/jm.woff?ycsbky') format('woff'), url('../font/jm-logo/jm.ttf?ycsbky') format('truetype'), url('../font/jm-logo/jm.svg?ycsbky#icomoon') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+.jm-icon {
+  font-family: "job-manager" !important;
+  font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  text-align: center;
+  /* For safety - reset parent styles, that can break glyph codes*/
+  font-variant: normal;
+  text-transform: none;
+  /* fix buttons height, for twitter bootstrap */
+  line-height: 1em;
+}
+.job-manager-settings-wrap .updated {
+  display: none;
+}
+.job-manager-settings-wrap .job-manager-updated {
+  display: block;
+  margin: 1em 0 0;
+}
+a.wpjm-activate-licence-link,
+a.wpjm-activate-licence-link:link,
+a.wpjm-activate-licence-link:hover,
+a.wpjm-activate-licence-link:visited,
+a.wpjm-activate-licence-link:active {
+  color: orangered;
+}
+.wpjm-licences {
+  margin-top: 10px;
+}
+.wpjm-licences .licence-row {
+  align-items: center;
+  border: solid 1px #e2e0e2;
+  display: flex;
+  background-color: #fff;
+  flex-wrap: wrap;
+  min-height: 82px;
+  margin-bottom: 20px;
+  position: relative;
+}
+.wpjm-licences .plugin-info {
+  font-size: 18px;
+  flex-basis: 320px;
+  padding: 0 20px;
+  margin-right: 10px;
+}
+.wpjm-licences .plugin-info .plugin-author {
+  font-size: 12px;
+}
+.wpjm-licences .plugin-licence {
+  flex: 1;
+  flex-basis: 40%;
+  padding-bottom: 5px;
+}
+.wpjm-licences .plugin-licence label {
+  white-space: nowrap;
+}
+.widefat td.column-featured_job,
+.widefat td.column-filled,
+.widefat td.column-job_status {
+  width: 46px;
+  text-align: left;
+  padding-left: 11px;
+}
+.widefat th.column-featured_job,
+.widefat th.column-filled,
+.widefat th.column-job_status {
+  width: 1em;
+}
+.widefat th.column-featured_job span,
+.widefat th.column-filled span,
+.widefat th.column-job_status span {
+  display: block;
+  width: 1em;
+  height: 1em;
+  line-height: 1em;
+  padding: 1px 0 0 0;
+  overflow: hidden;
+}
+.widefat th.column-featured_job span:before,
+.widefat th.column-filled span:before,
+.widefat th.column-job_status span:before {
+  content: '\e803';
+  font-family: "job-manager" !important;
+  font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  text-align: center;
+  /* For safety - reset parent styles, that can break glyph codes*/
+  font-variant: normal;
+  text-transform: none;
+  /* fix buttons height, for twitter bootstrap */
+  line-height: 1em;
+}
+.widefat th.column-filled span:before {
+  content: '\e807';
+}
+.widefat th.column-job_status span:before {
+  content: '\e828';
+}
+.widefat .column-job_posted strong {
+  display: block;
+  margin-bottom: .2em;
+}
+.widefat td.column-job_status span {
+  position: relative;
+  font-size: 1em;
+  line-height: 1.5em;
+  width: 1em;
+  height: 0;
+  padding: 2em 0 0 0;
+  overflow: hidden;
+  display: block;
+}
+.widefat td.column-job_status span:before {
+  font-family: "job-manager" !important;
+  font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  text-align: center;
+  /* For safety - reset parent styles, that can break glyph codes*/
+  font-variant: normal;
+  text-transform: none;
+  /* fix buttons height, for twitter bootstrap */
+  line-height: 1em;
+  position: absolute;
+  top: 0;
+  left: 0;
+  line-height: 1.5em;
+  vertical-align: middle;
+  color: #999;
+  content: '\e829';
+}
+.widefat td.column-job_status .status-trash:before {
+  content: '\e82b';
+  color: #a00;
+}
+.widefat td.column-job_status .status-pending:before {
+  content: '\e82c';
+  color: #ffba00;
+}
+.widefat td.column-job_status .status-publish:before {
+  content: '\e82f';
+  color: #73a724;
+}
+.widefat td.column-job_status .status-expired:before {
+  content: '\e82e';
+  color: #a00;
+}
+.widefat .column-job_listing_type {
+  text-align: left;
+  width: 6em;
+  word-wrap: normal !important;
+}
+.widefat .column-job_listing_type .job-type {
+  color: #fff;
+  padding: 4px;
+  font-size: 11px;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+  display: block;
+  background-color: #f08d3c;
+  text-align: center;
+}
+.widefat .column-job_listing_type .full-time {
+  background-color: #90da36;
+}
+.widefat .column-job_listing_type .part-time {
+  background-color: #f08d3c;
+}
+.widefat .column-job_listing_type .temporary {
+  background-color: #d93674;
+}
+.widefat .column-job_listing_type .freelance {
+  background-color: #3399cc;
+}
+.widefat .column-job_listing_type .internship {
+  background-color: #6033cc;
+}
+.widefat th.column-job_position {
+  width: 20%;
+}
+.widefat td.column-job_position {
+  width: 20%;
+  height: 34px;
+}
+.widefat td.column-job_position .job_position {
+  position: relative;
+  padding-right: 50px !important;
+}
+.widefat td.column-job_position a.job_title {
+  font-weight: bold;
+}
+.widefat td.column-job_position img {
+  width: 32px;
+  height: 32px;
+  position: absolute;
+  right: 7px;
+  top: 0;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+  box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.1);
+  -moz-box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.1);
+  border: 1px solid #fff;
+}
+.widefat td.column-job_position .company {
+  margin-top: .2em;
+  display: block;
+  padding-top: 2px;
+  color: #bbbbbb;
+}
+.widefat .column-job_location {
+  width: 10%;
+}
+.widefat .column-job_actions {
+  text-align: right;
+  width: 128px;
+}
+.widefat .column-job_actions strong {
+  display: block;
+  margin-bottom: .2em;
+}
+.widefat .column-job_actions .actions {
+  padding-top: 2px;
+}
+.widefat .column-job_actions a.button {
+  display: inline-block;
+  margin: 0 0 2px 4px;
+  cursor: pointer;
+  padding: 0 6px !important;
+  font-size: 1em !important;
+  line-height: 2em !important;
+  overflow: hidden;
+}
+.widefat .column-job_actions a.button-icon {
+  width: 2em !important;
+  padding: 0 !important;
+}
+.widefat .column-job_actions a.button-icon:before {
+  font-family: "job-manager" !important;
+  font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  text-align: center;
+  /* For safety - reset parent styles, that can break glyph codes*/
+  font-variant: normal;
+  text-transform: none;
+  /* fix buttons height, for twitter bootstrap */
+  line-height: 1em;
+  float: left;
+  width: 2em !important;
+  line-height: 2em;
+}
+.widefat .column-job_actions .icon-view:before {
+  content: '\e805';
+}
+.widefat .column-job_actions .icon-edit:before {
+  content: '\e804';
+}
+.widefat .column-job_actions .icon-delete:before {
+  content: '\e82b';
+}
+.widefat .column-job_actions .icon-approve:before {
+  content: '\e802';
+}
+.wp_job_manager_meta_data {
+  zoom: 1;
+}
+.wp_job_manager_meta_data:before,
+.wp_job_manager_meta_data:after {
+  content: "";
+  display: table;
+}
+.wp_job_manager_meta_data:after {
+  clear: both;
+}
+.wp_job_manager_meta_data .form-field {
+  width: 50%;
+  line-height: 2em;
+  float: left;
+  box-sizing: border-box;
+  padding: 0 12px 0 0;
+  margin: 0 0 12px;
+  clear: both;
+}
+.wp_job_manager_meta_data .form-field:nth-child(even) {
+  float: right;
+  padding: 0 0 0 12px;
+  clear: right;
+}
+.wp_job_manager_meta_data .form-field:nth-last-child(-n+2) {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+.wp_job_manager_meta_data .form-field label {
+  vertical-align: middle;
+  display: block;
+  font-weight: bold;
+  margin: 0;
+}
+.wp_job_manager_meta_data .form-field .tips {
+  cursor: help;
+  float: right;
+  font-weight: normal;
+  color: #999;
+}
+.wp_job_manager_meta_data .form-field input {
+  width: 100%;
+  margin: 1px 0;
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+  vertical-align: middle;
+}
+.wp_job_manager_meta_data .form-field input.checkbox,
+.wp_job_manager_meta_data .form-field input.radio {
+  width: auto;
+  margin: 4px 2px;
+  display: inline-block;
+}
+.wp_job_manager_meta_data .form-field .description {
+  display: block;
+  color: #999;
+}
+.wp_job_manager_meta_data .form-field.form-field-checkbox .description {
+  display: inline;
+}
+.wp_job_manager_meta_data .form-field .file_url input {
+  width: 75%;
+}
+.wp_job_manager_meta_data .form-field .button {
+  margin-left: 4px;
+}
+.wp_job_manager_meta_data .form-field .file_no_url {
+  -o-animation: flash 0.3s linear infinite alternate;
+  -webkit-animation: flash 0.3s linear infinite alternate;
+  -moz-animation: flash 0.3s linear infinite alternate;
+  animation: flash 0.3s linear infinite alternate;
+}
+@-o-keyframes flash {
+  from {
+    background-color: unset;
+  }
+  to {
+    background-color: #dc3232;
+  }
+}
+@-ms-keyframes flash {
+  from {
+    background-color: unset;
+  }
+  to {
+    background-color: #dc3232;
+  }
+}
+@-moz-keyframes flash {
+  from {
+    background-color: unset;
+  }
+  to {
+    background-color: #dc3232;
+  }
+}
+@-webkit-keyframes flash {
+  from {
+    background-color: unset;
+  }
+  to {
+    background-color: #dc3232;
+  }
+}
+@keyframes flash {
+  from {
+    background-color: unset;
+  }
+  to {
+    background-color: #dc3232;
+  }
+}
+/* TipTip CSS - Version 1.2 */
+#tiptip_holder {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 99999;
+}
+#tiptip_holder.tip_top {
+  padding-bottom: 5px;
+}
+#tiptip_holder.tip_bottom {
+  padding-top: 5px;
+}
+#tiptip_holder.tip_right {
+  padding-left: 5px;
+}
+#tiptip_holder.tip_left {
+  padding-right: 5px;
+}
+#tiptip_content {
+  font-size: 11px;
+  color: #fff;
+  padding: 4px 8px;
+  background: #464646;
+  border-radius: 3px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
+  -moz-box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+#tiptip_content code {
+  background: #999;
+  padding: 1px;
+}
+#tiptip_arrow,
+#tiptip_arrow_inner {
+  position: absolute;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 6px;
+  height: 0;
+  width: 0;
+}
+#tiptip_holder.tip_top #tiptip_arrow_inner {
+  margin-top: -7px;
+  margin-left: -6px;
+  border-top-color: #464646;
+}
+#tiptip_holder.tip_bottom #tiptip_arrow_inner {
+  margin-top: -5px;
+  margin-left: -6px;
+  border-bottom-color: #464646;
+}
+#tiptip_holder.tip_right #tiptip_arrow_inner {
+  margin-top: -6px;
+  margin-left: -5px;
+  border-right-color: #464646;
+}
+#tiptip_holder.tip_left #tiptip_arrow_inner {
+  margin-top: -6px;
+  margin-left: -7px;
+  border-left-color: #464646;
+}
+/* Addons */
+.wp_job_manager_addons_wrap #job-manager-addons-banner {
+  position: relative;
+  background: #d85677;
+  padding: 0 2em 0 5em;
+  color: #fff;
+  margin: 10px .25% 20px 0;
+  border-color: rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+.wp_job_manager_addons_wrap #job-manager-addons-banner strong {
+  font-size: 1.25em;
+  line-height: 0.8em;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.1);
+  font-weight: normal;
+  float: left;
+  padding: 1.6em 0;
+}
+.wp_job_manager_addons_wrap #job-manager-addons-banner a.button {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+  float: right;
+  background: #d85677;
+  border: 1px solid #fff;
+  line-height: 1em;
+  padding: 1em;
+  margin: 1em 0;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.1);
+  height: auto;
+  position: relative;
+}
+.wp_job_manager_addons_wrap #job-manager-addons-banner:before {
+  display: inline-block;
+  -webkit-font-smoothing: antialiased;
+  vertical-align: top;
+  font-family: 'jm-logo';
+  content: "\e600";
+  top: .02em;
+  left: 0;
+  position: absolute;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.1);
+  font-size: 5em;
+  font-weight: normal;
+  text-align: center;
+  width: 1em;
+  height: 1em;
+  line-height: 1em;
+}
+.wp_job_manager_addons_wrap .products {
+  overflow: hidden;
+}
+.wp_job_manager_addons_wrap .products li {
+  display: inline-block;
+  margin: 0 1% 10px 0 !important;
+  padding: 0;
+  vertical-align: top;
+  width: 24%;
+  min-width: 250px;
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+  border: 1px solid #ddd;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  position: relative;
+  opacity: 0.8;
+}
+.wp_job_manager_addons_wrap .products li:nth-child(4n+0) {
+  margin-right: 0 !important;
+}
+.wp_job_manager_addons_wrap .products li a {
+  color: inherit;
+  text-decoration: none;
+}
+.wp_job_manager_addons_wrap .products li img {
+  width: 100%;
+  height: auto;
+  display: block;
+  padding: 0;
+  margin: 0;
+  background: #fff;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+.wp_job_manager_addons_wrap .products li h2 {
+  margin: 0 !important;
+  padding: 10px 0 !important;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.6);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  color: #000;
+  text-align: center;
+  position: absolute;
+  width: 100%;
+  top: 0;
+  left: 0;
+  font-size: 16px;
+  text-shadow: none;
+  display: none;
+}
+.wp_job_manager_addons_wrap .products li:hover,
+.wp_job_manager_addons_wrap .products li:focus {
+  opacity: 1;
+}
+.wp_job_manager_addons_wrap .products li:hover h2,
+.wp_job_manager_addons_wrap .products li:focus h2 {
+  display: block;
+}
+.wp_job_manager_addons_wrap .products li .third_party {
+  display: none;
+}
+.wp_job_manager_addons_wrap .products li p {
+  padding: 20px !important;
+  margin: 0 !important;
+  border-top: 1px solid #f1f1f1;
+}
+.wp_job_manager_addons_wrap .products li .price {
+  display: none;
+}
+.rtl .widefat .column-job_actions a.button-icon:before {
+  float: right;
+}
+.rtl .wp_job_manager_meta_data p {
+  padding: 0 20% 0 0;
+}
+.rtl .wp_job_manager_meta_data label {
+  left: auto;
+  right: 0;
+}
+/**
+ * Mobile styles
+ */
+@media only screen and (max-width: 782px) {
+  .wpjm-licences .plugin-info {
+    padding: 10px;
+  }
+  .wpjm-licences .plugin-licence {
+    padding: 10px;
+  }
+  .widefat .job_position.column-primary {
+    display: table-cell !important;
+  }
+  .widefat .toggle-row:before {
+    top: 5px;
+  }
+  .widefat .column-job_actions {
+    text-align: left;
+  }
+  .widefat .column-job_actions a.button-icon:before {
+    float: left;
+  }
+  .rtl .widefat .column-job_actions {
+    text-align: right;
+  }
+  .rtl .widefat .column-job_actions a.button-icon:before {
+    float: right;
+  }
+  .wp_job_manager_meta_data .form-field {
+    width: 100%;
+    padding: 0;
+  }
+  .wp_job_manager_meta_data .form-field:nth-child(even) {
+    float: none;
+    padding: 0;
+    margin-bottom: 12px;
+    clear: both;
+  }
+  .wp_job_manager_meta_data .form-field:nth-last-child(-n+2) {
+    float: none;
+    padding: 0;
+    margin-bottom: 12px;
+    clear: both;
+  }
+}

--- a/assets/css/admin.less
+++ b/assets/css/admin.less
@@ -10,6 +10,46 @@
 		margin: 1em 0 0;
 	}
 }
+
+a.wpjm-activate-licence-link,
+a.wpjm-activate-licence-link:link,
+a.wpjm-activate-licence-link:hover,
+a.wpjm-activate-licence-link:visited,
+a.wpjm-activate-licence-link:active {
+	color: orangered;
+}
+
+.wpjm-licences {
+	margin-top: 10px;
+	.licence-row {
+		align-items: center;
+		border: solid 1px #e2e0e2;
+		display: flex;
+		background-color: #fff;
+		flex-wrap: wrap;
+		min-height: 82px;
+		margin-bottom: 20px;
+		position: relative;
+	}
+	.plugin-info {
+		font-size: 18px;
+		flex-basis: 320px;
+		padding: 0 20px;
+		margin-right: 10px;
+
+		.plugin-author {
+			font-size: 12px;
+		}
+	}
+	.plugin-licence {
+		flex: 1;
+		flex-basis: 40%;
+		padding-bottom: 5px;
+		label {
+			white-space: nowrap;
+		}
+	}
+}
 .widefat {
 	td.column-featured_job, td.column-filled, td.column-job_status {
 		width: 46px;
@@ -492,6 +532,14 @@
  * Mobile styles
  */
 @media only screen and (max-width: 782px) {
+	.wpjm-licences {
+		.plugin-info {
+			padding: 10px;
+		}
+		.plugin-licence {
+			padding: 10px;
+		}
+	}
 	.widefat {
 		.job_position.column-primary{
 			display: table-cell !important;

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -79,11 +79,21 @@ class WP_Job_Manager_Addons {
 
 		?>
 		<div class="wrap wp_job_manager wp_job_manager_addons_wrap">
-			<h2><?php _e( 'WP Job Manager Add-ons', 'wp-job-manager' ); ?></h2>
-
-			<div id="job-manager-addons-banner" class="notice updated below-h2"><strong><?php _e( 'Do you need multiple add-ons?', 'wp-job-manager' ); ?></strong> <a href="https://wpjobmanager.com/add-ons/bundle/" class="button"><?php _e( 'Check out the core add-on bundle &rarr;', 'wp-job-manager' ); ?></a></div>
-
-			<?php echo $addons; ?>
+			<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons' ) ); ?>" class="nav-tab<?php if ( ! isset( $_GET['section'] ) || 'helper' !== $_GET['section'] ) { echo ' nav-tab-active'; } ?>"><?php _e( 'WP Job Manager Add-ons', 'wp-job-manager' ); ?></a>
+				<?php if ( current_user_can( 'update_plugins' ) ) : ?>
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper' ) ); ?>" class="nav-tab<?php if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) { echo ' nav-tab-active'; } ?>"><?php _e( 'Licenses', 'wp-job-manager' ); ?></a>
+				<?php endif; ?>
+			</nav>
+			<?php
+			if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
+				do_action( 'job_manager_helper_output' );
+			} else {
+				echo '<h1 class="screen-reader-text">' . __( 'WP Job Manager Add-ons', 'wp-job-manager' ) . '</h1>';
+				echo '<div id="job-manager-addons-banner" class="notice updated below-h2"><strong>' . __( 'Do you need multiple add-ons?', 'wp-job-manager' ) . '</strong> <a href="https://wpjobmanager.com/add-ons/bundle/" class="button">' . __( 'Check out the core add-on bundle &rarr;', 'wp-job-manager' ) . '</a></div>';
+				echo $addons;
+			}
+			?>
 		</div>
 		<?php
 	}

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -86,7 +86,7 @@ class WP_Job_Manager_Admin {
 
 		$screen = get_current_screen();
 
-		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', array( 'edit-job_listing', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-addons' ) ) ) ) {
+		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', array( 'edit-job_listing', 'plugins', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-addons' ) ) ) ) {
 			$jquery_version = isset( $wp_scripts->registered['jquery-ui-core']->ver ) ? $wp_scripts->registered['jquery-ui-core']->ver : '1.9.2';
 
 			wp_enqueue_style( 'jquery-ui-style', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.css', array(), $jquery_version );
@@ -109,7 +109,7 @@ class WP_Job_Manager_Admin {
 	public function admin_menu() {
 		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), __( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', array( $this->settings_page, 'output' ) );
 
-		if ( apply_filters( 'job_manager_show_addons_page', true ) )
+		if ( WP_Job_Manager_Helper::instance()->has_licenced_products() || apply_filters( 'job_manager_show_addons_page', true ) )
 			add_submenu_page(  'edit.php?post_type=job_listing', __( 'WP Job Manager Add-ons', 'wp-job-manager' ),  __( 'Add-ons', 'wp-job-manager' ) , 'manage_options', 'job-manager-addons', array( $this, 'addons_page' ) );
 	}
 

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -1,0 +1,173 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WP_Job_Manager_Helper_API
+ */
+class WP_Job_Manager_Helper_API {
+
+	const API_BASE_URL = 'https://wpjobmanager.com/';
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var self
+	 * @since  1.29.0
+	 */
+	private static $_instance = null;
+
+	/**
+	 * Allows for accessing single instance of class. Class should only be constructed once per call.
+	 *
+	 * @since  1.29.0
+	 * @static
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Sends and receives data to and from the server API
+	 *
+	 * @param array|string $args
+	 * @return object|bool $response
+	 */
+	public function plugin_update_check( $args ) {
+		$args = wp_parse_args( $args );
+		$args['wc-api']  = 'wp_plugin_licencing_update_api';
+		$args['request'] = 'pluginupdatecheck';
+		return $this->request( $args );
+	}
+
+	/**
+	 * Sends and receives data to and from the server API
+	 *
+	 * @param array|string $args
+	 * @return object $response
+	 */
+	public function plugin_information( $args ) {
+		$args = wp_parse_args( $args );
+		$args['wc-api']  = 'wp_plugin_licencing_update_api';
+		$args['request'] = 'plugininformation';
+		return $this->request( $args );
+	}
+
+	/**
+	 * Attempt to activate a plugin licence.
+	 *
+	 * @param array|string $args
+	 * @return boolean|string JSON response or false if failed.
+	 */
+	public function activate( $args ) {
+		$args = wp_parse_args( $args );
+		$args['wc-api']  = 'wp_plugin_licencing_activation_api';
+		$args['request'] = 'activate';
+		$response = $this->request( $args, true );
+		if ( false === $response ) {
+			return false;
+		}
+		return $response;
+	}
+
+	/**
+	 * Attempt to deactivate a plugin licence.
+	 *
+	 * @param array|string $args
+	 * @return boolean|string JSON response or false if failed.
+	 */
+	public function deactivate( $args ) {
+		$args = wp_parse_args( $args );
+		$args['wc-api']  = 'wp_plugin_licencing_activation_api';
+		$args['request'] = 'deactivate';
+		$response = $this->request( $args, false );
+		if ( false === $response ) {
+			return false;
+		}
+		return $response;
+	}
+
+	/**
+	 * Make a licence helper API request.
+	 *
+	 * @param array $args
+	 * @param bool  $return_error
+	 *
+	 * @return array|bool|mixed|object
+	 */
+	private function request( $args, $return_error = false ) {
+		$defaults = array(
+			'instance'       => $this->get_site_url(),
+			'plugin_name'    => '',
+			'version'        => '',
+			'api_product_id' => '',
+			'licence_key'    => '',
+			'email'          => '',
+		);
+
+		$args    = wp_parse_args( $args, $defaults );
+		$request = wp_safe_remote_get( $this->get_api_base_url() . '?' . http_build_query( $args, '', '&' ), array(
+			'timeout' => 10,
+			'headers' => array(
+				'Accept' => 'application/json',
+			),
+		) );
+
+		if ( is_wp_error( $request ) || 200 !== wp_remote_retrieve_response_code( $request ) ) {
+			if ( $return_error ) {
+				if ( is_wp_error( $request ) ) {
+					return array(
+						'error_code' => $request->get_error_code(),
+						'error' => $request->get_error_message(),
+					);
+				}
+				return array(
+					'error_code' => wp_remote_retrieve_response_code( $request ),
+					'error' => 'Error code: ' . wp_remote_retrieve_response_code( $request ),
+				);
+			}
+			return false;
+		}
+
+		$response = @json_decode( wp_remote_retrieve_body( $request ), true );
+
+		if ( is_array( $response ) ) {
+			return $response;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the site URL that is MU safe.
+	 *
+	 * @return string
+	 */
+	private function get_site_url() {
+		if ( is_multisite() || is_network_admin() ) {
+			return network_site_url();
+		}
+		return site_url();
+	}
+
+	/**
+	 * Returns the API base URL.
+	 *
+	 * @return string
+	 */
+	private function get_api_base_url() {
+		if ( defined( 'JOB_MANAGER_VERSION' )
+			 && defined( 'JOB_MANAGER_DEV_API_BASE_URL')
+			 && '-dev' === substr( JOB_MANAGER_VERSION, -4 )
+		) {
+			return JOB_MANAGER_DEV_API_BASE_URL;
+		}
+		return self::API_BASE_URL;
+	}
+}

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -101,7 +101,7 @@ class WP_Job_Manager_Helper_API {
 	 *
 	 * @return array|bool|mixed|object
 	 */
-	private function request( $args, $return_error = false ) {
+	protected function request( $args, $return_error = false ) {
 		$defaults = array(
 			'instance'       => $this->get_site_url(),
 			'plugin_name'    => '',

--- a/includes/helper/class-wp-job-manager-helper-options.php
+++ b/includes/helper/class-wp-job-manager-helper-options.php
@@ -1,0 +1,114 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WP_Job_Manager_Helper_Options
+ */
+class WP_Job_Manager_Helper_Options {
+	const OPTION_NAME = 'job_manager_helper';
+
+	/**
+	 * Update a WPJM plugin's licence data.
+	 *
+	 * @param string $product_slug
+	 * @param string $key
+	 * @param mixed  $value
+	 *
+	 * @return bool
+	 */
+	public static function update( $product_slug, $key, $value ) {
+		$options = self::get_master_option();
+		if ( ! isset( $options[ $product_slug ] ) ) {
+			$options[ $product_slug ] = array();
+		}
+		$options[ $product_slug ][ $key ] = $value;
+		return self::update_master_option( $options );
+	}
+
+	/**
+	 * Retrieve a WPJM plugin's licence data.
+	 *
+	 * @param string $product_slug
+	 * @param string $key
+	 * @param mixed  $default
+	 *
+	 * @return mixed
+	 */
+	public static function get( $product_slug, $key, $default = false ) {
+		$options = self::get_master_option();
+		if ( ! isset( $options[ $product_slug ] ) ) {
+			$options[ $product_slug ] = self::attempt_legacy_restore( $product_slug );
+		}
+		if ( isset( $options[ $product_slug ][ $key ] ) ) {
+			return $options[ $product_slug ][ $key ];
+		}
+		return $default;
+	}
+
+	/**
+	 * Delete a WPJM plugin's licence data.
+	 *
+	 * @param string $product_slug
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
+	public static function delete( $product_slug, $key ) {
+		$options = self::get_master_option();
+		if ( ! isset( $options[ $product_slug ] ) ) {
+			$options[ $product_slug ] = array();
+		}
+		unset( $options[ $product_slug ][ $key ] );
+		return self::update_master_option( $options );
+	}
+
+	/**
+	 * Attempt to retrieve licence data from legacy storage.
+	 *
+	 * @param string $product_slug
+	 *
+	 * @return array
+	 */
+	private static function attempt_legacy_restore( $product_slug ) {
+		$options = self::get_master_option();
+		if ( ! isset( $options[ $product_slug ] ) ) {
+			$options[ $product_slug ] = array();
+		}
+		foreach ( array( 'licence_key', 'email', 'errors', 'hide_key_notice' ) as $key ) {
+			$option_value = get_option( $product_slug . '_' . $key, false );
+			if ( ! empty( $option_value ) ) {
+				$options[ $product_slug ][ $key ] = $option_value;
+				delete_option( $product_slug . '_' . $key );
+			}
+		}
+		self::update_master_option( $options );
+		return $options[ $product_slug ];
+	}
+
+	/**
+	 * Retrieve the master option.
+	 *
+	 * @return array
+	 */
+	private static function get_master_option() {
+		if ( is_multisite() || is_network_admin() ) {
+			return get_site_option( self::OPTION_NAME, array() );
+		}
+		return get_option( self::OPTION_NAME, array() );
+	}
+
+	/**
+	 * Update the master option.
+	 *
+	 * @return bool
+	 */
+	private static function update_master_option( $value ) {
+		if ( is_multisite() || is_network_admin() ) {
+			return update_site_option( self::OPTION_NAME, $value );
+		}
+		return update_option( self::OPTION_NAME, $value );
+	}
+}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -14,12 +14,12 @@ class WP_Job_Manager_Helper {
 	/**
 	 * @var array Messages when updating licences.
 	 */
-	private $licence_messages = array();
+	protected $licence_messages = array();
 
 	/**
 	 * @var WP_Job_Manager_Helper_API
 	 */
-	private $api;
+	protected $api;
 
 	/**
 	 * The single instance of the class.
@@ -232,7 +232,7 @@ class WP_Job_Manager_Helper {
 	 *
 	 * @return bool|object
 	 */
-	private function get_plugin_info( $product_slug ) {
+	protected function get_plugin_info( $product_slug ) {
 		if ( ! $this->is_product_installed( $product_slug ) ) {
 			return false;
 		}
@@ -322,7 +322,7 @@ class WP_Job_Manager_Helper {
 	 * @param bool $active_only Only return active plugins
 	 * @return array
 	 */
-	private function get_installed_plugins( $active_only = true ) {
+	protected function get_installed_plugins( $active_only = true ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		}
@@ -466,7 +466,6 @@ class WP_Job_Manager_Helper {
 		if ( ! isset( $plugin_products[ $product_slug ] ) ) {
 			return;
 		}
-		$plugin_data = $plugin_products[ $product_slug ];
 		if ( ! empty( $errors['no_activation'] ) ) {
 			$this->deactivate_licence( $product_slug );
 			$this->add_licence_error( $product_slug, $errors['no_activation'] );

--- a/includes/helper/views/html-licence-key-notice.php
+++ b/includes/helper/views/html-licence-key-notice.php
@@ -1,0 +1,9 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+<div class="updated">
+	<p class="wpjm-updater-dismiss" style="float:right;"><a href="<?php echo esc_url( add_query_arg( 'dismiss-wpjm-licence-notice', $product_slug ) ); ?>"><?php _e( 'Hide notice' ); ?></a></p>
+	<p><?php printf( '<a href="%s">Please enter your license key</a> to get updates for "%s".', esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) ), esc_html( $plugin_data['Name'] ) ); ?></p>
+</div>

--- a/includes/helper/views/html-licences.php
+++ b/includes/helper/views/html-licences.php
@@ -1,0 +1,81 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+<h1 class="screen-reader-text"><?php _e( 'Licenses', 'wp-job-manager' ); ?></h1>
+<div class="wpjm-licences">
+	<?php if ( ! empty( $licenced_plugins ) ) : ?>
+	<?php foreach ( $licenced_plugins as $product_slug => $plugin_data ) : ?>
+		<?php
+		$licence = WP_Job_Manager_Helper::get_plugin_licence( $product_slug );
+		?>
+		<div class="licence-row">
+			<div class="plugin-info">
+				<?php echo $plugin_data['Name']; ?>
+				<div class="plugin-author">
+					<?php
+					$author = $plugin_data['Author'];
+					if ( !empty( $plugin_data['AuthorURI'] ) ) {
+						$author = '<a href="' . $plugin_data['AuthorURI'] . '">' . $plugin_data['Author'] . '</a>';
+					}
+					echo $author;
+					?>
+				</div>
+			</div>
+			<div class="plugin-licence">
+				<?php
+					$notices = WP_Job_Manager_Helper::get_messages( $product_slug );
+					if ( empty( $notices) && ! empty( $licence['errors'] ) ) {
+						$notices = array();
+						foreach ( $licence['errors'] as $key => $error ) {
+							$notices[] = array(
+								'type' => 'error',
+								'message' => $error,
+							);
+						}
+					}
+					foreach ( $notices as $message ) {
+						echo '<div class="notice inline notice-'. esc_attr( $message['type'] ) .'"><p>'. wp_kses_post( $message['message'] ) . '</p></div>';
+					}
+				?>
+				<form method="post">
+				<?php wp_nonce_field( 'wpjm-manage-licence' ); ?>
+				<?php
+				if ( ! empty( $licence['licence_key'] ) && ! empty( $licence['email'] ) ) {
+					?>
+					<input type="hidden" id="<?php echo sanitize_title( $product_slug ); ?>_action" name="action" value="deactivate"/>
+					<input type="hidden" id="<?php echo sanitize_title( $product_slug ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
+
+					<label for="<?php echo sanitize_title( $product_slug ); ?>_licence_key"><?php _e( 'License' ); ?>:
+						<input type="text" disabled="disabled" id="<?php echo sanitize_title( $product_slug ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $licence['licence_key'] ); ?>"/>
+					</label>
+					<label for="<?php echo sanitize_title( $product_slug ); ?>_email"><?php _e( 'Email' ); ?>:
+						<input type="email" disabled="disabled" id="<?php echo sanitize_title( $product_slug ); ?>_email" name="email" placeholder="Email address" value="<?php echo esc_attr( $licence['email'] ); ?>"/>
+					</label>
+
+					<input type="submit" class="button" name="submit" value="<?php _e( 'Deactivate License' ); ?>" />
+					<?php
+				} else { // licence is not active
+					?>
+					<input type="hidden" id="<?php echo sanitize_title( $product_slug ); ?>_action" name="action" value="activate"/>
+					<input type="hidden" id="<?php echo sanitize_title( $product_slug ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
+					<label for="<?php echo sanitize_title( $product_slug ); ?>_licence_key"><?php _e( 'License' ); ?>:
+						<input type="text" id="<?php echo sanitize_title( $product_slug ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
+					</label>
+					<label for="<?php echo sanitize_title( $product_slug ); ?>_email"><?php _e( 'Email' ); ?>:
+						<input type="email" id="<?php echo sanitize_title( $product_slug ); ?>_email" name="email" placeholder="Email address" value="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>"/>
+					</label>
+					<input type="submit" class="button" name="submit" value="<?php _e( 'Activate License' ); ?>" />
+					<?php
+				} // end if : else licence is not active
+				?>
+				</form>
+			</div>
+		</div>
+	<?php endforeach; ?>
+		<div class="notice notice-info inline"><p><?php printf( 'Lost your license key? <a href="%s">Retrieve it here</a>.', esc_url( 'https://wpjobmanager.com/lost-licence-key/' ) ); ?></p></div>
+	<?php else: ?>
+		<div class="notice notice-warning inline"><p><?php _e( 'No plugins are activated that have licenses managed by WP Job Manager.', 'wp-job-manager' ); ?></p></div>
+	<?php endif; ?>
+</div>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,8 +19,8 @@
     <testsuites>
         <testsuite name="WPJM Test Suite">
             <directory prefix="test_class." suffix=".php">tests/php/tests</directory>
-            <directory prefix="test_class." suffix=".php" phpVersion="5.3.0" phpVersionOperator=">=">tests/php/tests/includes/rest-api</directory>
-        </testsuite>
+			<directory prefix="test_class." suffix=".php" phpVersion="5.3.0" phpVersionOperator=">=">tests/php/tests/includes/rest-api</directory>
+		</testsuite>
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="false">

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -85,6 +85,7 @@ class WPJM_Unit_Tests_Bootstrap {
 		// framework
 		require_once( $this->includes_dir . '/factories/class-wpjm-factory.php' );
 		require_once( $this->includes_dir . '/class-wpjm-base-test.php' );
+		require_once( $this->includes_dir . '/class-wpjm-helper-base-test.php' );
 		require_once( $this->includes_dir . '/class-wpjm-rest-testcase.php' );
 	}
 

--- a/tests/php/includes/class-requests-transport-faker.php
+++ b/tests/php/includes/class-requests-transport-faker.php
@@ -1,6 +1,7 @@
 <?php
 
 class Requests_Transport_Faker implements Requests_Transport {
+	public $headers_matter = false;
 	private $_log = array();
 	private $_responses = array();
 
@@ -96,7 +97,7 @@ class Requests_Transport_Faker implements Requests_Transport {
 	 * {@inheritdoc}
 	 */
 	public function request( $url, $headers = array(), $data = array(), $options = array() ) {
-		if ( isset( $options['headers_matter'] ) && true === $options['headers_matter'] ) {
+		if ( $this->headers_matter ) {
 			$signature = self::make_request_signature( $url, $headers, $data );
 		} else {
 			$signature = self::make_request_signature( $url, array(), $data );

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -2,12 +2,20 @@
 
 class WPJM_BaseTest extends WP_UnitTestCase {
 	/**
+	 * @var Requests_Transport
+	 */
+	protected $_transport;
+
+	/**
 	 * @var WPJM_Factory
 	 */
 	protected $factory;
 
 	function setUp() {
 		parent::setUp();
+		include_once( WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/class-requests-transport-faker.php' );
+		$this->_transport = null;
+
 		$this->factory = self::factory();
 		$this->enable_manage_job_listings_cap();
 	}
@@ -49,12 +57,26 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	/**
 	 * Helper to disable manage job listings capability.
 	 */
+	protected function disable_update_plugins_cap() {
+		remove_filter( 'user_has_cap', array( $this, 'add_manage_update_plugins_cap') );
+	}
+
+	/**
+	 * Helper to enable manage job listings capability.
+	 */
+	protected function enable_update_plugins_cap() {
+		add_filter( 'user_has_cap', array( $this, 'add_manage_update_plugins_cap') );
+	}
+
+	/**
+	 * Helper to disable update plugins capability.
+	 */
 	protected function disable_manage_job_listings_cap() {
 		remove_filter( 'user_has_cap', array( $this, 'add_manage_job_listing_cap') );
 	}
 
 	/**
-	 * Helper to enable manage job listings capability.
+	 * Helper to enable update plugins capability.
 	 */
 	protected function enable_manage_job_listings_cap() {
 		add_filter( 'user_has_cap', array( $this, 'add_manage_job_listing_cap') );
@@ -63,9 +85,40 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	/**
 	 * Helper to add capability for `user_has_cap` filter.
 	 */
+	public function add_manage_update_plugins_cap( $caps ) {
+		$caps['update_plugins'] = 1;
+		return $caps;
+	}
+
+	/**
+	 * Helper to add capability for `user_has_cap` filter.
+	 */
 	public function add_manage_job_listing_cap( $caps ) {
 		$caps['manage_job_listings'] = 1;
 		return $caps;
+	}
+
+	protected function disable_transport_faker() {
+		remove_action( 'requests-requests.before_request', array( $this, 'overload_request_transport' ), 10 );
+		remove_filter( 'job_manager_geolocation_api_key', '__return_empty_string', 10 );
+		add_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
+	}
+
+	protected function enable_transport_faker() {
+		add_action( 'requests-requests.before_request', array( $this, 'overload_request_transport' ), 10, 5 );
+		remove_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
+		add_filter( 'job_manager_geolocation_api_key', '__return_empty_string', 10 );
+	}
+
+	public function overload_request_transport(&$url, &$headers, &$data, &$type, &$options) {
+		$options['transport'] = $this->get_request_transport();
+	}
+
+	protected function get_request_transport() {
+		if ( ! isset( $this->_transport ) ) {
+			$this->_transport = new Requests_Transport_Faker();
+		}
+		return $this->_transport;
 	}
 
 	protected function assertTrashed( $post ) {

--- a/tests/php/includes/class-wpjm-helper-base-test.php
+++ b/tests/php/includes/class-wpjm-helper-base-test.php
@@ -1,0 +1,92 @@
+<?php
+include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-helper-options.php' );
+include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-helper-api.php' );
+
+class WPJM_Helper_Base_Test extends WPJM_BaseTest {
+	protected function plugin_data_with_update() {
+		return array(
+			'test' => array(
+				'_product_slug' => 'test',
+				'_filename' => 'test/test.php',
+				'Version' => '1.0.0',
+				'Name' => 'Test',
+			)
+		);
+	}
+
+	protected function plugin_data_without_update() {
+		return array(
+			'test' => array(
+				'_product_slug' => 'test',
+				'_filename' => 'test/test.php',
+				'Version' => '1.1.0',
+				'Name' => 'Test',
+			)
+		);
+	}
+
+	protected function result_plugin_information() {
+		return array(
+			'slug' => 'test',
+			'plugin' => 'test/test.php',
+			'version' => '1.1.0',
+			'last_updated' => '',
+			'author' => 'Test',
+			'requires' => '4.1',
+			'tested' => '4.8',
+			'sections' => array(),
+			'homepage' => 'http://test.dev',
+			'download_link' => 'http://test.dev',
+		);
+	}
+
+	protected function getMockHelper( $plugins = null ) {
+		if ( null === $plugins ) {
+			$plugins = $this->plugin_data_with_update();
+		}
+
+		WP_Job_Manager_Helper_Options::update( 'test', 'licence_key', '1234' );
+		WP_Job_Manager_Helper_Options::update( 'test', 'email', 'test@local.dev' );
+
+		$mock = $this->getMockBuilder( 'WP_Job_Manager_Helper' )
+					 ->setMethods( array( 'get_installed_plugins', '_get_api' ) )
+					 ->getMock();
+		$api = $this->getMockHelperApi();
+		$this->setProtectedProperty( $mock, 'api', $api );
+		$mock->method( 'get_installed_plugins' )->willReturn( $plugins );
+		$mock->method( '_get_api' )->willReturn( $api );
+		return $mock;
+	}
+
+	protected function getMockHelperApi() {
+		$mock = $this->getMockBuilder( 'WP_Job_Manager_Helper_API' )
+					 ->setMethods( array( 'plugin_update_check', 'plugin_information', 'activate', 'deactivate' ) )
+					 ->getMock();
+
+		$mock->method( 'plugin_update_check' )->willReturn( array(
+			'slug' => 'test',
+			'plugin' => 'test',
+			'new_version' => '1.1.0',
+			'url' => 'http://test.dev',
+			'package' => 'http://test.dev',
+		) );
+		$mock->method( 'plugin_information' )->willReturn( $this->result_plugin_information() );
+		$mock->method( 'activate' )->willReturn( array(
+			'success' => true,
+			'activated' => true,
+			'remaining' => -1,
+		) );
+		$mock->method( 'deactivate' )->willReturn( array(
+			'success' => true,
+		) );
+		return $mock;
+	}
+
+	protected function setProtectedProperty($object, $property, $value)
+	{
+		$reflection = new ReflectionClass($object);
+		$reflection_property = $reflection->getProperty($property);
+		$reflection_property->setAccessible(true);
+		$reflection_property->setValue($object, $value);
+	}
+}

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * @group helper
+ * @group helper-api
+ */
+class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
+
+	public function setUp() {
+		parent::setUp();
+		$this->enable_transport_faker();
+		$transport = $this->get_request_transport();
+		$transport->headers_matter = true;
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->disable_transport_faker();
+	}
+
+	/**
+	 * Tests the WP_Job_Manager_Helper_API::instance() always returns the same `WP_Job_Manager_Helper_API` instance.
+	 *
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::instance
+	 */
+	public function test_wp_job_manager_api_instance() {
+		$instance = WP_Job_Manager_Helper_API::instance();
+		// check the class
+		$this->assertInstanceOf( 'WP_Job_Manager_Helper_API', $instance, 'Job Manager Helper API object is instance of WP_Job_Manager_Helper_API class' );
+
+		// check it always returns the same object
+		$this->assertSame( WP_Job_Manager_Helper_API::instance(), $instance, 'WP_Job_Manager_Helper_API::instance() must always return the same object' );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::plugin_update_check
+	 */
+	public function test_plugin_update_check_valid() {
+		$base_args = $this->get_base_args();
+		$this->set_expected_response( array(
+			'args' => wp_parse_args( array(
+				'wc-api' => 'wp_plugin_licencing_update_api',
+				'request' => 'pluginupdatecheck',
+			), $base_args ),
+		) );
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->plugin_update_check( $base_args );
+
+		// If a request was made that we don't expect, `$response` would be false.
+		$this->assertEquals( $this->default_valid_response(), $response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::plugin_update_check
+	 */
+	public function test_plugin_update_check_invalid() {
+		$base_args = $this->get_base_args();
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->plugin_update_check( $base_args );
+
+		$this->assertFalse( $response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::plugin_information
+	 */
+	public function test_plugin_information_valid() {
+		$base_args = $this->get_base_args();
+		$this->set_expected_response( array(
+			'args' => wp_parse_args( array(
+				'wc-api' => 'wp_plugin_licencing_update_api',
+				'request' => 'plugininformation',
+			), $base_args ),
+		) );
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->plugin_information( $base_args );
+
+		// If a request was made that we don't expect, `$response` would be false.
+		$this->assertEquals( $this->default_valid_response(), $response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::plugin_information
+	 */
+	public function test_plugin_information_invalid() {
+		$base_args = $this->get_base_args();
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->plugin_information( $base_args );
+
+		$this->assertFalse( $response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::activate
+	 */
+	public function test_activate_valid() {
+		$base_args = $this->get_base_args();
+		$this->set_expected_response( array(
+			'args' => wp_parse_args( array(
+				'wc-api' => 'wp_plugin_licencing_activation_api',
+				'request' => 'activate',
+			), $base_args ),
+		) );
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->activate( $base_args );
+
+		// If a request was made that we don't expect, `$response` would be false.
+		$this->assertEquals( $this->default_valid_response(), $response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::activate
+	 */
+	public function test_activate_invalid() {
+		$base_args = $this->get_base_args();
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->activate( $base_args );
+
+		// For activation, we return the error from the request (if there was one)
+		$this->assertEquals( $this->default_invalid_response(), $response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::deactivate
+	 */
+	public function test_deactivate_valid() {
+		$base_args = $this->get_base_args();
+		$this->set_expected_response( array(
+			'args' => wp_parse_args( array(
+				'wc-api' => 'wp_plugin_licencing_activation_api',
+				'request' => 'deactivate',
+			), $base_args ),
+		) );
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->deactivate( $base_args );
+
+		// If a request was made that we don't expect, `$response` would be false.
+		$this->assertEquals( $this->default_valid_response(), $response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_API::deactivate
+	 */
+	public function test_deactivate_invalid() {
+		$base_args = $this->get_base_args();
+		$instance = new WP_Job_Manager_Helper_API;
+		$response = $instance->deactivate( $base_args );
+
+		$this->assertFalse( $response );
+	}
+
+	private function get_base_args() {
+		return array(
+			'instance' => site_url(),
+			'plugin_name' => 'test',
+			'version' => '1.0.0',
+			'api_product_id' => 'test',
+			'licence_key' => 'abcd',
+			'email' => 'test@local.dev',
+		);
+	}
+
+	protected function set_expected_response( $test_data ) {
+		$transport = $this->get_request_transport();
+		if ( ! isset( $test_data['request'] ) ) {
+			$test_data['request'] = array();
+		}
+		if ( ! isset( $test_data['request']['url'] ) ) {
+			$test_data['request']['url'] = $this->build_url( $test_data['args'] );
+		}
+		if ( ! isset( $test_data['request']['headers'] ) ) {
+			$test_data['request']['headers'] = array(
+				'Accept' => 'application/json',
+			);
+		}
+		if ( ! isset( $test_data['response'] ) ) {
+			$test_data['response'] = $this->default_valid_response();
+		}
+		$transport->add_fake_request( $test_data['request'], array( 'body' => $test_data['response'] ) );
+	}
+
+	protected function default_valid_response() {
+		return array( 'status' => 1 );
+	}
+
+	protected function default_invalid_response() {
+		// Prebaked response in Requests_Transport_Faker
+		return array( 'error_code' => 'http_request_failed', 'error' => 'Computer says no' );
+	}
+
+	protected function build_url( $args ) {
+		return 'https://wpjobmanager.com/?' . http_build_query( $args, '', '&' );
+	}
+}

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-options.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-options.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @group helper
+ * @group helper-options
+ */
+class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_Helper_Base_Test {
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_Options::update
+	 */
+	public function test_update_simple() {
+		$this->setup_master_option();
+		WP_Job_Manager_Helper_Options::update( 'test', 'licence_key', 'new-value' );
+		$new_option = $this->get_master_option();
+		$this->assertTrue( isset( $new_option['test']['licence_key'] ) );
+		$this->assertEquals( 'new-value', $new_option['test']['licence_key'] );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_Options::get
+	 */
+	public function test_get_return_default() {
+		$result_expected = 'simple';
+		$result = WP_Job_Manager_Helper_Options::get( 'test', 'licence_key', $result_expected );
+		$this->assertEquals( $result_expected, $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_Options::get
+	 */
+	public function test_get_return_value() {
+		$this->setup_master_option();
+		$result = WP_Job_Manager_Helper_Options::get( 'test', 'licence_key', 'simple' );
+		$this->assertEquals( 'abcd', $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_Options::get
+	 * @covers WP_Job_Manager_Helper_Options::attempt_legacy_restore
+	 */
+	public function test_get_return_legacy() {
+		$this->setup_legacy_options();
+		$licence_key_result = WP_Job_Manager_Helper_Options::get( 'legacy', 'licence_key', 'simple' );
+		$this->assertEquals( 'legacy-abcd', $licence_key_result );
+
+		$email_result = WP_Job_Manager_Helper_Options::get( 'legacy', 'email', 'simple' );
+		$this->assertEquals( 'legacy@test.dev', $email_result );
+
+		$errors_result = WP_Job_Manager_Helper_Options::get( 'legacy', 'errors', 'simple' );
+		$this->assertEquals( 'legacy-errors', $errors_result );
+
+		$errors_hide_key_notice = WP_Job_Manager_Helper_Options::get( 'legacy', 'hide_key_notice', 'simple' );
+		$this->assertEquals( 'legacy-hide', $errors_hide_key_notice );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper_Options::delete
+	 */
+	public function test_delete_simple() {
+		$this->setup_master_option();
+		$result = WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
+
+		$new_option = $this->get_master_option();
+		$this->assertFalse( isset( $new_option['test']['licence_key'] ) );
+	}
+
+	private function setup_legacy_options() {
+		update_option( 'legacy_licence_key', 'legacy-abcd' );
+		update_option( 'legacy_email', 'legacy@test.dev' );
+		update_option( 'legacy_errors', 'legacy-errors' );
+		update_option( 'legacy_hide_key_notice', 'legacy-hide' );
+	}
+
+	private function setup_master_option( $value = null ) {
+		if ( null === $value ) {
+			$value = array(
+				'test' => array(
+					'licence_key' => 'abcd',
+					'email' => 'local@local.dev',
+					'errors' => null,
+					'hide_key_notice' => false,
+				),
+			);
+		}
+		update_option( 'job_manager_helper', $value );
+	}
+
+	private function get_master_option() {
+		return get_option( 'job_manager_helper', array() );
+	}
+}

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * @group helper
+ * @group helper-base
+ */
+class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
+	/**
+	 * Tests the WP_Job_Manager_Helper::instance() always returns the same `WP_Job_Manager_Helper` instance.
+	 *
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::instance
+	 */
+	public function test_wp_job_manager_instance() {
+		$instance = WP_Job_Manager_Helper::instance();
+		// check the class
+		$this->assertInstanceOf( 'WP_Job_Manager_Helper', $instance, 'Job Manager Helper object is instance of WP_Job_Manager_Helper class' );
+
+		// check it always returns the same object
+		$this->assertSame( WP_Job_Manager_Helper::instance(), $instance, 'WP_Job_Manager_Helper::instance() must always return the same object' );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::admin_init
+	 * @requires PHP 5.3.0
+	 */
+	public function test_admin_init_no_dismiss() {
+		$instance = $this->getMockHelper();
+		$product_slug = 'test';
+		$default = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertNull( $default );
+		unset( $_GET['dismiss-wpjm-licence-notice'] );
+		$instance->admin_init();
+		$key_notice_status = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertNull( $key_notice_status );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::admin_init
+	 * @requires PHP 5.3.0
+	 */
+	public function test_admin_init_with_dismiss() {
+		$instance = $this->getMockHelper();
+		$product_slug = 'test';
+		$default = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertNull( $default );
+		$_GET['dismiss-wpjm-licence-notice'] = $product_slug;
+		$instance->admin_init();
+		$key_notice_status = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertTrue( $key_notice_status );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::has_licenced_products
+	 * @covers WP_Job_Manager_Helper::get_plugin_version
+	 * @covers WP_Job_Manager_Helper::get_plugin_licence
+	 * @requires PHP 5.3.0
+	 */
+	public function test_check_for_updates_has_update() {
+		$instance = $this->getMockHelper( $this->plugin_data_with_update() );
+		$data = new stdClass;
+		$data->response = array();
+		$instance->check_for_updates( $data );
+		$this->assertTrue( isset( $data->response['test/test.php'] ) );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::has_licenced_products
+	 * @covers WP_Job_Manager_Helper::get_plugin_version
+	 * @covers WP_Job_Manager_Helper::get_plugin_licence
+	 * @requires PHP 5.3.0
+	 */
+	public function test_check_for_updates_no_update() {
+		$instance = $this->getMockHelper( $this->plugin_data_without_update() );
+		$data = new stdClass;
+		$data->response = array();
+		$instance->check_for_updates( $data );
+		$this->assertEmpty( $data->response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::has_licenced_products
+	 * @covers WP_Job_Manager_Helper::get_plugin_version
+	 * @covers WP_Job_Manager_Helper::get_plugin_licence
+	 * @requires PHP 5.3.0
+	 */
+	public function test_check_for_updates_no_license() {
+		$instance = $this->getMockHelper( $this->plugin_data_with_update() );
+
+		WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
+		WP_Job_Manager_Helper_Options::delete( 'test', 'email' );
+
+		$data = new stdClass;
+		$data->response = array();
+		$instance->check_for_updates( $data );
+		$this->assertEmpty( $data->response );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugin_activated
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugin_activated_actual_plugin() {
+		$instance = $this->getMockHelper();
+		$product_slug = 'test';
+		WP_Job_Manager_Helper_Options::update( $product_slug, 'hide_key_notice', true );
+		$this->assertTrue( WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null ) );
+		$instance->plugin_activated( 'test/test.php' );
+		$this->assertNull( WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null ) );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugin_activated
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugin_activated_untracked_plugin() {
+		$instance = $this->getMockHelper();
+		$product_slug = 'rhino';
+		WP_Job_Manager_Helper_Options::update( $product_slug, 'hide_key_notice', true );
+		$this->assertTrue( WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null ) );
+		$instance->plugin_activated( 'rhino/rhino.php' );
+		$this->assertTrue( WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null ) );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugin_deactivated
+	 * @covers WP_Job_Manager_Helper::deactivate_licence
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugin_deactivated_actual_plugin() {
+		$instance = $this->getMockHelper();
+		$api = $instance->_get_api();
+		$api->expects( $this->once() )->method('deactivate');
+
+		$product_slug = 'test';
+		WP_Job_Manager_Helper_Options::update( $product_slug, 'hide_key_notice', true );
+		$this->assertNotEmpty( WP_Job_Manager_Helper_Options::get( $product_slug, 'licence_key', null ) );
+		$this->assertNotEmpty( WP_Job_Manager_Helper_Options::get( $product_slug, 'email', null ) );
+		$instance->plugin_deactivated( 'test/test.php' );
+		$this->assertEmpty( WP_Job_Manager_Helper_Options::get( $product_slug, 'licence_key', null ) );
+		$this->assertEmpty( WP_Job_Manager_Helper_Options::get( $product_slug, 'email', null ) );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugins_api
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugins_api_unknown_plugin() {
+		$instance = $this->getMockHelper();
+
+		$plugin_slug = 'rhino';
+		$response = new stdClass;
+		$args = new stdClass;
+		$args->slug = $plugin_slug;
+		$result = $instance->plugins_api( $response, 'plugin_information', $args );
+		$this->assertSame( $response, $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugins_api
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugins_api_empty_plugin() {
+		$instance = $this->getMockHelper();
+
+		$response = new stdClass;
+		$args = new stdClass;
+		$result = $instance->plugins_api( $response, 'plugin_information', $args );
+		$this->assertSame( $response, $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugins_api
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugins_api_bad_action() {
+		$instance = $this->getMockHelper();
+
+		$plugin_slug = 'rhino';
+		$response = new stdClass;
+		$args = new stdClass;
+		$args->slug = $plugin_slug;
+		$args = new stdClass( array( 'slug' => $plugin_slug ) );
+		$result = $instance->plugins_api( $response, 'what_the_what', $args );
+		$this->assertSame( $response, $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugins_api
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugins_api_valid_plugin() {
+		$instance = $this->getMockHelper();
+
+		$plugin_slug = 'test';
+		$response = new stdClass;
+		$args = new stdClass;
+		$args->slug = $plugin_slug;
+		$result = $instance->plugins_api( $response, 'plugin_information', $args );
+		$expected = (object) $this->result_plugin_information();
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugin_links
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugin_links_valid_plugin_valid_license() {
+		$instance = $this->getMockHelper();
+		$this->enable_update_plugins_cap();
+		$actions = $instance->plugin_links( array(), 'test/test.php');
+		$this->disable_update_plugins_cap();
+		$this->assertCount( 1, $actions );
+		$this->assertContains( __( 'Manage License', 'wp-job-manager' ), $actions[0] );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugin_links
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugin_links_valid_plugin_invalid_license() {
+		$instance = $this->getMockHelper();
+		$this->enable_update_plugins_cap();
+		WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
+		WP_Job_Manager_Helper_Options::delete( 'test', 'email' );
+		$actions = $instance->plugin_links( array(), 'test/test.php');
+		$this->disable_update_plugins_cap();
+		$this->assertCount( 1, $actions );
+		$this->assertContains( __( 'Activate License', 'wp-job-manager' ), $actions[0] );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugin_links
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugin_links_invalid_plugin() {
+		$instance = $this->getMockHelper();
+		$this->enable_update_plugins_cap();
+		$actions = $instance->plugin_links( array(), 'rhino/rhino.php');
+		$this->disable_update_plugins_cap();
+		$this->assertCount( 0, $actions );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::plugin_links
+	 * @requires PHP 5.3.0
+	 */
+	public function test_plugin_links_invalid_cap() {
+		$instance = $this->getMockHelper();
+		$actions = $instance->plugin_links( array(), 'test/test.php');
+		$this->assertCount( 0, $actions );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::is_product_installed
+	 * @requires PHP 5.3.0
+	 */
+	public function test_is_product_installed_valid() {
+		$instance = $this->getMockHelper();
+		$result = $instance->is_product_installed( 'test' );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::is_product_installed
+	 * @requires PHP 5.3.0
+	 */
+	public function test_is_product_installed_invalid() {
+		$instance = $this->getMockHelper();
+		$result = $instance->is_product_installed( 'rhino' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::has_licenced_products
+	 * @covers WP_Job_Manager_Helper::get_plugin_info
+	 * @requires PHP 5.3.0
+	 */
+	public function test_has_licenced_products_true() {
+		// Simulate no installed plugins
+		$instance = $this->getMockHelper( array() );
+		$this->assertFalse( $instance->has_licenced_products() );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::has_licenced_products
+	 * @covers WP_Job_Manager_Helper::get_plugin_info
+	 * @requires PHP 5.3.0
+	 */
+	public function test_has_licenced_products_false() {
+		// Simulate a installed plugin
+		$instance = $this->getMockHelper( array( 'test' => array() ) );
+		$this->assertTrue( $instance->has_licenced_products() );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::get_plugin_licence
+	 */
+	public function test_get_plugin_license_valid() {
+		WP_Job_Manager_Helper_Options::update( 'rhino', 'licence_key', '1234' );
+		WP_Job_Manager_Helper_Options::update( 'rhino', 'email', 'test@local.dev' );
+		WP_Job_Manager_Helper_Options::update( 'rhino', 'errors', null );
+		$instance = new WP_Job_Manager_Helper();
+		$result = $instance->get_plugin_licence( 'rhino' );
+		WP_Job_Manager_Helper_Options::delete( 'rhino', 'licence_key' );
+		WP_Job_Manager_Helper_Options::delete( 'rhino', 'email' );
+		WP_Job_Manager_Helper_Options::delete( 'rhino', 'errors' );
+		$expected = array(
+			'licence_key' => '1234',
+			'email' => 'test@local.dev',
+			'errors' => null,
+		);
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::get_plugin_info
+	 */
+	public function test_get_plugin_license_invalid() {
+		$instance = new WP_Job_Manager_Helper();
+		$result = $instance->get_plugin_licence( 'rhino' );
+		$expected = array(
+			'licence_key' => null,
+			'email' => null,
+			'errors' => null,
+		);
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * @since 1.29.0
+	 * @covers WP_Job_Manager_Helper::extra_headers
+	 */
+	public function test_extra_headers() {
+		$instance = new WP_Job_Manager_Helper();
+		$result = $instance->extra_headers( array() );
+		$expected = array( 'WPJM-Product' );
+		$this->assertEquals( $expected, $result );
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-cache-helper.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-cache-helper.php
@@ -270,7 +270,6 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 	/**
 	 * @since 1.27.0
 	 * @covers WP_Job_Manager_Cache_Helper::maybe_clear_count_transients
-	 * @group wip
 	 */
 	public function test_maybe_clear_count_transients() {
 		global $wpdb;

--- a/tests/php/tests/includes/test_class.wp-job-manager-geocode.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-geocode.php
@@ -1,17 +1,14 @@
 <?php
 
+/**
+ * @group geocode
+ */
 class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
-	/**
-	 * @var Requests_Transport
-	 */
-	private $_transport;
 
 	public function setUp() {
 		parent::setUp();
-		include_once( WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/class-requests-transport-faker.php' );
 		add_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
 		add_filter( 'job_manager_geolocation_enabled', '__return_true' );
-		$this->_transport = null;
 		$this->enable_transport_faker();
 	}
 
@@ -277,29 +274,6 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 			$this->markTestSkipped( 'Geocode test requires WPJM_PHPUNIT_GOOGLE_GEOCODE_API_KEY environment variable to be set to valid Google Maps Geocode API Key' );
 		}
 		$this->disable_transport_faker();
-	}
-
-	protected function disable_transport_faker() {
-		remove_action( 'requests-requests.before_request', array( $this, 'overload_request_transport' ), 10 );
-		remove_filter( 'job_manager_geolocation_api_key', '__return_empty_string', 10 );
-		add_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
-	}
-
-	protected function enable_transport_faker() {
-		add_action( 'requests-requests.before_request', array( $this, 'overload_request_transport' ), 10, 5 );
-		remove_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
-		add_filter( 'job_manager_geolocation_api_key', '__return_empty_string', 10 );
-	}
-
-	public function overload_request_transport(&$url, &$headers, &$data, &$type, &$options) {
-		$options['transport'] = $this->get_request_transport();
-	}
-
-	private function get_request_transport() {
-		if ( ! isset( $this->_transport ) ) {
-			$this->_transport = new Requests_Transport_Faker();
-		}
-		return $this->_transport;
 	}
 
 	public function get_google_maps_api_key() {

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -71,6 +71,7 @@ class WP_Job_Manager {
 		include_once( 'includes/class-wp-job-manager-forms.php' );
 		include_once( 'includes/class-wp-job-manager-geocode.php' );
 		include_once( 'includes/class-wp-job-manager-cache-helper.php' );
+		include_once( 'includes/helper/class-wp-job-manager-helper.php' );
 
 		add_action( 'rest_api_init', array( $this, 'rest_api' ) );
 


### PR DESCRIPTION
#### To do:
- [x] Add tests

#### Changes proposed in this Pull Request:

* Moves and updates license/helper code from individual wpjobmanager.com plugins to WPJM core.
* Licenses are now stored in one option. Old license activations should be migrated although WordPress MU users should re-activate their licenses.
* WordPress MU users are now activated network-wide (which makes sense as this is for plugin updates). Before there was a hack-ish work-around to use the active site to test for plugin updates.
* Moves license management to WP Admin > Job Listings > Add-ons > Licenses.
* Requests JSON responses from wpjobmanager.com's License API. 
* Uses new docblock notation of `WPJM-Product` in our plugins to pass along the wpjobmanager.com's product slug (consistently also happens to be the plugin's slug, but I decoupled the two). 

Dev note: I kept the usage of the British `licence` in the code but used `license` in all strings. Now that I'm already migrating the old options to a single option, I'm happy with moving all over to `license` if people think it is necessary.

Internal note: I'm updating all of our plugins using a standard branch name `change/wpjm-core-updater`.

<img width="1235" alt="screen shot 2017-09-08 at 2 24 47 pm" src="https://user-images.githubusercontent.com/68693/30213621-86f12ff2-94a1-11e7-96ea-90b300406a18.png">
