### PR TITLE
Add PHP 7.2 to Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,11 @@ matrix:
   - php: "5.5"
     env: WP_VERSION=4.4
   - php: "5.6"
+    env: WP_VERSION=latest
+  - php: "5.6"
+    env: WP_VERSION=master
+  - php: "5.6"
+    env: WP_VERSION=previous
   - php: "7.0"
     env: WP_VERSION=latest
   - php: "7.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,33 @@ env:
   global:
     - WP_TRAVISCI=phpunit
 
-cache: yarn
+cache:
+  directories:
+  - vendor
+  - "$HOME/.composer/cache"
+
+branches:
+  only:
+  - master
 
 # Next we define our matrix of additional build configurations to test against.
-# The versions listed above will automatically create our first configuration,
-# so it doesn't need to be re-defined below.
-
-# Test WP trunk/master and two latest versions on minimum (5.2).
-# Test WP latest two versions (4.5, 4.3) on most popular (5.5, 5.6).
-# Test WP latest stable (4.5) on other supported PHP (5.3, 5.4).
-# Test WP trunk/master on edge platforms (7.0, hhvm, PHP nightly).
-
-# WP_VERSION specifies the tag to use. The way these tests are configured to run
-# requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
-
 matrix:
   include:
   - php: "5.2"
     dist: precise
+    env: WP_VERSION=latest
   - php: "5.3"
     dist: precise
+    env: WP_VERSION=latest
   - php: "5.5"
+    env: WP_VERSION=4.4
   - php: "5.6"
   - php: "7.0"
+    env: WP_VERSION=latest
   - php: "7.1"
+    env: WP_VERSION=latest
   - php: "7.2"
+    env: WP_VERSION=latest
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
   - php: "5.6"
   - php: "7.0"
   - php: "7.1"
+  - php: "7.2"
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     dist: precise
     env: WP_VERSION=latest
   - php: "5.5"
-    env: WP_VERSION=4.4
+    env: WP_VERSION=latest
   - php: "5.6"
     env: WP_VERSION=latest
   - php: "5.6"

--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -14,7 +14,13 @@ mysql -u root -e "CREATE DATABASE wordpress_tests;"
 
 CURRENT_DIR=$(pwd)
 
-for WP_SLUG in 'master' 'latest' 'previous'; do
+WP_SLUGS=('master' 'latest' 'previous')
+
+if [ ! -z "$WP_VERSION" ]; then
+	WP_SLUGS=("$WP_VERSION")
+fi
+
+for WP_SLUG in "${WP_SLUGS[@]}"; do
 	echo "Preparing $WP_SLUG WordPress...";
 
 	cd $CURRENT_DIR/..
@@ -28,6 +34,9 @@ for WP_SLUG in 'master' 'latest' 'previous'; do
 		;;
 	previous)
 		git clone --depth=1 --branch `php ./$PLUGIN_BASE_DIR/tests/get-wp-version.php --previous` https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-previous
+		;;
+	*)
+		git clone --depth=1 --branch $WP_SLUG https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-$WP_SLUG
 		;;
 	esac
 

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -21,9 +21,15 @@ run_phpunit_for() {
 }
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
-    run_phpunit_for "wordpress-master"
-    run_phpunit_for "wordpress-latest"
-    run_phpunit_for "wordpress-previous"
+	WP_SLUGS=('master' 'latest' 'previous')
+
+	if [ ! -z "$WP_VERSION" ]; then
+		WP_SLUGS=("$WP_VERSION")
+	fi
+
+	for WP_SLUG in "${WP_SLUGS[@]}"; do
+		run_phpunit_for "wordpress-$WP_SLUG"
+	done
 else
 
     gem install less

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -432,7 +432,12 @@ function job_manager_get_filtered_links( $args = array() ) {
 		)
 	), $args );
 
-	if ( sizeof( $args['filter_job_types'] ) === sizeof( $types ) && ! $args['search_keywords'] && ! $args['search_location'] && ! $args['search_categories'] && ! apply_filters( 'job_manager_get_listings_custom_filter', false ) ) {
+	if ( count( (array) $args['filter_job_types'] ) === count( $types )
+		 && empty( $args['search_keywords'] )
+		 && empty( $args['search_location'] )
+		 && empty( $args['search_categories'] )
+		 && ! apply_filters( 'job_manager_get_listings_custom_filter', false )
+	) {
 		unset( $links['reset'] );
 	}
 


### PR DESCRIPTION
## Proposed changes
- Fix one minor PHP 7.2 issue with `job_manager_get_filtered_links()` by casting and arg to array when necessary.
- Add PHP 7.2 to Travis testing.
- Optimize the Travis testing strategy for WPJM by following Sensei's lead of not testing all 3 WP versions for every version of PHP.