### PR TITLE
Sanitize field input using different strategies

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -142,14 +142,17 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			case 'email' :
 				$application_method_label       = __( 'Application email', 'wp-job-manager' );
 				$application_method_placeholder = __( 'you@yourdomain.com', 'wp-job-manager' );
+				$application_method_sanitizer   = 'email';
 			break;
 			case 'url' :
 				$application_method_label       = __( 'Application URL', 'wp-job-manager' );
 				$application_method_placeholder = __( 'http://', 'wp-job-manager' );
+				$application_method_sanitizer   = 'url';
 			break;
 			default :
 				$application_method_label       = __( 'Application email/URL', 'wp-job-manager' );
 				$application_method_placeholder = __( 'Enter an email address or website URL', 'wp-job-manager' );
+				$application_method_sanitizer   = 'url_or_email';
 			break;
 		}
 
@@ -202,6 +205,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				'application' => array(
 					'label'       => $application_method_label,
 					'type'        => 'text',
+					'sanitizer'   => $application_method_sanitizer,
 					'required'    => true,
 					'placeholder' => $application_method_placeholder,
 					'priority'    => 6
@@ -218,6 +222,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				'company_website' => array(
 					'label'       => __( 'Website', 'wp-job-manager' ),
 					'type'        => 'text',
+					'sanitizer'   => 'url',
 					'required'    => false,
 					'placeholder' => __( 'http://', 'wp-job-manager' ),
 					'priority'    => 2


### PR DESCRIPTION
Fixes #1205 

#### Changes proposed in this Pull Request:

* Allows text fields to specify their sanitization strategy. Built-in options: `url`, `email`, `url_or_email`.  Callables with a single argument allowed.
* Changes the `application` field to use the correct sanitization strategy. This will allow for octets in URLs.
* Changes the `company_website` field to use the `url` sanitization. 

#### Testing instructions:

* Apply for jobs using standard URLs, URLs with non-Latin characters, emails, bad emails, dangerous strings, etc.