### PR TITLE
Add setting to moderate edits to listings once published

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -249,6 +249,20 @@ class WP_Job_Manager_Settings {
 							'attributes' => array()
 						),
 						array(
+							'name'       => 'job_manager_user_edit_published_submissions',
+							'std'        => 'yes',
+							'label'      => __( 'Allow Published Edits', 'wp-job-manager' ),
+							'cb_label'   => __( 'Allow editing of published listings', 'wp-job-manager' ),
+							'desc'       => __( 'Choose whether published job listings can be edited and if edits require admin approval. When moderation is required, the original job listings will be unpublished while edits await admin approval.', 'wp-job-manager' ),
+							'type'       => 'radio',
+							'options'    => array(
+								'no'             => __( 'Users cannot edit', 'wp-job-manager' ),
+								'yes'            => __( 'Users can edit without admin approval', 'wp-job-manager' ),
+								'yes_moderated'  => __( 'Users can edit, but edits require admin approval', 'wp-job-manager' ),
+							),
+							'attributes' => array()
+						),
+						array(
 							'name'       => 'job_manager_submission_duration',
 							'std'        => '30',
 							'label'      => __( 'Listing Duration', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -533,7 +533,7 @@ class WP_Job_Manager_Writepanels {
 	 * @param int|WP_Post $post
 	 */
 	public function job_listing_data( $post ) {
-		global $post, $thepostid;
+		global $post, $thepostid, $wp_post_types;
 
 		$thepostid = $post->ID;
 
@@ -551,6 +551,13 @@ class WP_Job_Manager_Writepanels {
 			} elseif ( method_exists( $this, 'input_' . $type ) ) {
 				call_user_func( array( $this, 'input_' . $type ), $key, $field );
 			}
+		}
+
+		$user_edited_date = get_post_meta( $post->ID, '_job_edited', true );
+		if ( $user_edited_date ) {
+			echo '<p class="form-field">';
+			echo '<em>' . sprintf( __( '%s was last modified by the user on %s.', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, date_i18n( get_option( 'date_format' ), $user_edited_date ) ) . '</em>';
+			echo '</p>';
 		}
 
 		do_action( 'job_manager_job_listing_data_end', $thepostid );

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -47,8 +47,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 											switch ( $job->post_status ) {
 												case 'publish' :
-													$actions['edit'] = array( 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false );
-
+													if ( wpjm_user_can_edit_published_submissions() ) {
+														$actions[ 'edit' ] = array( 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false );
+													}
 													if ( is_position_filled( $job ) ) {
 														$actions['mark_not_filled'] = array( 'label' => __( 'Mark not filled', 'wp-job-manager' ), 'nonce' => true );
 													} else {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -793,6 +793,42 @@ function job_manager_user_can_edit_pending_submissions() {
 }
 
 /**
+ * Checks if users are allowed to edit published submissions.
+ *
+ * @since 1.19.0
+ * @return bool
+ */
+function wpjm_user_can_edit_published_submissions() {
+	/**
+	 * Override the setting for allowing a user to edit published job listings.
+	 *
+	 * @since 1.19.0
+	 *
+	 * @param bool $can_edit_published_submissions
+	 */
+	return apply_filters( 'job_manager_user_can_edit_published_submissions', in_array( get_option( 'job_manager_user_edit_published_submissions' ), array( 'yes', 'yes_moderated' ) ) );
+}
+
+/**
+ * Checks if moderation is required when users edit published submissions.
+ *
+ * @since 1.19.0
+ * @return bool
+ */
+function wpjm_published_submission_edits_require_moderation() {
+	$require_moderation = 'yes_moderated' === get_option( 'job_manager_user_edit_published_submissions' );
+
+	/**
+	 * Override the setting for user edits to job listings requiring moderation.
+	 *
+	 * @since 1.19.0
+	 *
+	 * @param bool $require_moderation
+	 */
+	return apply_filters( 'job_manager_published_submission_edits_require_moderation', $require_moderation );
+}
+
+/**
  * Displays category select dropdown.
  *
  * Based on wp_dropdown_categories, with the exception of supporting multiple selected categories.


### PR DESCRIPTION
Fixes #509 

#### Changes proposed in this Pull Request:

* For edits to published listings in the job dashboard, add setting to disable, allow without admin approval (legacy/default), and allow _with_ admin approval.
* If moderation (admin approval) is required, edited posts will be unpublished until re-approved. 
* Updates messages where appropriate.
* Expiration dates aren't reset by default but you can filter `job_manager_reset_listing_expiration_on_user_edit` to return true to do this.

<img width="1218" alt="screen shot 2017-12-22 at 2 44 50 pm" src="https://user-images.githubusercontent.com/68693/34314301-08bd9228-e727-11e7-8224-4c0245ee02f4.png">

#### Testing instructions:

* Go through each setting value. 
  * If disabled, make sure edit links don't appear and the edit page doesn't work for published posts. 
  * If enabled without admin approval, make sure edits become published right away. 
  * If enabled with admin approval, verify the post status is moved to `pending` and an admin has to approve again.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Change: Add setting to moderate edits users make to listings once published.