### PR TITLE
Add Usage Tracking

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Usage tracking data
+ **/
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Supplies the usage tracking data for logging.
+ *
+ * @package Usage Tracking
+ * @since 1.30.0
+ */
+class WP_Job_Manager_Usage_Tracking_Data {
+	/**
+	 * Get the usage tracking data to send.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @return array Usage data.
+	 **/
+	public static function get_usage_data() {
+		return array(
+			'jobs' => wp_count_posts( 'job_listing' )->publish,
+		);
+	}
+}

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -11,7 +11,16 @@ include dirname( __FILE__ ) . '/../lib/usage-tracking/class-usage-tracking-base.
  **/
 class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 
+	const WPJM_SETTING_NAME = 'job_manager_usage_tracking_enabled';
+
 	const WPJM_TRACKING_INFO_URL = 'https://wpjobmanager.com/document/what-data-does-wpjm-track';
+
+	protected function __construct() {
+		parent::__construct();
+
+		// Add filter for settings.
+		add_filter( 'job_manager_settings', array( $this, 'add_setting_field' ) );
+	}
 
 	/*
 	 * Implementation for abstract functions.
@@ -26,11 +35,11 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	protected function get_tracking_enabled() {
-		// TODO
+		return get_option( self::WPJM_SETTING_NAME  ) || false;
 	}
 
 	protected function set_tracking_enabled( $enable ) {
-		// TODO
+		update_option( self::WPJM_SETTING_NAME, $enable );
 	}
 
 	protected function current_user_can_manage_tracking() {
@@ -42,5 +51,29 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			<a href=\"%s\" target=\"_blank\">usage tracking data</a>.
 			No sensitive information is collected, and you can opt out at any time.",
 			'wp-job-manager' ), self::WPJM_TRACKING_INFO_URL );
+	}
+
+
+	/*
+	 * Hooks.
+	 */
+
+	public function add_setting_field( $fields ) {
+		$fields['general'][1][] = array(
+			'name'     => self::WPJM_SETTING_NAME,
+			'std'      => '0',
+			'type'     => 'checkbox',
+			'desc'     => '',
+			'label'    => __( 'Enable usage tracking', 'wp-job-manager' ),
+			'cb_label' => sprintf(
+				__(
+					'Help us make WP Job Manager better by allowing us to collect
+					<a href="%s" target="_blank">usage tracking data</a>.
+					No sensitive information is collected.', 'wp-job-manager'
+				), self::WPJM_TRACKING_INFO_URL
+			),
+		);
+
+		return $fields;
 	}
 }

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -1,0 +1,46 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+include dirname( __FILE__ ) . '/../lib/usage-tracking/class-usage-tracking-base.php';
+
+/**
+ * WPJM Usage Tracking subclass.
+ **/
+class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
+
+	const WPJM_TRACKING_INFO_URL = 'https://wpjobmanager.com/document/what-data-does-wpjm-track';
+
+	/*
+	 * Implementation for abstract functions.
+	 */
+
+	public static function get_instance() {
+		return self::get_instance_for_subclass( get_class() );
+	}
+
+	protected function get_prefix() {
+		return 'wpjm';
+	}
+
+	protected function get_tracking_enabled() {
+		// TODO
+	}
+
+	protected function set_tracking_enabled( $enable ) {
+		// TODO
+	}
+
+	protected function current_user_can_manage_tracking() {
+		return current_user_can( 'manage_options' );
+	}
+
+	protected function opt_in_dialog_text() {
+		return sprintf( __( "We'd love if you helped us make WP Job Manager better by allowing us to collect
+			<a href=\"%s\" target=\"_blank\">usage tracking data</a>.
+			No sensitive information is collected, and you can opt out at any time.",
+			'wp-job-manager' ), self::WPJM_TRACKING_INFO_URL );
+	}
+}

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Usage Tracking class. Please update the prefix to something unique to your
  * plugin.
  */
