### PR TITLE
Order job listings by ID just in case there are duplicate dates

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -114,7 +114,8 @@ function get_job_listings( $args = array() ) {
 	if ( 'featured' === $args['orderby'] ) {
 		$query_args['orderby'] = array(
 			'menu_order' => 'ASC',
-			'date'       => 'DESC'
+			'date'       => 'DESC',
+			'ID'         => 'DESC',
 		);
 	}
 


### PR DESCRIPTION
Fixes #1254 

#### Changes proposed in this Pull Request:

* When ordering by featured flag, also sort by `ID` (in addition to `date`) to prevent issue with posts showing up on multiple pages if they have the same datestamp. 

#### Testing instructions:

* I used `wp post generate --count=50 --post_type=job_listing` to create a bunch of jobs at the same time.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fix: Issue where job listings would show up on multiple pages when using the `[jobs]` shortcode.