### PR TITLE
Fix the nonce check

### DIFF
--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -130,7 +130,7 @@ class WP_Job_Manager_Setup {
 				&& '1' === $_POST['job_manager_usage_tracking_enabled'];
 
 			$nonce       = isset( $_POST['nonce'] ) ? $_POST['nonce'] : null;
-			$valid_nonce = wp_verify_nonce( $_POST['nonce'], 'enable-usage-tracking' );
+			$valid_nonce = wp_verify_nonce( $nonce, 'enable-usage-tracking' );
 
 			if ( $valid_nonce ) {
 				$usage_tracking->set_tracking_enabled( $enable );


### PR DESCRIPTION
Small bugfix for the nonce check in the setup wizard.

## Testing

- Ensure that opting into usage tracking through the setup wizard (which uses a nonce) works without error.

- Ensure that working the rest of the way through the setup wizard works without error. Particularly step two which does a POST without a nonce.