### PR TITLE
Adds `job_manager_enable_job_archive_page` filter

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -197,7 +197,14 @@ class WP_Job_Manager_Post_Types {
 		$singular  = __( 'Job', 'wp-job-manager' );
 		$plural    = __( 'Jobs', 'wp-job-manager' );
 
-		if ( current_theme_supports( 'job-manager-templates' ) ) {
+		/**
+		 * Set whether to add archive page support when registering the job listing post type.
+		 *
+		 * @since 1.30.0
+		 *
+		 * @param bool $enable_job_archive_page
+		 */
+		if ( apply_filters( 'job_manager_enable_job_archive_page', current_theme_supports( 'job-manager-templates' ) ) ) {
 			$has_archive = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
 		} else {
 			$has_archive = false;


### PR DESCRIPTION

For now, I opted to not add a setting, but if we get enough requests we can do that.

Fixes #889

#### Changes proposed in this Pull Request:

* Adds `job_manager_enable_job_archive_page` filter to allow for easily overriding that config of the post type.

#### Example Usage
`add_filter( 'job_manager_enable_job_archive_page', '__return_false' );`