### PR TITLE
Remove usage tracking option values when plugin is deleted

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -76,4 +76,14 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 
 		return $fields;
 	}
+
+
+	/*
+	 * Helpers.
+	 */
+
+	public function clear_options() {
+		delete_option( self::WPJM_SETTING_NAME );
+		delete_option( $this->hide_tracking_opt_in_option_name );
+	}
 }

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -22,7 +22,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *
 	 * @var string
 	 **/
-	private $hide_tracking_opt_in_option_name;
+	protected $hide_tracking_opt_in_option_name;
 
 	/**
 	 * The name of the cron job action for regularly logging usage data.

--- a/uninstall.php
+++ b/uninstall.php
@@ -36,3 +36,6 @@ $options = array(
 foreach ( $options as $option ) {
 	delete_option( $option );
 }
+
+include dirname( __FILE__ ) . '/includes/class-wp-job-manager-usage-tracking.php';
+WP_Job_Manager_Usage_Tracking::get_instance()->clear_options();


### PR DESCRIPTION
Removes the options for the setting itself, and for hiding the dialog, on uninstall. On reinstall, the user will see the opt-in dialog again.

## Testing

- Opt into usage tracking.

- Uninstall the plugin.

- Reinstall and activate the plugin.

- Ensure that you are prompted to opt in again.