### PR TITLE
Add usage tracking opt-in to setup wizard

### DIFF
--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -145,18 +145,7 @@ class WP_Job_Manager_Setup {
 	 * Usage tracking opt in text for setup page.
 	 */
 	private function opt_in_text() {
-		return sprintf(
-
-			/*
-			 * translators: the href tag contains the URL for the page
-			 * telling users what data WPJM tracks.
-			 */
-			__(
-				'Check the box below to allow us to collect <a href="%s" target="_blank">usage tracking data</a>.  No sensitive information is collected.',
-				'wp-job-manager'
-			),
-			WP_Job_Manager_Usage_Tracking::WPJM_TRACKING_INFO_URL
-		);
+		return WP_Job_Manager_Usage_Tracking::get_instance()->opt_in_checkbox_text();
 	}
 
 	/**
@@ -168,24 +157,17 @@ class WP_Job_Manager_Setup {
 		if ( ! $usage_tracking->get_tracking_enabled() ) {
 			?>
 			<p>
-				<strong>
-					<?php esc_html_e( 'Help us make WP Job Manager better!', 'wp-job-manager' ); ?>
-				</strong>
-				<?php
-				echo wp_kses(
-					$this->opt_in_text(),
-					$usage_tracking->opt_in_dialog_text_allowed_html()
-				);
-				?>
-			</p>
-
-			<p>
 				<label>
 					<input
 						type="checkbox"
 						name="job_manager_usage_tracking_enabled"
 						value="1" />
-					<?php esc_html_e( 'Enable Usage Tracking.', 'wp-job-manager' ); ?>
+					<?php
+					echo wp_kses(
+						$this->opt_in_text(),
+						$usage_tracking->opt_in_dialog_text_allowed_html()
+					);
+					?>
 				</label>
 			</p>
 			<?php

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -143,6 +143,19 @@ class WP_Job_Manager_Setup {
 				$this->create_page( sanitize_text_field( $page_titles[ $page ] ), $content, 'job_manager_' . $page . '_page_id' );
 			}
 		}
+
+		$usage_tracking = WP_Job_Manager_Usage_Tracking::get_instance();
+
+		ob_start();
+		?>
+		<p class="submit">
+			<a href="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>" class="button button-primary"><?php _e( 'Start setup', 'wp-job-manager' ); ?></a>
+			<a href="<?php echo esc_url( add_query_arg( 'skip-job-manager-setup', 1, admin_url( 'index.php?page=job-manager-setup&step=3' ) ) ); ?>" class="button"><?php _e( 'Skip setup. I will set up the plugin manually.', 'wp-job-manager' ); ?></a>
+		</p>
+		<?php
+		$step_one_submit = ob_get_contents();
+		ob_end_clean();
+
 		?>
 		<div class="wrap wp_job_manager wp_job_manager_addons_wrap">
 			<h2><?php _e( 'WP Job Manager Setup', 'wp-job-manager' ); ?></h2>
@@ -161,10 +174,7 @@ class WP_Job_Manager_Setup {
 				<p><?php _e( 'This setup wizard will walk you through the process of creating pages for job submissions, management, and listings.', 'wp-job-manager' ); ?></p>
 				<p><?php printf( __( 'If you\'d prefer to skip this and set up your pages manually, our %sdocumentation%s will walk you through each step.', 'wp-job-manager' ), '<a href="https://wpjobmanager.com/documentation/">', '</a>' ); ?></p>
 
-				<p class="submit">
-					<a href="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>" class="button button-primary"><?php _e( 'Start setup', 'wp-job-manager' ); ?></a>
-					<a href="<?php echo esc_url( add_query_arg( 'skip-job-manager-setup', 1, admin_url( 'index.php?page=job-manager-setup&step=3' ) ) ); ?>" class="button"><?php _e( 'Skip setup. I will set up the plugin manually.', 'wp-job-manager' ); ?></a>
-				</p>
+				<?php $usage_tracking->maybe_display_tracking_opt_in_for_wizard( $step_one_submit ); ?>
 
 			<?php endif; ?>
 			<?php if ( 2 === $step ) : ?>

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -129,8 +129,13 @@ class WP_Job_Manager_Setup {
 			$enable = isset( $_POST['job_manager_usage_tracking_enabled'] )
 				&& '1' === $_POST['job_manager_usage_tracking_enabled'];
 
-			$usage_tracking->set_tracking_enabled( $enable );
-			$usage_tracking->hide_tracking_opt_in();
+			$nonce = isset( $_POST['nonce'] ) ? $_POST['nonce'] : null;
+			$valid_nonce = wp_verify_nonce( $_POST['nonce'], 'enable-usage-tracking' );
+
+			if ( $valid_nonce ) {
+				$usage_tracking->set_tracking_enabled( $enable );
+				$usage_tracking->hide_tracking_opt_in();
+			}
 		}
 
 		$this->output();
@@ -217,6 +222,7 @@ class WP_Job_Manager_Setup {
 				<p><?php printf( __( 'If you\'d prefer to skip this and set up your pages manually, our %sdocumentation%s will walk you through each step.', 'wp-job-manager' ), '<a href="https://wpjobmanager.com/documentation/">', '</a>' ); ?></p>
 
 				<form method="post" action="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>">
+					<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'enable-usage-tracking' ); ?>" />
 
 					<?php $this->maybe_output_opt_in_checkbox(); ?>
 

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -48,7 +48,7 @@ class WP_Job_Manager_Setup {
 	 * Adds setup link to admin dashboard menu briefly so the page callback is registered.
 	 */
 	public function admin_menu() {
-		add_dashboard_page( __( 'Setup', 'wp-job-manager' ), __( 'Setup', 'wp-job-manager' ), 'manage_options', 'job-manager-setup', array( $this, 'output' ) );
+		add_dashboard_page( __( 'Setup', 'wp-job-manager' ), __( 'Setup', 'wp-job-manager' ), 'manage_options', 'job-manager-setup', array( $this, 'setup_page' ) );
 	}
 
 	/**
@@ -120,6 +120,61 @@ class WP_Job_Manager_Setup {
 	}
 
 	/**
+	 * Handle request to the setup page.
+	 */
+	public function setup_page() {
+		$usage_tracking = WP_Job_Manager_Usage_Tracking::get_instance();
+
+		if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+			$enable = isset( $_POST['job_manager_usage_tracking_enabled'] )
+				&& '1' === $_POST['job_manager_usage_tracking_enabled'];
+
+			$usage_tracking->set_tracking_enabled( $enable );
+			$usage_tracking->hide_tracking_opt_in();
+		}
+
+		$this->output();
+	}
+
+	private function opt_in_text() {
+		return sprintf(
+			__(
+				'Check the box below to allow us to collect <a href="%s" target="_blank">usage tracking data</a>.  No sensitive information is collected.',
+				'wp-job-manager'
+			),
+			WP_Job_Manager_Usage_Tracking::WPJM_TRACKING_INFO_URL
+		);
+	}
+
+	private function maybe_output_opt_in_checkbox() {
+		// Only show the checkbox if we aren't already opted in.
+		$usage_tracking = WP_Job_Manager_Usage_Tracking::get_instance();
+		if ( ! $usage_tracking->get_tracking_enabled() ) {
+			?>
+			<p>
+				<strong>
+					<?php esc_html_e( 'Help us make WP Job Manager better!', 'wp-job-manager' ); ?>
+				</strong>
+				<?php echo wp_kses(
+					$this->opt_in_text(),
+					$usage_tracking->opt_in_dialog_text_allowed_html()
+				); ?>
+			</p>
+
+			<p>
+				<label>
+					<input
+						type="checkbox"
+						name="job_manager_usage_tracking_enabled"
+						value="1" />
+					<?php esc_html_e( 'Enable Usage Tracking.', 'wp-job-manager' ); ?>
+				</label>
+			</p>
+			<?php
+		}
+	}
+
+	/**
 	 * Displays setup page.
 	 */
 	public function output() {
@@ -143,19 +198,6 @@ class WP_Job_Manager_Setup {
 				$this->create_page( sanitize_text_field( $page_titles[ $page ] ), $content, 'job_manager_' . $page . '_page_id' );
 			}
 		}
