### PR TITLE
[WIP] Track system data

### DIFF
--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -284,11 +284,12 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 			return;
 		}
 
-		return self::send_event( 'stats_log', $usage_data );
+		self::send_event( 'system_log', $this->get_system_data() );
+		self::send_event( 'stats_log', $usage_data );
 	}
 
 
-	/*
+	/**
 	 * Internal methods.
 	 */
 
@@ -306,6 +307,70 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		);
 
 		return $schedules;
+	}
+
+	/**
+	 * Collect system data to track.
+	 *
+	 * @return array
+	 */
+	public function get_system_data() {
+		global $wp_version;
+
+		/**
+		 * @var WP_Theme $theme Current active theme.
+		 */
+		$theme = wp_get_theme();
+
+		$system_data                         = array();
+		$system_data['wp_version']           = $wp_version;
+		$system_data['php_version']          = PHP_VERSION;
+		$system_data['locale']               = get_locale();
+		$system_data['multisite']            = is_multisite() ? 1 : 0;
+		$system_data['active_theme']         = $theme['Name'];
+		$system_data['active_theme_version'] = $theme['Version'];
+
+		$plugin_data = $this->get_plugin_data();
+		foreach ( $plugin_data as $plugin_name => $plugin_version ) {
+			$system_data[ self::PLUGIN_PREFIX . $plugin_name ] = $plugin_version;
+		}
+
+		return $system_data;
+	}
+
+	/**
+	 * Gets a list of activated plugins.
+	 *
+	 * @return array List of plugins. Index is friendly name, value is version.
+	 */
+	protected function get_plugin_data() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$plugins = array();
+		foreach ( get_plugins() as $path => $plugin ) {
+			if ( ! is_plugin_active( $path ) ) {
+				continue;
+			}
+			$plugin_name                      = $this->get_plugin_name( plugin_basename( $path ) );
+			$plugin_friendly_name             = preg_replace( '/[^a-zA-Z0-9\-]/', '_', $plugin_name );
+			$plugins[ $plugin_friendly_name ] = $plugin['Version'];
+		}
+		return $plugins;
+	}
+
+	/**
+	 * Returns a friendly slug for a plugin.
+	 *
+	 * @param string $basename Plugin basename.
+	 *
+	 * @return string
+	 */
+	private function get_plugin_name( $basename ) {
+		if ( false === strpos( $basename, '/' ) ) {
+			return basename( $basename, '.php' );
+		}
+		return dirname( $basename );
 	}
 
 	/**

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -9,6 +9,8 @@ Usage_Tracking_Test_Subclass::get_instance();
 /**
  * Usage Tracking tests. Please update the prefix to something unique to your
  * plugin.
+ *
+ * @group usage-tracking
  */
 class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -351,6 +351,46 @@ class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/* END tests for tracking opt in dialog */
 
+	/* Tests for system data */
+
+	/**
+	 * Tests the basic structure for collected system data.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::get_system_data
+	 * @group track-system-data
+	 */
+	public function testSystemDataStructure() {
+		global $wp_version;
+
+		$system_data = 		$this->usage_tracking->get_system_data();
+
+		$this->assertInternalType( 'array', $system_data, 'System data must be returned as an array' );
+
+		$this->assertArrayHasKey( 'wp_version', $system_data, '`wp_version` key must exist in system data' );
+		$this->assertEquals( $wp_version, $system_data['wp_version'], '`wp_version` does not match expected value' );
+
+		$this->assertArrayHasKey( 'php_version', $system_data, '`php_version` key must exist in system data' );
+		$this->assertEquals( PHP_VERSION, $system_data['php_version'], '`php_version` does not match expected value' );
+
+		$this->assertArrayHasKey( 'locale', $system_data, '`locale` key must exist in system data' );
+		$this->assertEquals( get_locale(), $system_data['locale'], '`locale` does not match expected value' );
+
+		$this->assertArrayHasKey( 'multisite', $system_data, '`multisite` key must exist in system data' );
+		$this->assertEquals( is_multisite(), $system_data['multisite'], '`multisite` does not match expected value' );
+
+		/**
+		 * @var WP_Theme $theme Current active theme.
+		 */
+		$theme = wp_get_theme();
+
+		$this->assertArrayHasKey( 'active_theme', $system_data, '`active_theme` key must exist in system data' );
+		$this->assertEquals( $theme['Name'], $system_data['active_theme'], '`active_theme` does not match expected value' );
+
+		$this->assertArrayHasKey( 'active_theme_version', $system_data, '`active_theme_version` key must exist in system data' );
+		$this->assertEquals( $theme['Version'], $system_data['active_theme_version'], '`active_theme_version` does not match expected value' );
+	}
+
+	/* END tests for system data */
 
 	/****** Helper methods ******/
 

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -119,7 +119,7 @@ class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
 		}
 
-		$this->assertEquals( 1, $count, 'Data was sent on usage tracking enable' );
+		$this->assertEquals( 2, $count, 'Data was sent on usage tracking enable' );
 	}
 
 	/**
@@ -291,7 +291,7 @@ class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->usage_tracking->set_tracking_enabled( true );
 
 		$this->usage_tracking->send_usage_data();
-		$this->assertEquals( 1, $count, 'Request sent when Usage Tracking enabled' );
+		$this->assertEquals( 2, $count, 'Request sent when Usage Tracking enabled' );
 	}
 
 	/* Tests for tracking opt in dialog */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
 	<testsuites>
 		<testsuite name="WPJM Test Suite">
 			<directory prefix="test_class." suffix=".php">tests/php/tests</directory>
+			<directory prefix="test-class-" suffix=".php">lib/usage-tracking/tests</directory>
 			<directory prefix="test_class." suffix=".php" phpVersion="5.3.0" phpVersionOperator=">=">tests/php/tests/includes/rest-api</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
Proposal for tracking system data.

To do:
- [ ] Figure out how to mock `get_plugins()` or better unit test the plugins part.

#### Changes in this PR
- Added the base library tests to the `phpunit.xml.dist` file.
- Sending new `system_log` event with basic environment information.

Basic structure is:
```php
[
     'wp_version': '4.9',
     'php_version': '5.6',
     'locale': 'en_US',
     'multisite': 0,
     'active_theme': 'storefront',
     'active_theme_version': '2.4',
     'plugin_jetpack': '4.9.0',
     'plugin_wp_job_manager': '1.30.0',
     'plugin_wordpress_seo': '6.3'
 ]
```