### PR TITLE
Apply 'the_job_application_method' even when false by default

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -227,8 +227,9 @@ function get_the_job_application_method( $post = null ) {
 	$method = new stdClass();
 	$apply  = $post->_application;
 
-	if ( empty( $apply ) )
-		return false;
+	if ( empty( $apply ) ) {
+		return apply_filters( 'the_job_application_method', false, $post );
+	}
 
 	if ( strstr( $apply, '@' ) && is_email( $apply ) ) {
 		$method->type      = 'email';


### PR DESCRIPTION
Fixes #1164

@turtlepod Instead of passing the empty object back (as in your enhancement request), I'm passing `false` to the filter. Will that work for your implementation needs?