### PR TITLE
Show notice when using old version of WordPress

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -61,7 +61,41 @@ class WP_Job_Manager_Admin {
 	 * Set up actions during admin initialization.
 	 */
 	public function admin_init() {
+		global $wp_version;
+
 		include_once( dirname( __FILE__ ) . '/class-wp-job-manager-taxonomy-meta.php' );
+
+		if ( version_compare( $wp_version, JOB_MANAGER_MINIMUM_WP_VERSION, '<' ) ) {
+			add_action( 'admin_notices', array( $this, 'wp_version_admin_notice' ) );
+			add_filter( 'plugin_action_links_' . JOB_MANAGER_PLUGIN_BASENAME, array( $this, 'wp_version_plugin_action_notice' ) );
+		}
+	}
+
+	/**
+	 * Display notice if WordPress core is out-of-date in admin notice section.
+	 */
+	public function wp_version_admin_notice() {
+		// We only want to show the notices on the plugins page and WPJM admin pages.
+		$screen = get_current_screen();
+		$valid_screens = array( 'plugins', 'edit-job_listing', 'job_listing_page_job-manager-settings', 'edit-job_listing_type', 'edit-job_listing_category', 'job_listing' );
+		if ( null === $screen || ! in_array( $screen->id, $valid_screens ) ) {
+			return;
+		}
+
+		echo '<div class="error">';
+		echo '<p>' . sprintf( __( 'The upcoming release of <strong>WP Job Manager 1.31.0</strong> will require a more recent version of WordPress. <a href="%s">Please update WordPress</a> before updating WP Job Manager.', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) . '</p>';
+		echo '</div>';
+	}
+
+	/**
+	 * Add admin notice when WP upgrade is required.
+	 *
+	 * @param array $actions
+	 * @return array
+	 */
+	public function wp_version_plugin_action_notice( $actions ) {
+		$actions[] = sprintf( __( '<a href="%s" style="color: red">WordPress Update Required</a>', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) );
+		return $actions;
 	}
 
 	/**

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -59,8 +59,10 @@ class WP_Job_Manager {
 	public function __construct() {
 		// Define constants
 		define( 'JOB_MANAGER_VERSION', '1.30.1' );
+		define( 'JOB_MANAGER_MINIMUM_WP_VERSION', '4.7' );
 		define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 		define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
+		define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 		// Includes
 		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-install.php' );


### PR DESCRIPTION
Fixes #1395

#### Changes proposed in this Pull Request:

* Adds an admin notice on certain screens for versions of WordPress before 4.7.

I'll follow this up with a new PR for 1.31.0 that updates the language in the error message.

<img width="1541" alt="screen shot 2018-03-28 at 10 27 01 am" src="https://user-images.githubusercontent.com/68693/38020601-93f64452-3272-11e8-9d17-03e93f2e5f5b.png">

#### Testing instructions:

* Using an older version WordPress, verify the message shows up.
Note: Before WordPress 4.5 an error shows on activation due to the addition of `unregister_post_type()` from 4ebc4fa5b2796bf0cf8b98b29c088beed5502b90.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Show a notice for older versions of WordPress.