### PR TITLE
Only remove Mixtape in `lib` pre-build, not entire lib dir

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -208,7 +208,7 @@ module.exports = function( grunt ){
 		},
 
 		clean: {
-			main: [ 'tmp/', 'lib/' ], //Clean up build folder
+			main: [ 'tmp/', 'lib/wpjm_rest' ], //Clean up build folder
 		},
 
 		jshint: {


### PR DESCRIPTION
Small fix for build script.