### PR TITLE
Update/usage tracking prefix

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -39,6 +39,10 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		return 'job_manager';
 	}
 
+	protected function get_event_prefix() {
+		return 'wpjm';
+	}
+
 	protected function get_text_domain() {
 		return 'wp-job-manager';
 	}

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -36,7 +36,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	protected function get_prefix() {
-		return 'wpjm';
+		return 'job_manager';
 	}
 
 	protected function get_text_domain() {

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -191,7 +191,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		}
 
 		$pixel      = 'http://pixel.wp.com/t.gif';
-		$event_name = $this->get_prefix() . '_' . $event;
+		$event_name = $this->get_event_prefix() . '_' . $event;
 		$user       = wp_get_current_user();
 
 		if ( null === $event_timestamp ) {
@@ -199,7 +199,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		}
 
 		$properties['admin_email'] = get_option( 'admin_email' );
-		$properties['_ut']         = $this->get_prefix() . ':site_url';
+		$properties['_ut']         = $this->get_event_prefix() . ':site_url';
 		// Use site URL as the userid to enable usage tracking at the site level.
 		// Note that we would likely want to use site URL + user ID for userid if we were
 		// to ever add event tracking at the user level.
@@ -221,7 +221,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 				'timeout'     => 1,
 				'redirection' => 2,
 				'httpversion' => '1.1',
-				'user-agent'  => $this->get_prefix() . '_usage_tracking',
+				'user-agent'  => $this->get_event_prefix() . '_usage_tracking',
 			)
 		);
 
@@ -291,6 +291,15 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	/*
 	 * Internal methods.
 	 */
+
+	/**
+	 * Get the prefix for the event-related values. By default, this is the
+	 * same prefix used everywhere else, but plugins may override this if
+	 * needed.
+	 */
+	protected function get_event_prefix() {
+		return $this->get_prefix();
+	}
 
 	/**
 	 * Add two week schedule to use for cron job. Should not be called


### PR DESCRIPTION
Changes prefix to `job_manager` instead of `wpjm`, but uses `wpjm` for data sent to Tracks.

## Testing

- Remove the `wpjm_usage_tracking_send_usage_data` cron task.

- Ensure the `job_manager_usage_tracking_send_usage_data` cron task was created.

- Delete the `option_usage_tracking_opt_in_hide` and disable tracking. You should see the opt-in dialog.

- Try enabling and disabling tracking through the opt-in dialog. In either case, the `job_manager_usage_tracking_opt_in_hide` option should be set to `true`. Also, the ajax handling is affected by the prefix change, so verify that the dialog works properly.

- Inspect the data sent to Tracks. The prefix here should still be `wpjm`. This affects the event name (`wpjm_usage_data`), the `ut` parameter (`wpjm:site_url`) and the user agent (`wpjm_usage_tracking`).