### PR TITLE
Add job categories usage tracking

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -29,6 +29,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		return array(
 			'employers'                   => self::get_employer_count(),
 			'job_categories'              => wp_count_terms( 'job_listing_category', array( 'hide_empty' => false ) ),
+			'job_categories_desc'         => self::get_job_category_has_description_count(),
 			'jobs_type'                   => self::get_job_type_count(),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,
@@ -53,6 +54,33 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		);
 
 		return $employer_query->total_users;
+	}
+
+	/**
+	 * Get the number of job categories that have a description.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @return int Number of job categories with a description.
+	 **/
+	private static function get_job_category_has_description_count() {
+		$count = 0;
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'job_listing_category',
+				'hide_empty' => false,
+			)
+		);
+
+		foreach ( $terms as $term ) {
+			$description = isset( $term->description ) ? trim( $term->description ) : '';
+
+			if ( ! empty( $description ) ) {
+				$count++;
+			}
+		}
+
+		return $count;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -66,8 +66,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_job_category_has_description_count() {
 		$count = 0;
 		$terms = get_terms(
-			array(
-				'taxonomy'   => 'job_listing_category',
+			'job_listing_category', array(
 				'hide_empty' => false,
 			)
 		);

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -24,11 +24,16 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 * @return array Usage data.
 	 **/
 	public static function get_usage_data() {
+		$categories  = 0;
 		$count_posts = wp_count_posts( 'job_listing' );
+
+		if ( taxonomy_exists( 'job_listing_category' ) ) {
+			$categories = wp_count_terms( 'job_listing_category', array( 'hide_empty' => false ) );
+		}
 
 		return array(
 			'employers'                   => self::get_employer_count(),
-			'job_categories'              => wp_count_terms( 'job_listing_category', array( 'hide_empty' => false ) ),
+			'job_categories'              => $categories,
 			'job_categories_desc'         => self::get_job_category_has_description_count(),
 			'jobs_type'                   => self::get_job_type_count(),
 			'jobs_logo'                   => self::get_company_logo_count(),
@@ -64,6 +69,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 * @return int Number of job categories with a description.
 	 **/
 	private static function get_job_category_has_description_count() {
+		if ( ! taxonomy_exists( 'job_listing_category' ) ) {
+			return 0;
+		}
+
 		$count = 0;
 		$terms = get_terms(
 			'job_listing_category', array(

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -28,6 +28,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 
 		return array(
 			'employers'                   => self::get_employer_count(),
+			'job_categories'              => wp_count_terms( 'job_listing_category', array( 'hide_empty' => false ) ),
 			'jobs_type'                   => self::get_job_type_count(),
 			'jobs_logo'                   => self::get_company_logo_count(),
 			'jobs_status_expired'         => isset( $count_posts->expired ) ? $count_posts->expired : 0,

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -120,6 +120,33 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of job categories that have a description.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_category_has_description_count
+	 */
+	public function test_get_job_category_has_description_count() {
+		// Create some terms with varying descriptions.
+		$valid   = $this->factory->term->create_many(
+			2, array(
+				'taxonomy'    => 'job_listing_category',
+				'description' => ' Valid description ',
+			)
+		);
+		$invalid = $this->factory->term->create(
+			array(
+				'taxonomy'    => 'job_listing_category',
+				'description' => "\t\n",
+			)
+		);
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 2, $data['job_categories_desc'] );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -120,6 +120,18 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of job categories.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_no_job_categories_count() {
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 0, $data['job_categories'] );
+	}
+
+	/**
 	 * Count of job categories that have a description.
 	 *
 	 * @since 1.30.0
@@ -144,6 +156,19 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 2, $data['job_categories_desc'] );
+	}
+
+	/**
+	 * Count of job categories that have a description.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_category_has_description_count
+	 */
+	public function test_get_no_job_category_has_description_count() {
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 0, $data['job_categories_desc'] );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -106,6 +106,20 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Count of job categories.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_job_categories_count() {
+		$terms = $this->factory->term->create_many( 14, array( 'taxonomy' => 'job_listing_category' ) );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 14, $data['job_categories'] );
+	}
+
+	/**
 	 * Expired jobs count.
 	 *
 	 * @since 1.30.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR logs the following usage tracking data:
- Total number of job categories (`job_categories`)
- Total number of job categories that have a non-empty description (`job_categories_desc`)

#### Testing instructions:

1. Check that the tests run.
2. Ensure that the _Categories_ setting in _Settings_ > _Job Listings_ is checked.
3. Add some job categories and give a few of them a description.
4. Check that the properties are logged to Tracks correctly.