### PR TITLE
Remove test dependencies from usage data tests

### DIFF
--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -54,6 +54,20 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	private $publish;
 
 	/**
+	 * Set up for tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Ensure job categories and types are enabled.
+		update_option( 'job_manager_enable_categories', 1 );
+		update_option( 'job_manager_enable_types', 1 );
+		unregister_post_type( 'job_listing' );
+		$post_type_instance = WP_Job_Manager_Post_Types::instance();
+		$post_type_instance->register_post_types();
+	}
+
+	/**
 	 * Create a number of job listings with different statuses.
 	 */
 	private function create_default_job_listings() {


### PR DESCRIPTION
Specifically, ensure that job listing categories and types are enabled before running the usage data tests.

## Testing

- Ensure the full test suite passes (`phpunit`)

- Ensure that the usage data tests pass when run independently (`phpunit tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php`)