### PR TITLE
REST API: Job Types

### DIFF
--- a/includes/rest-api/class-wp-job-manager-models-job-types-custom-fields.php
+++ b/includes/rest-api/class-wp-job-manager-models-job-types-custom-fields.php
@@ -14,6 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WP_Job_Manager_Models_Job_Types_Custom_Fields extends WP_Job_Manager_REST_Model
 	implements WP_Job_Manager_REST_Interfaces_Model {
+
+	/**
+	 * Accepted employment types
+	 *
+	 * @var array
+	 */
 	private static $accepted_employment_types = array();
 	/**
 	 * Declare Fields
@@ -32,13 +38,18 @@ class WP_Job_Manager_Models_Job_Types_Custom_Fields extends WP_Job_Manager_REST_
 		);
 	}
 
+	/**
+	 * Validate this
+	 *
+	 * @return bool|WP_Error
+	 */
 	public function validate() {
 		$employment_type = $this->get( 'employment_type' );
-		if ( ! empty( $employment_type ) && ! in_array( $employment_type, self::$accepted_employment_types ) ) {
+		if ( ! empty( $employment_type ) && ! in_array( $employment_type, self::$accepted_employment_types, true ) ) {
 			return new WP_Error('invalid_employment_type', __( 'Invalid Employment Type', 'wp-job-manager' ), array(
 				'input' => $employment_type,
 				'acceptable_values' => self::$accepted_employment_types,
-                'status' => 400,
+				'status' => 400,
 			) );
 		}
 		return parent::validate();

--- a/includes/rest-api/class-wp-job-manager-models-job-types-custom-fields.php
+++ b/includes/rest-api/class-wp-job-manager-models-job-types-custom-fields.php
@@ -21,6 +21,7 @@ class WP_Job_Manager_Models_Job_Types_Custom_Fields extends WP_Job_Manager_REST_
 	 * @var array
 	 */
 	private static $accepted_employment_types = array();
+
 	/**
 	 * Declare Fields
 	 *

--- a/includes/rest-api/class-wp-job-manager-models-job-types-custom-fields.php
+++ b/includes/rest-api/class-wp-job-manager-models-job-types-custom-fields.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Declaration of Job Types Custom Fields Model
+ *
+ * @package WPJM/REST
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class WP_Job_Manager_Models_Job_Types_Custom_Fields
+ */
+class WP_Job_Manager_Models_Job_Types_Custom_Fields extends WP_Job_Manager_REST_Model
+	implements WP_Job_Manager_REST_Interfaces_Model {
+	private static $accepted_employment_types = array();
+	/**
+	 * Declare Fields
+	 *
+	 * @return array
+	 */
+	public function declare_fields() {
+		$env = $this->get_environment();
+		$employment_types = wpjm_job_listing_employment_type_options();
+		self::$accepted_employment_types = array_keys( $employment_types );
+		return array(
+			$env->field( 'employment_type', __( 'Employment Type', 'wp-job-manager' ) )
+				->with_kind( WP_Job_Manager_REST_Field_Declaration::META )
+				->with_type( $env->type( 'string' ) )
+				->with_choices( self::$accepted_employment_types ),
+		);
+	}
+
+	public function validate() {
+		$employment_type = $this->get( 'employment_type' );
+		if ( ! empty( $employment_type ) && ! in_array( $employment_type, self::$accepted_employment_types ) ) {
+			return new WP_Error('invalid_employment_type', __( 'Invalid Employment Type', 'wp-job-manager' ), array(
+				'input' => $employment_type,
+				'acceptable_values' => self::$accepted_employment_types,
+                'status' => 400,
+			) );
+		}
+		return parent::validate();
+	}
+}

--- a/includes/rest-api/class-wp-job-manager-registrable-job-listings.php
+++ b/includes/rest-api/class-wp-job-manager-registrable-job-listings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Used for RESTifying the job_listing post type
- * 
+ *
  * Adds custom fields. Needs a model definition that will provide the extra fields.
  *
  * @package WPJM/REST
@@ -10,7 +10,7 @@
 /**
  * Class MT_Controller_Extension
  */
-class WP_Job_Manager_REST_Registrable_Job_Listings implements WP_Job_Manager_REST_Interfaces_Registrable {
+class WP_Job_Manager_Registrable_Job_Listings implements WP_Job_Manager_REST_Interfaces_Registrable {
 
 	/**
 	 * Environment

--- a/includes/rest-api/class-wp-job-manager-registrable-job-types.php
+++ b/includes/rest-api/class-wp-job-manager-registrable-job-types.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Exposes Job Types Taxonomy REST Api
+ *
+ * @package WPJM/REST
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class WP_Job_Manager_Registrable_Job_Types
+ */
+class WP_Job_Manager_Registrable_Job_Types implements WP_Job_Manager_REST_Interfaces_Registrable {
+
+	/**
+	 * The Model Prototype
+	 *
+	 * @var WP_Job_Manager_REST_Model
+	 */
+	private $model_prototype;
+
+	/**
+	 * Rest Field Name
+	 *
+	 * @var string
+	 */
+	private $rest_field_name;
+
+	/**
+	 * Taxonomy Type
+	 *
+	 * @var string
+	 */
+	private $taxonomy_type;
+
+	/**
+	 * Register Job Types
+	 *
+	 * @param WP_Job_Manager_REST_Environment $environment The Environment to use.
+	 * @throws WP_Job_Manager_REST_Exception Throws.
+	 *
+	 * @return bool|WP_Error true if valid otherwise error.
+	 */
+	public function register( $environment ) {
+		global $wp_taxonomies;
+		$this->taxonomy_type = 'job_listing_type';
+		$this->rest_field_name = 'fields';
+
+		if ( ! isset( $wp_taxonomies[ $this->taxonomy_type ] ) ) {
+			return false;
+		}
+
+		if ( $wp_taxonomies[ $this->taxonomy_type ]->show_in_rest ) {
+			return true;
+		}
+
+		$wp_taxonomies[ $this->taxonomy_type ]->show_in_rest = true;
+		$wp_taxonomies[ $this->taxonomy_type ]->rest_base = 'job-types';
+
+		$this->model_prototype = $environment->model( 'WP_Job_Manager_Models_Job_Types_Custom_Fields' );
+
+		if ( ! $this->model_prototype ) {
+			return new WP_Error( 'model-not-found' );
+		}
+		register_rest_field( $this->taxonomy_type, $this->rest_field_name, array(
+			'get_callback' => array( $this, 'get_employment_type' ),
+			'update_callback' => array( $this, 'update_employment_type' ),
+			'schema' => $this->get_item_schema(),
+		) );
+
+		return true;
+	}
+
+	/**
+	 * Get Item Schema
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$fields = $this->model_prototype->get_fields();
+		$properties = array();
+		$required = array();
+		foreach ( $fields as $field_declaration ) {
+			/**
+			 * Our declaration
+			 *
+			 * @var WP_Job_Manager_REST_Field_Declaration $field_declaration
+			 */
+			$properties[ $field_declaration->get_data_transfer_name() ] = $field_declaration->as_item_schema_property();
+			if ( $field_declaration->is_required() ) {
+				$required[] = $field_declaration->get_data_transfer_name();
+			}
+		}
+		$schema = array(
+			'$schema' => 'http://json-schema.org/schema#',
+			'title' => $this->model_prototype->get_name(),
+			'type' => 'object',
+			'properties' => (array) apply_filters( 'mixtape_rest_api_schema_properties', $properties, $this->model_prototype ),
+		);
+
+		if ( ! empty( $required ) ) {
+			$schema['required'] = $required;
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Our Get Fields.
+	 *
+	 * @param array           $object Object.
+	 * @param string          $field_name Field Name.
+	 * @param WP_REST_Request $request Request.
+	 * @param string          $object_type Object Type.
+	 *
+	 * @return mixed|string
+	 * @throws WP_Job_Manager_REST_Exception If type not there.
+	 */
+	function get_employment_type( $object, $field_name, $request, $object_type ) {
+		if ( $this->taxonomy_type !== $object_type ) {
+			return null;
+		}
+
+		if ( $this->rest_field_name !== $field_name ) {
+			return null;
+		}
+
+		$object_id = absint( $object['id'] );
+		$model = $this->get_model( $object_id );
+		return $model->to_dto();
+	}
+
+	/**
+	 * Get a model if exists
+	 *
+	 * @param int $object_id Object ID.
+	 * @return WP_Job_Manager_REST_Interfaces_Model
+	 * @throws WP_Job_Manager_REST_Exception On Error.
+	 */
+	private function get_model( $object_id ) {
+		$data = array();
+		foreach ( $this->model_prototype->get_fields( WP_Job_Manager_REST_Field_Declaration::META ) as $field_declaration ) {
+			$field_name = $field_declaration->get_name();
+			if ( metadata_exists( 'term', $object_id, $field_name ) ) {
+				$meta = get_term_meta( $object_id, $field_name, true );
+				$data[ $field_name ] = $meta;
+			}
+		}
+
+		return $this->model_prototype->create( $data, array(
+			'deserialize' => true,
+		) );
+	}
+
+	/**
+	 * Our Reader.
+	 *
+	 * @param mixed 		  $data Data.
+	 * @param object          $object Object.
+	 * @param string          $field_name Field Name.
+	 * @param WP_REST_Request $request Request.
+	 * @param string          $object_type Object Type.
+	 *
+	 * @return mixed|string
+	 * @throws WP_Job_Manager_REST_Exception If type not there.
+	 */
+	function update_employment_type( $data, $object, $field_name, $request, $object_type ) {
+		if ( $this->taxonomy_type !== $object_type ) {
+			return null;
+		}
+
+		if ( $this->rest_field_name !== $field_name ) {
+			return null;
+		}
+
+		if ( ! is_a( $object, 'WP_Term' ) ) {
+		    return null;
+        }
+
+		$term_id = absint( $object->term_id );
+		if ( ! $term_id ) {
+		    // we got no way to update this. Bail
+            return new WP_Error('job-types-error-invalid-id', 'job-types-error-invalid-id', array( 'status' => 400 ) );
+        }
+		$existing_model = $this->get_model( $term_id );
+
+		$updated = $existing_model->update_from_array( $data );
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+
+		$maybe_validation_error = $updated->sanitize()->validate();
+		if ( is_wp_error( $maybe_validation_error ) ) {
+			return $maybe_validation_error;
+		}
+
+		$serialized_data = $updated->serialize( WP_Job_Manager_REST_Field_Declaration::META );
+
+
+		foreach ( $serialized_data as $field_name => $val ) {
+			if ( metadata_exists( 'term', $term_id, $field_name ) ) {
+              update_term_meta( $term_id, $field_name, $val );
+			} else {
+				add_term_meta( $term_id, $field_name, $val );
+			}
+		}
+
+		return true;
+	}
+}

--- a/includes/rest-api/class-wp-job-manager-registrable-job-types.php
+++ b/includes/rest-api/class-wp-job-manager-registrable-job-types.php
@@ -118,7 +118,7 @@ class WP_Job_Manager_Registrable_Job_Types implements WP_Job_Manager_REST_Interf
 	 * @return mixed|string
 	 * @throws WP_Job_Manager_REST_Exception If type not there.
 	 */
-	function get_employment_type( $object, $field_name, $request, $object_type ) {
+	public function get_employment_type( $object, $field_name, $request, $object_type ) {
 		if ( $this->taxonomy_type !== $object_type ) {
 			return null;
 		}
@@ -166,7 +166,7 @@ class WP_Job_Manager_Registrable_Job_Types implements WP_Job_Manager_REST_Interf
 	 * @return mixed|string
 	 * @throws WP_Job_Manager_REST_Exception If type not there.
 	 */
-	function update_employment_type( $data, $object, $field_name, $request, $object_type ) {
+	public function update_employment_type( $data, $object, $field_name, $request, $object_type ) {
 		if ( $this->taxonomy_type !== $object_type ) {
 			return null;
 		}

--- a/includes/rest-api/class-wp-job-manager-registrable-job-types.php
+++ b/includes/rest-api/class-wp-job-manager-registrable-job-types.php
@@ -4,6 +4,7 @@
  *
  * @package WPJM/REST
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -175,14 +176,16 @@ class WP_Job_Manager_Registrable_Job_Types implements WP_Job_Manager_REST_Interf
 		}
 
 		if ( ! is_a( $object, 'WP_Term' ) ) {
-		    return null;
-        }
+			return null;
+		}
 
 		$term_id = absint( $object->term_id );
 		if ( ! $term_id ) {
-		    // we got no way to update this. Bail
-            return new WP_Error('job-types-error-invalid-id', 'job-types-error-invalid-id', array( 'status' => 400 ) );
-        }
+			// No way to update this. Bail.
+			return new WP_Error( 'job-types-error-invalid-id', 'job-types-error-invalid-id', array(
+				'status' => 400,
+			) );
+		}
 		$existing_model = $this->get_model( $term_id );
 
 		$updated = $existing_model->update_from_array( $data );
@@ -197,10 +200,9 @@ class WP_Job_Manager_Registrable_Job_Types implements WP_Job_Manager_REST_Interf
 
 		$serialized_data = $updated->serialize( WP_Job_Manager_REST_Field_Declaration::META );
 
-
 		foreach ( $serialized_data as $field_name => $val ) {
 			if ( metadata_exists( 'term', $term_id, $field_name ) ) {
-              update_term_meta( $term_id, $field_name, $val );
+				update_term_meta( $term_id, $field_name, $val );
 			} else {
 				add_term_meta( $term_id, $field_name, $val );
 			}

--- a/includes/rest-api/class-wp-job-manager-rest-api.php
+++ b/includes/rest-api/class-wp-job-manager-rest-api.php
@@ -88,7 +88,9 @@ class WP_Job_Manager_REST_API {
 		include_once 'class-wp-job-manager-data-stores-status.php';
 		include_once 'class-wp-job-manager-controllers-status.php';
 		include_once 'class-wp-job-manager-models-job-listings-custom-fields.php';
+		include_once 'class-wp-job-manager-models-job-types-custom-fields.php';
 		include_once 'class-wp-job-manager-registrable-job-listings.php';
+		include_once 'class-wp-job-manager-registrable-job-types.php';
 
 		// Models.
 		$env->define_model( 'WP_Job_Manager_Models_Settings' )
@@ -97,6 +99,7 @@ class WP_Job_Manager_REST_API {
 			->with_data_store( new WP_Job_Manager_Data_Stores_Status( $env->model( 'WP_Job_Manager_Models_Status' ) ) );
 		$env->define_model( 'WP_Job_Manager_Filters_Status' );
 		$env->define_model( 'WP_Job_Manager_Models_Job_Listings_Custom_Fields' );
+		$env->define_model( 'WP_Job_Manager_Models_Job_Types_Custom_Fields' );
 
 		// Endpoints.
 		$env->rest_api( 'wpjm/v1' )
@@ -106,6 +109,7 @@ class WP_Job_Manager_REST_API {
 			'job_listing',
 			'WP_Job_Manager_Models_Job_Listings_Custom_Fields',
 			'fields' ) );
+		$env->add_registrable( new WP_Job_Manager_Registrable_Job_Types() );
 	}
 }
 

--- a/includes/rest-api/class-wp-job-manager-rest-api.php
+++ b/includes/rest-api/class-wp-job-manager-rest-api.php
@@ -105,10 +105,10 @@ class WP_Job_Manager_REST_API {
 		$env->rest_api( 'wpjm/v1' )
 			->add_endpoint( new WP_Job_Manager_REST_Controller_Settings( '/settings', 'WP_Job_Manager_Models_Settings' ) )
 			->add_endpoint( new WP_Job_Manager_Controllers_Status( '/status', 'WP_Job_Manager_Models_Status' ) );
-		$env->add_registrable( new WP_Job_Manager_REST_Registrable_Job_Listings(
+		$env->add_registrable( new WP_Job_Manager_Registrable_Job_Listings(
 			'job_listing',
 			'WP_Job_Manager_Models_Job_Listings_Custom_Fields',
-			'fields' ) );
+		'fields' ) );
 		$env->add_registrable( new WP_Job_Manager_Registrable_Job_Types() );
 	}
 }

--- a/includes/rest-api/class-wp-job-manager-rest-api.php
+++ b/includes/rest-api/class-wp-job-manager-rest-api.php
@@ -41,11 +41,14 @@ class WP_Job_Manager_REST_API {
 	public function __construct( $base_dir ) {
 		$this->base_dir = trailingslashit( $base_dir );
 		$this->is_rest_api_enabled = defined( 'WPJM_REST_API_ENABLED' ) && ( true === constant( 'WPJM_REST_API_ENABLED' ) );
-		add_action( 'mt_environment_before_start', array( $this, 'define_api' ) );
 		$file = $this->base_dir . 'lib/wpjm_rest/class-wp-job-manager-rest-bootstrap.php';
 		if ( file_exists( $file ) && $this->is_rest_api_enabled ) {
 			include_once $file;
 			$this->wpjm_rest_api = WP_Job_Manager_REST_Bootstrap::create();
+			$this->wpjm_rest_api
+				->environment()
+				->get_event_dispatcher()
+				->add_action( 'environment_before_start', array( $this, 'define_api' ) );
 			$this->wpjm_rest_api->run();
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-wp-i18n": "~0.5.4",
     "grunt-wp-readme-to-markdown": "^2.0.0",
     "grunt-zip": "^0.17.1",
-    "mixtape": "git+https://github.com/Automattic/mixtape.git#3a84400af7fd0004102f7f63a50d2dd4f441e273"
+    "mixtape": "git+https://github.com/Automattic/mixtape.git#49f7490bf11ab3f2305d3216f3bee1066f13a1cd"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-wp-i18n": "~0.5.4",
     "grunt-wp-readme-to-markdown": "^2.0.0",
     "grunt-zip": "^0.17.1",
-    "mixtape": "git+https://github.com/Automattic/mixtape.git#49f7490bf11ab3f2305d3216f3bee1066f13a1cd"
+    "mixtape": "git+https://github.com/Automattic/mixtape.git#faca4e486ae88661bd642c1b44e058b9bc461fa2"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -57,6 +57,10 @@ class WPJM_Unit_Tests_Bootstrap {
 	 * @since 1.26.0
 	 */
 	public function load_plugin() {
+        $enabled = get_option( 'job_manager_enable_types' );
+        if (! $enabled ) {
+            update_option( 'job_manager_enable_types', true );
+        }
 		require_once( $this->plugin_dir . '/wp-job-manager.php' );
 	}
 

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -4,7 +4,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	/**
 	 * @group rest
-	 * @covers WP_Job_Manager_REST_Registrable_Job_Listings::get_fields
+	 * @covers WP_Job_Manager_Registrable_Job_Listings::get_fields
 	 */
 	function test_get_job_listings_success() {
 		$this->login_as( $this->default_user_id );
@@ -14,7 +14,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	/**
 	 * @group rest
-	 * @covers WP_Job_Manager_REST_Registrable_Job_Listings::get_fields
+	 * @covers WP_Job_Manager_Registrable_Job_Listings::get_fields
 	 */
 	function test_get_job_listings_add_fields() {
 		$published = $this->factory->job_listing->create_many( 2 );

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
@@ -1,0 +1,79 @@
+<?php
+
+class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
+
+	/**
+	 * @group rest
+	 */
+	function test_wp_v2_has_job_types_route() {
+		$this->login_as( $this->default_user_id );
+        $response = $this->get( '/wp/v2' );
+        $this->assertResponseStatus( $response, 200 );
+        $data = $response->get_data();
+
+        $routes =  array_keys( $data['routes'] );
+        $this->assertTrue( in_array( '/wp/v2/job-types', $routes ) );
+	}
+
+    /**
+     * @group rest
+     */
+	function test_get_job_types_success() {
+        $this->login_as( $this->default_user_id );
+        $response = $this->get( '/wp/v2/job-types' );
+        $this->assertResponseStatus( $response, 200 );
+    }
+
+    /**
+     * @group rest
+     */
+    function test_post_job_types_fail_if_invalid_employment_type() {
+        $this->login_as( $this->admin_id );
+        $response = $this->post( '/wp/v2/job-types', array(
+            'name' => 'Software Engineer',
+            'slug' => 'software-engineer',
+            'fields' => array(
+                'employment_type' => 'invalid',
+            ),
+        ) );
+        $this->assertResponseStatus( $response, 400 );
+    }
+
+    /**
+     * @group rest
+     */
+    function test_post_job_types_succeed_if_valid_employment_type() {
+        $this->login_as( $this->admin_id );
+        $response = $this->post( '/wp/v2/job-types', array(
+            'name' => 'Software Engineer',
+            'slug' => 'software-engineer',
+            'fields' => array(
+                'employment_type' => 'FULL_TIME',
+            ),
+        ) );
+
+        $this->assertResponseStatus( $response, 201 );
+    }
+
+    /**
+     * @group rest
+     */
+    function test_post_job_types_save_employment_type() {
+        $this->login_as( $this->admin_id );
+        $response = $this->post( '/wp/v2/job-types', array(
+            'name' => 'Software Engineer',
+            'slug' => 'software-engineer',
+            'fields' => array(
+                'employment_type' => 'FULL_TIME',
+            ),
+        ) );
+
+        $this->assertResponseStatus( $response, 201 );
+        $data = $response->get_data();
+        $this->assertTrue( array_key_exists( 'fields', $data ) );
+        $fields = $data['fields'];
+        $this->assertTrue( array_key_exists( 'employment_type', $fields ) );
+        $job_type_employment_type = $fields['employment_type'];
+        $this->assertSame( 'FULL_TIME', $job_type_employment_type );
+    }
+}

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-models-job-types-custom-fields.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-models-job-types-custom-fields.php
@@ -1,0 +1,24 @@
+<?php
+
+class WP_Test_WP_Job_Manager_Models_Job_Types_Custom_Fields extends WPJM_REST_TestCase {
+
+    /**
+     * @group rest
+     */
+    function test_exists() {
+        $this->assertClassExists( 'WP_Job_Manager_Models_Job_Types_Custom_Fields' );
+    }
+
+    /**
+     * @group rest
+     */
+    function test_can_set_employment_type() {
+        $model = $this
+            ->environment()
+            ->model( 'WP_Job_Manager_Models_Job_Types_Custom_Fields' )
+            ->create( array() );
+
+        $model->set( 'employment_type', 'FULL_TIME' );
+        $this->assertEquals( $model->get( 'employment_type' ), 'FULL_TIME' );
+    }
+}


### PR DESCRIPTION
Adds a job-type endpoint under `wp/v2`.

#### Changes proposed in this Pull Request:

* Enables `show_in_rest` for the job type taxonomy
* Adds a custom nested field, via `register_rest_field`

#### Testing instructions:

* Update mixtape locally (`./node_modules/.bin/mixtape build` )
* Do CRUD requests on `wp/v2/job-types`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* REST API: Add Job Types Support