### PR TITLE
Add job types usage tracking

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -35,6 +35,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'employers'                   => self::get_employer_count(),
 			'job_categories'              => $categories,
 			'job_categories_desc'         => self::get_job_category_has_description_count(),
+			'job_types'                   => wp_count_terms( 'job_listing_type', array( 'hide_empty' => false ) ),
 			'jobs_type'                   => self::get_job_type_count(),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
@@ -50,8 +51,16 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_company_twitter'        => self::get_jobs_count_with_meta( '_company_twitter' ),
 			'jobs_company_video'          => self::get_jobs_count_with_meta( '_company_video' ),
 			'jobs_expiry'                 => self::get_jobs_count_with_meta( '_job_expires' ),
-			'jobs_filled'                 => self::get_jobs_count_with_checked_meta( '_filled' ),
 			'jobs_featured'               => self::get_jobs_count_with_checked_meta( '_featured' ),
+			'jobs_filled'                 => self::get_jobs_count_with_checked_meta( '_filled' ),
+			'jobs_location'               => self::get_jobs_count_with_meta( '_job_location' ),
+			'jobs_logo'                   => self::get_company_logo_count(),
+			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
+			'jobs_status_pending'         => $count_posts->pending,
+			'jobs_status_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
+			'jobs_status_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
+			'jobs_status_publish'         => $count_posts->publish,
+			'jobs_type'                   => self::get_job_type_count(),
 		);
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -56,6 +56,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_featured'               => self::get_jobs_count_with_checked_meta( '_featured' ),
 			'jobs_filled'                 => self::get_jobs_count_with_checked_meta( '_filled' ),
 			'jobs_freelance'              => self::get_jobs_by_type_count( 'freelance' ),
+			'jobs_full_time'              => self::get_jobs_by_type_count( 'full-time' ),
 			'jobs_location'               => self::get_jobs_count_with_meta( '_job_location' ),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -57,6 +57,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_filled'                 => self::get_jobs_count_with_checked_meta( '_filled' ),
 			'jobs_freelance'              => self::get_jobs_by_type_count( 'freelance' ),
 			'jobs_full_time'              => self::get_jobs_by_type_count( 'full-time' ),
+			'jobs_intern'                 => self::get_jobs_by_type_count( 'internship' ),
 			'jobs_location'               => self::get_jobs_count_with_meta( '_job_location' ),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -66,6 +66,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_status_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,
 			'jobs_status_preview'         => isset( $count_posts->preview ) ? $count_posts->preview : 0,
 			'jobs_status_publish'         => $count_posts->publish,
+			'jobs_temp'                   => self::get_jobs_by_type_count( 'temporary' ),
 			'jobs_type'                   => self::get_job_type_count(),
 		);
 	}

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -36,6 +36,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'job_categories'              => $categories,
 			'job_categories_desc'         => self::get_job_category_has_description_count(),
 			'job_types'                   => wp_count_terms( 'job_listing_type', array( 'hide_empty' => false ) ),
+			'job_types_desc'              => self::get_job_type_has_description_count(),
 			'jobs_type'                   => self::get_job_type_count(),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
@@ -95,6 +96,33 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		$count = 0;
 		$terms = get_terms(
 			'job_listing_category', array(
+				'hide_empty' => false,
+			)
+		);
+
+		foreach ( $terms as $term ) {
+			$description = isset( $term->description ) ? trim( $term->description ) : '';
+
+			if ( ! empty( $description ) ) {
+				$count++;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Get the number of job types that have a description.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @return int Number of job types with a description.
+	 **/
+	private static function get_job_type_has_description_count() {
+		$count = 0;
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'job_listing_type',
 				'hide_empty' => false,
 			)
 		);

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -55,6 +55,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_expiry'                 => self::get_jobs_count_with_meta( '_job_expires' ),
 			'jobs_featured'               => self::get_jobs_count_with_checked_meta( '_featured' ),
 			'jobs_filled'                 => self::get_jobs_count_with_checked_meta( '_filled' ),
+			'jobs_freelance'              => self::get_jobs_by_type_count( 'freelance' ),
 			'jobs_location'               => self::get_jobs_count_with_meta( '_job_location' ),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
@@ -164,6 +165,34 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		}
 
 		return $count;
