### PR TITLE
Stagger release of new asset enqueuing strategy until 1.32.0

### DIFF
--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -307,7 +307,16 @@ class WP_Job_Manager {
 			'i18n_confirm_delete' => __( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
 		) );
 
-		if ( is_wpjm() ) {
+
+		/**
+		 * Filter whether to enqueue WPJM core's frontend scripts. By default, they will only be enqueued on WPJM related
+		 * pages.
+		 *
+		 * @since 1.30.0
+		 *
+		 * @param bool $is_frontend_style_enabled
+		 */
+		if ( apply_filters( 'job_manager_enqueue_frontend_style', is_wpjm() ) ) {
 			wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css', array(), JOB_MANAGER_VERSION );
 		}
 	}

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -227,6 +227,39 @@ class WP_Job_Manager {
 	public function frontend_scripts() {
 		global $post;
 
+		/**
+		 * Starting in WP Job Manager 1.31.0, the chosen JS library and core frontend WPJM CSS will only be enqueued
+		 * when used on a particular page. Theme and plugin authors as well as people who have overloaded WPJM's default
+		 * template files should test this upcoming behavior.
+		 *
+		 * To test this behavior before 1.31.0, add this to your `wp-config.php`:
+		 * define( 'JOB_MANAGER_TEST_NEW_ASSET_BEHAVIOR', true );
+		 *
+		 * Unless this constant is defined, WP Job Manager 1.30.0 will default to its old behavior: chosen JS library and
+		 * frontend styles are always enqueued.
+		 *
+		 * If your theme or plugin depend on the `frontend.css` or chosen JS library from WPJM core, you can use the
+		 * `job_manager_chosen_enabled` and `job_manager_enqueue_frontend_style` filters.
+		 *
+		 * Example code for a custom shortcode that depends on the chosen library:
+		 *
+		 * add_filter( 'job_manager_chosen_enabled', function( $chosen_used_on_page ) {
+		 *   global $post;
+		 *   if ( is_singular()
+		 *        && is_a( $post, 'WP_Post' )
+		 *        && has_shortcode( $post->post_content, 'resumes' )
+		 *   ) {
+		 *     $chosen_used_on_page = true;
+		 *   }
+		 *   return $chosen_used_on_page;
+		 * } );
+		 * 
+		 */
+		if ( ! defined( 'JOB_MANAGER_TEST_NEW_ASSET_BEHAVIOR' ) || true !== JOB_MANAGER_TEST_NEW_ASSET_BEHAVIOR ) {
+			add_filter( 'job_manager_chosen_enabled', '__return_true' );
+			add_filter( 'job_manager_enqueue_frontend_style', '__return_true' );
+		}
+
 		$ajax_url         = WP_Job_Manager_Ajax::get_endpoint();
 		$ajax_filter_deps = array( 'jquery', 'jquery-deserialize' );
 		$ajax_data 		  = array(
@@ -249,6 +282,8 @@ class WP_Job_Manager {
 
 		/**
 		 * Filter the use of the chosen library.
+		 *
+		 * NOTE: See above. In WP Job Manager 1.30.0, `job_manager_enqueue_frontend_style` will be filtered to `true` by default.
 		 *
 		 * @since 1.19.0
 		 *
@@ -311,6 +346,8 @@ class WP_Job_Manager {
 		/**
 		 * Filter whether to enqueue WPJM core's frontend scripts. By default, they will only be enqueued on WPJM related
 		 * pages.
+		 *
+		 * NOTE: See above. In WP Job Manager 1.30.0, `job_manager_enqueue_frontend_style` will be filtered to `true` by default.
 		 *
 		 * @since 1.30.0
 		 *

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -228,14 +228,14 @@ class WP_Job_Manager {
 		global $post;
 
 		/**
-		 * Starting in WP Job Manager 1.31.0, the chosen JS library and core frontend WPJM CSS will only be enqueued
+		 * Starting in WP Job Manager 1.32.0, the chosen JS library and core frontend WPJM CSS will only be enqueued
 		 * when used on a particular page. Theme and plugin authors as well as people who have overloaded WPJM's default
 		 * template files should test this upcoming behavior.
 		 *
-		 * To test this behavior before 1.31.0, add this to your `wp-config.php`:
+		 * To test this behavior before 1.32.0, add this to your `wp-config.php`:
 		 * define( 'JOB_MANAGER_TEST_NEW_ASSET_BEHAVIOR', true );
 		 *
-		 * Unless this constant is defined, WP Job Manager 1.30.0 will default to its old behavior: chosen JS library and
+		 * Unless this constant is defined, WP Job Manager will default to its old behavior: chosen JS library and
 		 * frontend styles are always enqueued.
 		 *
 		 * If your theme or plugin depend on the `frontend.css` or chosen JS library from WPJM core, you can use the
@@ -253,7 +253,7 @@ class WP_Job_Manager {
 		 *   }
 		 *   return $chosen_used_on_page;
 		 * } );
-		 * 
+		 *
 		 */
 		if ( ! defined( 'JOB_MANAGER_TEST_NEW_ASSET_BEHAVIOR' ) || true !== JOB_MANAGER_TEST_NEW_ASSET_BEHAVIOR ) {
 			add_filter( 'job_manager_chosen_enabled', '__return_true' );
@@ -283,7 +283,7 @@ class WP_Job_Manager {
 		/**
 		 * Filter the use of the chosen library.
 		 *
-		 * NOTE: See above. In WP Job Manager 1.30.0, `job_manager_enqueue_frontend_style` will be filtered to `true` by default.
+		 * NOTE: See above. Before WP Job Manager 1.32.0 is released, `job_manager_enqueue_frontend_style` will be filtered to `true` by default.
 		 *
 		 * @since 1.19.0
 		 *
@@ -347,7 +347,7 @@ class WP_Job_Manager {
 		 * Filter whether to enqueue WPJM core's frontend scripts. By default, they will only be enqueued on WPJM related
 		 * pages.
 		 *
-		 * NOTE: See above. In WP Job Manager 1.30.0, `job_manager_enqueue_frontend_style` will be filtered to `true` by default.
+		 * NOTE: See above. Before WP Job Manager 1.32.0 is released, `job_manager_enqueue_frontend_style` will be filtered to `true` by default.
 		 *
 		 * @since 1.30.0
 		 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This will stagger the new asset enqueueing strategy to 1.32.0. This will give devs more time to add this to their themes and plugins. Theme and plugin developers can try out the upcoming behavior by adding this to their `wp-config.php`:
`define( 'JOB_MANAGER_TEST_NEW_ASSET_BEHAVIOR', true );`

* It also introduces a new filter for the frontend CSS. I think this should encourage the use of better patterns instead of having plugin and theme developers use `is_wpjm()` functions and filters. If we don't choose to stagger the release, I think we should still merge ed03d50.

Easily copy-able code to test using the behaviors (with that constant defined):
```php
add_filter( 'job_manager_chosen_enabled', function( $chosen_used_on_page ) {
	global $post;
	if ( is_singular()
		&& is_a( $post, 'WP_Post' )
		&& has_shortcode( $post->post_content, 'resumes' )
	) {
		$chosen_used_on_page = true;
	}
	return $chosen_used_on_page;
} );
```
#### Testing instructions:

* Make sure the chosen library and `frontend.css` are enqueued on all frontend pages. Once you define the constant, make sure they are only enqueued on WPJM pages. 


#### Post-merge:
- [ ] Create issue for 1.32.0