### PR TITLE
Fix usage tracking strict standards

### DIFF
--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -52,11 +52,6 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 **/
 	private static $instances = array();
 
-
-	/*
-	 * Abstract methods.
-	 */
-
 	/**
 	 * Gets the singleton instance of this class. Subclasses should implement
 	 * this as follows:
@@ -66,8 +61,19 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *   return self::get_instance_for_subclass( get_class() );
 	 * }
 	 * ```
+	 *
+	 * This function cannot be abstract (because it is static) but it *must* be
+	 * implemented by subclasses.
 	 */
-	abstract public static function get_instance();
+	public static function get_instance() {
+		throw new Exception( 'Usage Tracking subclasses must implement get_instance. See class-usage-tracking-base.php' );
+	}
+
+
+	/*
+	 * Abstract methods.
+	 */
+
 
 	/**
 	 * Get prefix for actions and strings. Should be unique to this plugin.


### PR DESCRIPTION
Fixes #1363 

I was able to reproduce this on PHP 5.6 with the following code in `wp-config.php`:

```php
// Set up strict error reporting.
ini_set( 'display_errors','On' );
ini_set( 'error_reporting', E_ALL | E_STRICT );
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_DISPLAY', true );
```

Note: Adding the strict checking in Travis made no difference. Something more is needed there in order to make something fail if there is this type of error. I've put this into a new issue: https://github.com/Automattic/WP-Job-Manager/issues/1365

#### Changes proposed in this Pull Request:

* Change the `get_instance` method in Usage Tracking to not be abstract.

#### Testing instructions:

* Put the lines from the description above into `wp-config.php` on a WordPress installation running on PHP 5.6. Load any page. You should not see any Strict Standards warnings.