### PR TITLE
Add support for paged param in job RSS feed

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -352,6 +352,7 @@ class WP_Job_Manager_Post_Types {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
 			'posts_per_page'      => isset( $_GET['posts_per_page'] ) ? absint( $_GET['posts_per_page'] ) : 10,
+			'paged'               => absint( get_query_var( 'paged', 1 ) ),
 			'tax_query'           => array(),
 			'meta_query'          => array()
 		);


### PR DESCRIPTION
Fixes #1369 

#### Changes proposed in this Pull Request:

* Add support for paged param in job RSS feed

#### Testing instructions:

*
 `http://example.com/?feed=job_feed&posts_per_page=10&paged=1`
`http://example.com/?feed=job_feed&posts_per_page=10&paged=2`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Add Support for job feed pagination