### PR TITLE
Allow featured jobs widget to sort by different fields

### DIFF
--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -167,6 +167,17 @@ class WP_Job_Manager_Widget extends WP_Widget {
 					</p>
 					<?php
 				break;
+				case 'select' :
+					?>
+					<p>
+						<label for="<?php echo $this->get_field_id( $key ); ?>"><?php echo $setting['label']; ?></label>
+						<select class="widefat" id="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>" name="<?php echo $this->get_field_name( $key ); ?>">
+							<?php foreach ( $setting['options'] as $key => $label ) : ?>
+								<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $value, $key ); ?>><?php echo esc_html( $label ); ?></option>
+							<?php endforeach; ?></select>
+					</p>
+					<?php
+				break;
 			}
 		}
 	}

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -35,6 +35,26 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 				'std'   => 10,
 				'label' => __( 'Number of listings to show', 'wp-job-manager' ),
 			),
+			'orderby' => array(
+				'type'  => 'select',
+				'std'   => 'date',
+				'label' => __( 'Sort By', 'wp-job-manager' ),
+				'options' => array(
+					'date'           => __( 'Date', 'wp-job-manager' ),
+					'title'          => __( 'Title', 'wp-job-manager' ),
+					'author'         => __( 'Author', 'wp-job-manager' ),
+					'rand_featured'  => __( 'Random', 'wp-job-manager' ),
+				),
+			),
+			'order' => array(
+				'type'  => 'select',
+				'std'   => 'DESC',
+				'label' => __( 'Sort Direction', 'wp-job-manager' ),
+				'options' => array(
+					'ASC'   => __( 'Ascending', 'wp-job-manager' ),
+					'DESC'  => __( 'Descending', 'wp-job-manager' ),
+				),
+			),
 		);
 		$this->register();
 	}
@@ -55,12 +75,14 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 		extract( $args );
 		$titleInstance = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-		$number = isset( $instance['number'] ) ? absint( $instance['number'] ) : '';
-		$title  = apply_filters( 'widget_title', $titleInstance, $instance, $this->id_base );		
-		$jobs   = get_job_listings( array(
+		$number  = isset( $instance['number'] ) ? absint( $instance['number'] ) : '';
+		$orderby = isset( $instance['orderby'] ) ? esc_attr( $instance['orderby'] ) : 'date';
+		$order   = isset( $instance['order'] ) ? esc_attr( $instance['order'] ) : 'DESC';
+		$title   = apply_filters( 'widget_title', $titleInstance, $instance, $this->id_base );
+		$jobs    = get_job_listings( array(
 			'posts_per_page' => $number,
-			'orderby'        => 'date',
-			'order'          => 'DESC',
+			'orderby'        => $orderby,
+			'order'          => $order,
 			'featured'       => true,
 		) );
 


### PR DESCRIPTION
Fixes #1009 

#### Changes proposed in this Pull Request:

* Add `select` field for widget settings.
* Add option to the Featured Jobs widget to change how the listings are sorted.

#### Testing instructions:

* Add featured jobs listing. Choose `Random` for the `Sort by` option. Verify the featured listings are randomly sorted.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Adds 'Sort By' option to featured jobs widget
