### PR TITLE
Add `is_wpjm()` and related functions

### DIFF
--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -5,6 +5,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		parent::setUp();
 		update_option( 'job_manager_enable_categories', 1 );
 		update_option( 'job_manager_enable_types', 1 );
+		add_theme_support( 'job-manager-templates' );
 		unregister_post_type( 'job_listing' );
 		$post_type_instance = WP_Job_Manager_Post_Types::instance();
 		$post_type_instance->register_post_types();
@@ -414,6 +415,176 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		foreach ( $results as $key => $result ) {
 			$this->assertEqualSets( $result['expected'], wp_list_pluck( $result['results']->posts, 'ID' ), "{$key} doesn't match" );
 		}
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 */
+	public function test_is_wpjm_no_request() {
+		$this->assertFalse( is_wpjm() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_page
+	 */
+	public function test_is_wpjm_job_listing_archive_request() {
+		$this->assertFalse( is_wpjm() );
+		$this->assertFalse( is_wpjm_page() );
+		$this->set_up_request_page();
+		$this->assertTrue( is_wpjm() );
+		$this->assertTrue( is_wpjm_page() );
+		$this->assertFalse( is_wpjm_job_listing() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_page
+	 * @covers ::has_wpjm_shortcode
+	 */
+	public function test_is_wpjm_job_listing_jobs_shortcode_request() {
+		$this->assertFalse( is_wpjm() );
+		$this->assertFalse( is_wpjm_page() );
+		$this->assertFalse( has_wpjm_shortcode( null, 'jobs' ) );
+		$page_id = $this->set_up_request_shortcode( 'jobs' );
+		update_option( 'job_manager_jobs_page_id', $page_id, true );
+		$this->assertTrue( is_wpjm() );
+		$this->assertTrue( is_wpjm_page() );
+		$this->assertTrue( has_wpjm_shortcode( null, 'jobs' ) );
+		$this->assertFalse( has_wpjm_shortcode( null, 'job' ) );
+		$this->assertFalse( is_wpjm_job_listing() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_page
+	 * @covers ::has_wpjm_shortcode
+	 */
+	public function test_is_wpjm_job_listing_jobs_dashboard_shortcode_request() {
+		$this->assertFalse( is_wpjm() );
+		$this->assertFalse( is_wpjm_page() );
+		$this->assertFalse( has_wpjm_shortcode( null, 'job_dashboard' ) );
+		$page_id = $this->set_up_request_shortcode( 'job_dashboard' );
+		update_option( 'job_manager_job_dashboard_page_id', $page_id, true );
+		$this->assertTrue( is_wpjm() );
+		$this->assertTrue( is_wpjm_page() );
+		$this->assertTrue( has_wpjm_shortcode( null, 'job_dashboard' ) );
+		$this->assertFalse( has_wpjm_shortcode( null, 'job' ) );
+		$this->assertFalse( is_wpjm_job_listing() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_page
+	 * @covers ::has_wpjm_shortcode
+	 */
+	public function test_is_wpjm_job_listing_submit_jobs_shortcode_request() {
+		$this->assertFalse( is_wpjm() );
+		$this->assertFalse( is_wpjm_page() );
+		$this->assertFalse( has_wpjm_shortcode( null, 'submit_job_form' ) );
+		$page_id = $this->set_up_request_shortcode( 'submit_job_form' );
+		update_option( 'job_manager_submit_job_form_page_id', $page_id, true );
+		$this->assertTrue( is_wpjm() );
+		$this->assertTrue( is_wpjm_page() );
+		$this->assertTrue( has_wpjm_shortcode( null, 'submit_job_form' ) );
+		$this->assertFalse( has_wpjm_shortcode( null, 'job' ) );
+		$this->assertFalse( is_wpjm_job_listing() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_page
+	 * @covers ::is_wpjm_job_listing
+	 */
+	public function test_is_wpjm_job_listing_request() {
+		$this->assertFalse( is_wpjm_job_listing() );
+		$this->set_up_request_job_listing();
+		$this->assertTrue( is_wpjm() );
+		$this->assertFalse( is_wpjm_page() );
+		$this->assertTrue( is_wpjm_job_listing() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_page
+	 * @covers ::is_wpjm_job_listing
+	 */
+	public function test_is_wpjm_not_job_listing_request() {
+		$this->assertFalse( is_wpjm_job_listing() );
+		$this->set_up_request_normal_page();
+		$this->assertFalse( is_wpjm() );
+		$this->assertFalse( is_wpjm_page() );
+		$this->assertFalse( is_wpjm_job_listing() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_page
+	 * @covers ::is_wpjm_job_listing
+	 */
+	public function test_is_wpjm_not_job_listing_home_request() {
+		$this->assertFalse( is_wpjm_job_listing() );
+		$this->set_up_request_home_page();
+		$this->assertFalse( is_wpjm() );
+		$this->assertFalse( is_wpjm_page() );
+		$this->assertFalse( is_wpjm_job_listing() );
+	}
+
+	/**
+	 * @since 1.30.0
+	 * @covers ::is_wpjm
+	 * @covers ::is_wpjm_taxonomy
+	 */
+	public function test_is_wpjm_taxonomy_success() {
+		$this->assertFalse( is_wpjm_taxonomy() );
+		$this->assertFalse( is_wpjm() );
+		$this->assertTrue( taxonomy_exists('job_listing_category') );
+		$this->assertTrue( current_user_can( get_taxonomy( 'job_listing_category' )->cap->assign_terms ) );
+		$this->set_up_request_taxonomy();
+		$this->assertTrue( is_wpjm_taxonomy() );
+		$this->assertTrue( is_wpjm() );
+	}
+
+	protected function set_up_request_page() {
+		$this->go_to( get_post_type_archive_link( 'job_listing' ) );
+	}
+
+	protected function set_up_request_shortcode( $tag = 'jobs' ) {
+		$page = $this->create_shortcode_page( ucfirst( $tag ), $tag );
+		$this->go_to( get_post_permalink( $page ) );
+		$GLOBALS['wp_query']->is_page = true;
+		return $page;
+	}
+
+	protected function set_up_request_job_listing() {
+		$job_listing = $this->factory->job_listing->create();
+		$this->go_to( get_post_permalink( $job_listing ) );
+	}
+
+	protected function set_up_request_normal_page() {
+		$page = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Cool', 'post_content' => 'Awesome' ) );
+		$this->go_to( get_post_permalink( $page ) );
+	}
+
+	protected function set_up_request_home_page() {
+		$this->go_to( home_url() );
+	}
+
+	protected function set_up_request_taxonomy() {
+		$term = wp_create_term( 'jazz', 'job_listing_category' );
+		$this->go_to( get_term_link( $term['term_id'] ) );
+	}
+
+	protected function create_shortcode_page( $title, $tag ) {
+		return $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => $title, 'post_content' => '[' . $tag .']' ) );
 	}
 
 	protected function disable_job_listing_cache() {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -631,6 +631,138 @@ function job_manager_user_can_edit_job( $job_id ) {
 }
 
 /**
+ * Checks if the visitor is currently on a WPJM page, job listing, or taxonomy.
+ *
+ * @since 1.30.0
+ *
+ * @return bool
+ */
+function is_wpjm() {
+	/**
+	 * Filter the result of is_wpjm()
+	 *
+	 * @since 1.30.0
+	 *
+	 * @param bool $is_wpjm
+	 */
+	return apply_filters( 'is_wpjm', ( is_wpjm_page() || has_wpjm_shortcode() || is_wpjm_job_listing() || is_wpjm_taxonomy() ) ? true : false );
+}
+
+/**
+ * Checks if the visitor is currently on a WPJM page.
+ *
+ * @since 1.30.0
+ *
+ * @return bool
+ */
+function is_wpjm_page() {
+	$is_wpjm_page = is_post_type_archive( 'job_listing' );
+
+	if ( ! $is_wpjm_page ) {
+		$wpjm_page_ids = array_filter( array(
+			get_option( 'job_manager_submit_job_form_page_id', false ),
+			get_option( 'job_manager_job_dashboard_page_id', false ),
+			get_option( 'job_manager_jobs_page_id', false ),
+		) );
+
+		/**
+		 * Filters a list of all page IDs related to WPJM.
+		 *
+		 * @since 1.30.0
+		 *
+		 * @param int[] $wpjm_page_ids
+		 */
+		$wpjm_page_ids = array_unique( apply_filters( 'job_manager_page_ids', $wpjm_page_ids ) );
+
+		$is_wpjm_page  = is_page( $wpjm_page_ids );
+	}
+
+	/**
+	 * Filter the result of is_wpjm_page()
+	 *
+	 * @since 1.30.0
+	 *
+	 * @param bool $is_wpjm_page
+	 */
+	return apply_filters( 'is_wpjm_page', $is_wpjm_page );
+}
+
+/**
+ * Checks if the provided content or the current single page or post has a WPJM shortcode.
+ *
+ * @param string|null       $content   Content to check. If not provided, it uses the current post content.
+ * @param string|array|null $tag Check specifically for one or more shortcodes. If not provided, checks for any WPJM shortcode.
+ *
+ * @return bool
+ */
+function has_wpjm_shortcode( $content = null, $tag = null ) {
+	global $post;
+
+	$has_wpjm_shortcode = false;
+
+	if ( null === $content && is_single() && is_a( $post, 'WP_Post' ) ) {
+		$content = $post->post_content;
+	}
+
+	if ( ! empty( $content ) ) {
+		$wpjm_shortcodes = array( 'submit_job_form', 'job_dashboard', 'jobs', 'job', 'job_summary', 'job_apply' );
+		/**
+		 * Filters a list of all shortcodes associated with WPJM.
+		 *
+		 * @since 1.30.0
+		 *
+		 * @param string[] $wpjm_shortcodes
+		 */
+		$wpjm_shortcodes = array_unique( apply_filters( 'job_manager_shortcodes', $wpjm_shortcodes ) );
+
+		if ( null !== $tag ) {
+			if ( ! is_array( $tag ) ) {
+				$tag = array( $tag );
+			}
+			$wpjm_shortcodes = array_intersect( $wpjm_shortcodes, $tag );
+		}
+
+		foreach ( $wpjm_shortcodes as $shortcode ) {
+			if ( has_shortcode( $content, $shortcode ) ) {
+				$has_wpjm_shortcode = true;
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Filter the result of has_wpjm_shortcode()
+	 *
+	 * @since 1.30.0
+	 *
+	 * @param bool $has_wpjm_shortcode
+	 */
+	return apply_filters( 'has_wpjm_shortcode', $has_wpjm_shortcode );
+}
+
+/**
+ * Checks if the current page is a job listing.
+ *
+ * @since 1.30.0
+ *
+ * @return bool
+ */
+function is_wpjm_job_listing() {
+	return is_singular( array( 'job_listing' ) );
+}
+
+/**
+ * Checks if the visitor is on a page for a WPJM taxonomy.
+ *
+ * @since 1.30.0
+ *
+ * @return bool
+ */
+function is_wpjm_taxonomy() {
+	return is_tax( get_object_taxonomies( 'job_listing' ) );
+}
+
+/**
  * Checks to see if the standard password setup email should be used.
  *
  * @since 1.27.0


### PR DESCRIPTION
Fixes #947 
In support of upcoming #657 work

#### Changes proposed in this Pull Request:

* Adds `is_wpjm()` function to test if anything related to WPJM is happening on current (non-admin) view.
* In support of that, also adds `is_wpjm_page()` to test if on a job listing archive page or a page set in settings for the `[jobs]` shortcode, `[jobs_dashboard]` shortcode, or `[submit_job_form]` shortcode.
* Adds `has_wpjm_shortcode()` to support the checking of shortcodes on a page.
* Adds `is_wpjm_job_listing()` to check if viewing a single job listing.
* Adds `is_wpjm_taxonomy()` to check if viewing a WPJM related taxonomy page. 

#### Testing instructions:

* Use these functions throughout site to test if on WPJM related page/view.
