### PR TITLE
Update class-wp-job-manager-widget-featured-jobs.php

### DIFF
--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -54,9 +54,10 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 		ob_start();
 
 		extract( $args );
-
-		$title  = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
-		$number = absint( $instance['number'] );
+		//Isset should be used before using instance
+		$titleInstance = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+		$number = isset( $instance['number'] ) ? absint($instance['number']) : '';
+		$title  = apply_filters( 'widget_title', $titleInstance, $instance, $this->id_base );		
 		$jobs   = get_job_listings( array(
 			'posts_per_page' => $number,
 			'orderby'        => 'date',

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -54,9 +54,8 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 		ob_start();
 
 		extract( $args );
-		//Isset should be used before using instance
 		$titleInstance = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-		$number = isset( $instance['number'] ) ? absint($instance['number']) : '';
+		$number = isset( $instance['number'] ) ? absint( $instance['number'] ) : '';
 		$title  = apply_filters( 'widget_title', $titleInstance, $instance, $this->id_base );		
 		$jobs   = get_job_listings( array(
 			'posts_per_page' => $number,


### PR DESCRIPTION
Check instance index's so that it will not give any Notice or Warning

Notice: Undefined index: title in includes\widgets\class-wp-job-manager-widget-featured-jobs.php on line 58
Notice: Undefined index: number in includes\widgets\class-wp-job-manager-widget-featured-jobs.php on line 59

Fixes #
Notice on Line 58,59 in class-wp-job-manager-widget-featured-jobs.php

#### Changes proposed in this Pull Request:

*Use of isset() so that instance must be checked before use so that no notice or warning is there

#### Testing instructions:

* Enable WP-DEBUG and see Featured Widget has Undefined Notice on Line 58,59

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