-
-		$usage_tracking = WP_Job_Manager_Usage_Tracking::get_instance();
-
-		ob_start();
-		?>
-		<p class="submit">
-			<a href="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>" class="button button-primary"><?php _e( 'Start setup', 'wp-job-manager' ); ?></a>
-			<a href="<?php echo esc_url( add_query_arg( 'skip-job-manager-setup', 1, admin_url( 'index.php?page=job-manager-setup&step=3' ) ) ); ?>" class="button"><?php _e( 'Skip setup. I will set up the plugin manually.', 'wp-job-manager' ); ?></a>
-		</p>
-		<?php
-		$step_one_submit = ob_get_contents();
-		ob_end_clean();
-
 		?>
 		<div class="wrap wp_job_manager wp_job_manager_addons_wrap">
 			<h2><?php _e( 'WP Job Manager Setup', 'wp-job-manager' ); ?></h2>
@@ -174,7 +216,15 @@ class WP_Job_Manager_Setup {
 				<p><?php _e( 'This setup wizard will walk you through the process of creating pages for job submissions, management, and listings.', 'wp-job-manager' ); ?></p>
 				<p><?php printf( __( 'If you\'d prefer to skip this and set up your pages manually, our %sdocumentation%s will walk you through each step.', 'wp-job-manager' ), '<a href="https://wpjobmanager.com/documentation/">', '</a>' ); ?></p>
 
-				<?php $usage_tracking->maybe_display_tracking_opt_in_for_wizard( $step_one_submit ); ?>
+				<form method="post" action="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>">
+
+					<?php $this->maybe_output_opt_in_checkbox(); ?>
+
+					<p class="submit">
+						<input type="submit" value="<?php _e( 'Start setup', 'wp-job-manager' ); ?>" class="button button-primary" />
+						<a href="<?php echo esc_url( add_query_arg( 'skip-job-manager-setup', 1, admin_url( 'index.php?page=job-manager-setup&step=3' ) ) ); ?>" class="button"><?php _e( 'Skip setup. I will set up the plugin manually.', 'wp-job-manager' ); ?></a>
+					</p>
+				</form>
 
 			<?php endif; ?>
 			<?php if ( 2 === $step ) : ?>

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -129,7 +129,7 @@ class WP_Job_Manager_Setup {
 			$enable = isset( $_POST['job_manager_usage_tracking_enabled'] )
 				&& '1' === $_POST['job_manager_usage_tracking_enabled'];
 
-			$nonce = isset( $_POST['nonce'] ) ? $_POST['nonce'] : null;
+			$nonce       = isset( $_POST['nonce'] ) ? $_POST['nonce'] : null;
 			$valid_nonce = wp_verify_nonce( $_POST['nonce'], 'enable-usage-tracking' );
 
 			if ( $valid_nonce ) {
@@ -141,8 +141,16 @@ class WP_Job_Manager_Setup {
 		$this->output();
 	}
 
+	/**
+	 * Usage tracking opt in text for setup page.
+	 */
 	private function opt_in_text() {
 		return sprintf(
+
+			/*
+			 * translators: the href tag contains the URL for the page
+			 * telling users what data WPJM tracks.
+			 */
 			__(
 				'Check the box below to allow us to collect <a href="%s" target="_blank">usage tracking data</a>.  No sensitive information is collected.',
 				'wp-job-manager'
@@ -151,6 +159,9 @@ class WP_Job_Manager_Setup {
 		);
 	}
 
+	/**
+	 * Output opt-in checkbox if usage tracking isn't already enabled.
+	 */
 	private function maybe_output_opt_in_checkbox() {
 		// Only show the checkbox if we aren't already opted in.
 		$usage_tracking = WP_Job_Manager_Usage_Tracking::get_instance();
@@ -160,10 +171,12 @@ class WP_Job_Manager_Setup {
 				<strong>
 					<?php esc_html_e( 'Help us make WP Job Manager better!', 'wp-job-manager' ); ?>
 				</strong>
-				<?php echo wp_kses(
+				<?php
+				echo wp_kses(
 					$this->opt_in_text(),
 					$usage_tracking->opt_in_dialog_text_allowed_html()
-				); ?>
+				);
+				?>
 			</p>
 
 			<p>
@@ -222,13 +235,13 @@ class WP_Job_Manager_Setup {
 				<p><?php printf( __( 'If you\'d prefer to skip this and set up your pages manually, our %sdocumentation%s will walk you through each step.', 'wp-job-manager' ), '<a href="https://wpjobmanager.com/documentation/">', '</a>' ); ?></p>
 
 				<form method="post" action="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>">
-					<input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'enable-usage-tracking' ); ?>" />
+					<input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'enable-usage-tracking' ) ); ?>" />
 
 					<?php $this->maybe_output_opt_in_checkbox(); ?>
 
 					<p class="submit">
-						<input type="submit" value="<?php _e( 'Start setup', 'wp-job-manager' ); ?>" class="button button-primary" />
-						<a href="<?php echo esc_url( add_query_arg( 'skip-job-manager-setup', 1, admin_url( 'index.php?page=job-manager-setup&step=3' ) ) ); ?>" class="button"><?php _e( 'Skip setup. I will set up the plugin manually.', 'wp-job-manager' ); ?></a>
+						<input type="submit" value="<?php esc_html_e( 'Start setup', 'wp-job-manager' ); ?>" class="button button-primary" />
+						<a href="<?php echo esc_url( add_query_arg( 'skip-job-manager-setup', 1, admin_url( 'index.php?page=job-manager-setup&step=3' ) ) ); ?>" class="button"><?php esc_html_e( 'Skip setup. I will set up the plugin manually.', 'wp-job-manager' ); ?></a>
 					</p>
 				</form>
 

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -43,11 +43,11 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		return 'wp-job-manager';
 	}
 
-	protected function get_tracking_enabled() {
+	public function get_tracking_enabled() {
 		return get_option( self::WPJM_SETTING_NAME  ) || false;
 	}
 
-	protected function set_tracking_enabled( $enable ) {
+	public function set_tracking_enabled( $enable ) {
 		update_option( self::WPJM_SETTING_NAME, $enable );
 	}
 
@@ -63,50 +63,16 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 
-	/**
-	 * If needed, display opt-in dialog for the setup wizard. This is
-	 * designed to use the same JavaScript code as the usual opt-in dialog.
-	 *
-	 * @param string $html the HTML code to display if opt-in is not needed,
-	 * or after opt-in is completed.
+	/*
+	 * Public functions.
 	 */
-	public function maybe_display_tracking_opt_in_for_wizard( $html ) {
-		$opt_in_hidden         = $this->is_opt_in_hidden();
-		$user_tracking_enabled = $this->is_tracking_enabled();
-		$can_manage_tracking   = $this->current_user_can_manage_tracking();
 
-		if ( ! $user_tracking_enabled && ! $opt_in_hidden && $can_manage_tracking ) { ?>
-			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-notice"
-				data-nonce="<?php echo esc_attr( wp_create_nonce( 'tracking-opt-in' ) ); ?>">
-				<p>
-					<?php echo wp_kses( $this->opt_in_dialog_text(), $this->opt_in_dialog_text_allowed_html() ); ?>
-				</p>
-				<p>
-					<button class="button button-primary" data-enable-tracking="yes">
-						<?php esc_html_e( 'Enable Usage Tracking', 'a8c-usage-tracking' ); ?>
-					</button>
-					<button class="button" data-enable-tracking="no">
-						<?php esc_html_e( 'Disable Usage Tracking', 'a8c-usage-tracking' ); ?>
-					</button>
-					<span id="progress" class="spinner alignleft"></span>
-				</p>
-			</div>
-			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-enable-success" class="hidden">
-				<p><?php esc_html_e( 'Usage data enabled. Thank you!', 'a8c-usage-tracking' ); ?></p>
-				<?php echo $html;?>
-			</div>
-			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-disable-success" class="hidden">
-				<p><?php esc_html_e( 'Disabled usage tracking.', 'a8c-usage-tracking' ); ?></p>
-				<?php echo $html;?>
-			</div>
-			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-failure" class="hidden">
-				<p><?php esc_html_e( 'Something went wrong. Please try again later.', 'a8c-usage-tracking' ); ?></p>
-				<?php echo $html;?>
-			</div>
-		<?php
-		} else {
-			echo $html;
-		}
+	public function hide_tracking_opt_in() {
+		parent::hide_tracking_opt_in();
+	}
+
+	public function opt_in_dialog_text_allowed_html() {
+		return parent::opt_in_dialog_text_allowed_html();
 	}
 
 

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		add_filter( 'job_manager_settings', array( $this, 'add_setting_field' ) );
 
 		// In the setup wizard, do not display the normal opt-in dialog.
-		if ( isset( $_GET['page'] ) && 'job-manager-setup' == $_GET['page'] ) {
+		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
 			remove_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
 		}
 	}
@@ -44,7 +44,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	public function get_tracking_enabled() {
-		return get_option( self::WPJM_SETTING_NAME  ) || false;
+		return get_option( self::WPJM_SETTING_NAME ) || false;
 	}
 
 	public function set_tracking_enabled( $enable ) {

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -75,6 +75,21 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		return parent::opt_in_dialog_text_allowed_html();
 	}
 
+	public function opt_in_checkbox_text() {
+		return sprintf(
+
+			/*
+			 * translators: the href tag contains the URL for the page
+			 * telling users what data WPJM tracks.
+			 */
+			__(
+				'Help us make WP Job Manager better by allowing us to collect
+				<a href="%s" target="_blank">usage tracking data</a>.
+				No sensitive information is collected.', 'wp-job-manager'
+			), self::WPJM_TRACKING_INFO_URL
+		);
+	}
+
 
 	/*
 	 * Hooks.
@@ -87,13 +102,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			'type'     => 'checkbox',
 			'desc'     => '',
 			'label'    => __( 'Enable usage tracking', 'wp-job-manager' ),
-			'cb_label' => sprintf(
-				__(
-					'Help us make WP Job Manager better by allowing us to collect
-					<a href="%s" target="_blank">usage tracking data</a>.
-					No sensitive information is collected.', 'wp-job-manager'
-				), self::WPJM_TRACKING_INFO_URL
-			),
+			'cb_label' => $this->opt_in_checkbox_text(),
 		);
 
 		return $fields;

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -20,6 +20,11 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 
 		// Add filter for settings.
 		add_filter( 'job_manager_settings', array( $this, 'add_setting_field' ) );
+
+		// In the setup wizard, do not display the normal opt-in dialog.
+		if ( isset( $_GET['page'] ) && 'job-manager-setup' == $_GET['page'] ) {
+			remove_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
+		}
 	}
 
 	/*
@@ -55,6 +60,53 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			<a href=\"%s\" target=\"_blank\">usage tracking data</a>.
 			No sensitive information is collected, and you can opt out at any time.",
 			'wp-job-manager' ), self::WPJM_TRACKING_INFO_URL );
+	}
+
+
+	/**
+	 * If needed, display opt-in dialog for the setup wizard. This is
+	 * designed to use the same JavaScript code as the usual opt-in dialog.
+	 *
+	 * @param string $html the HTML code to display if opt-in is not needed,
+	 * or after opt-in is completed.
+	 */
+	public function maybe_display_tracking_opt_in_for_wizard( $html ) {
+		$opt_in_hidden         = $this->is_opt_in_hidden();
+		$user_tracking_enabled = $this->is_tracking_enabled();
+		$can_manage_tracking   = $this->current_user_can_manage_tracking();
+
+		if ( ! $user_tracking_enabled && ! $opt_in_hidden && $can_manage_tracking ) { ?>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-notice"
+				data-nonce="<?php echo esc_attr( wp_create_nonce( 'tracking-opt-in' ) ); ?>">
+				<p>
+					<?php echo wp_kses( $this->opt_in_dialog_text(), $this->opt_in_dialog_text_allowed_html() ); ?>
+				</p>
+				<p>
+					<button class="button button-primary" data-enable-tracking="yes">
+						<?php esc_html_e( 'Enable Usage Tracking', 'a8c-usage-tracking' ); ?>
+					</button>
+					<button class="button" data-enable-tracking="no">
+						<?php esc_html_e( 'Disable Usage Tracking', 'a8c-usage-tracking' ); ?>
+					</button>
+					<span id="progress" class="spinner alignleft"></span>
+				</p>
+			</div>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-enable-success" class="hidden">
+				<p><?php esc_html_e( 'Usage data enabled. Thank you!', 'a8c-usage-tracking' ); ?></p>
+				<?php echo $html;?>
+			</div>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-disable-success" class="hidden">
+				<p><?php esc_html_e( 'Disabled usage tracking.', 'a8c-usage-tracking' ); ?></p>
+				<?php echo $html;?>
+			</div>
+			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-failure" class="hidden">
+				<p><?php esc_html_e( 'Something went wrong. Please try again later.', 'a8c-usage-tracking' ); ?></p>
+				<?php echo $html;?>
+			</div>
+		<?php
+		} else {
+			echo $html;
+		}
 	}
 
 

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -320,7 +320,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *
 	 * @return bool true if the opt-in is hidden, false otherwise.
 	 **/
-	private function is_opt_in_hidden() {
+	protected function is_opt_in_hidden() {
 		return (bool) get_option( $this->hide_tracking_opt_in_option_name );
 	}
 
@@ -330,7 +330,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *
 	 * @return array the html tags.
 	 **/
-	private function opt_in_dialog_text_allowed_html() {
+	protected function opt_in_dialog_text_allowed_html() {
 		return array(
 			'a'      => array(
 				'href'  => array(),

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -311,7 +311,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	/**
 	 * Hide the opt-in for enabling usage tracking.
 	 **/
-	private function hide_tracking_opt_in() {
+	protected function hide_tracking_opt_in() {
 		update_option( $this->hide_tracking_opt_in_option_name, true );
 	}
 


### PR DESCRIPTION
In the setup wizard, display the opt-in dialog inline as a checkbox.

## Testing

- Disable usage tracking and unhide the opt-in dialog - `delete_option( 'wpjm_usage_tracking_opt_in_hide' );`

- Visit `/wp-admin/index.php?page=job-manager-setup`.

- You should not see the opt-in dialog. Instead, the opt-in text and checkbox should be inline in the wizard.

- When the `Start setup` button is pressed, usage tracking should be enabled or disabled, depending on the value of the checkbox. You can check this on the settings page.

- Regardless of the checkbox value, the opt-in dialog should be hidden afterward.

- If the user opt to skip the wizard, usage tracking should not be enabled and the opt-in dialog should not be hidden.

- If usage tracking has already been enabled, the opt-in text and checkbox should not be displayed in the wizard.