### PR TITLE
Add usage tracking data for number of Employers

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -23,6 +23,21 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	public static function get_usage_data() {
 		return array(
 			'jobs' => wp_count_posts( 'job_listing' )->publish,
+			'employers' => self::get_employer_count(),
 		);
+	}
+
+	/**
+	 * Get the total number of users with the "employer" role.
+	 *
+	 * @return int the number of "employers".
+	 */
+	private static function get_employer_count() {
+		$employer_query = new WP_User_Query( array(
+			'fields' => 'ID',
+			'role' => 'employer',
+		) );
+
+		return $employer_query->total_users;
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -1,0 +1,47 @@
+<?php
+
+class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
+	/**
+	 * Tests that get_usage_data() returns the correct number of published job
+	 * listings.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_job_listings() {
+		$published_listing_count = 3;
+		$draft_listing_count = 2;
+
+		$this->factory->job_listing->create_many(
+			$published_listing_count, array( 'post_status' => 'publish' )
+		);
+		$this->factory->job_listing->create_many(
+			$draft_listing_count, array( 'post_status' => 'draft' )
+		);
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $published_listing_count, $data['jobs'] );
+	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of users with the
+	 * "employer" role.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_employers() {
+		$employer_count = 3;
+		$subscriber_count = 2;
+
+		$this->factory->user->create_many(
+			$employer_count, array( 'role' => 'employer' )
+		);
+		$this->factory->user->create_many(
+			$subscriber_count, array( 'role' => 'subscriber' )
+		);
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $employer_count, $data['employers'] );
+	}
+}


### PR DESCRIPTION
Adds usage data for Employers.

See https://github.com/Automattic/WP-Job-Manager/issues/1263

## Testing

- Ensure tests pass.

- Send usage tracking data manually. This can be done using the Crontrol plugin to trigger the cron job, or by calling `WP_Job_Manager_Usage_Tracking::get_instance()->send_usage_data()`.

- Ensure the value for the URL parameter `employers` is the correct number.