### PR TITLE
Usage tracking for Jobs data

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -42,6 +42,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_company_tagline'        => self::get_jobs_count_with_meta( '_company_tagline' ),
 			'jobs_company_twitter'        => self::get_jobs_count_with_meta( '_company_twitter' ),
 			'jobs_company_video'          => self::get_jobs_count_with_meta( '_company_video' ),
+			'jobs_expiry'                 => self::get_jobs_count_with_meta( '_job_expires' ),
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -121,6 +121,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_jobs_count_with_meta( $meta_key ) {
 		$query = new WP_Query( array(
 			'post_type'  => 'job_listing',
+			'post_status' => 'publish,expired',
 			'fields'     => 'ids',
 			'meta_query' => array(
 				array(

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -39,6 +39,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_app_contact'            => self::get_jobs_count_with_meta( '_application' ),
 			'jobs_company_name'           => self::get_jobs_count_with_meta( '_company_name' ),
 			'jobs_company_site'           => self::get_jobs_count_with_meta( '_company_website' ),
+			'jobs_company_tagline'        => self::get_jobs_count_with_meta( '_company_tagline' ),
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -44,6 +44,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_company_video'          => self::get_jobs_count_with_meta( '_company_video' ),
 			'jobs_expiry'                 => self::get_jobs_count_with_meta( '_job_expires' ),
 			'jobs_filled'                 => self::get_jobs_count_with_checked_meta( '_filled' ),
+			'jobs_featured'               => self::get_jobs_count_with_checked_meta( '_featured' ),
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -35,8 +35,9 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_status_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
 			'jobs_status_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
 			'jobs_status_publish'         => $count_posts->publish,
-			'jobs_location'               => self::get_jobs_with_location_count(),
-			'jobs_app_contact'            => self::get_jobs_with_application_contact_count(),
+			'jobs_location'               => self::get_jobs_count_with_meta( '_job_location' ),
+			'jobs_app_contact'            => self::get_jobs_count_with_meta( '_application' ),
+			'jobs_company_name'           => self::get_jobs_count_with_meta( '_company_name' ),
 		);
 	}
 
@@ -107,39 +108,19 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	}
 
 	/**
-	 * Get the number of job listings with a non-empty location.
+	 * Get the number of job listings where the given meta value is non-empty.
+	 *
+	 * @param string $meta_key the key for the meta value to check.
 	 *
 	 * @return int the number of job listings.
 	 */
-	private static function get_jobs_with_location_count() {
+	private static function get_jobs_count_with_meta( $meta_key ) {
 		$query = new WP_Query( array(
 			'post_type'  => 'job_listing',
 			'fields'     => 'ids',
 			'meta_query' => array(
 				array(
-					'key'     => '_job_location',
-					'value'   => '[^[:space:]]',
-					'compare' => 'REGEXP',
-				),
-			),
-		) );
-
-		return $query->found_posts;
-	}
-
-	/**
-	 * Get the number of job listings with a non-empty application email or
-	 * URL.
-	 *
-	 * @return int the number of job listings.
-	 */
-	private static function get_jobs_with_application_contact_count() {
-		$query = new WP_Query( array(
-			'post_type'  => 'job_listing',
-			'fields'     => 'ids',
-			'meta_query' => array(
-				array(
-					'key'     => '_application',
+					'key'     => $meta_key,
 					'value'   => '[^[:space:]]',
 					'compare' => 'REGEXP',
 				),

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -123,10 +123,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_jobs_count_with_meta( $meta_key ) {
 		$query = new WP_Query( array(
-			'post_type'  => 'job_listing',
-			'post_status' => 'publish,expired',
-			'fields'     => 'ids',
-			'meta_query' => array(
+			'post_type'   => 'job_listing',
+			'post_status' => array( 'publish', 'expired' ),
+			'fields'      => 'ids',
+			'meta_query'  => array(
 				array(
 					'key'     => $meta_key,
 					'value'   => '[^[:space:]]',
@@ -148,9 +148,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_jobs_count_with_checked_meta( $meta_key ) {
 		$query = new WP_Query( array(
-			'post_type'  => 'job_listing',
-			'fields'     => 'ids',
-			'meta_query' => array(
+			'post_type'   => 'job_listing',
+			'post_status' => array( 'publish', 'expired' ),
+			'fields'      => 'ids',
+			'meta_query'  => array(
 				array(
 					'key'   => $meta_key,
 					'value' => '1',

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -38,6 +38,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_location'               => self::get_jobs_count_with_meta( '_job_location' ),
 			'jobs_app_contact'            => self::get_jobs_count_with_meta( '_application' ),
 			'jobs_company_name'           => self::get_jobs_count_with_meta( '_company_name' ),
+			'jobs_company_site'           => self::get_jobs_count_with_meta( '_company_website' ),
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -36,6 +36,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_status_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
 			'jobs_status_publish'         => $count_posts->publish,
 			'jobs_location'               => self::get_jobs_with_location_count(),
+			'jobs_app_contact'            => self::get_jobs_with_application_contact_count(),
 		);
 	}
 
@@ -117,6 +118,28 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'meta_query' => array(
 				array(
 					'key'     => '_job_location',
+					'value'   => '[^[:space:]]',
+					'compare' => 'REGEXP',
+				),
+			),
+		) );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the number of job listings with a non-empty application email or
+	 * URL.
+	 *
+	 * @return int the number of job listings.
+	 */
+	private static function get_jobs_with_application_contact_count() {
+		$query = new WP_Query( array(
+			'post_type'  => 'job_listing',
+			'fields'     => 'ids',
+			'meta_query' => array(
+				array(
+					'key'     => '_application',
 					'value'   => '[^[:space:]]',
 					'compare' => 'REGEXP',
 				),

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -35,6 +35,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_status_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
 			'jobs_status_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
 			'jobs_status_publish'         => $count_posts->publish,
+			'jobs_location'               => self::get_jobs_with_location_count(),
 		);
 	}
 
@@ -100,6 +101,27 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				),
 			)
 		);
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the number of job listings with a non-empty location.
+	 *
+	 * @return int the number of job listings.
+	 */
+	private static function get_jobs_with_location_count() {
+		$query = new WP_Query( array(
+			'post_type'  => 'job_listing',
+			'fields'     => 'ids',
+			'meta_query' => array(
+				array(
+					'key'     => '_job_location',
+					'value'   => '[^[:space:]]',
+					'compare' => 'REGEXP',
+				),
+			),
+		) );
 
 		return $query->found_posts;
 	}

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -43,6 +43,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_company_twitter'        => self::get_jobs_count_with_meta( '_company_twitter' ),
 			'jobs_company_video'          => self::get_jobs_count_with_meta( '_company_video' ),
 			'jobs_expiry'                 => self::get_jobs_count_with_meta( '_job_expires' ),
+			'jobs_filled'                 => self::get_jobs_count_with_checked_meta( '_filled' ),
 		);
 	}
 
@@ -129,6 +130,29 @@ class WP_Job_Manager_Usage_Tracking_Data {
 					'key'     => $meta_key,
 					'value'   => '[^[:space:]]',
 					'compare' => 'REGEXP',
+				),
+			),
+		) );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the number of job listings where the given checkbox meta value is
+	 * checked.
+	 *
+	 * @param string $meta_key the key for the meta value to check.
+	 *
+	 * @return int the number of job listings.
+	 */
+	private static function get_jobs_count_with_checked_meta( $meta_key ) {
+		$query = new WP_Query( array(
+			'post_type'  => 'job_listing',
+			'fields'     => 'ids',
+			'meta_query' => array(
+				array(
+					'key'   => $meta_key,
+					'value' => '1',
 				),
 			),
 		) );

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -41,6 +41,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_company_site'           => self::get_jobs_count_with_meta( '_company_website' ),
 			'jobs_company_tagline'        => self::get_jobs_count_with_meta( '_company_tagline' ),
 			'jobs_company_twitter'        => self::get_jobs_count_with_meta( '_company_twitter' ),
+			'jobs_company_video'          => self::get_jobs_count_with_meta( '_company_video' ),
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -40,6 +40,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_company_name'           => self::get_jobs_count_with_meta( '_company_name' ),
 			'jobs_company_site'           => self::get_jobs_count_with_meta( '_company_website' ),
 			'jobs_company_tagline'        => self::get_jobs_count_with_meta( '_company_tagline' ),
+			'jobs_company_twitter'        => self::get_jobs_count_with_meta( '_company_twitter' ),
 		);
 	}
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -232,7 +232,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_job_location', 'Toronto', $published, $expired );
+		$this->create_job_listings_with_meta( '_job_location', 'Toronto', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_location'] );
@@ -249,7 +249,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_application', 'email@example.com', $published, $expired );
+		$this->create_job_listings_with_meta( '_application', 'email@example.com', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_app_contact'] );
@@ -266,7 +266,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_company_name', 'Automattic', $published, $expired );
+		$this->create_job_listings_with_meta( '_company_name', 'Automattic', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_company_name'] );
@@ -283,7 +283,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_company_website', 'automattic.com', $published, $expired );
+		$this->create_job_listings_with_meta( '_company_website', 'automattic.com', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_company_site'] );
@@ -300,7 +300,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_company_tagline', 'We are passionate about making the web a better place.', $published, $expired );
+		$this->create_job_listings_with_meta( '_company_tagline', 'We are passionate about making the web a better place.', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_company_tagline'] );
@@ -317,7 +317,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_company_twitter', '@automattic', $published, $expired );
+		$this->create_job_listings_with_meta( '_company_twitter', '@automattic', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_company_twitter'] );
@@ -334,7 +334,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_company_video', 'youtube.com/1234', $published, $expired );
+		$this->create_job_listings_with_meta( '_company_video', 'youtube.com/1234', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_company_video'] );
@@ -351,7 +351,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_job_expires', '2018-01-01', $published, $expired );
+		$this->create_job_listings_with_meta( '_job_expires', '2018-01-01', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_expiry'] );
@@ -368,7 +368,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_filled', '1', $published, $expired, array( '0' ) );
+		$this->create_job_listings_with_meta( '_filled', '1', $published, $expired, array( '0' ) );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_filled'] );
@@ -385,7 +385,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings( '_featured', '1', $published, $expired, array( '0' ) );
+		$this->create_job_listings_with_meta( '_featured', '1', $published, $expired, array( '0' ) );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_featured'] );
@@ -405,7 +405,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @param int $expired       the number of expired listings to create.
 	 * @param int $other_values  other values for which to create listings (optional).
 	 */
-	private function create_job_listings( $meta_name, $meta_value, $published, $expired, $other_values = array() ) {
+	private function create_job_listings_with_meta( $meta_name, $meta_value, $published, $expired, $other_values = array() ) {
 		// Create published listings.
 		$this->factory->job_listing->create_many( $published, array(
 			'meta_input' => array(

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -340,6 +340,23 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$this->assertEquals( $published + $expired, $data['jobs_company_video'] );
 	}
 
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with an expiry date.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_expiry() {
+		$published = 3;
+		$expired   = 2;
+
+		$this->create_job_listings( '_job_expires', '2018-01-01', $published, $expired );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $published + $expired, $data['jobs_expiry'] );
+	}
+
 
 	/**
 	 * Creates job listings with the given meta values. This will also create

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -357,6 +357,23 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$this->assertEquals( $published + $expired, $data['jobs_expiry'] );
 	}
 
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with the Position Filled box checked.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_filled() {
+		$published = 3;
+		$expired   = 2;
+
+		$this->create_job_listings( '_filled', '1', $published, $expired, array( '0' ) );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $published + $expired, $data['jobs_filled'] );
+	}
+
 
 	/**
 	 * Creates job listings with the given meta values. This will also create
@@ -369,8 +386,9 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @param string $meta_value the desired value of the meta parameter.
 	 * @param int $published     the number of published listings to create.
 	 * @param int $expired       the number of expired listings to create.
+	 * @param int $other_values  other values for which to create listings (optional).
 	 */
-	private function create_job_listings( $meta_name, $meta_value, $published, $expired ) {
+	private function create_job_listings( $meta_name, $meta_value, $published, $expired, $other_values = array() ) {
 		// Create published listings.
 		$this->factory->job_listing->create_many( $published, array(
 			'meta_input' => array(
@@ -411,6 +429,15 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 			}
 
 			$this->factory->job_listing->create( $params );
+		}
+
+		// Create listings with other values.
+		foreach ( $other_values as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					$meta_name => $val,
+				)
+			) );
 		}
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -282,4 +282,35 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $with_app_contact_count, $data['jobs_app_contact'] );
 	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with a company name.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_company_name() {
+		$with_company_name_count = 3;
+
+		$this->factory->job_listing->create_many(
+			$with_company_name_count, array(
+				'meta_input' => array(
+					'_company_name' => 'Automattic',
+				),
+			)
+		);
+
+		// Add 4 with no company name
+		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					'_company_name' => $val,
+				),
+			) );
+		}
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $with_company_name_count, $data['jobs_company_name'] );
+	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -363,9 +363,9 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		// Create expired listings.
 		$this->factory->job_listing->create_many( $expired, array(
+			'post_status' => 'expired',
 			'meta_input' => array(
-				$meta_name     => $meta_value,
-				'_job_expires' => "2018-01-01",
+				$meta_name => $meta_value,
 			),
 		) );
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -250,4 +250,36 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $with_location_count, $data['jobs_location'] );
 	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with an application email or URL.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_application_contact() {
+		$with_app_contact_count = 3;
+
+		$this->factory->job_listing->create_many(
+			$with_app_contact_count, array(
+				'meta_input' => array(
+					'_application' => 'email@example.com',
+				),
+			)
+		);
+
+		// Add 5 with no contact
+		$this->factory->job_listing->create( array() );
+		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					'_application' => $val,
+				),
+			) );
+		}
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $with_app_contact_count, $data['jobs_app_contact'] );
+	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -374,6 +374,23 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$this->assertEquals( $published + $expired, $data['jobs_filled'] );
 	}
 
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with the Featured Listing box checked.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_featured() {
+		$published = 3;
+		$expired   = 2;
+
+		$this->create_job_listings( '_featured', '1', $published, $expired, array( '0' ) );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $published + $expired, $data['jobs_featured'] );
+	}
+
 
 	/**
 	 * Creates job listings with the given meta values. This will also create

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -346,4 +346,35 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $with_company_website_count, $data['jobs_company_site'] );
 	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with a company tagline.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_company_tagline() {
+		$with_company_tagline_count = 3;
+
+		$this->factory->job_listing->create_many(
+			$with_company_tagline_count, array(
+				'meta_input' => array(
+					'_company_tagline' => 'We are passionate about making the web a better place.',
+				),
+			)
+		);
+
+		// Add 4 with no company tagline
+		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					'_company_tagline' => $val,
+				),
+			) );
+		}
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $with_company_tagline_count, $data['jobs_company_tagline'] );
+	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -229,28 +229,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_location() {
-		$with_location_count = 3;
+		$published = 3;
+		$expired   = 2;
 
-		$this->factory->job_listing->create_many(
-			$with_location_count, array(
-				'meta_input' => array(
-					'_job_location' => 'Toronto',
-				),
-			)
-		);
-
-		// Add 5 with no location
-		$this->factory->job_listing->create( array() );
-		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					'_job_location' => $val,
-				),
-			) );
-		}
+		$this->create_job_listings( '_job_location', 'Toronto', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $with_location_count, $data['jobs_location'] );
+		$this->assertEquals( $published + $expired, $data['jobs_location'] );
 	}
 
 	/**
@@ -261,28 +246,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_application_contact() {
-		$with_app_contact_count = 3;
+		$published = 3;
+		$expired   = 2;
 
-		$this->factory->job_listing->create_many(
-			$with_app_contact_count, array(
-				'meta_input' => array(
-					'_application' => 'email@example.com',
-				),
-			)
-		);
-
-		// Add 5 with no contact
-		$this->factory->job_listing->create( array() );
-		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					'_application' => $val,
-				),
-			) );
-		}
+		$this->create_job_listings( '_application', 'email@example.com', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $with_app_contact_count, $data['jobs_app_contact'] );
+		$this->assertEquals( $published + $expired, $data['jobs_app_contact'] );
 	}
 
 	/**
@@ -293,27 +263,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_company_name() {
-		$with_company_name_count = 3;
+		$published = 3;
+		$expired   = 2;
 
-		$this->factory->job_listing->create_many(
-			$with_company_name_count, array(
-				'meta_input' => array(
-					'_company_name' => 'Automattic',
-				),
-			)
-		);
-
-		// Add 4 with no company name
-		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					'_company_name' => $val,
-				),
-			) );
-		}
+		$this->create_job_listings( '_company_name', 'Automattic', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $with_company_name_count, $data['jobs_company_name'] );
+		$this->assertEquals( $published + $expired, $data['jobs_company_name'] );
 	}
 
 	/**
@@ -324,27 +280,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_company_website() {
-		$with_company_website_count = 3;
+		$published = 3;
+		$expired   = 2;
 
-		$this->factory->job_listing->create_many(
-			$with_company_website_count, array(
-				'meta_input' => array(
-					'_company_website' => 'automattic.com',
-				),
-			)
-		);
-
-		// Add 4 with no company website
-		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					'_company_website' => $val,
-				),
-			) );
-		}
+		$this->create_job_listings( '_company_website', 'automattic.com', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $with_company_website_count, $data['jobs_company_site'] );
+		$this->assertEquals( $published + $expired, $data['jobs_company_site'] );
 	}
 
 	/**
@@ -355,27 +297,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_company_tagline() {
-		$with_company_tagline_count = 3;
+		$published = 3;
+		$expired   = 2;
 
-		$this->factory->job_listing->create_many(
-			$with_company_tagline_count, array(
-				'meta_input' => array(
-					'_company_tagline' => 'We are passionate about making the web a better place.',
-				),
-			)
-		);
-
-		// Add 4 with no company tagline
-		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					'_company_tagline' => $val,
-				),
-			) );
-		}
+		$this->create_job_listings( '_company_tagline', 'We are passionate about making the web a better place.', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $with_company_tagline_count, $data['jobs_company_tagline'] );
+		$this->assertEquals( $published + $expired, $data['jobs_company_tagline'] );
 	}
 
 	/**
@@ -386,28 +314,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_company_twitter() {
-		$with_company_twitter_count = 3;
+		$published = 3;
+		$expired   = 2;
 
-		$this->factory->job_listing->create_many(
-			$with_company_twitter_count, array(
-				'meta_input' => array(
-					'_company_twitter' => '@automattic',
-				),
-			)
-		);
-
-		// Add 5 with no company twitter handle
-		$this->factory->job_listing->create( array() );
-		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					'_company_twitter' => $val,
-				),
-			) );
-		}
+		$this->create_job_listings( '_company_twitter', '@automattic', $published, $expired );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $with_company_twitter_count, $data['jobs_company_twitter'] );
+		$this->assertEquals( $published + $expired, $data['jobs_company_twitter'] );
 	}
 
 	/**
@@ -418,27 +331,69 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_company_video() {
-		$with_company_video_count = 3;
+		$published = 3;
+		$expired   = 2;
 
-		$this->factory->job_listing->create_many(
-			$with_company_video_count, array(
-				'meta_input' => array(
-					'_company_video' => 'youtube.com/1234',
-				),
-			)
-		);
+		$this->create_job_listings( '_company_video', 'youtube.com/1234', $published, $expired );
 
-		// Add 5 with no company video
-		$this->factory->job_listing->create( array() );
-		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $published + $expired, $data['jobs_company_video'] );
+	}
+
+
+	/**
+	 * Creates job listings with the given meta values. This will also create
+	 * some listings with values for the meta parameter that should be
+	 * considered empty (e.g. spaces) and some entries with other statuses
+	 * (such as draft). For tracking data, only the published and expired
+	 * entries should be counted.
+	 *
+	 * @param string $meta_name  the name of the meta parameter to set.
+	 * @param string $meta_value the desired value of the meta parameter.
+	 * @param int $published     the number of published listings to create.
+	 * @param int $expired       the number of expired listings to create.
+	 */
+	private function create_job_listings( $meta_name, $meta_value, $published, $expired ) {
+		// Create published listings.
+		$this->factory->job_listing->create_many( $published, array(
+			'meta_input' => array(
+				$meta_name => $meta_value,
+			),
+		) );
+
+		// Create expired listings.
+		$this->factory->job_listing->create_many( $expired, array(
+			'meta_input' => array(
+				$meta_name     => $meta_value,
+				'_job_expires' => "2018-01-01",
+			),
+		) );
+
+		// Create listings with empty values.
+		$empty_values = array( '', '   ', "\n\t", " \n \t " );
+		foreach ( $empty_values as $val ) {
 			$this->factory->job_listing->create( array(
 				'meta_input' => array(
-					'_company_video' => $val,
+					$meta_name => $val,
 				),
 			) );
 		}
 
-		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
-		$this->assertEquals( $with_company_video_count, $data['jobs_company_video'] );
+		// Create listings with other statuses.
+		$statuses = array( 'future', 'draft', 'pending', 'private', 'trash' );
+		foreach ( $statuses as $status ) {
+			$params = array(
+				'post_status' => $status,
+				'meta_input'  => array(
+					$meta_name => $meta_value,
+				),
+			);
+
+			if ( 'future' == $status ) {
+				$params['post_date'] = '3018-02-15 00:00:00';
+			}
+
+			$this->factory->job_listing->create( $params );
+		}
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -218,4 +218,36 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		// 2 expired + 1 publish
 		$this->assertEquals( 3, $data['jobs_type'] );
 	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with a location.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_location() {
+		$with_location_count = 3;
+
+		$this->factory->job_listing->create_many(
+			$with_location_count, array(
+				'meta_input' => array(
+					'_job_location' => 'Toronto',
+				),
+			)
+		);
+
+		// Add 5 with no location
+		$this->factory->job_listing->create( array() );
+		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					'_job_location' => $val,
+				),
+			) );
+		}
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $with_location_count, $data['jobs_location'] );
+	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -409,4 +409,36 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $with_company_twitter_count, $data['jobs_company_twitter'] );
 	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with a company video.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_company_video() {
+		$with_company_video_count = 3;
+
+		$this->factory->job_listing->create_many(
+			$with_company_video_count, array(
+				'meta_input' => array(
+					'_company_video' => 'youtube.com/1234',
+				),
+			)
+		);
+
+		// Add 5 with no company video
+		$this->factory->job_listing->create( array() );
+		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					'_company_video' => $val,
+				),
+			) );
+		}
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $with_company_video_count, $data['jobs_company_video'] );
+	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -315,4 +315,35 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $with_company_name_count, $data['jobs_company_name'] );
 	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with a company website.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_company_website() {
+		$with_company_website_count = 3;
+
+		$this->factory->job_listing->create_many(
+			$with_company_website_count, array(
+				'meta_input' => array(
+					'_company_website' => 'automattic.com',
+				),
+			)
+		);
+
+		// Add 4 with no company website
+		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					'_company_website' => $val,
+				),
+			) );
+		}
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $with_company_website_count, $data['jobs_company_site'] );
+	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -377,4 +377,36 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $with_company_tagline_count, $data['jobs_company_tagline'] );
 	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with a company twitter handle.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_company_twitter() {
+		$with_company_twitter_count = 3;
+
+		$this->factory->job_listing->create_many(
+			$with_company_twitter_count, array(
+				'meta_input' => array(
+					'_company_twitter' => '@automattic',
+				),
+			)
+		);
+
+		// Add 5 with no company twitter handle
+		$this->factory->job_listing->create( array() );
+		foreach ( array( '', '   ', "\n\t", " \n \t " ) as $val ) {
+			$this->factory->job_listing->create( array(
+				'meta_input' => array(
+					'_company_twitter' => $val,
+				),
+			) );
+		}
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $with_company_twitter_count, $data['jobs_company_twitter'] );
+	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -53,16 +53,10 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 */
 	private $publish;
 
