### PR TITLE
Add usage data for jobs created by guests

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -68,6 +68,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_status_publish'         => $count_posts->publish,
 			'jobs_temp'                   => self::get_jobs_by_type_count( 'temporary' ),
 			'jobs_type'                   => self::get_job_type_count(),
+			'jobs_by_guests'              => self::get_jobs_by_guests(),
 		);
 	}
 
@@ -291,6 +292,22 @@ class WP_Job_Manager_Usage_Tracking_Data {
 					'value' => '1',
 				),
 			),
+		) );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the number of job listings posted by guests.
+	 *
+	 * @return int the number of job listings.
+	 */
+	private static function get_jobs_by_guests() {
+		$query = new WP_Query( array(
+			'post_type'   => 'job_listing',
+			'post_status' => array( 'publish', 'expired' ),
+			'fields'      => 'ids',
+			'author__in'  => array( 0 ),
 		) );
 
 		return $query->found_posts;

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -658,7 +658,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 				'post_status' => $status,
 			);
 
-			if ( 'future' == $status ) {
+			if ( 'future' === $status ) {
 				$params['post_date'] = '3018-02-15 00:00:00';
 			}
 
@@ -674,7 +674,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 				'post_status' => $status,
 			);
 
-			if ( 'future' == $status ) {
+			if ( 'future' === $status ) {
 				$params['post_date'] = '3018-02-15 00:00:00';
 			}
 
@@ -693,11 +693,11 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * (such as draft). For tracking data, only the published and expired
 	 * entries should be counted.
 	 *
-	 * @param string $meta_name  the name of the meta parameter to set.
+	 * @param string $meta_name the name of the meta parameter to set.
 	 * @param string $meta_value the desired value of the meta parameter.
-	 * @param int    $published     the number of published listings to create.
-	 * @param int    $expired       the number of expired listings to create.
-	 * @param int    $other_values  other values for which to create listings (optional).
+	 * @param int    $published the number of published listings to create.
+	 * @param int    $expired the number of expired listings to create.
+	 * @param int    $other_values other values for which to create listings (optional).
 	 */
 	private function create_job_listings_with_meta( $meta_name, $meta_value, $published, $expired, $other_values = array() ) {
 		// Create published listings.

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -677,6 +677,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 			if ( 'future' == $status ) {
 				$params['post_date'] = '3018-02-15 00:00:00';
 			}
+
+			$this->factory->job_listing->create( $params );
 		}
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();


### PR DESCRIPTION
Adds the count of job listings that were posted by guest users. Note that this does not include guests who opted to create an account while posting the job listing.

## Testing

- Ensure the tests pass.

- On the Settings > Job Submission page ensure that "Account Required" is unchecked. You may also want to uncheck "Require admin approval of all new listing submissions".

- Log out (or open a private browsing window) and post a job. Do not include an email address to create an account.

- If needed, log in and ensure that the new posting is published.

- Inspect the usage data. Ensure that the `jobs_by_guests` key has the correct number.

- Change the job listing status to various values. A listing should only be counted if it is Published (Active) or Expired.