-abstract class Sensei_Usage_Tracking_Base {
+abstract class WP_Job_Manager_Usage_Tracking_Base {
 	/*
 	 * Instance variables.
 	 */

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -291,8 +291,9 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @param array $schedules the existing cron schedules.
 	 **/
 	public function add_usage_tracking_two_week_schedule( $schedules ) {
+		$day_in_seconds = 86400;
 		$schedules[ $this->get_prefix() . '_usage_tracking_two_weeks' ] = array(
-			'interval' => 15 * DAY_IN_SECONDS,
+			'interval' => 15 * $day_in_seconds,
 			'display'  => esc_html__( 'Every Two Weeks', 'a8c-usage-tracking' ),
 		);
 
@@ -384,6 +385,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		$enable_tracking = isset( $_POST['enable_tracking'] ) && '1' === $_POST['enable_tracking'];
 		$this->set_tracking_enabled( $enable_tracking );
 		$this->hide_tracking_opt_in();
+		$this->send_usage_data();
 		wp_die();
 	}
 

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -1,0 +1,457 @@
+<?php
+/**
+ * Reusable Usage Tracking library. For sending plugin usage data and events to
+ * Tracks.
+ **/
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Usage Tracking class. Please update the prefix to something unique to your
+ * plugin.
+ */
+abstract class Sensei_Usage_Tracking_Base {
+	/*
+	 * Instance variables.
+	 */
+
+	/**
+	 * The name of the option for hiding the Usage Tracking opt-in dialog.
+	 *
+	 * @var string
+	 **/
+	private $hide_tracking_opt_in_option_name;
+
+	/**
+	 * The name of the cron job action for regularly logging usage data.
+	 *
+	 * @var string
+	 **/
+	private $job_name;
+
+	/**
+	 * Callback function for the usage tracking job.
+	 *
+	 * @var array
+	 **/
+	private $callback;
+
+
+	/*
+	 * Class variables.
+	 */
+
+	/**
+	 * Subclass instances.
+	 *
+	 * @var array
+	 **/
+	private static $instances = array();
+
+
+	/*
+	 * Abstract methods.
+	 */
+
+	/**
+	 * Gets the singleton instance of this class. Subclasses should implement
+	 * this as follows:
+	 *
+	 * ```
+	 * public static function get_instance() {
+	 *   return self::get_instance_for_subclass( get_class() );
+	 * }
+	 * ```
+	 */
+	abstract public static function get_instance();
+
+	/**
+	 * Get prefix for actions and strings. Should be unique to this plugin.
+	 *
+	 * @return string The prefix string
+	 **/
+	abstract protected function get_prefix();
+
+	/**
+	 * Determine whether usage tracking is enabled.
+	 *
+	 * @return bool true if usage tracking is enabled, false otherwise.
+	 **/
+	abstract protected function get_tracking_enabled();
+
+	/**
+	 * Set whether usage tracking is enabled.
+	 *
+	 * @param bool $enable true if usage tracking should be enabled, false if
+	 * it should be disabled.
+	 **/
+	abstract protected function set_tracking_enabled( $enable );
+
+	/**
+	 * Determine whether current user can manage the tracking options.
+	 *
+	 * @return bool true if the current user is allowed to manage the tracking
+	 * options, false otherwise.
+	 **/
+	abstract protected function current_user_can_manage_tracking();
+
+	/**
+	 * Get the text to display in the opt-in dialog for users to enable
+	 * tracking. This text should include a link to a page indicating what data
+	 * is being tracked.
+	 *
+	 * @return string the text to display in the opt-in dialog.
+	 **/
+	abstract protected function opt_in_dialog_text();
+
+
+	/*
+	 * Initialization.
+	 */
+
+	/**
+	 * Subclasses may override this to add plugin-specific initialization code.
+	 * However, this constructor must be called by the subclass in order to
+	 * properly initialize the Usage Tracking system.
+	 *
+	 * This class is meant to be a singleton, and assumes that the subclass is
+	 * implemented as such. If multiple instances are instantiated, the results
+	 * are undefined.
+	 **/
+	protected function __construct() {
+		// Init instance vars.
+		$this->hide_tracking_opt_in_option_name = $this->get_prefix() . '_usage_tracking_opt_in_hide';
+		$this->job_name                         = $this->get_prefix() . '_usage_tracking_send_usage_data';
+
+		// Set up the opt-in dialog.
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_script_deps' ) );
+		add_action( 'admin_footer', array( $this, 'output_opt_in_js' ) );
+		add_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
+		add_action( 'wp_ajax_' . $this->get_prefix() . '_handle_tracking_opt_in', array( $this, 'handle_tracking_opt_in' ) );
+
+		// Set up schedule and action needed for cron job.
+		add_filter( 'cron_schedules', array( $this, 'add_usage_tracking_two_week_schedule' ) );
+		add_action( $this->job_name, array( $this, 'send_usage_data' ) );
+	}
+
+	/**
+	 * Create (if necessary) and return the singleton instance for the given
+	 * subclass.
+	 *
+	 * @param string $subclass the name of the subclass.
+	 */
+	protected static function get_instance_for_subclass( $subclass ) {
+		if ( ! isset( self::$instances[ $subclass ] ) ) {
+			self::$instances[ $subclass ] = new $subclass();
+		}
+		return self::$instances[ $subclass ];
+	}
+
+
+	/*
+	 * Public methods.
+	 */
+
+	/**
+	 * Set the Usage Data Callback. This callback should return an array of
+	 * data to be logged periodically to Tracks.
+	 *
+	 * @param callable $callback the callback returning the usage data to be logged.
+	 **/
+	public function set_callback( $callback ) {
+		$this->callback = $callback;
+	}
+
+	/**
+	 * Send an event to Tracks if tracking is enabled.
+	 *
+	 * @param string   $event The event name. The prefix string will be
+	 *   automatically prepended to this, so please supply this string without a
+	 *   prefix.
+	 * @param array    $properties Event Properties.
+	 * @param null|int $event_timestamp When the event occurred.
+	 *
+	 * @return null|WP_Error
+	 **/
+	public function send_event( $event, $properties = array(), $event_timestamp = null ) {
+
+		// Only continue if tracking is enabled.
+		if ( ! $this->is_tracking_enabled() ) {
+			return false;
+		}
+
+		$pixel      = 'http://pixel.wp.com/t.gif';
+		$event_name = $this->get_prefix() . '_' . $event;
+		$user       = wp_get_current_user();
+
+		if ( null === $event_timestamp ) {
+			$event_timestamp = time();
+		}
+
+		$properties['admin_email'] = get_option( 'admin_email' );
+		$properties['_ut']         = $this->get_prefix() . ':site_url';
+		// Use site URL as the userid to enable usage tracking at the site level.
+		// Note that we would likely want to use site URL + user ID for userid if we were
+		// to ever add event tracking at the user level.
+		$properties['_ui'] = site_url();
+		$properties['_ul'] = $user->user_login;
+		$properties['_en'] = $event_name;
+		$properties['_ts'] = $event_timestamp . '000';
+		$properties['_rt'] = round( microtime( true ) * 1000 );  // log time.
+		$p                 = array();
+
+		foreach ( $properties as $key => $value ) {
+			$p[] = rawurlencode( $key ) . '=' . rawurlencode( $value );
+		}
+
+		$pixel   .= '?' . implode( '&', $p ) . '&_=_'; // EOF marker.
+		$response = wp_remote_get(
+			$pixel, array(
+				'blocking'    => true,
+				'timeout'     => 1,
+				'redirection' => 2,
+				'httpversion' => '1.1',
+				'user-agent'  => $this->get_prefix() . '_usage_tracking',
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = isset( $response['response']['code'] ) ? $response['response']['code'] : 0;
+
+		if ( 200 !== $code ) {
+			return new WP_Error( 'request_failed', 'HTTP Request failed', $code );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Set up a regular cron job to send usage data. The job will only send
+	 * the data if tracking is enabled, so it is safe to call this function,
+	 * and schedule the job, before the user opts into tracking.
+	 **/
+	public function schedule_tracking_task() {
+		if ( ! wp_next_scheduled( $this->job_name ) ) {
+			wp_schedule_event( time(), $this->get_prefix() . '_usage_tracking_two_weeks', $this->job_name );
+		}
+	}
+
+	/**
+	 * Unschedule the job scheduled by schedule_tracking_task if any is
+	 * scheduled. This should be called on plugin deactivation.
+	 **/
+	public function unschedule_tracking_task() {
+		if ( wp_next_scheduled( $this->job_name ) ) {
+			wp_clear_scheduled_hook( $this->job_name );
+		}
+	}
+
+	/**
+	 * Check if tracking is enabled.
+	 *
+	 * @return bool true if tracking is enabled, false otherwise
+	 **/
+	public function is_tracking_enabled() {
+		// Defer to the plugin-specific function.
+		return $this->get_tracking_enabled();
+	}
+
+	/**
+	 * Call the usage data callback and send the usage data to Tracks. Only
+	 * sends data if tracking is enabled.
+	 **/
+	public function send_usage_data() {
+		if ( ! self::is_tracking_enabled() || ! is_callable( $this->callback ) ) {
+			return;
+		}
+
+		$usage_data = call_user_func( $this->callback );
+
+		if ( ! is_array( $usage_data ) ) {
+			return;
+		}
+
+		return self::send_event( 'stats_log', $usage_data );
+	}
+
+
+	/*
+	 * Internal methods.
+	 */
+
+	/**
+	 * Add two week schedule to use for cron job. Should not be called
+	 * externally.
+	 *
+	 * @param array $schedules the existing cron schedules.
+	 **/
+	public function add_usage_tracking_two_week_schedule( $schedules ) {
+		$schedules[ $this->get_prefix() . '_usage_tracking_two_weeks' ] = array(
+			'interval' => 15 * DAY_IN_SECONDS,
+			'display'  => esc_html__( 'Every Two Weeks', 'a8c-usage-tracking' ),
+		);
+
+		return $schedules;
+	}
+
+	/**
+	 * Hide the opt-in for enabling usage tracking.
+	 **/
+	private function hide_tracking_opt_in() {
+		update_option( $this->hide_tracking_opt_in_option_name, true );
+	}
+
+	/**
+	 * Determine whether the opt-in for enabling usage tracking is hidden.
+	 *
+	 * @return bool true if the opt-in is hidden, false otherwise.
+	 **/
+	private function is_opt_in_hidden() {
+		return (bool) get_option( $this->hide_tracking_opt_in_option_name );
+	}
+
+	/**
+	 * Allowed html tags, used by wp_kses, for the translated opt-in dialog
+	 * text.
+	 *
+	 * @return array the html tags.
+	 **/
+	private function opt_in_dialog_text_allowed_html() {
+		return array(
+			'a'      => array(
+				'href'  => array(),
+				'title' => array(),
+			),
+			'em'     => array(),
+			'strong' => array(),
+		);
+	}
+
+	/**
+	 * If needed, display opt-in dialog to enable tracking. Should not be
+	 * called externally.
+	 **/
+	public function maybe_display_tracking_opt_in() {
+		$opt_in_hidden         = $this->is_opt_in_hidden();
+		$user_tracking_enabled = $this->is_tracking_enabled();
+		$can_manage_tracking   = $this->current_user_can_manage_tracking();
+
+		if ( ! $user_tracking_enabled && ! $opt_in_hidden && $can_manage_tracking ) { ?>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-notice" class="notice notice-info"
+				data-nonce="<?php echo esc_attr( wp_create_nonce( 'tracking-opt-in' ) ); ?>">
+				<p>
+					<?php echo wp_kses( $this->opt_in_dialog_text(), $this->opt_in_dialog_text_allowed_html() ); ?>
+				</p>
+				<p>
+					<button class="button button-primary" data-enable-tracking="yes">
+						<?php esc_html_e( 'Enable Usage Tracking', 'a8c-usage-tracking' ); ?>
+					</button>
+					<button class="button" data-enable-tracking="no">
+						<?php esc_html_e( 'Disable Usage Tracking', 'a8c-usage-tracking' ); ?>
+					</button>
+					<span id="progress" class="spinner alignleft"></span>
+				</p>
+			</div>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-enable-success" class="notice notice-success hidden">
+				<p><?php esc_html_e( 'Usage data enabled. Thank you!', 'a8c-usage-tracking' ); ?></p>
+			</div>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-disable-success" class="notice notice-success hidden">
+				<p><?php esc_html_e( 'Disabled usage tracking.', 'a8c-usage-tracking' ); ?></p>
+			</div>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-failure" class="notice notice-error hidden">
+				<p><?php esc_html_e( 'Something went wrong. Please try again later.', 'a8c-usage-tracking' ); ?></p>
+			</div>
+		<?php
+		}
+	}
+
+	/**
+	 * Handle ajax request from the opt-in dialog. Should not be called
+	 * externally.
+	 **/
+	public function handle_tracking_opt_in() {
+		check_ajax_referer( 'tracking-opt-in', 'nonce' );
+
+		if ( ! $this->current_user_can_manage_tracking() ) {
+			wp_die( '', '', 403 );
+		}
+
+		$enable_tracking = isset( $_POST['enable_tracking'] ) && '1' === $_POST['enable_tracking'];
+		$this->set_tracking_enabled( $enable_tracking );
+		$this->hide_tracking_opt_in();
+		wp_die();
+	}
+
+	/**
+	 * Ensure that jQuery has been enqueued since the opt-in dialog JS depends
+	 * on it. Should not be called externally.
+	 **/
+	public function enqueue_script_deps() {
+		// Ensure jQuery is loaded.
+		wp_enqueue_script(
+			$this->get_prefix() . '_usage-tracking-notice', '',
+			array( 'jquery' ), null, true
+		);
+	}
+
+	/**
+	 * Output the JS code to handle the opt-in dialog. Should not be called
+	 * externally.
+	 **/
+	public function output_opt_in_js() {
+?>
+<script type="text/javascript">
+	(function( prefix ) {
+		jQuery( document ).ready( function() {
+			function displayProgressIndicator() {
+				jQuery( '#' + prefix + '-usage-tracking-notice #progress' ).addClass( 'is-active' );
+			}
+
+			function displaySuccess( enabledTracking ) {
+				if ( enabledTracking ) {
+					jQuery( '#' + prefix + '-usage-tracking-enable-success' ).show();
+				} else {
+					jQuery( '#' + prefix + '-usage-tracking-disable-success' ).show();
+				}
+				jQuery( '#' + prefix + '-usage-tracking-notice' ).hide();
+			}
+
+			function displayError() {
+				jQuery( '#' + prefix + '-usage-tracking-failure' ).show();
+				jQuery( '#' + prefix + '-usage-tracking-notice' ).hide();
+			}
+
+			// Handle button clicks
+			jQuery( '#' + prefix + '-usage-tracking-notice button' ).click( function( event ) {
+				event.preventDefault();
+
+				var enableTracking = jQuery( this ).data( 'enable-tracking' ) == 'yes';
+				var nonce          = jQuery( '#' + prefix + '-usage-tracking-notice' ).data( 'nonce' );
+
+				displayProgressIndicator();
+
+				jQuery.ajax( {
+					type: 'POST',
+					url: ajaxurl,
+					data: {
+						action: prefix + '_handle_tracking_opt_in',
+						enable_tracking: enableTracking ? 1 : 0,
+						nonce: nonce,
+					},
+					success: function() {
+						displaySuccess( enableTracking );
+					},
+					error: displayError,
+				} );
+			});
+		});
+	})( "<?php echo esc_js( $this->get_prefix() ); ?>" );
+</script>
+<?php
+	}
+}

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -327,6 +327,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 			'a'      => array(
 				'href'  => array(),
 				'title' => array(),
+				'target' => array(),
 			),
 			'em'     => array(),
 			'strong' => array(),

--- a/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -6,7 +6,7 @@ require_once dirname( __FILE__ ) . '/../../class-usage-tracking-base.php';
  * Usage Tracking subclass for testing. Please update the superclass name to
  * match the one used by your plugin (usage-tracking/class-usage-tracking-base.php).
  */
-class Usage_Tracking_Test_Subclass extends Sensei_Usage_Tracking_Base {
+class Usage_Tracking_Test_Subclass extends WP_Job_Manager_Usage_Tracking_Base {
 
 	const TRACKING_ENABLED_OPTION_NAME = 'testing-usage-tracking-enabled';
 

--- a/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -1,0 +1,36 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/../../class-usage-tracking-base.php';
+
+/**
+ * Usage Tracking subclass for testing. Please update the superclass name to
+ * match the one used by your plugin (usage-tracking/class-usage-tracking-base.php).
+ */
+class Usage_Tracking_Test_Subclass extends Sensei_Usage_Tracking_Base {
+
+	const TRACKING_ENABLED_OPTION_NAME = 'testing-usage-tracking-enabled';
+
+	public static function get_instance() {
+		return self::get_instance_for_subclass( get_class() );
+	}
+
+	public function get_prefix() {
+		return 'testing';
+	}
+
+	public function get_tracking_enabled() {
+		return get_option( self::TRACKING_ENABLED_OPTION_NAME ) || false;
+	}
+
+	public function set_tracking_enabled( $enable ) {
+		update_option( self::TRACKING_ENABLED_OPTION_NAME, $enable );
+	}
+
+	public function current_user_can_manage_tracking() {
+		return current_user_can( 'manage_usage_tracking' );
+	}
+
+	public function opt_in_dialog_text() {
+		return 'Please enable Usage Tracking!';
+	}
+}

--- a/lib/usage-tracking/tests/support/wp-die-exception.php
+++ b/lib/usage-tracking/tests/support/wp-die-exception.php
@@ -1,0 +1,18 @@
+<?php
+
+class WP_Die_Exception extends Exception {
+	private $wp_die_args = null;
+
+	public function set_wp_die_args( $message, $title, $args ) {
+		$this->wp_die_args = array(
+			'message' => $message,
+			'title'   => $title,
+			'args'    => $args,
+		);
+	}
+
+	public function get_wp_die_args() {
+		return $this->wp_die_args;
+	}
+}
+

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -10,7 +10,7 @@ Usage_Tracking_Test_Subclass::get_instance();
  * Usage Tracking tests. Please update the prefix to something unique to your
  * plugin.
  */
-class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
+class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -95,6 +95,32 @@ class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure usage data is sent when tracking is enabled.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in
+	 */
+	public function testAjaxRequestEnableTrackingSendsData() {
+		$this->setupAjaxRequest();
+		$_POST['enable_tracking'] = '1';
+
+		// Count the number of network requests
+		$count = 0;
+		add_filter( 'pre_http_request', function() use ( &$count ) {
+			$count++;
+			return new WP_Error();
+		} );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
+		}
+
+		$this->assertEquals( 1, $count, 'Data was sent on usage tracking enable' );
+	}
+
+	/**
 	 * Ensure tracking is disabled through ajax request.
 	 *
 	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -1,0 +1,380 @@
+<?php
+
+include dirname( __FILE__ ) . '/support/class-usage-tracking-test-subclass.php';
+include dirname( __FILE__ ) . '/support/wp-die-exception.php';
+
+// Ensure instance is set up before PHPUnit starts removing hooks.
+Usage_Tracking_Test_Subclass::get_instance();
+
+/**
+ * Usage Tracking tests. Please update the prefix to something unique to your
+ * plugin.
+ */
+class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		// Update the class name here to match the Usage Tracking class.
+		$this->usage_tracking = Usage_Tracking_Test_Subclass::get_instance();
+		$this->usage_tracking->set_callback( function() {
+			return array( 'testing' => true );
+		} );
+	}
+
+	/**
+	 * Ensure cron job action is set up.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::hook
+	 */
+	public function testCronJobActionAdded() {
+		$this->assertTrue( !! has_action( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data', array( $this->usage_tracking, 'send_usage_data' ) ) );
+	}
+
+	/**
+	 * Ensure scheduling function works properly.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::schedule_tracking_task
+	 */
+	public function testScheduleTrackingTask() {
+		// Make sure it's cleared initially
+		wp_clear_scheduled_hook( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' );
+
+		// Record how many times the event is scheduled
+		$prefix = $this->usage_tracking->get_prefix();
+		$event_count = 0;
+		add_filter( 'schedule_event', function( $event ) use ( &$event_count, $prefix ) {
+			if ( $event->hook === $prefix . '_usage_tracking_send_usage_data' ) {
+				$event_count++;
+			}
+			return $event;
+		} );
+
+		// Should successfully schedule the task
+		$this->assertFalse( wp_get_schedule( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' ), 'Not scheduled initial' );
+		$this->usage_tracking->schedule_tracking_task();
+		$this->assertNotFalse( wp_get_schedule( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' ), 'Schedules a job' );
+		$this->assertEquals( 1, $event_count, 'Schedules only one job' );
+
+		// Should not duplicate when called again
+		$this->usage_tracking->schedule_tracking_task();
+		$this->assertEquals( 1, $event_count, 'Does not schedule an additional job' );
+	}
+
+	/* Test ajax request cases */
+
+	/**
+	 * Ensure ajax hook is set up properly.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::hook
+	 */
+	public function testAjaxRequestSetup() {
+		$this->assertTrue( !! has_action( 'wp_ajax_' . $this->usage_tracking->get_prefix() . '_handle_tracking_opt_in', array( $this->usage_tracking, 'handle_tracking_opt_in' ) ) );
+	}
+
+	/**
+	 * Ensure tracking is enabled through ajax request.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in
+	 */
+	public function testAjaxRequestEnableTracking() {
+		$this->setupAjaxRequest();
+		$_POST['enable_tracking'] = '1';
+
+		$this->assertFalse( !! $this->usage_tracking->is_tracking_enabled(), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
+		}
+
+		$this->assertTrue( $this->usage_tracking->is_tracking_enabled(), 'Usage tracking enabled' );
+		$this->assertTrue( get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog hidden' );
+	}
+
+	/**
+	 * Ensure tracking is disabled through ajax request.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in
+	 */
+	public function testAjaxRequestDisableTracking() {
+		$this->setupAjaxRequest();
+		$_POST['enable_tracking'] = '0';
+
+		$this->assertFalse( !! $this->usage_tracking->is_tracking_enabled(), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
+		}
+
+		$this->assertFalse( !! $this->usage_tracking->is_tracking_enabled(), 'Usage tracking disabled' );
+		$this->assertTrue( get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog hidden' );
+	}
+
+	/**
+	 * Ensure ajax request fails on nonce failure and does not update option.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in
+	 */
+	public function testAjaxRequestFailedNonce() {
+		$this->setupAjaxRequest();
+		$_REQUEST['nonce'] = 'invalid_nonce_1234';
+
+		$this->assertFalse( !! $this->usage_tracking->is_tracking_enabled(), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( 403, $wp_die_args['args']['response'], 'wp_die called has "Forbidden" status' );
+		}
+
+		$this->assertFalse( !! $this->usage_tracking->is_tracking_enabled(), 'Usage tracking disabled' );
+		$this->assertFalse( !! get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog not hidden' );
+	}
+
+	/**
+	 * Ensure ajax request fails on authorization failure and does not update option.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in
+	 */
+	public function testAjaxRequestFailedAuth() {
+		$this->setupAjaxRequest();
+
+		// Current user cannot enable tracking
+		$this->allowCurrentUserToEnableTracking( false );
+
+		$this->assertFalse( !! $this->usage_tracking->is_tracking_enabled(), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( 403, $wp_die_args['args']['response'], 'wp_die called has "Forbidden" status' );
+		}
+
+		$this->assertFalse( !! $this->usage_tracking->is_tracking_enabled(), 'Usage tracking disabled' );
+		$this->assertFalse( !! get_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide' ), 'Dialog not hidden' );
+	}
+
+	/* END test ajax request cases */
+
+	/**
+	 * Ensure that a request is made to the correct URL with the given
+	 * properties and the default properties.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::send_event
+	 */
+	public function testSendEvent() {
+		$event      = 'my_event';
+		$properties = array(
+			'button_clicked' => 'my_button'
+		);
+		$timestamp  = '1234';
+
+		// Enable tracking
+		$this->usage_tracking->set_tracking_enabled( true );
+
+		// Capture the network request, save the request URL and arguments, and
+		// simulate a WP_Error
+		$request_params = null;
+		$request_url    = null;
+		add_filter( 'pre_http_request', function( $preempt, $r, $url ) use ( &$request_params, &$request_url ) {
+			$request_params = $r;
+			$request_url    = $url;
+			return new WP_Error();
+		}, 10, 3 );
+
+		$this->usage_tracking->send_event( 'my_event', $properties, $timestamp );
+
+		$parsed_url = parse_url( $request_url );
+
+		$this->assertEquals( 'pixel.wp.com', $parsed_url['host'], 'Host' );
+		$this->assertEquals( '/t.gif', $parsed_url['path'], 'Path' );
+
+		$query = array();
+		parse_str( $parsed_url['query'], $query );
+		$this->assertArraySubset( array(
+			'button_clicked' => 'my_button',
+			'admin_email'    => 'admin@example.org',
+			'_ut'            => $this->usage_tracking->get_prefix() . ':site_url',
+			'_ui'            => 'http://example.org',
+			'_ul'            => '',
+			'_en'            => $this->usage_tracking->get_prefix() . '_my_event',
+			'_ts'            => '1234000',
+			'_'              => '_',
+		), $query, 'Query parameters' );
+	}
+
+	/**
+	 * Ensure that the request is not made if tracking is not enabled, unless
+	 * $force is true.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::send_event
+	 */
+	public function testSendEventWithTrackingDisabled() {
+		$event      = 'my_event';
+		$properties = array(
+			'button_clicked' => 'my_button'
+		);
+		$timestamp  = '1234';
+
+		// Disable tracking
+		$this->usage_tracking->set_tracking_enabled( false );
+
+		// Count network requests
+		$count = 0;
+		add_filter( 'pre_http_request', function() use ( &$count ) {
+			$count++;
+			return new WP_Error();
+		} );
+
+		$this->usage_tracking->send_event( 'my_event', $properties, $timestamp );
+		$this->assertEquals( 0, $count, 'No request when disabled' );
+	}
+
+	/**
+	 * Ensure that the request is only sent when the setting is enabled.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::maybe_send_usage_data
+	 */
+	public function testSendUsageData() {
+		$count = 0;
+
+		// Count the number of network requests
+		add_filter( 'pre_http_request', function() use ( &$count ) {
+			$count++;
+			return new WP_Error();
+		} );
+
+		// Setting is not set, ensure the request is not sent.
+		$this->usage_tracking->send_usage_data();
+		$this->assertEquals( 0, $count, 'Request not sent when Usage Tracking disabled' );
+
+		// Set the setting and ensure request is sent.
+		$this->usage_tracking->set_tracking_enabled( true );
+
+		$this->usage_tracking->send_usage_data();
+		$this->assertEquals( 1, $count, 'Request sent when Usage Tracking enabled' );
+	}
+
+	/* Tests for tracking opt in dialog */
+
+	/**
+	 * When setting is not set, dialog is not hidden, and user has capability,
+	 * we should see the dialog and Enable Usage Tracking button.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_maybe_display_tracking_opt_in
+	 */
+	public function testDisplayTrackingOptIn() {
+		$this->setupOptInDialog();
+
+		$this->expectOutputRegex( '/Enable Usage Tracking/' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/**
+	 * When setting is already set, dialog should not appear.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_maybe_display_tracking_opt_in
+	 */
+	public function testDoNotDisplayTrackingOptInWhenSettingEnabled() {
+		$this->setupOptInDialog();
+		$this->usage_tracking->set_tracking_enabled( true );
+
+		$this->expectOutputString( '' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/**
+	 * When option is set to hide the dialog, it should not appear.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_maybe_display_tracking_opt_in
+	 */
+	public function testDoNotDisplayTrackingOptInWhenDialogHidden() {
+		$this->setupOptInDialog();
+		update_option( $this->usage_tracking->get_prefix() . '_usage_tracking_opt_in_hide', true );
+
+		$this->expectOutputString( '' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/**
+	 * When user does not have permission to manage usage tracking, dialog
+	 * should not appear.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_maybe_display_tracking_opt_in
+	 */
+	public function testDoNotDisplayTrackingOptInWhenUserNotAuthorized() {
+		$this->setupOptInDialog();
+		$this->allowCurrentUserToEnableTracking( false );
+
+		$this->expectOutputString( '' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/* END tests for tracking opt in dialog */
+
+
+	/****** Helper methods ******/
+
+	/**
+	 * Helper method for ajax request.
+	 */
+	private function setupAjaxRequest() {
+		// Simulate an ajax request
+		add_filter( 'wp_doing_ajax', function() { return true; } );
+
+		// Set up nonce
+		$_REQUEST['nonce'] = wp_create_nonce( 'tracking-opt-in' );
+
+		// Ensure current user can enable tracking
+		$this->allowCurrentUserToEnableTracking();
+
+		// When wp_die is called, save the args and throw an exception to stop
+		// execution.
+		add_filter( 'wp_die_ajax_handler', function() {
+			return function( $message, $title, $args ) {
+				$e = new WP_Die_Exception( 'wp_die called' );
+				$e->set_wp_die_args( $message, $title, $args );
+				throw $e;
+			};
+		} );
+	}
+
+	/**
+	 * Helper method to set up tracking opt-in dialog.
+	 */
+	private function setupOptInDialog() {
+		// Ensure current user can enable tracking
+		$this->allowCurrentUserToEnableTracking();
+
+		// Ensure setting is not set
+		$this->usage_tracking->set_tracking_enabled( false );
+	}
+
+	/**
+	 * Update the capaility for the current user to be able to enable or
+	 * disable tracking.
+	 *
+	 * @param bool $allow true if the current user should be allowed to update
+	 * the tracking setting, false otherwise. Default: true
+	 **/
+	private function allowCurrentUserToEnableTracking( $allow = true ) {
+		$user = wp_get_current_user();
+
+		if ( $allow ) {
+			$user->add_cap( 'manage_usage_tracking' );
+		} else {
+			$user->remove_cap( 'manage_usage_tracking' );
+		}
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -6,8 +6,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
 wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
 
-WP_Job_Manager_Usage_Tracking::get_instance()->unschedule_tracking_task();
-
 wp_trash_post( get_option( 'job_manager_submit_job_form_page_id' ) );
 wp_trash_post( get_option( 'job_manager_job_dashboard_page_id' ) );
 wp_trash_post( get_option( 'job_manager_jobs_page_id' ) );

--- a/uninstall.php
+++ b/uninstall.php
@@ -6,6 +6,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
 wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
 
+WP_Job_Manager_Usage_Tracking::get_instance()->unschedule_tracking_task();
+
 wp_trash_post( get_option( 'job_manager_submit_job_form_page_id' ) );
 wp_trash_post( get_option( 'job_manager_job_dashboard_page_id' ) );
 wp_trash_post( get_option( 'job_manager_jobs_page_id' ) );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -106,6 +106,7 @@ class WP_Job_Manager {
 		add_action( 'wp_logout', array( $this, 'cleanup_job_posting_cookies' ) );
 
 		add_action( 'init', array( $this, 'usage_tracking_init' ) );
+		register_deactivation_hook( __FILE__, array( $this, 'usage_tracking_cleanup' ) );
 
 		// Defaults for WPJM core actions
 		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );
@@ -184,6 +185,13 @@ class WP_Job_Manager {
 			array( 'WP_Job_Manager_Usage_Tracking_Data', 'get_usage_data' )
 		);
 		WP_Job_Manager_Usage_Tracking::get_instance()->schedule_tracking_task();
+	}
+
+	/**
+	 * Cleanup the Usage Tracking system for plugin deactivation.
+	 */
+	public function usage_tracking_cleanup() {
+		WP_Job_Manager_Usage_Tracking::get_instance()->unschedule_tracking_task();
 	}
 
 	/**

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -105,6 +105,8 @@ class WP_Job_Manager {
 		add_action( 'admin_init', array( $this, 'updater' ) );
 		add_action( 'wp_logout', array( $this, 'cleanup_job_posting_cookies' ) );
 
+		add_action( 'init', array( $this, 'usage_tracking_init' ) );
+
 		// Defaults for WPJM core actions
 		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );
 	}
@@ -169,6 +171,19 @@ class WP_Job_Manager {
 		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-widget.php' );
 		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/widgets/class-wp-job-manager-widget-recent-jobs.php' );
 		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/widgets/class-wp-job-manager-widget-featured-jobs.php' );
+	}
+
+	/**
+	 * Initialize the Usage Tracking system.
+	 */
+	public function usage_tracking_init() {
+		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-usage-tracking.php' );
+		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-usage-tracking-data.php' );
+
+		WP_Job_Manager_Usage_Tracking::get_instance()->set_callback(
+			array( 'WP_Job_Manager_Usage_Tracking_Data', 'get_usage_data' )
+		);
+		WP_Job_Manager_Usage_Tracking::get_instance()->schedule_tracking_task();
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/Automattic/WP-Job-Manager/issues/1263

Adds Usage Tracking to WP Job Manager. The Usage Tracking functionality is copied from Sensei, and tweaked to support WPJM. Please see the individual commits for better visibility into the specific changes.

## Testing

- Ensure that the opt-in dialog works. To reset, run the following:

```php
delete_option( 'wpjm_usage_tracking_opt_in_hide' );
delete_option( 'job_manager_usage_tracking_enabled' );
```

- Ensure that the setting in the General tab works.

- Ensure that the cron job is scheduled (`wpjm_usage_tracking_send_usage_data` - the Crontrol plugin is a great way to check this).

- Ensure that the data is sent by manually running the cron job (the Crontrol plugin can also be used for this) and monitoring the HTTP request that is sent.

- Ensure, in the HTTP request, the `jobs` URL parameter value represents the number of job listings on your site.

- If usage tracking is not enabled, the cron job may still be scheduled, but the data should not be sent when the job runs.

- Ensure that Usage Tracking can only be managed by admins.

- Ensure the cron job is unscheduled when the plugin is deactivated.

- Ensure that the links in the opt-in dialog and Settings page go to the right place.

- ~[WIP] Ensure that the activation wizard displays the opt-in, and it works properly.~ This will need some discussion, so I'm going to put it in a separate PR.