### PR TITLE
Add data deletion for WPJM CPTs

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Defines a class with methods for cleaning up plugin data. To be used when
+ * the plugin is deleted.
+ *
+ * @package Core
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// Exit if accessed directly.
+	exit;
+}
+
+/**
+ * Methods for cleaning up all plugin data.
+ *
+ * @author Automattic
+ * @since 1.31.0
+ */
+class WP_Job_Manager_Data_Cleaner {
+
+	/**
+	 * Custom post types to be deleted.
+	 *
+	 * @var $custom_post_types
+	 */
+	private static $custom_post_types = array(
+		'job_listing',
+	);
+
+	/**
+	 * Cleanup all data.
+	 *
+	 * @access public
+	 */
+	public static function cleanup_all() {
+		self::cleanup_custom_post_types();
+	}
+
+	/**
+	 * Cleanup data for custom post types.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_custom_post_types() {
+		foreach ( self::$custom_post_types as $post_type ) {
+			$items = get_posts( array(
+				'post_type'   => $post_type,
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			) );
+
+			foreach ( $items as $item ) {
+				wp_trash_post( $item );
+			}
+		}
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -1,0 +1,79 @@
+<?php
+
+require 'includes/class-wp-job-manager-data-cleaner.php';
+
+class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
+	// Posts.
+	private $post_ids;
+	private $biography_ids;
+	private $job_listing_ids;
+
+	/**
+	 * Add some posts to run tests against. Any that are associated with WPJM
+	 * should be trashed on cleanup. The others should not be trashed.
+	 */
+	private function setupPosts() {
+		// Create some regular posts.
+		$this->post_ids = $this->factory->post->create_many( 2, array(
+			'post_status' => 'publish',
+			'post_type'   => 'post',
+		) );
+
+		// Create an unrelated CPT to ensure its posts do not get deleted.
+		register_post_type( 'biography', array(
+			'label'       => 'Biographies',
+			'description' => 'A biography of a famous person (for testing)',
+			'public'      => true,
+		) );
+		$this->biography_ids = $this->factory->post->create_many( 4, array(
+			'post_status' => 'publish',
+			'post_type'   => 'biography',
+		) );
+
+		// Create some Job Listings.
+		$this->job_listing_ids = $this->factory->post->create_many( 8, array(
+			'post_status' => 'publish',
+			'post_type'   => 'job_listing',
+		) );
+	}
+
+	/**
+	 * Set up for tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setupPosts();
+	}
+
+	/**
+	 * Ensure the WPJM posts are moved to trash.
+	 *
+	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_all
+	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_custom_post_types
+	 */
+	public function testJobManagerPostsTrashed() {
+		WP_Job_Manager_Data_Cleaner::cleanup_all();
+
+		foreach ( $this->job_listing_ids as $id ) {
+			$post = get_post( $id );
+			$this->assertEquals( 'trash', $post->post_status, 'WPJM post should be trashed' );
+		}
+	}
+
+	/**
+	 * Ensure the non-WPJM posts are not moved to trash.
+	 *
+	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_all
+	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_custom_post_types
+	 */
+	public function testOtherPostsUntouched() {
+		WP_Job_Manager_Data_Cleaner::cleanup_all();
+
+		$ids = array_merge( $this->post_ids, $this->biography_ids );
+		foreach ( $ids as $id ) {
+			$post = get_post( $id );
+			$this->assertNotEquals( 'trash', $post->post_status, 'Non-WPJM post should not be trashed' );
+		}
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,6 +3,25 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit();
 }
 
+// Cleanup all data.
+require 'includes/class-wp-job-manager-data-cleaner.php';
+
+if ( ! is_multisite() ) {
+	WP_Job_Manager_Data_Cleaner::cleanup_all();
+} else {
+	global $wpdb;
+
+	$blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+	$original_blog_id = get_current_blog_id();
+
+	foreach ( $blog_ids as $blog_id ) {
+		switch_to_blog( $blog_id );
+		WP_Job_Manager_Data_Cleaner::cleanup_all();
+	}
+
+	switch_to_blog( $original_blog_id );
+}
+
 wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
 wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
 


### PR DESCRIPTION
Added initial functionality to delete data when WP Job Manager is deleted. This is for GDPR compliance (see #1362).

This first PR moves all posts of type `job_listing` to the Trash.

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Delete the WP Job Manager plugin.

- Look at your Posts, Pages, and other CPT's from other plugins. Ensure they have not been deleted or trashed.

- Inspect the database. All posts of type `job_listing` should have the status `trash`.

- If WP Job Manager is reinstalled and activated, you should be able to see those posts in your Trash and restore them.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the data should be trashed across all sites.