### PR TITLE
Adds hook after user makes a job edit

### DIFF
--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -178,6 +178,17 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 			}
 
 			/**
+			 * Fire action after the user edits a job listing.
+			 *
+			 * @since 1.30.0
+			 *
+			 * @param int    $job_id        Job ID.
+			 * @param string $save_message  Save message to filter.
+			 * @param array  $values        Submitted values for job listing.
+			 */
+			do_action( 'job_manager_user_edit_job_listing', $this->job_id, $save_message, $values );
+
+			/**
 			 * Change the message that appears when a user edits a job listing.
 			 *
 			 * @since 1.29.0

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -168,7 +168,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 				 * Resets the job expiration date when a user submits their job listing edit for approval.
 				 * Defaults to `false`.
 				 *
-				 * @since 1.19.0
+				 * @since 1.29.0
 				 *
 				 * @param bool $reset_expiration If true, reset expiration date.
 				 */
@@ -180,7 +180,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 			/**
 			 * Change the message that appears when a user edits a job listing.
 			 *
-			 * @since 1.19.0
+			 * @since 1.29.0
 			 *
 			 * @param string $save_message  Save message to filter.
 			 * @param int    $job_id        Job ID.

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -19,6 +19,16 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 	public $form_name = 'edit-job';
 
 	/**
+	 * @var bool|string
+	 */
+	private $save_message = false;
+
+	/**
+	 * @var bool|string
+	 */
+	private $save_error = false;
+
+	/**
 	 * Instance
 	 *
 	 * @access protected
@@ -40,6 +50,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 	 * Constructor
 	 */
 	public function __construct() {
+		add_action( 'wp', array( $this, 'submit_handler' ) );
 		$this->job_id = ! empty( $_REQUEST['job_id'] ) ? absint( $_REQUEST[ 'job_id' ] ) : 0;
 
 		if  ( ! job_manager_user_can_edit_job( $this->job_id ) ) {
@@ -63,7 +74,12 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 	 * @param array $atts
 	 */
 	public function output( $atts = array() ) {
-		$this->submit_handler();
+		if ( ! empty( $this->save_message ) ) {
+			echo '<div class="job-manager-message">' . $this->save_message . '</div>';
+		}
+		if ( ! empty( $this->save_error ) ) {
+			echo '<div class="job-manager-error">' . $this->save_error . '</div>';
+		}
 		$this->submit();
 	}
 
@@ -197,10 +213,10 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 			 * @param int    $job_id        Job ID.
 			 * @param array  $values        Submitted values for job listing.
 			 */
-			echo '<div class="job-manager-message">' . apply_filters( 'job_manager_update_job_listings_message', $save_message, $this->job_id, $values ) . '</div>';
+			$this->save_message = apply_filters( 'job_manager_update_job_listings_message', $save_message, $this->job_id, $values );
+
 		} catch ( Exception $e ) {
-			echo '<div class="job-manager-error">' . $e->getMessage() . '</div>';
-			return;
+			$this->save_error = $e->getMessage();
 		}
 	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -795,14 +795,14 @@ function job_manager_user_can_edit_pending_submissions() {
 /**
  * Checks if users are allowed to edit published submissions.
  *
- * @since 1.19.0
+ * @since 1.29.0
  * @return bool
  */
 function wpjm_user_can_edit_published_submissions() {
 	/**
 	 * Override the setting for allowing a user to edit published job listings.
 	 *
-	 * @since 1.19.0
+	 * @since 1.29.0
 	 *
 	 * @param bool $can_edit_published_submissions
 	 */
@@ -812,7 +812,7 @@ function wpjm_user_can_edit_published_submissions() {
 /**
  * Checks if moderation is required when users edit published submissions.
  *
- * @since 1.19.0
+ * @since 1.29.0
  * @return bool
  */
 function wpjm_published_submission_edits_require_moderation() {
@@ -821,7 +821,7 @@ function wpjm_published_submission_edits_require_moderation() {
 	/**
 	 * Override the setting for user edits to job listings requiring moderation.
 	 *
-	 * @since 1.19.0
+	 * @since 1.29.0
 	 *
 	 * @param bool $require_moderation
 	 */


### PR DESCRIPTION
Fixes #1298 

#### Changes proposed in this Pull Request:

* Moves edit job form submission handling outside of `WP_Job_Manager_Form_Edit_Job::output()` so redirections can happen.
* Adds a new action `job_manager_user_edit_job_listing` that fires after a user saves a job listing from the dashboard.

Example code for handling the redirect:
```php
add_action( 'job_manager_user_edit_job_listing', function() {
	wp_redirect( 'https://example.com/good-job' );
	exit();
} );
```