### PR TITLE
Add jobs usage tracking

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -27,14 +27,14 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		$count_posts = wp_count_posts( 'job_listing' );
 
 		return array(
-			'employers'            => self::get_employer_count(),
-			'jobs_type'            => self::get_job_type_count(),
-			'jobs_logo'            => self::get_company_logo_count(),
-			'jobs_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
-			'jobs_pending'         => $count_posts->pending,
-			'jobs_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
-			'jobs_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
-			'jobs_publish'         => $count_posts->publish,
+			'employers'                   => self::get_employer_count(),
+			'jobs_type'                   => self::get_job_type_count(),
+			'jobs_logo'                   => self::get_company_logo_count(),
+			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
+			'jobs_status_pending'         => $count_posts->pending,
+			'jobs_status_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
+			'jobs_status_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
+			'jobs_status_publish'         => $count_posts->publish,
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -9,12 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Supplies the usage tracking data for logging.
- *
- * @package Usage Tracking
- * @since 1.30.0
- */
+	/**
+	 * Supplies the usage tracking data for logging.
+	 *
+	 * @package Usage Tracking
+	 * @since 1.30.0
+	 */
 class WP_Job_Manager_Usage_Tracking_Data {
 	/**
 	 * Get the usage tracking data to send.
@@ -28,6 +28,8 @@ class WP_Job_Manager_Usage_Tracking_Data {
 
 		return array(
 			'employers'            => self::get_employer_count(),
+			'jobs_type'            => self::get_job_type_count(),
+			'jobs_logo'            => self::get_company_logo_count(),
 			'jobs_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
 			'jobs_pending'         => $count_posts->pending,
 			'jobs_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
@@ -50,5 +52,55 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		);
 
 		return $employer_query->total_users;
+	}
+
+	/**
+	 * Get the number of job listings that have a company logo.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @return int Number of job listings with a company logo.
+	 */
+	private static function get_company_logo_count() {
+		$query = new WP_Query(
+			array(
+				'post_type'   => 'job_listing',
+				'post_status' => array( 'expired', 'publish' ),
+				'fields'      => 'ids',
+				'meta_query'  => array(
+					array(
+						'key'     => '_thumbnail_id',
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the total number of job listings that have one or more job types selected.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @return array Number of job listings associated with at least one job type.
+	 **/
+	private static function get_job_type_count() {
+		$query = new WP_Query(
+			array(
+				'post_type'   => 'job_listing',
+				'post_status' => array( 'expired', 'publish' ),
+				'fields'      => 'ids',
+				'tax_query'   => array(
+					array(
+						'taxonomy' => 'job_listing_type',
+						'operator' => 'EXISTS',
+					),
+				),
+			)
+		);
+
+		return $query->found_posts;
 	}
 }

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -9,12 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-	/**
-	 * Supplies the usage tracking data for logging.
-	 *
-	 * @package Usage Tracking
-	 * @since 1.30.0
-	 */
+/**
+ * Supplies the usage tracking data for logging.
+ *
+ * @package Usage Tracking
+ * @since 1.30.0
+ */
 class WP_Job_Manager_Usage_Tracking_Data {
 	/**
 	 * Get the usage tracking data to send.

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -21,9 +21,15 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 * @return array Usage data.
 	 **/
 	public static function get_usage_data() {
+		$count_posts = wp_count_posts( 'job_listing' );
+
 		return array(
-			'jobs_published' => wp_count_posts( 'job_listing' )->publish,
-			'employers' => self::get_employer_count(),
+			'employers'            => self::get_employer_count(),
+			'jobs_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
+			'jobs_pending'         => $count_posts->pending,
+			'jobs_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
+			'jobs_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
+			'jobs_publish'         => $count_posts->publish,
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Usage tracking data
+ *
+ * @package Usage Tracking
  **/
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -39,10 +42,12 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 * @return int the number of "employers".
 	 */
 	private static function get_employer_count() {
-		$employer_query = new WP_User_Query( array(
-			'fields' => 'ID',
-			'role' => 'employer',
-		) );
+		$employer_query = new WP_User_Query(
+			array(
+				'fields' => 'ID',
+				'role'   => 'employer',
+			)
+		);
 
 		return $employer_query->total_users;
 	}

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 **/
 	public static function get_usage_data() {
 		return array(
-			'jobs' => wp_count_posts( 'job_listing' )->publish,
+			'jobs_published' => wp_count_posts( 'job_listing' )->publish,
 			'employers' => self::get_employer_count(),
 		);
 	}

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -47,27 +47,42 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	private $publish_count = 15;
 
 	/**
+	 * Job listing IDs
+	 *
+	 * @var array
+	 */
+	private $listings;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->create_job_listings();
+	}
+
+	/**
 	 * Create a number of job listings with different statuses.
 	 */
 	private function create_job_listings() {
-		$this->factory->job_listing->create_many(
+		$draft           = $this->factory->job_listing->create_many(
 			2, array( 'post_status' => 'draft' )
 		);
-		$this->factory->job_listing->create_many(
+		$expired         = $this->factory->job_listing->create_many(
 			$this->expired_count, array( 'post_status' => 'expired' )
 		);
-		$this->factory->job_listing->create_many(
+		$preview         = $this->factory->job_listing->create_many(
 			$this->preview_count, array( 'post_status' => 'preview' )
 		);
-		$this->factory->job_listing->create_many(
+		$pending         = $this->factory->job_listing->create_many(
 			$this->pending_count, array( 'post_status' => 'pending' )
 		);
-		$this->factory->job_listing->create_many(
+		$pending_payment = $this->factory->job_listing->create_many(
 			$this->pending_payment_count, array( 'post_status' => 'pending_payment' )
 		);
-		$this->factory->job_listing->create_many(
+		$publish         = $this->factory->job_listing->create_many(
 			$this->publish_count, array( 'post_status' => 'publish' )
 		);
+
+		$this->listings = array_merge( $draft, $expired, $preview, $pending, $pending_payment, $publish );
 	}
 
 	/**
@@ -78,7 +93,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_employers() {
-		$employer_count = 3;
+		$employer_count   = 3;
 		$subscriber_count = 2;
 
 		$this->factory->user->create_many(
@@ -99,8 +114,6 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_expired_jobs() {
-		$this->create_job_listings();
-
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( $this->expired_count, $data['jobs_expired'] );
@@ -113,8 +126,6 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_pending_jobs() {
-		$this->create_job_listings();
-
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( $this->pending_count, $data['jobs_pending'] );
@@ -127,8 +138,6 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_pending_payment_jobs() {
-		$this->create_job_listings();
-
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( $this->pending_payment_count, $data['jobs_pending_payment'] );
@@ -141,8 +150,6 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_preview_jobs() {
-		$this->create_job_listings();
-
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( $this->preview_count, $data['jobs_preview'] );
@@ -155,10 +162,62 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_publish_jobs() {
-		$this->create_job_listings();
-
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( $this->publish_count, $data['jobs_publish'] );
+	}
+
+	/**
+	 * Jobs with a company logo count.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_company_logo_count
+	 */
+	public function test_get_company_logo_count() {
+		// Create some media attachments.
+		$media = $this->factory->attachment->create_many(
+			6, array(
+				'post_type'   => 'job_listing',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Add logos to some listings with varying statuses.
+		add_post_meta( $this->listings[0], '_thumbnail_id', $media[0] );
+		add_post_meta( $this->listings[5], '_thumbnail_id', $media[1] );
+		add_post_meta( $this->listings[6], '_thumbnail_id', $media[2] );
+		add_post_meta( $this->listings[12], '_thumbnail_id', $media[3] );
+		add_post_meta( $this->listings[20], '_thumbnail_id', $media[4] );
+		add_post_meta( $this->listings[24], '_thumbnail_id', $media[5] );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		// 2 expired + 1 publish
+		$this->assertEquals( 3, $data['jobs_logo'] );
+	}
+
+	/**
+	 * Jobs with a company logo count.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_type_count
+	 */
+	public function test_get_job_type_count() {
+		$terms = $this->factory->term->create_many( 6, array( 'taxonomy' => 'job_listing_type' ) );
+
+		// Assign job types to some jobs.
+		wp_set_object_terms( $this->listings[0], $terms[0], 'job_listing_type', false );
+		wp_set_object_terms( $this->listings[5], $terms[1], 'job_listing_type', false );
+		wp_set_object_terms( $this->listings[6], $terms[2], 'job_listing_type', false );
+		wp_set_object_terms( $this->listings[12], $terms[3], 'job_listing_type', false );
+		wp_set_object_terms( $this->listings[20], $terms[4], 'job_listing_type', false );
+		wp_set_object_terms( $this->listings[24], $terms[5], 'job_listing_type', false );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		// 2 expired + 1 publish
+		$this->assertEquals( 3, $data['jobs_type'] );
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -116,7 +116,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_expired_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->expired_count, $data['jobs_expired'] );
+		$this->assertEquals( $this->expired_count, $data['jobs_status_expired'] );
 	}
 
 	/**
@@ -128,7 +128,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_pending_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->pending_count, $data['jobs_pending'] );
+		$this->assertEquals( $this->pending_count, $data['jobs_status_pending'] );
 	}
 
 	/**
@@ -140,7 +140,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_pending_payment_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->pending_payment_count, $data['jobs_pending_payment'] );
+		$this->assertEquals( $this->pending_payment_count, $data['jobs_status_pending_payment'] );
 	}
 
 	/**
@@ -152,7 +152,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_preview_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->preview_count, $data['jobs_preview'] );
+		$this->assertEquals( $this->preview_count, $data['jobs_status_preview'] );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_publish_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->publish_count, $data['jobs_publish'] );
+		$this->assertEquals( $this->publish_count, $data['jobs_status_publish'] );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -20,7 +20,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		);
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $published_listing_count, $data['jobs'] );
+		$this->assertEquals( $published_listing_count, $data['jobs_published'] );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -1,30 +1,72 @@
 <?php
+/**
+ * Usage tracking unit test cases
+ *
+ * @package Usage Tracking
+ **/
 
+/**
+ * Usage tracking unit test cases
+ *
+ * @package Usage Tracking
+ **/
 class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
-	private $expired_count         = 10;
-	private $preview_count         = 1;
-	private $pending_count         = 8;
-	private $pending_payment_count = 3;
-	private $publish_count         = 15;
+	/**
+	 * Number of job listings with expired status
+	 *
+	 * @var int
+	 */
+	private $expired_count = 10;
 
+	/**
+	 * Number of job listings with preview status
+	 *
+	 * @var int
+	 */
+	private $preview_count = 1;
+
+	/**
+	 * Number of job listings with pending status
+	 *
+	 * @var int
+	 */
+	private $pending_count = 8;
+
+	/**
+	 * Number of job listings with pending payment status
+	 *
+	 * @var int
+	 */
+	private $pending_payment_count = 3;
+
+	/**
+	 * Number of job listings with publish status
+	 *
+	 * @var int
+	 */
+	private $publish_count = 15;
+
+	/**
+	 * Create a number of job listings with different statuses.
+	 */
 	private function create_job_listings() {
 		$this->factory->job_listing->create_many(
 			2, array( 'post_status' => 'draft' )
 		);
 		$this->factory->job_listing->create_many(
-			$expired_count, array( 'post_status' => 'expired' )
+			$this->expired_count, array( 'post_status' => 'expired' )
 		);
 		$this->factory->job_listing->create_many(
-			$preview_count, array( 'post_status' => 'preview' )
+			$this->preview_count, array( 'post_status' => 'preview' )
 		);
 		$this->factory->job_listing->create_many(
-			$pending_count, array( 'post_status' => 'pending' )
+			$this->pending_count, array( 'post_status' => 'pending' )
 		);
 		$this->factory->job_listing->create_many(
-			$pending_payment_count, array( 'post_status' => 'pending_payment' )
+			$this->pending_payment_count, array( 'post_status' => 'pending_payment' )
 		);
 		$this->factory->job_listing->create_many(
-			$publish_count, array( 'post_status' => 'publish' )
+			$this->publish_count, array( 'post_status' => 'publish' )
 		);
 	}
 
@@ -61,7 +103,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $expired_count, $data['jobs_expired'] );
+		$this->assertEquals( $this->expired_count, $data['jobs_expired'] );
 	}
 
 	/**
@@ -75,7 +117,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $pending_count, $data['jobs_pending'] );
+		$this->assertEquals( $this->pending_count, $data['jobs_pending'] );
 	}
 
 	/**
@@ -89,7 +131,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $pending_payment_count, $data['jobs_pending_payment'] );
+		$this->assertEquals( $this->pending_payment_count, $data['jobs_pending_payment'] );
 	}
 
 	/**
@@ -103,7 +145,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $preview_count, $data['jobs_preview'] );
+		$this->assertEquals( $this->preview_count, $data['jobs_preview'] );
 	}
 
 	/**
@@ -117,6 +159,6 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $publish_count, $data['jobs_publish'] );
+		$this->assertEquals( $this->publish_count, $data['jobs_publish'] );
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -1,26 +1,31 @@
 <?php
 
 class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
-	/**
-	 * Tests that get_usage_data() returns the correct number of published job
-	 * listings.
-	 *
-	 * @since 1.30.0
-	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
-	 */
-	public function test_job_listings() {
-		$published_listing_count = 3;
-		$draft_listing_count = 2;
+	private $expired_count         = 10;
+	private $preview_count         = 1;
+	private $pending_count         = 8;
+	private $pending_payment_count = 3;
+	private $publish_count         = 15;
 
+	private function create_job_listings() {
 		$this->factory->job_listing->create_many(
-			$published_listing_count, array( 'post_status' => 'publish' )
+			2, array( 'post_status' => 'draft' )
 		);
 		$this->factory->job_listing->create_many(
-			$draft_listing_count, array( 'post_status' => 'draft' )
+			$expired_count, array( 'post_status' => 'expired' )
 		);
-
-		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $published_listing_count, $data['jobs_published'] );
+		$this->factory->job_listing->create_many(
+			$preview_count, array( 'post_status' => 'preview' )
+		);
+		$this->factory->job_listing->create_many(
+			$pending_count, array( 'post_status' => 'pending' )
+		);
+		$this->factory->job_listing->create_many(
+			$pending_payment_count, array( 'post_status' => 'pending_payment' )
+		);
+		$this->factory->job_listing->create_many(
+			$publish_count, array( 'post_status' => 'publish' )
+		);
 	}
 
 	/**
@@ -43,5 +48,75 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $employer_count, $data['employers'] );
+	}
+
+	/**
+	 * Expired jobs count.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_get_usage_data_expired_jobs() {
+		$this->create_job_listings();
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( $expired_count, $data['jobs_expired'] );
+	}
+
+	/**
+	 * Pending jobs count.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_get_usage_data_pending_jobs() {
+		$this->create_job_listings();
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( $pending_count, $data['jobs_pending'] );
+	}
+
+	/**
+	 * Pending payment jobs count.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_get_usage_data_pending_payment_jobs() {
+		$this->create_job_listings();
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( $pending_payment_count, $data['jobs_pending_payment'] );
+	}
+
+	/**
+	 * Preview jobs count.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_get_usage_data_preview_jobs() {
+		$this->create_job_listings();
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( $preview_count, $data['jobs_preview'] );
+	}
+
+	/**
+	 * Published jobs count.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_get_usage_data_publish_jobs() {
+		$this->create_job_listings();
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( $publish_count, $data['jobs_publish'] );
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -12,46 +12,46 @@
  **/
 class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	/**
-	 * Number of job listings with expired status
-	 *
-	 * @var int
-	 */
-	private $expired_count = 10;
-
-	/**
-	 * Number of job listings with preview status
-	 *
-	 * @var int
-	 */
-	private $preview_count = 1;
-
-	/**
-	 * Number of job listings with pending status
-	 *
-	 * @var int
-	 */
-	private $pending_count = 8;
-
-	/**
-	 * Number of job listings with pending payment status
-	 *
-	 * @var int
-	 */
-	private $pending_payment_count = 3;
-
-	/**
-	 * Number of job listings with publish status
-	 *
-	 * @var int
-	 */
-	private $publish_count = 15;
-
-	/**
-	 * Job listing IDs
+	 * IDs for job listings that are in draft status
 	 *
 	 * @var array
 	 */
-	private $listings;
+	private $draft;
+
+	/**
+	 * IDs for job listings that have expired
+	 *
+	 * @var array
+	 */
+	private $expired;
+
+	/**
+	 * IDs for job listings that are in preview status
+	 *
+	 * @var array
+	 */
+	private $preview;
+
+	/**
+	 * IDs for job listings that are pending approval
+	 *
+	 * @var array
+	 */
+	private $pending;
+
+	/**
+	 * IDs for job listings that are pending payment
+	 *
+	 * @var array
+	 */
+	private $pending_payment;
+
+	/**
+	 * IDs for job listings that are published
+	 *
+	 * @var array
+	 */
+	private $publish;
 
 	public function setUp() {
 		parent::setUp();
@@ -63,26 +63,24 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * Create a number of job listings with different statuses.
 	 */
 	private function create_job_listings() {
-		$draft           = $this->factory->job_listing->create_many(
+		$this->draft           = $this->factory->job_listing->create_many(
 			2, array( 'post_status' => 'draft' )
 		);
-		$expired         = $this->factory->job_listing->create_many(
-			$this->expired_count, array( 'post_status' => 'expired' )
+		$this->expired         = $this->factory->job_listing->create_many(
+			10, array( 'post_status' => 'expired' )
 		);
-		$preview         = $this->factory->job_listing->create_many(
-			$this->preview_count, array( 'post_status' => 'preview' )
+		$this->preview         = $this->factory->job_listing->create_many(
+			1, array( 'post_status' => 'preview' )
 		);
-		$pending         = $this->factory->job_listing->create_many(
-			$this->pending_count, array( 'post_status' => 'pending' )
+		$this->pending         = $this->factory->job_listing->create_many(
+			8, array( 'post_status' => 'pending' )
 		);
-		$pending_payment = $this->factory->job_listing->create_many(
-			$this->pending_payment_count, array( 'post_status' => 'pending_payment' )
+		$this->pending_payment = $this->factory->job_listing->create_many(
+			3, array( 'post_status' => 'pending_payment' )
 		);
-		$publish         = $this->factory->job_listing->create_many(
-			$this->publish_count, array( 'post_status' => 'publish' )
+		$this->publish         = $this->factory->job_listing->create_many(
+			15, array( 'post_status' => 'publish' )
 		);
-
-		$this->listings = array_merge( $draft, $expired, $preview, $pending, $pending_payment, $publish );
 	}
 
 	/**
@@ -116,7 +114,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_expired_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->expired_count, $data['jobs_status_expired'] );
+		$this->assertEquals( count( $this->expired ), $data['jobs_status_expired'] );
 	}
 
 	/**
@@ -128,7 +126,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_pending_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->pending_count, $data['jobs_status_pending'] );
+		$this->assertEquals( count( $this->pending ), $data['jobs_status_pending'] );
 	}
 
 	/**
@@ -140,7 +138,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_pending_payment_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->pending_payment_count, $data['jobs_status_pending_payment'] );
+		$this->assertEquals( count( $this->pending_payment ), $data['jobs_status_pending_payment'] );
 	}
 
 	/**
@@ -152,7 +150,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_preview_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->preview_count, $data['jobs_status_preview'] );
+		$this->assertEquals( count( $this->preview ), $data['jobs_status_preview'] );
 	}
 
 	/**
@@ -164,7 +162,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_usage_data_publish_jobs() {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $this->publish_count, $data['jobs_status_publish'] );
+		$this->assertEquals( count( $this->publish ), $data['jobs_status_publish'] );
 	}
 
 	/**
@@ -184,12 +182,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		);
 
 		// Add logos to some listings with varying statuses.
-		add_post_meta( $this->listings[0], '_thumbnail_id', $media[0] );
-		add_post_meta( $this->listings[5], '_thumbnail_id', $media[1] );
-		add_post_meta( $this->listings[6], '_thumbnail_id', $media[2] );
-		add_post_meta( $this->listings[12], '_thumbnail_id', $media[3] );
-		add_post_meta( $this->listings[20], '_thumbnail_id', $media[4] );
-		add_post_meta( $this->listings[24], '_thumbnail_id', $media[5] );
+		add_post_meta( $this->draft[0], '_thumbnail_id', $media[0] );
+		add_post_meta( $this->expired[5], '_thumbnail_id', $media[1] );
+		add_post_meta( $this->expired[6], '_thumbnail_id', $media[2] );
+		add_post_meta( $this->preview[0], '_thumbnail_id', $media[3] );
+		add_post_meta( $this->pending[3], '_thumbnail_id', $media[4] );
+		add_post_meta( $this->publish[9], '_thumbnail_id', $media[5] );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -208,12 +206,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$terms = $this->factory->term->create_many( 6, array( 'taxonomy' => 'job_listing_type' ) );
 
 		// Assign job types to some jobs.
-		wp_set_object_terms( $this->listings[0], $terms[0], 'job_listing_type', false );
-		wp_set_object_terms( $this->listings[5], $terms[1], 'job_listing_type', false );
-		wp_set_object_terms( $this->listings[6], $terms[2], 'job_listing_type', false );
-		wp_set_object_terms( $this->listings[12], $terms[3], 'job_listing_type', false );
-		wp_set_object_terms( $this->listings[20], $terms[4], 'job_listing_type', false );
-		wp_set_object_terms( $this->listings[24], $terms[5], 'job_listing_type', false );
+		wp_set_object_terms( $this->draft[0], $terms[0], 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[5], $terms[1], 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[6], $terms[2], 'job_listing_type', false );
+		wp_set_object_terms( $this->preview[0], $terms[3], 'job_listing_type', false );
+		wp_set_object_terms( $this->pending[3], $terms[4], 'job_listing_type', false );
+		wp_set_object_terms( $this->publish[9], $terms[5], 'job_listing_type', false );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR logs the following usage tracking data:
- Total number of expired jobs
- Total number of preview jobs
- Total number of pending jobs
- Total number of pending payment jobs
- Total number of published jobs

Total number of published or expired jobs that have:
  - A company logo
  - One or more job types selected

#### Testing instructions:

1. Check that the tests run.
2. Set job listings with varying statuses including _Expired_, _Pending Approval_, _Pending Payment_, '_Preview_ and _Active_ (i.e. publish). (Note that in order to set a job to _Pending Payment_ status, the WooCommerce Paid Listings plugin must be installed.)
3. Assign a company logo and select a job type for some of the jobs.
4. For bonus points, in _Job Listings_ > _Settings_ > _Job Listings_, check the _Multi-select Listing Types_ setting, and ensure that some jobs have multiple job types selected, but that they are only included once in the count.

Check that the following properties are logged to Tracks correctly:
- `jobs_type`
- `jobs_logo`
- `jobs_status_expired`
- `jobs_status_pending`
- `jobs_status_pending_payment`
- `jobs_status_preview`
- `jobs_status_publish`