### PR TITLE
Decode textarea first before re-encoding

### DIFF
--- a/templates/form-fields/textarea-field.php
+++ b/templates/form-fields/textarea-field.php
@@ -8,12 +8,12 @@
  * @author      Automattic
  * @package     WP Job Manager
  * @category    Template
- * @version     1.29.0
+ * @version     1.30.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 ?>
-<textarea cols="20" rows="3" class="input-text" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>" id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" maxlength="<?php echo ! empty( $field['maxlength'] ) ? $field['maxlength'] : ''; ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?>><?php echo isset( $field['value'] ) ? esc_textarea( $field['value'] ) : ''; ?></textarea>
+<textarea cols="20" rows="3" class="input-text" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>" id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" maxlength="<?php echo ! empty( $field['maxlength'] ) ? $field['maxlength'] : ''; ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?>><?php echo isset( $field['value'] ) ? esc_textarea( html_entity_decode( $field['value'] ) ) : ''; ?></textarea>
 <?php if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo $field['description']; ?></small><?php endif; ?>


### PR DESCRIPTION
Fixes #1277 

#### Changes proposed in this Pull Request:

* Prevent double encoding of `textarea` fields.

#### Testing instructions:

* Add a text area field and test with special characters:
```php
add_filter( 'submit_job_form_fields', function( $f ) {
	$f['job']['benefits'] = array(
		'label'       => __( 'Benefits', 'wp-job-manager' ),
		'type'        => 'textarea',
		'required'    => false,
		'priority'    => 5
	);
	return $f;
} );
```
* Submit a job listing with &, <, and > symbols.
* Edit the job listing and verify symbols are not encoded in text area. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Fix: Double encoding issue with `textarea` job listing fields.