### PR TITLE
Fix issue with "sanitize_posted_field" method when an array of values is provided.

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -294,10 +294,13 @@ abstract class WP_Job_Manager_Form {
 	protected function sanitize_posted_field( $value, $sanitizer = null ) {
 		// Sanitize value
 		if ( is_array( $value ) ) {
-			return array_map( function( $value ) use ( $sanitizer ) {
-				return $this->sanitize_posted_field( $value, $sanitizer );
-			}, $value );
+			foreach ($value as $key => $val) {
+				$value[ $key ] = $this->sanitize_posted_field( $val, $sanitizer );
+			}
+
+			return $value;
 		}
+
 		$value = trim( $value );
 
 		if ( 'url' === $sanitizer ) {

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -294,7 +294,9 @@ abstract class WP_Job_Manager_Form {
 	protected function sanitize_posted_field( $value, $sanitizer = null ) {
 		// Sanitize value
 		if ( is_array( $value ) ) {
-			return array_map( array( $this, 'sanitize_posted_field' ), $value, $sanitizer );
+			return array_map( function( $value ) use ( $sanitizer ) {
+				return $this->sanitize_posted_field( $value, $sanitizer );
+			}, $value );
 		}
 		$value = trim( $value );
 


### PR DESCRIPTION
Right now, the sanitizer in `includes/abstracts/abstract-wp-job-manager-form.php` checks if the given value is an array, and if so, does the following:
`array_map( array( $this, 'sanitize_posted_field' ), $value, $sanitizer );`

I think the author tried to pass the `$value` and `$sanitizer` as function parameters to the `sanitize_posted_field` method call, but `array_map` doesn't work this way, at it expects every other argument to be an array, so it throws a PHP Warning: `array_map(): Argument #3 should be an array`

This bug also prevents multilevel fields, like image galleries, and other custom fields, from being saved.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- BUGFIX: `array_map(): Argument #3 should be an array` error.
