### PR TITLE
Consider featured flag when randomly sorting job listing results

### DIFF
--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -36,6 +36,9 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 			$args['meta_input'] = array();
 		}
 		$args['meta_input'] = $this->generate_args( $args['meta_input'], $this->default_job_listing_meta );
+		if ( ! empty( $args['meta_input']['_featured'] ) ) {
+			$args['menu_order'] = -1;
+		}
 		$post = wp_insert_post( $args );
 		if ( isset( $args['age'] ) ) {
 			$this->set_post_age( $post, $args['age'] );

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -309,6 +309,82 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @since 1.29.1
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_featured_rand_cache() {
+		$this->enable_job_listing_cache();
+		$featured_flag = array( 'featured' => array(), 'not-featured' => array() );
+
+		$featured_flag['featured'] = $this->factory->job_listing->create_many( 5, array(
+			'post_title' => 'Featured Post',
+			'meta_input' => array(
+				'_featured' => 1,
+			),
+		) );
+		$featured_flag['not-featured'] = $this->factory->job_listing->create_many( 5, array(
+			'post_title' => 'Not Featured Post',
+			'meta_input' => array(
+				'_featured' => 0,
+			),
+		) );
+
+		// Try 10x, verfying first 5 are always job listings
+		for ($i = 1; $i <= 10; $i++) {
+			$results = get_job_listings( array( 'search_keywords' => '', 'orderby' => 'rand_featured' ) );
+			$tc = 0;
+			foreach ( $results->posts as $result ) {
+				if ( $tc < 5 ) {
+					$this->assertEquals( 1, $result->_featured );
+					$this->assertEquals( -1, $result->menu_order );
+				} else {
+					$this->assertEquals( 0, $result->_featured );
+					$this->assertEquals( 0, $result->menu_order );
+				}
+				$tc++;
+			}
+		}
+	}
+
+	/**
+	 * @since 1.29.1
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_featured_rand_no_cache() {
+		$this->disable_job_listing_cache();
+		$featured_flag = array( 'featured' => array(), 'not-featured' => array() );
+
+		$featured_flag['featured'] = $this->factory->job_listing->create_many( 5, array(
+			'post_title' => 'Featured Post',
+			'meta_input' => array(
+				'_featured' => 1,
+			),
+		) );
+		$featured_flag['not-featured'] = $this->factory->job_listing->create_many( 5, array(
+			'post_title' => 'Not Featured Post',
+			'meta_input' => array(
+				'_featured' => 0,
+			),
+		) );
+
+		// Try 10x, verifying first 5 are always job listings
+		for ($i = 1; $i <= 10; $i++) {
+			$results = get_job_listings( array( 'search_keywords' => '', 'orderby' => 'rand_featured' ) );
+			$tc = 0;
+			foreach ( $results->posts as $result ) {
+				if ( $tc < 5 ) {
+					$this->assertEquals( 1, $result->_featured );
+					$this->assertEquals( -1, $result->menu_order );
+				} else {
+					$this->assertEquals( 0, $result->_featured );
+					$this->assertEquals( 0, $result->menu_order );
+				}
+				$tc++;
+			}
+		}
+	}
+
+	/**
 	 * @since 1.27.0
 	 * @covers ::get_job_listings
 	 */


### PR DESCRIPTION
Fixes #971 

#### Changes proposed in this Pull Request:

* When using `get_job_listings()` and setting the `orderby` argument to `rand_featured`, featured listings are still considered and randomly listed at the top of all other listings. 

#### Testing instructions:

* Easiest to test in the `[jobs]` shortcode by setting the `orderby` argument:
`[jobs orderby=rand_featured]` and for the old, all shuffled behavior, using `[jobs orderby=rand]`.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Enhancement: When retrieving job listings in `[jobs]`, setting `orderby` to `rand_featured` will still place featured listings at the top. 


cc: @bikedorkjon @aheckler 