### PR TITLE
Adds Job Category REST API Endpoints

### DIFF
--- a/includes/rest-api/class-wp-job-manager-models-job-categories-custom-fields.php
+++ b/includes/rest-api/class-wp-job-manager-models-job-categories-custom-fields.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Declaration of Job Categories Custom Fields Model
+ *
+ * @package WPJM/REST
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class WP_Job_Manager_Models_Job_Categories_Custom_Fields
+ */
+class WP_Job_Manager_Models_Job_Categories_Custom_Fields extends WP_Job_Manager_REST_Model
+	implements WP_Job_Manager_REST_Interfaces_Model {
+
+	/**
+	 * Declare Fields.
+	 *
+	 * @return array
+	 */
+	public function declare_fields() {
+		return array();
+	}
+}

--- a/includes/rest-api/class-wp-job-manager-registrable-job-categories.php
+++ b/includes/rest-api/class-wp-job-manager-registrable-job-categories.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Exposes Job Types Taxonomy REST Api
+ * Exposes Job Categories Taxonomy REST Api
  *
  * @package WPJM/REST
  */
@@ -10,16 +10,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class WP_Job_Manager_Registrable_Job_Types
+ * Class WP_Job_Manager_Registrable_Job_Categories
  */
-class WP_Job_Manager_Registrable_Job_Types extends WP_Job_Manager_Registrable_Taxonomy_Type {
+class WP_Job_Manager_Registrable_Job_Categories extends WP_Job_Manager_Registrable_Taxonomy_Type {
 	/**
 	 * Gets the taxonomy type to register.
 	 *
 	 * @return string Taxonomy type to expose.
 	 */
 	public function get_taxonomy_type() {
-		return 'job_listing_type';
+		return 'job_listing_category';
 	}
 
 	/**
@@ -28,7 +28,7 @@ class WP_Job_Manager_Registrable_Job_Types extends WP_Job_Manager_Registrable_Ta
 	 * @return string Slug for REST API base.
 	 */
 	public function get_rest_base() {
-		return 'job-types';
+		return 'job-categories';
 	}
 
 	/**
@@ -37,6 +37,6 @@ class WP_Job_Manager_Registrable_Job_Types extends WP_Job_Manager_Registrable_Ta
 	 * @return string Class name for the taxonomy type's model.
 	 */
 	public function get_model_class_name() {
-		return 'WP_Job_Manager_Models_Job_Types_Custom_Fields';
+		return 'WP_Job_Manager_Models_Job_Categories_Custom_Fields';
 	}
 }

--- a/includes/rest-api/class-wp-job-manager-registrable-job-listings.php
+++ b/includes/rest-api/class-wp-job-manager-registrable-job-listings.php
@@ -7,6 +7,10 @@
  * @package WPJM/REST
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Class MT_Controller_Extension
  */

--- a/includes/rest-api/class-wp-job-manager-registrable-taxonomy-type.php
+++ b/includes/rest-api/class-wp-job-manager-registrable-taxonomy-type.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Exposes Taxonomy REST Api
+ *
+ * @package WPJM/REST
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class WP_Job_Manager_Registrable_Taxonomy_Type
+ */
+abstract class WP_Job_Manager_Registrable_Taxonomy_Type implements WP_Job_Manager_REST_Interfaces_Registrable {
+
+	/**
+	 * The Model Prototype
+	 *
+	 * @var WP_Job_Manager_REST_Model
+	 */
+	private $model_prototype;
+
+	/**
+	 * REST Field Name
+	 *
+	 * @var string
+	 */
+	private $rest_field_name;
+
+	/**
+	 * Gets the taxonomy type to register.
+	 *
+	 * @return string Taxonomy type to expose.
+	 */
+	abstract public function get_taxonomy_type();
+
+	/**
+	 * Gets the REST API base slug.
+	 *
+	 * @return string Slug for REST API base.
+	 */
+	abstract public function get_rest_base();
+
+	/**
+	 * Gets the REST API model class name.
+	 *
+	 * @return string Class name for the taxonomy type's model.
+	 */
+	abstract public function get_model_class_name();
+	
+	/**
+	 * Register Job Categories
+	 *
+	 * @param WP_Job_Manager_REST_Environment $environment The Environment to use.
+	 * @throws WP_Job_Manager_REST_Exception Throws.
+	 *
+	 * @return bool|WP_Error true if valid otherwise error.
+	 */
+	public function register( $environment ) {
+		global $wp_taxonomies;
+
+		$taxonomy_type = $this->get_taxonomy_type();
+		$this->rest_field_name = 'fields';
+
+		if ( ! isset( $wp_taxonomies[ $taxonomy_type ] ) ) {
+			return false;
+		}
+
+		if ( $wp_taxonomies[ $taxonomy_type ]->show_in_rest ) {
+			return true;
+		}
+
+		$wp_taxonomies[ $taxonomy_type ]->show_in_rest = true;
+		$wp_taxonomies[ $taxonomy_type ]->rest_base = $this->get_rest_base();
+
+		$this->model_prototype = $environment->model( $this->get_model_class_name() );
+
+		if ( ! $this->model_prototype ) {
+			return new WP_Error( 'model-not-found' );
+		}
+		register_rest_field( $taxonomy_type, $this->rest_field_name, array(
+			'get_callback' => array( $this, 'get_taxonomy_term' ),
+			'update_callback' => array( $this, 'update_taxonomy_term' ),
+			'schema' => $this->get_item_schema(),
+		) );
+
+		return true;
+	}
+
+	/**
+	 * Get Item Schema
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$fields = $this->model_prototype->get_fields();
+		$properties = array();
+		$required = array();
+		foreach ( $fields as $field_declaration ) {
+			/**
+			 * Our declaration
+			 *
+			 * @var WP_Job_Manager_REST_Field_Declaration $field_declaration
+			 */
+			$properties[ $field_declaration->get_data_transfer_name() ] = $field_declaration->as_item_schema_property();
+			if ( $field_declaration->is_required() ) {
+				$required[] = $field_declaration->get_data_transfer_name();
+			}
+		}
+		$schema = array(
+			'$schema' => 'http://json-schema.org/schema#',
+			'title' => $this->model_prototype->get_name(),
+			'type' => 'object',
+			'properties' => (array) apply_filters( 'mixtape_rest_api_schema_properties', $properties, $this->model_prototype ),
+		);
+
+		if ( ! empty( $required ) ) {
+			$schema['required'] = $required;
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Our Get Fields.
+	 *
+	 * @param array           $object Object.
+	 * @param string          $field_name Field Name.
+	 * @param WP_REST_Request $request Request.
+	 * @param string          $object_type Object Type.
+	 *
+	 * @return mixed|string
+	 * @throws WP_Job_Manager_REST_Exception If type not there.
+	 */
+	public function get_taxonomy_term( $object, $field_name, $request, $object_type ) {
+		if ( $this->get_taxonomy_type() !== $object_type ) {
+			return null;
+		}
+
+		if ( $this->rest_field_name !== $field_name ) {
+			return null;
+		}
+
+		$object_id = absint( $object['id'] );
+		$model = $this->get_model( $object_id );
+		return $model->to_dto();
+	}
+
+	/**
+	 * Get a model if exists
+	 *
+	 * @param int $object_id Object ID.
+	 * @return WP_Job_Manager_REST_Interfaces_Model
+	 * @throws WP_Job_Manager_REST_Exception On Error.
+	 */
+	private function get_model( $object_id ) {
+		$data = array();
+		foreach ( $this->model_prototype->get_fields( WP_Job_Manager_REST_Field_Declaration::META ) as $field_declaration ) {
+			$field_name = $field_declaration->get_name();
+			if ( metadata_exists( 'term', $object_id, $field_name ) ) {
+				$meta = get_term_meta( $object_id, $field_name, true );
+				$data[ $field_name ] = $meta;
+			}
+		}
+
+		return $this->model_prototype->create( $data, array(
+			'deserialize' => true,
+		) );
+	}
+
+	/**
+	 * Our Reader.
+	 *
+	 * @param mixed 		  $data Data.
+	 * @param object          $object Object.
+	 * @param string          $field_name Field Name.
+	 * @param WP_REST_Request $request Request.
+	 * @param string          $object_type Object Type.
+	 *
+	 * @return mixed|string
+	 * @throws WP_Job_Manager_REST_Exception If type not there.
+	 */
+	public function update_taxonomy_term( $data, $object, $field_name, $request, $object_type ) {
+		if ( $this->get_taxonomy_type() !== $object_type ) {
+			return null;
+		}
+
+		if ( $this->rest_field_name !== $field_name ) {
+			return null;
+		}
+
+		if ( ! is_a( $object, 'WP_Term' ) ) {
+			return null;
+		}
+
+		$rest_base = $this->get_rest_base();
+		$term_id = absint( $object->term_id );
+		if ( ! $term_id ) {
+			// No way to update this. Bail.
+			return new WP_Error( $rest_base . '-error-invalid-id', $rest_base . '-error-invalid-id', array(
+				'status' => 400,
+			) );
+		}
+		$existing_model = $this->get_model( $term_id );
+
+		$updated = $existing_model->update_from_array( $data );
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+
+		$maybe_validation_error = $updated->sanitize()->validate();
+		if ( is_wp_error( $maybe_validation_error ) ) {
+			return $maybe_validation_error;
+		}
+
+		$serialized_data = $updated->serialize( WP_Job_Manager_REST_Field_Declaration::META );
+
+		foreach ( $serialized_data as $field_name => $val ) {
+			if ( metadata_exists( 'term', $term_id, $field_name ) ) {
+				update_term_meta( $term_id, $field_name, $val );
+			} else {
+				add_term_meta( $term_id, $field_name, $val );
+			}
+		}
+
+		return true;
+	}
+}

--- a/includes/rest-api/class-wp-job-manager-rest-api.php
+++ b/includes/rest-api/class-wp-job-manager-rest-api.php
@@ -92,8 +92,11 @@ class WP_Job_Manager_REST_API {
 		include_once 'class-wp-job-manager-controllers-status.php';
 		include_once 'class-wp-job-manager-models-job-listings-custom-fields.php';
 		include_once 'class-wp-job-manager-models-job-types-custom-fields.php';
+		include_once 'class-wp-job-manager-models-job-categories-custom-fields.php';
 		include_once 'class-wp-job-manager-registrable-job-listings.php';
+		include_once 'class-wp-job-manager-registrable-taxonomy-type.php';
 		include_once 'class-wp-job-manager-registrable-job-types.php';
+		include_once 'class-wp-job-manager-registrable-job-categories.php';
 
 		// Models.
 		$env->define_model( 'WP_Job_Manager_Models_Settings' )
@@ -103,6 +106,7 @@ class WP_Job_Manager_REST_API {
 		$env->define_model( 'WP_Job_Manager_Filters_Status' );
 		$env->define_model( 'WP_Job_Manager_Models_Job_Listings_Custom_Fields' );
 		$env->define_model( 'WP_Job_Manager_Models_Job_Types_Custom_Fields' );
+		$env->define_model( 'WP_Job_Manager_Models_Job_Categories_Custom_Fields' );
 
 		// Endpoints.
 		$env->rest_api( 'wpjm/v1' )
@@ -113,6 +117,7 @@ class WP_Job_Manager_REST_API {
 			'WP_Job_Manager_Models_Job_Listings_Custom_Fields',
 		'fields' ) );
 		$env->add_registrable( new WP_Job_Manager_Registrable_Job_Types() );
+		$env->add_registrable( new WP_Job_Manager_Registrable_Job_Categories() );
 	}
 }
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -62,10 +62,8 @@ class WPJM_Unit_Tests_Bootstrap {
 	 */
 	public function load_plugin() {
 		error_reporting( E_ALL );
-		$enabled = get_option( 'job_manager_enable_types' );
-		if (! $enabled ) {
-			update_option( 'job_manager_enable_types', true );
-		}
+		update_option( 'job_manager_enable_types', true );
+		update_option( 'job_manager_enable_categories', true );
 
 		require_once( $this->plugin_dir . '/wp-job-manager.php' );
 	}

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
@@ -1,0 +1,26 @@
+<?php
+
+class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
+
+	/**
+	 * @group rest
+	 */
+	function test_wp_v2_has_job_categories_route() {
+		$this->login_as( $this->default_user_id );
+		$response = $this->get( '/wp/v2' );
+		$this->assertResponseStatus( $response, 200 );
+		$data = $response->get_data();
+
+		$routes =  array_keys( $data['routes'] );
+		$this->assertTrue( in_array( '/wp/v2/job-categories', $routes ) );
+	}
+
+	/**
+	 * @group rest
+	 */
+	function test_get_job_categories_success() {
+		$this->login_as( $this->default_user_id );
+		$response = $this->get( '/wp/v2/job-categories' );
+		$this->assertResponseStatus( $response, 200 );
+	}
+}


### PR DESCRIPTION
Fixes #1267 
Fixes #1271

Adds a `job-categories` endpoint under `wp/v2`.

#### Changes proposed in this Pull Request:

* Enables `show_in_rest` for the job caategory taxonomy
* Adds a custom nested field, via `register_rest_field`

#### Testing instructions:

* Update mixtape locally (`./node_modules/.bin/mixtape build` )
* Do CRUD requests on `wp/v2/job-categories`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* REST API: Add Job Categories Support