### PR TITLE
Hide empty categories on filter

### DIFF
--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     WP Job Manager
  * @category    Template
- * @version     1.21.0
+ * @version     1.31.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -44,9 +44,9 @@ do_action( 'job_manager_job_filters_before', $atts );
 			<div class="search_categories">
 				<label for="search_categories"><?php _e( 'Category', 'wp-job-manager' ); ?></label>
 				<?php if ( $show_category_multiselect ) : ?>
-					<?php job_manager_dropdown_categories( array( 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'hide_empty' => false ) ); ?>
+					<?php job_manager_dropdown_categories( array( 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'hide_empty' => true ) ); ?>
 				<?php else : ?>
-					<?php job_manager_dropdown_categories( array( 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'show_option_all' => __( 'Any category', 'wp-job-manager' ), 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'multiple' => false ) ); ?>
+					<?php job_manager_dropdown_categories( array( 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'show_option_all' => __( 'Any category', 'wp-job-manager' ), 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'multiple' => false, 'hide_empty' => true ) ); ?>
 				<?php endif; ?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
Fixes #764 

#### Changes proposed in this Pull Request:

* Hide empty categories on `[jobs]` filter.

#### Testing instructions:

* With job categories enabled, add a job category but don't assign it to a job listing.
* With multiple job category select setting enabled, verify the empty category doesn't show up on the `[jobs]` page.
* With multiple job category select setting disabled, verify the empty category doesn't show up on the `[jobs]` page.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Template: Hide unused categories on jobs filter.