-	public function setUp() {
-		parent::setUp();
-
-		$this->create_job_listings();
-	}
-
 	/**
 	 * Create a number of job listings with different statuses.
 	 */
-	private function create_job_listings() {
+	private function create_default_job_listings() {
 		$this->draft           = $this->factory->job_listing->create_many(
 			2, array( 'post_status' => 'draft' )
 		);
@@ -112,6 +106,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_expired_jobs() {
+		$this->create_default_job_listings();
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( count( $this->expired ), $data['jobs_status_expired'] );
@@ -124,6 +119,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_pending_jobs() {
+		$this->create_default_job_listings();
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( count( $this->pending ), $data['jobs_status_pending'] );
@@ -136,6 +132,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_pending_payment_jobs() {
+		$this->create_default_job_listings();
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( count( $this->pending_payment ), $data['jobs_status_pending_payment'] );
@@ -148,6 +145,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_preview_jobs() {
+		$this->create_default_job_listings();
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( count( $this->preview ), $data['jobs_status_preview'] );
@@ -160,6 +158,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_get_usage_data_publish_jobs() {
+		$this->create_default_job_listings();
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( count( $this->publish ), $data['jobs_status_publish'] );
@@ -173,6 +172,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_company_logo_count
 	 */
 	public function test_get_company_logo_count() {
+		$this->create_default_job_listings();
+
 		// Create some media attachments.
 		$media = $this->factory->attachment->create_many(
 			6, array(
@@ -203,6 +204,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_type_count
 	 */
 	public function test_get_job_type_count() {
+		$this->create_default_job_listings();
 		$terms = $this->factory->term->create_many( 6, array( 'taxonomy' => 'job_listing_type' ) );
 
 		// Assign job types to some jobs.


### PR DESCRIPTION
Adds usage tracking to count jobs with non-empty:

- Location
- Application email or URL
- Company name
- Company site
- Company tagline
- Company Twitter handle
- Company video
- Job expiry date
- Filled position checkbox
- Featured listing checkbox

@donnapep I took a different approach to testing than you did in #1331. Instead of a helper that gets called in `setUp`, I have one that is called in individual tests with some params. ~There's going to be some work in getting the two PR's to work together, so I'll rebase after #1331 is merged.~ Rebased this, and refactored a bit.

## Testing

- Ensure the tests pass

- Create jobs with and without values for the above attributes. Ensure that when usage data is sent, the counts are correct.