+	}
+
+	/**
+	 * Get the total number of published or expired jobs for a particular job type.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @param string $job_type Job type to search for.
+	 *
+	 * @return array Number of published or expired jobs for a particular job type.
+	 **/
+	private static function get_jobs_by_type_count( $job_type ) {
+		$query = new WP_Query(
+			array(
+				'post_type'   => 'job_listing',
+				'post_status' => array( 'expired', 'publish' ),
+				'fields'      => 'ids',
+				'tax_query'   => array(
+					array(
+						'field'    => 'slug',
+						'taxonomy' => 'job_listing_type',
+						'terms'    => $job_type,
+					),
+				),
+			)
+		);
+
+		return $query->found_posts;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -37,6 +37,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'job_categories_desc'         => self::get_job_category_has_description_count(),
 			'job_types'                   => wp_count_terms( 'job_listing_type', array( 'hide_empty' => false ) ),
 			'job_types_desc'              => self::get_job_type_has_description_count(),
+			'job_types_emp_type'          => self::get_job_type_has_employment_type_count(),
 			'jobs_type'                   => self::get_job_type_count(),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
@@ -131,6 +132,33 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			$description = isset( $term->description ) ? trim( $term->description ) : '';
 
 			if ( ! empty( $description ) ) {
+				$count++;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Get the number of job types that have Employment Type set.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @return int Number of job types with an employment type.
+	 **/
+	private static function get_job_type_has_employment_type_count() {
+		$count = 0;
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'job_listing_type',
+				'hide_empty' => false,
+			)
+		);
+
+		foreach ( $terms as $term ) {
+			$employment_type = get_term_meta( $term->term_id, 'employment_type', true );
+
+			if ( ! empty( $employment_type ) ) {
 				$count++;
 			}
 		}

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -60,6 +60,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_intern'                 => self::get_jobs_by_type_count( 'internship' ),
 			'jobs_location'               => self::get_jobs_count_with_meta( '_job_location' ),
 			'jobs_logo'                   => self::get_company_logo_count(),
+			'jobs_part_time'              => self::get_jobs_by_type_count( 'part-time' ),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
 			'jobs_status_pending'         => $count_posts->pending,
 			'jobs_status_pending_payment' => isset( $count_posts->pending_payment ) ? $count_posts->pending_payment : 0,

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -127,8 +127,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_job_type_has_description_count() {
 		$count = 0;
 		$terms = get_terms(
-			array(
-				'taxonomy'   => 'job_listing_type',
+			'job_listing_type', array(
 				'hide_empty' => false,
 			)
 		);

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -247,6 +247,26 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of full-time jobs.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
+	 */
+	public function test_get_full_time_jobs_count() {
+		wp_set_object_terms( $this->draft[0], 'full-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[5], 'full-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[6], 'full-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->preview[0], 'full-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->pending[3], 'full-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->publish[9], 'full-time', 'job_listing_type', false );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 3, $data['jobs_full_time'], 'Full Time' );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -227,6 +227,26 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of freelance jobs.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
+	 */
+	public function test_get_freelance_jobs_count() {
+		wp_set_object_terms( $this->draft[0], 'freelance', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[5], 'freelance', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[6], 'freelance', 'job_listing_type', false );
+		wp_set_object_terms( $this->preview[0], 'freelance', 'job_listing_type', false );
+		wp_set_object_terms( $this->pending[3], 'freelance', 'job_listing_type', false );
+		wp_set_object_terms( $this->publish[9], 'freelance', 'job_listing_type', false );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 3, $data['jobs_freelance'], 'Freelance' );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -207,6 +207,26 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of job types that have en employment type.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_type_has_employment_type_count
+	 */
+	public function test_get_job_type_has_employment_type_count() {
+		$terms = $this->factory->term->create_many( 5, array( 'taxonomy' => 'job_listing_type' ) );
+
+		// Set the employment type for some terms.
+		add_term_meta( $terms[1], 'employment_type', 'FULL_TIME' );
+		add_term_meta( $terms[2], 'employment_type', 'VOLUNTEER' );
+		add_term_meta( $terms[4], 'employment_type', 'TEMPORARY' );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 3, $data['job_types_emp_type'] );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -166,6 +166,20 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of job types.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_job_types_count() {
+		$terms = $this->factory->term->create_many( 14, array( 'taxonomy' => 'job_listing_type' ) );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 14, $data['job_types'] );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -307,6 +307,26 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of temporary jobs.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
+	 */
+	public function test_get_temporary_jobs_count() {
+		wp_set_object_terms( $this->draft[0], 'temporary', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[5], 'temporary', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[6], 'temporary', 'job_listing_type', false );
+		wp_set_object_terms( $this->preview[0], 'temporary', 'job_listing_type', false );
+		wp_set_object_terms( $this->pending[3], 'temporary', 'job_listing_type', false );
+		wp_set_object_terms( $this->publish[9], 'temporary', 'job_listing_type', false );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 3, $data['jobs_temp'], 'Temporary' );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -267,6 +267,26 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of internship jobs.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
+	 */
+	public function test_get_internship_jobs_count() {
+		wp_set_object_terms( $this->draft[0], 'internship', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[5], 'internship', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[6], 'internship', 'job_listing_type', false );
+		wp_set_object_terms( $this->preview[0], 'internship', 'job_listing_type', false );
+		wp_set_object_terms( $this->pending[3], 'internship', 'job_listing_type', false );
+		wp_set_object_terms( $this->publish[9], 'internship', 'job_listing_type', false );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 3, $data['jobs_intern'], 'Internship' );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -180,6 +180,33 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of job types that have a description.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_type_has_description_count
+	 */
+	public function test_get_job_type_has_description_count() {
+		// Create some terms with varying descriptions.
+		$valid   = $this->factory->term->create_many(
+			2, array(
+				'taxonomy'    => 'job_listing_type',
+				'description' => ' Valid description ',
+			)
+		);
+		$invalid = $this->factory->term->create(
+			array(
+				'taxonomy'    => 'job_listing_type',
+				'description' => "\t\n",
+			)
+		);
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 2, $data['job_types_desc'] );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -234,6 +234,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
 	 */
 	public function test_get_freelance_jobs_count() {
+		$this->create_default_job_listings();
+
 		wp_set_object_terms( $this->draft[0], 'freelance', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[5], 'freelance', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[6], 'freelance', 'job_listing_type', false );
@@ -254,6 +256,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
 	 */
 	public function test_get_full_time_jobs_count() {
+		$this->create_default_job_listings();
+
 		wp_set_object_terms( $this->draft[0], 'full-time', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[5], 'full-time', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[6], 'full-time', 'job_listing_type', false );
@@ -274,6 +278,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
 	 */
 	public function test_get_internship_jobs_count() {
+		$this->create_default_job_listings();
+
 		wp_set_object_terms( $this->draft[0], 'internship', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[5], 'internship', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[6], 'internship', 'job_listing_type', false );
@@ -294,6 +300,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
 	 */
 	public function test_get_part_time_jobs_count() {
+		$this->create_default_job_listings();
+
 		wp_set_object_terms( $this->draft[0], 'part-time', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[5], 'part-time', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[6], 'part-time', 'job_listing_type', false );
@@ -314,6 +322,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
 	 */
 	public function test_get_temporary_jobs_count() {
+		$this->create_default_job_listings();
+
 		wp_set_object_terms( $this->draft[0], 'temporary', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[5], 'temporary', 'job_listing_type', false );
 		wp_set_object_terms( $this->expired[6], 'temporary', 'job_listing_type', false );
@@ -628,34 +638,40 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 *
 	 * @param string $meta_name  the name of the meta parameter to set.
 	 * @param string $meta_value the desired value of the meta parameter.
-	 * @param int $published     the number of published listings to create.
-	 * @param int $expired       the number of expired listings to create.
-	 * @param int $other_values  other values for which to create listings (optional).
+	 * @param int    $published     the number of published listings to create.
+	 * @param int    $expired       the number of expired listings to create.
+	 * @param int    $other_values  other values for which to create listings (optional).
 	 */
 	private function create_job_listings_with_meta( $meta_name, $meta_value, $published, $expired, $other_values = array() ) {
 		// Create published listings.
-		$this->factory->job_listing->create_many( $published, array(
-			'meta_input' => array(
-				$meta_name => $meta_value,
-			),
-		) );
+		$this->factory->job_listing->create_many(
+			$published, array(
+				'meta_input' => array(
+					$meta_name => $meta_value,
+				),
+			)
+		);
 
 		// Create expired listings.
-		$this->factory->job_listing->create_many( $expired, array(
-			'post_status' => 'expired',
-			'meta_input' => array(
-				$meta_name => $meta_value,
-			),
-		) );
+		$this->factory->job_listing->create_many(
+			$expired, array(
+				'post_status' => 'expired',
+				'meta_input'  => array(
+					$meta_name => $meta_value,
+				),
+			)
+		);
 
 		// Create listings with empty values.
 		$empty_values = array( '', '   ', "\n\t", " \n \t " );
 		foreach ( $empty_values as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					$meta_name => $val,
-				),
-			) );
+			$this->factory->job_listing->create(
+				array(
+					'meta_input' => array(
+						$meta_name => $val,
+					),
+				)
+			);
 		}
 
 		// Create listings with other statuses.
@@ -668,7 +684,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 				),
 			);
 
-			if ( 'future' == $status ) {
+			if ( 'future' === $status ) {
 				$params['post_date'] = '3018-02-15 00:00:00';
 			}
 
@@ -677,11 +693,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		// Create listings with other values.
 		foreach ( $other_values as $val ) {
-			$this->factory->job_listing->create( array(
-				'meta_input' => array(
-					$meta_name => $val,
+			$this->factory->job_listing->create(
+				array(
+					'meta_input' => array(
+						$meta_name => $val,
+					),
 				)
-			) );
+			);
 		}
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -287,6 +287,26 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of part-time jobs.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_jobs_by_type_count
+	 */
+	public function test_get_part_time_jobs_count() {
+		wp_set_object_terms( $this->draft[0], 'part-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[5], 'part-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->expired[6], 'part-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->preview[0], 'part-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->pending[3], 'part-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->publish[9], 'part-time', 'job_listing_type', false );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 3, $data['jobs_part_time'], 'Part Time' );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR logs the following usage tracking data:
- Total number of job types (`job_types`)
- Total number of job types that have a non-empty description (`job_types_desc`)
- Total number of job types that have _Employment Type_ set (`job_types_emp_type`)

Total number of published or expired jobs of each type (if they exist):
  - Freelance (`jobs_freelance`)
  - Full Time (`jobs_full_time`)
  - Internship (`jobs_intern`)
  - Part Time (`jobs_part_time`)
  - Temporary (`jobs_temp`)

#### Testing instructions:

1. Check that the tests run.
2. Give some of the job types a description.
3. Set the _Employment Type_ for some of the job types.
4. Add job types to some jobs.
5. Check that the properties are logged to Tracks correctly.