### PR TITLE
Dev version bump for next release target: 1.29.0

### DIFF
--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.28.0
+ * Version: 1.29.0-dev
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 4.1
@@ -58,7 +58,7 @@ class WP_Job_Manager {
 	 */
 	public function __construct() {
 		// Define constants
-		define( 'JOB_MANAGER_VERSION', '1.28.0' );
+		define( 'JOB_MANAGER_VERSION', '1.29.0-dev' );
 		define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 		define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 


### PR DESCRIPTION
I was thinking about trying out bumping the version constant/header to the next release target with a "-dev" postfix. I was going to use this in a few places (testing; license endpoint overriding).