### PR TITLE
Change wpjm_get_the_job_types() to return empty array if job type is disabled

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -580,6 +580,10 @@ function wpjm_get_the_job_types( $post = null ) {
 
 	$types = get_the_terms( $post->ID, 'job_listing_type' );
 
+	if ( empty( $types ) || is_wp_error( $types ) ) {
+		$types = array();
+	}
+
 	// Return single if not enabled.
 	if ( ! empty( $types ) && ! job_manager_multi_job_type() ) {
 		$types = array( current( $types ) );


### PR DESCRIPTION
Fixes #1140

#### Changes proposed in this Pull Request:

* Change `wpjm_get_the_job_types()` to return an empty array when job types are disabled

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Dev: Change `wpjm_get_the_job_types()` to return an empty array when job types are disabled.

cc: @turtlepod 