### PR TITLE
Add/data deletion pages

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -46,6 +46,7 @@ class WP_Job_Manager_Data_Cleaner {
 	public static function cleanup_all() {
 		self::cleanup_custom_post_types();
 		self::cleanup_taxonomies();
+		self::cleanup_pages();
 	}
 
 	/**
@@ -91,6 +92,31 @@ class WP_Job_Manager_Data_Cleaner {
 				$wpdb->delete( $wpdb->terms, array( 'term_id' => $term->term_id ) );
 				$wpdb->delete( $wpdb->termmeta, array( 'term_id' => $term->term_id ) );
 			}
+		}
+	}
+
+	/**
+	 * Cleanup data for pages.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_pages() {
+		// Trash the Submit Job page.
+		$submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
+		if ( $submit_job_form_page_id ) {
+			wp_trash_post( $submit_job_form_page_id );
+		}
+
+		// Trash the Job Dashboard page.
+		$job_dashboard_page_id = get_option( 'job_manager_job_dashboard_page_id' );
+		if ( $job_dashboard_page_id ) {
+			wp_trash_post( $job_dashboard_page_id );
+		}
+
+		// Trash the Jobs page.
+		$jobs_page_id = get_option( 'job_manager_jobs_page_id' );
+		if ( $jobs_page_id ) {
+			wp_trash_post( $jobs_page_id );
 		}
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,10 +25,6 @@ if ( ! is_multisite() ) {
 wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
 wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
 
-wp_trash_post( get_option( 'job_manager_submit_job_form_page_id' ) );
-wp_trash_post( get_option( 'job_manager_job_dashboard_page_id' ) );
-wp_trash_post( get_option( 'job_manager_jobs_page_id' ) );
-
 $options = array(
 	'wp_job_manager_version',
 	'job_manager_per_page',


### PR DESCRIPTION
Contributes to https://github.com/Automattic/WP-Job-Manager/issues/1362

This PR deletes all pages associated with WPJM: the Submit Job page, the Job Dashboard page, and the Job Listings page.

_Note: this builds upon https://github.com/Automattic/WP-Job-Manager/pull/1418 and so the first commit (which is shared) should be ignored. After #1418 is merged, this will be rebased._

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Ensure that WPJM has set up the pages above. (You also may want to test it without some of the pages set up, to ensure that it behaves as expected).

- Delete the WP Job Manager plugin.

- Look at the Pages. Ensure that the pages listed above have been Trashed, and the other pages have not.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the data should be deleted across all sites.