### PR TITLE
REST API: Enable/Disable via setting (and filter)

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -294,6 +294,19 @@ class WP_Job_Manager_Settings {
 							'type'      => 'page'
 						),
 					)
+				),
+				'rest_api' => array(
+					__( 'REST API', 'wp-job-manager' ),
+					array(
+						array(
+							'name'       => 'job_manager_rest_api_enabled',
+							'std'        => '1',
+							'label'      => __( 'REST API enabled', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable the REST API', 'wp-job-manager' ),
+							'desc'       => __( 'Enables Job Manager\'s REST API', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+						),
+					),
 				)
 			)
 		);

--- a/includes/rest-api/class-wp-job-manager-models-settings.php
+++ b/includes/rest-api/class-wp-job-manager-models-settings.php
@@ -38,7 +38,16 @@ class WP_Job_Manager_Models_Settings extends WP_Job_Manager_REST_Model_Settings
 			include_once $parent . '/admin/class-wp-job-manager-settings.php';
 		}
 
-		return WP_Job_Manager_Settings::instance()->get_settings();
+		$settings = WP_Job_Manager_Settings::instance()->get_settings();
+		$filtered_settings = array();
+		foreach ( $settings as $key => $value ) {
+			// We don't want the rest api setting block to be tweaked via the rest api.
+			if ( 'rest_api' === $key ) {
+				continue;
+			}
+			$filtered_settings[ $key ] = $value;
+		}
+		return $filtered_settings;
 	}
 
 	/**

--- a/includes/rest-api/class-wp-job-manager-rest-api.php
+++ b/includes/rest-api/class-wp-job-manager-rest-api.php
@@ -15,12 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WP_Job_Manager_REST_API {
 
 	/**
-	 * Is the api enabled?
-	 *
-	 * @var bool
-	 */
-	private $is_rest_api_enabled;
-	/**
 	 * Our bootstrap
 	 *
 	 * @var WP_Job_Manager_REST_Bootstrap
@@ -40,10 +34,9 @@ class WP_Job_Manager_REST_API {
 	 */
 	public function __construct( $base_dir ) {
 		$this->base_dir = trailingslashit( $base_dir );
-		$this->is_rest_api_enabled = defined( 'WPJM_REST_API_ENABLED' ) && ( true === constant( 'WPJM_REST_API_ENABLED' ) );
 		add_action( 'mt_environment_before_start', array( $this, 'define_api' ) );
 		$file = $this->base_dir . 'lib/wpjm_rest/class-wp-job-manager-rest-bootstrap.php';
-		if ( file_exists( $file ) && $this->is_rest_api_enabled ) {
+		if ( file_exists( $file ) && self::is_rest_api_enabled() ) {
 			include_once $file;
 			$this->wpjm_rest_api = WP_Job_Manager_REST_Bootstrap::create();
 			$this->wpjm_rest_api->run();
@@ -65,7 +58,7 @@ class WP_Job_Manager_REST_API {
 	 * @return WP_Job_Manager_REST_API $this
 	 */
 	public function init() {
-		if ( ! $this->is_rest_api_enabled ) {
+		if ( ! self::is_rest_api_enabled() ) {
 			return $this;
 		}
 		$this->define_api( $this->wpjm_rest_api->environment() );
@@ -106,6 +99,24 @@ class WP_Job_Manager_REST_API {
 			'job_listing',
 			'WP_Job_Manager_Models_Job_Listings_Custom_Fields',
 			'fields' ) );
+	}
+
+	/**
+	 * Is REST API Enabled?
+	 *
+	 * @return bool
+	 */
+	public static function is_rest_api_enabled() {
+		$is_rest_api_enabled = (bool) get_option( 'job_manager_rest_api_enabled', true );
+
+		/**
+		 * Determine if the REST API should be enabled.
+		 *
+		 * @param bool $is_rest_api_enabled
+		 * @return bool
+		 * @since ?
+		 */
+		return (bool) apply_filters( 'job_manager_rest_api_enabled', $is_rest_api_enabled );
 	}
 }
 

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-rest-api.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-rest-api.php
@@ -20,4 +20,20 @@ class WP_Test_WP_Job_Manager_REST_API extends WPJM_REST_TestCase {
 		$this->assertArrayHasKey( 'routes', $data );
 		$this->assertArrayHasKey( '/wpjm/v1/settings', $data['routes'] );
 	}
+
+	/**
+	 * @group rest
+	 */
+	function test_is_rest_api_enabled_defaults_to_option_value() {
+		$this->assertTrue( WP_Job_Manager_REST_API::is_rest_api_enabled() );
+	}
+
+	/**
+	 * @group rest
+	 */
+	function test_is_rest_api_enabled_controlled_via_filter() {
+		add_filter( 'job_manager_rest_api_enabled', '__return_false' );
+		$this->assertFalse( WP_Job_Manager_REST_API::is_rest_api_enabled() );
+		remove_filter( 'job_manager_rest_api_enabled', '__return_false' );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This adds a setting in the admin area that allows users to opt-out of
enabling the api (enabled by default)
* Add a filter to programmatically control this too.

![screen shot 2017-10-20 at 11 33 39](https://user-images.githubusercontent.com/500744/31812097-9044b920-b58a-11e7-9cae-5151d06735d0.png)

N.B. This assumes there is a proper mixtape install in place.


#### Testing instructions:

* Navigate to Job Listings > Settings > REST API
* Test that toggling the checkbox enables/disables the wpjm/v1 api namespace
