### PR TITLE
Add additional arg to job dashboard action hook to provide more context

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -152,7 +152,7 @@ class WP_Job_Manager_Shortcodes {
 
 						break;
 					default :
-						do_action( 'job_manager_job_dashboard_do_action_' . $action );
+						do_action( 'job_manager_job_dashboard_do_action_' . $action, $job_id );
 						break;
 				}
 


### PR DESCRIPTION
For custom job dashboard action handlers, the `$job_id` was missing as argument to provide more context (e.g. what job was changed with this action).

#### Changes proposed in this Pull Request:

* Added additional arg to action hook to `job_manager_job_dashboard_do_action_' . $action`



