### PR TITLE
Enqueue the datepicker UI when using a date field in the front-end

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -82,14 +82,10 @@ class WP_Job_Manager_Admin {
 	 * Enqueues CSS and JS assets.
 	 */
 	public function admin_enqueue_scripts() {
-		global $wp_scripts;
-
 		$screen = get_current_screen();
 
 		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', array( 'edit-job_listing', 'plugins', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-addons' ) ) ) ) {
-			$jquery_version = isset( $wp_scripts->registered['jquery-ui-core']->ver ) ? $wp_scripts->registered['jquery-ui-core']->ver : '1.9.2';
-
-			wp_enqueue_style( 'jquery-ui-style', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.css', array(), $jquery_version );
+			wp_enqueue_style( 'jquery-ui' );
 			wp_enqueue_style( 'job_manager_admin_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/admin.css', array(), JOB_MANAGER_VERSION );
 			wp_register_script( 'jquery-tiptip', JOB_MANAGER_PLUGIN_URL. '/assets/js/jquery-tiptip/jquery.tipTip.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
 			wp_enqueue_script( 'job_manager_datepicker_js', JOB_MANAGER_PLUGIN_URL. '/assets/js/datepicker.min.js', array( 'jquery', 'jquery-ui-datepicker' ), JOB_MANAGER_VERSION, true );

--- a/templates/form-fields/date-field.php
+++ b/templates/form-fields/date-field.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     WP Job Manager
  * @category    Template
- * @version     1.30.0
+ * @version     1.30.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 wp_enqueue_script( 'wp-job-manager-datepicker' );
+wp_enqueue_style( 'jquery-ui' );
 
 ?>
 <input type="text" class="input-date job-manager-datepicker" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>"<?php if ( isset( $field['autocomplete'] ) && false === $field['autocomplete'] ) { echo ' autocomplete="off"'; } ?> id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" value="<?php echo isset( $field['value'] ) ? esc_attr( $field['value'] ) : ''; ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -101,6 +101,7 @@ class WP_Job_Manager {
 		add_action( 'after_setup_theme', array( $this, 'load_plugin_textdomain' ) );
 		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
 		add_action( 'widgets_init', array( $this, 'widgets_init' ) );
+		add_action( 'wp_loaded', array( $this, 'register_shared_assets' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
 		add_action( 'admin_init', array( $this, 'updater' ) );
 		add_action( 'wp_logout', array( $this, 'cleanup_job_posting_cookies' ) );
@@ -219,6 +220,16 @@ class WP_Job_Manager {
 		if ( isset( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
 			setcookie( 'wp-job-manager-submitting-job-key', '', 0, COOKIEPATH, COOKIE_DOMAIN, false );
 		}
+	}
+
+	/**
+	 * Registers assets used in both the frontend and WP admin.
+	 */
+	public function register_shared_assets() {
+		global $wp_scripts;
+
+		$jquery_version = isset( $wp_scripts->registered['jquery-ui-core']->ver ) ? $wp_scripts->registered['jquery-ui-core']->ver : '1.9.2';
+		wp_register_style( 'jquery-ui', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.css', array(), $jquery_version );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Enqueue the jQuery UI CSS when using the datepicker on the front-end.

#### Testing instructions:

* Add a datepicker field and verify it is styled correctly on the front-end.
```
add_filter( 'submit_job_form_fields', function( $fields ) {
	$fields['job']['fancy_date'] = array(
		'label'       => __( 'Fanciest of Dates', 'wp-job-manager' ),
		'type'        => 'date',
		'required'    => false,
		'priority'    => 5
	);
	return $fields;
} );
```

Builds off of #1353