### PR TITLE
No longer deactivate/remove expired license records

### DIFF
--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -517,9 +517,9 @@ class WP_Job_Manager_Helper {
 		}
 		if ( ! empty( $errors['no_activation'] ) ) {
 			$this->deactivate_licence( $product_slug );
-			$this->add_licence_error( $product_slug, $errors['no_activation'] );
+			$this->add_licence_error( $product_slug, $errors['no_activation'], 'no_activation' );
 		} elseif ( ! empty( $errors['expired_key'] ) ) {
-			$this->add_licence_error( $product_slug, $errors['expired_key'] );
+			$this->add_licence_error( $product_slug, $errors['expired_key'], 'expired_key' );
 		}
 	}
 

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -250,7 +250,12 @@ class WP_Job_Manager_Helper {
 		$licence = $this->get_plugin_licence( $product_slug );
 		$css_class = '';
 		if ( $licence && ! empty( $licence['licence_key'] ) ) {
-			$manage_licence_label = __( 'Manage License', 'wp-job-manager' );
+			if ( ! empty( $licence['errors'] ) ) {
+				$manage_licence_label = __( 'Manage License (Requires Attention)', 'wp-job-manager' );
+				$css_class = 'wpjm-activate-licence-link';
+			} else {
+				$manage_licence_label = __( 'Manage License', 'wp-job-manager' );
+			}
 		} else {
 			$manage_licence_label = __( 'Activate License', 'wp-job-manager' );
 			$css_class = 'wpjm-activate-licence-link';
@@ -407,10 +412,18 @@ class WP_Job_Manager_Helper {
 	 * Outputs unset license key notices.
 	 */
 	public function licence_error_notices() {
+		$screen = get_current_screen();
+		if ( null === $screen || in_array( $screen->id, array( 'job_listing_page_job-manager-addons' ) ) ) {
+			return;
+		}
 		foreach( $this->get_installed_plugins() as $product_slug => $plugin_data ) {
 			$licence = $this->get_plugin_licence( $product_slug );
-			if ( empty( $licence['licence_key'] ) && ! WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice' ) ) {
-				include( 'views/html-licence-key-notice.php' );
+			if ( ! WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice' ) ) {
+				if ( empty( $licence[ 'licence_key' ] ) ) {
+					include( 'views/html-licence-key-notice.php' );
+				} elseif ( ! empty( $licence[ 'errors' ] ) ) {
+					include( 'views/html-licence-key-error.php' );
+				}
 			}
 		}
 	}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -519,7 +519,6 @@ class WP_Job_Manager_Helper {
 			$this->deactivate_licence( $product_slug );
 			$this->add_licence_error( $product_slug, $errors['no_activation'] );
 		} elseif ( ! empty( $errors['expired_key'] ) ) {
-			$this->deactivate_licence( $product_slug );
 			$this->add_licence_error( $product_slug, $errors['expired_key'] );
 		}
 	}

--- a/includes/helper/views/html-licence-key-error.php
+++ b/includes/helper/views/html-licence-key-error.php
@@ -1,0 +1,9 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+<div class="error">
+	<p class="wpjm-updater-dismiss" style="float:right;"><a href="<?php echo esc_url( add_query_arg( 'dismiss-wpjm-licence-notice', $product_slug ) ); ?>"><?php _e( 'Hide notice' ); ?></a></p>
+	<p><?php printf( 'There is a problem with the license for "%s". Please <a href="%s">manage the license</a> to check for a solution and continue receiving updates.', esc_html( $plugin_data['Name'] ), esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) ) ); ?></p>
+</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* No longer deactivate expired license records.

#### Testing instructions:

* Have a license expire for a paid WPJM add-on plugin. Make sure the license information stays in the WPJM instance after a plugin update check.
