### PR TITLE
Improve JS/CSS asset usage

### DIFF
--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -120,7 +120,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 
 		$this->fields = apply_filters( 'submit_job_form_fields_get_job_data', $this->fields, $job );
 
-		wp_enqueue_script( 'wp-job-manager-job-submission' );
+		$this->enqueue_job_form_assets();
 
 		$save_button_text = __( 'Save changes', 'wp-job-manager' );
 		if ( 'publish' === get_post_status( $this->job_id )

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -375,6 +375,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
+	 * Enqueues styles for editing and posting a job listing.
+	 */
+	protected function enqueue_job_form_assets() {
+		wp_enqueue_script( 'wp-job-manager-job-submission' );
+		wp_enqueue_style( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-submission.css', array(), JOB_MANAGER_VERSION );
+	}
+
+	/**
 	 * Returns an array of the job types indexed by slug. (Unused)
 	 *
 	 * @return array
@@ -444,8 +452,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$this->fields = apply_filters( 'submit_job_form_fields_get_user_data', $this->fields, get_current_user_id() );
 		}
 
-		wp_enqueue_script( 'wp-job-manager-job-submission' );
-
+		$this->enqueue_job_form_assets();
 		get_job_manager_template( 'job-submit.php', array(
 			'form'               => $this->form_name,
 			'job_id'             => $this->get_job_id(),

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -730,7 +730,7 @@ function has_wpjm_shortcode( $content = null, $tag = null ) {
 
 	$has_wpjm_shortcode = false;
 
-	if ( null === $content && is_single() && is_a( $post, 'WP_Post' ) ) {
+	if ( null === $content && is_singular() && is_a( $post, 'WP_Post' ) ) {
 		$content = $post->post_content;
 	}
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -605,6 +605,11 @@ endif;
 function job_manager_user_can_upload_file_via_ajax() {
 	$can_upload = is_user_logged_in() && job_manager_user_can_post_job();
 
+	if ( has_filter( 'job_manager_ajax_file_upload_enabled' ) ) {
+		_deprecated_hook( 'job_manager_ajax_file_upload_enabled', '1.30.0', 'job_manager_user_can_upload_file_via_ajax' );
+		$can_upload = apply_filters( 'job_manager_ajax_file_upload_enabled', true );
+	}
+
 	/**
 	 * Override ability of a user to upload a file via Ajax.
 	 *

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -221,7 +221,17 @@ class WP_Job_Manager {
 		 */
 		$ajax_data['lang'] = apply_filters( 'wpjm_lang', null );
 
-		if ( apply_filters( 'job_manager_chosen_enabled', true ) ) {
+		$chosen_shortcodes = array( 'submit_job_form', 'job_dashboard', 'jobs' );
+		$chosen_used_on_page = has_wpjm_shortcode( null, $chosen_shortcodes );
+
+		/**
+		 * Filter the use of the chosen library.
+		 *
+		 * @since 1.19.0
+		 *
+		 * @param bool $chosen_used_on_page Defaults to only when there are known shortcodes on the page.
+		 */
+		if ( apply_filters( 'job_manager_chosen_enabled', $chosen_used_on_page ) ) {
 			wp_register_script( 'chosen', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-chosen/chosen.jquery.min.js', array( 'jquery' ), '1.1.0', true );
 			wp_register_script( 'wp-job-manager-term-multiselect', JOB_MANAGER_PLUGIN_URL . '/assets/js/term-multiselect.min.js', array( 'jquery', 'chosen' ), JOB_MANAGER_VERSION, true );
 			wp_register_script( 'wp-job-manager-multiselect', JOB_MANAGER_PLUGIN_URL . '/assets/js/multiselect.min.js', array( 'jquery', 'chosen' ), JOB_MANAGER_VERSION, true );
@@ -235,7 +245,7 @@ class WP_Job_Manager {
 			);
 		}
 
-		if ( apply_filters( 'job_manager_ajax_file_upload_enabled', true ) ) {
+		if ( job_manager_user_can_upload_file_via_ajax() ) {
 			wp_register_script( 'jquery-iframe-transport', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-fileupload/jquery.iframe-transport.js', array( 'jquery' ), '1.8.3', true );
 			wp_register_script( 'jquery-fileupload', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-fileupload/jquery.fileupload.js', array( 'jquery', 'jquery-iframe-transport', 'jquery-ui-widget' ), '9.11.2', true );
 			wp_register_script( 'wp-job-manager-ajax-file-upload', JOB_MANAGER_PLUGIN_URL . '/assets/js/ajax-file-upload.min.js', array( 'jquery', 'jquery-fileupload' ), JOB_MANAGER_VERSION, true );
@@ -274,9 +284,8 @@ class WP_Job_Manager {
 			'i18n_confirm_delete' => __( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
 		) );
 
-		wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css', array(), JOB_MANAGER_VERSION );
-		if ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'submit_job_form' ) ) {
-			wp_enqueue_style( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-submission.css', array(), JOB_MANAGER_VERSION );
+		if ( is_wpjm() ) {
+			wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css', array(), JOB_MANAGER_VERSION );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #657

#### Changes proposed in this Pull Request:

* Enqueues assets only when necessary.
* Deprecates `job_manager_ajax_file_upload_enabled` filter in favor of the `job_manager_user_can_upload_file_via_ajax` filter that was introduced a few weeks ago.

#### Testing instructions:
Note: This PR has some breaking potential. 

* We need to check all of our shortcodes with various arguments. Visit pages with shortcodes and make sure none of them are broken. 
* Check individual job listing pages and verify our CSS is loaded for job listings.
* When we do the community testing release, we should highlight this for plugin and theme developers.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Improved: Only enqueue CSS and JS when used on the current page.