### PR TITLE
Adds core email notification handling

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-email-template.php
+++ b/includes/abstracts/abstract-wp-job-manager-email-template.php
@@ -1,0 +1,88 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Abstract class for an email notification built using templates.
+ *
+ * @package wp-job-manager
+ *
+ * @since 1.31.0
+ */
+
+abstract class WP_Job_Manager_Email_Template extends WP_Job_Manager_Email {
+
+	/**
+	 * Get the rich text version of the email content.
+	 *
+	 * @return string
+	 */
+	public function get_rich_content() {
+		return $this->get_template( false );
+	}
+
+	/**
+	 * Get the plaintext version of the email content.
+	 *
+	 * @return string
+	 */
+	public function get_plain_content() {
+		if ( $this->has_template( true ) ) {
+			return $this->get_template( true );
+		}
+		return strip_tags( $this->get_rich_content() );
+	}
+
+	/**
+	 * Get the contents of a template.
+	 *
+	 * @param bool $plain_text
+	 * @return string|bool
+	 */
+	public function get_template( $plain_text = false ) {
+		$template = $this->locate_template( $plain_text );
+		if ( ! $template ) {
+			return false;
+		}
+		$args = $this->get_args();
+		$email = $this;
+
+		ob_start();
+		include $template;
+		return ob_get_clean();
+	}
+
+	/**
+	 * Check to see if a template exists for this email.
+	 *
+	 * @param bool $plain_text
+	 * @return bool
+	 */
+	public function has_template( $plain_text = false ) {
+		$template_file = $this->locate_template( $plain_text );
+		return $template_file && file_exists( $template_file );
+	}
+
+	/**
+	 * Locate template for this email.
+	 *
+	 * @param bool $plain_text
+	 * @return string
+	 */
+	protected function locate_template( $plain_text ) {
+		return locate_job_manager_template( $this->get_template_file_name( $plain_text ) );
+	}
+
+	/**
+	 * Generate the file name for the email template.
+	 *
+	 * @param bool $plain_text
+	 * @return string
+	 */
+	protected function get_template_file_name( $plain_text = false ) {
+		$class_name = get_class( $this );
+		return WP_Job_Manager_Email_Notifications::get_template_file_name( $class_name::get_key(), $plain_text );
+	}
+}

--- a/includes/abstracts/abstract-wp-job-manager-email-template.php
+++ b/includes/abstracts/abstract-wp-job-manager-email-template.php
@@ -83,6 +83,8 @@ abstract class WP_Job_Manager_Email_Template extends WP_Job_Manager_Email {
 	 */
 	protected function get_template_file_name( $plain_text = false ) {
 		$class_name = get_class( $this );
-		return WP_Job_Manager_Email_Notifications::get_template_file_name( $class_name::get_key(), $plain_text );
+		// PHP 5.2: Using `call_user_func()` but `$class_name::get_key()` preferred.
+		$email_notification_key = call_user_func( array( $class_name, 'get_key') );
+		return WP_Job_Manager_Email_Notifications::get_template_file_name( $email_notification_key, $plain_text );
 	}
 }

--- a/includes/abstracts/abstract-wp-job-manager-email-template.php
+++ b/includes/abstracts/abstract-wp-job-manager-email-template.php
@@ -39,12 +39,12 @@ abstract class WP_Job_Manager_Email_Template extends WP_Job_Manager_Email {
 	 * Get the contents of a template.
 	 *
 	 * @param bool $plain_text
-	 * @return string|bool
+	 * @return string
 	 */
 	public function get_template( $plain_text = false ) {
 		$template = $this->locate_template( $plain_text );
 		if ( ! $template ) {
-			return false;
+			return '';
 		}
 		$args = $this->get_args();
 		$email = $this;

--- a/includes/abstracts/abstract-wp-job-manager-email-template.php
+++ b/includes/abstracts/abstract-wp-job-manager-email-template.php
@@ -32,7 +32,7 @@ abstract class WP_Job_Manager_Email_Template extends WP_Job_Manager_Email {
 		if ( $this->has_template( true ) ) {
 			return $this->get_template( true );
 		}
-		return strip_tags( $this->get_rich_content() );
+		return parent::get_plain_content();
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -1,0 +1,157 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Abstract class for an email notification.
+ *
+ * Do not rely on WordPress global variables or functions that rely on global variables such as `wp_get_current_user()`.
+ * Email might be generated when no longer in scope. Instead, pass the values on as an argument when initiating the email
+ * notification.
+ *
+ * Additionally, inside of plugins and themes, load email notification files based on this class inside the
+ * `job_manager_email_init` hook. This will prevent unnecessary loading and won't include the files if this abstract
+ * class isn't available.
+ *
+ * Example:
+ * ```
+ * add_action( 'job_manager_email_init', 'custom_plugin_include_emails' );
+ * function custom_plugin_include_emails() {
+ *     include_once 'emails/custom-plugin-sent-resume.php`;
+ * }
+ * ```
+ *
+ * @package wp-job-manager
+ *
+ * @since 1.31.0
+ */
+
+abstract class WP_Job_Manager_Email {
+	/**
+	 * @var array
+	 */
+	private $args = array();
+
+	/**
+	 * WP_Job_Manager_Email constructor.
+	 *
+	 * @param array $args Arguments used in forming email notification.
+	 */
+	final public function __construct( $args ) {
+		$this->args = $this->prepare_args( (array) $args );
+	}
+
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @type abstract
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return false;
+	}
+
+	/**
+	 * Get the friendly name for this email notification.
+	 *
+	 * @type abstract
+	 * @return string
+	 */
+	public static function get_name() {
+		return false;
+	}
+
+	/**
+	 * Expand arguments as necessary for the generation of the email.
+	 *
+	 * @param $args
+	 * @return mixed
+	 */
+	protected function prepare_args( $args ) {
+		return $args;
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	abstract public function get_subject();
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	abstract public function get_from();
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	abstract public function get_to();
+
+	/**
+	 * Get the rich text version of the email content.
+	 *
+	 * @return string
+	 */
+	abstract public function get_rich_content();
+
+	/**
+	 * Returns the list of file paths to attach to an email.
+	 *
+	 * @return array
+	 */
+	public function get_attachments() {
+		return array();
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	abstract public function is_valid();
+
+	/**
+	 * Returns the value of the CC header, if needed.
+	 *
+	 * @return string|null
+	 */
+	public function get_cc() {
+		return null;
+	}
+
+	/**
+	 * Get the base headers for the email. No need to add CC or From headers. Content-type is added when sending rich-text.
+	 *
+	 * @return array
+	 */
+	public function get_headers() {
+		return array();
+	}
+
+	/**
+	 * Get the plaintext version of the email content.
+	 *
+	 * @return string
+	 */
+	public function get_plain_content() {
+		return strip_tags( $this->get_rich_content() );
+	}
+
+	/**
+	 * Returns the args that the email notification was sent with.
+	 *
+	 * @return array
+	 */
+	final protected function get_args() {
+		return $this->args;
+	}
+
+}

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -243,6 +243,21 @@ final class WP_Job_Manager_Email_Notifications {
 
 		$content = self::get_email_content( $email_notification_key, $args );
 
+		/**
+		 * Allows for short-circuiting the actual sending of email notifications.
+		 *
+		 * @since 1.31.0
+		 *
+		 * @param bool                  $do_send_notification   True if we should send the notification.
+		 * @param WP_Job_Manager_Email  $email                  Email notification object.
+		 * @param array                 $args                   Email arguments for generating email.
+		 * @param string                $content                Email content.
+		 * @param array                 $headers                Email headers.
+		 * @param
+		 */
+		if ( ! apply_filters( 'job_manager_email_do_send_notification', true, $email, $args, $content, $headers ) ) {
+			return false;
+		}
 		return wp_mail( $args['to'], $args['subject'], $content, $headers, $args['attachments'] );
 	}
 

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -174,7 +174,7 @@ final class WP_Job_Manager_Email_Notifications {
 	}
 
 	/**
-	 * Returns the total number of deferred notifications to be sent.
+	 * Returns the total number of deferred notifications to be sent. Used in unit tests.
 	 *
 	 * @access private
 	 *

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -1,0 +1,332 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Base class for WP Job Manager's email notification system.
+ *
+ * @package wp-job-manager
+ * @since 1.31.0
+ */
+final class WP_Job_Manager_Email_Notifications {
+	/**
+	 * @var array
+	 */
+	private static $deferred_notifications = array();
+
+	/**
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
+	 * Sets up initial hooks.
+	 *
+	 * @static
+	 */
+	public static function init() {
+		add_action( 'job_manager_send_notification', array( __CLASS__, '_schedule_notification' ), 10, 2 );
+		add_action( 'job_manager_email_init', array( __CLASS__, '_lazy_init' ) );
+	}
+
+	/**
+	 * Gets list of email notifications handled by WP Job Manager core.
+	 *
+	 * @return array
+	 */
+	private static function core_email_notifications() {
+		return array(
+			'WP_Job_Manager_Email_Admin_New_Job',
+		);
+	}
+
+	/**
+	 * Sets up an email notification to be sent at the end of the script's execution.
+	 *
+	 * @param string $notification
+	 * @param array  $args
+	 */
+	public static function _schedule_notification( $notification, $args = array() ) {
+		if ( ! self::$initialized ) {
+			/**
+			 * Lazily load remaining files needed for email notifications. Do this here instead of in
+			 * `shutdown` for proper logging in case of syntax errors.
+			 *
+			 * @since 1.31.0
+			 */
+			do_action( 'job_manager_email_init' );
+			self::$initialized = true;
+		}
+
+		self::$deferred_notifications[] = array( $notification, $args );
+	}
+
+	/**
+	 * Sends all notifications collected during execution.
+	 *
+	 * Do not call manually.
+	 *
+	 * @access private
+	 */
+	public static function _send_deferred_notifications() {
+		$email_notifications = self::get_email_notifications( true );
+		foreach ( self::$deferred_notifications as $email ) {
+			if (
+				! is_string( $email[0] )
+				|| ! isset( $email_notifications[ $email[0] ] )
+			) {
+				continue;
+			}
+
+			$class_name = $email_notifications[ $email[0] ];
+			$email_args = is_array( $email[1] ) ? $email[1] : array();
+
+			self::send_email( $email[0], new $class_name( $email_args ) );
+		}
+	}
+
+	/**
+	 * Include email files.
+	 *
+	 * Do not call manually.
+	 *
+	 * @access private
+	 */
+	public static function _lazy_init() {
+		add_action( 'shutdown', array( __CLASS__, '_send_deferred_notifications' ) );
+
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-new-job.php';
+	}
+
+	/**
+	 * Clear the deferred notifications email array.
+	 *
+	 * Do not call manually. Only for help with tests.
+	 *
+	 * @access private
+	 */
+	public static function _clear_deferred_notifications() {
+		if ( ! defined( 'PHPUNIT_WPJM_TESTSUITE' ) || ! PHPUNIT_WPJM_TESTSUITE ) {
+			die( "This is just for use while testing" );
+		}
+		self::$deferred_notifications = array();
+	}
+
+	/**
+	 * Gets a list of all email notifications that WP Job Manager handles.
+	 *
+	 * @param bool $enabled_notifications_only
+	 * @return array
+	 */
+	public static function get_email_notifications( $enabled_notifications_only = false ) {
+		/**
+		 * Retrieves all email notifications to be sent.
+		 *
+		 * @since 1.31.0
+		 *
+		 * @param array $email_notifications All the email notifications to be registered.
+		 */
+		$email_notification_classes = array_unique( apply_filters( 'job_manager_email_notifications', self::core_email_notifications() ) );
+		$email_notifications = array();
+
+		/**
+		 * @var WP_Job_Manager_Email $email_class
+		 */
+		foreach ( $email_notification_classes as $email_class ) {
+			// Check to make sure email notification is valid.
+			if ( ! self::is_email_notification_valid( $email_class ) ) {
+				continue;
+			}
+
+			$email_notification_key = $email_class::get_key();
+			if (
+				isset( $email_notifications[ $email_notification_key ] )
+				|| ( $enabled_notifications_only && ! self::is_email_notification_enabled( $email_notification_key ) )
+			) {
+				continue;
+			}
+
+			$email_notifications[ $email_notification_key ] = $email_class;
+		}
+
+		return $email_notifications;
+	}
+
+	/**
+	 * Generate the file name for the email template.
+	 *
+	 * @param string $template_name
+	 * @param bool   $plain_text
+	 * @return string
+	 */
+	public static function get_template_file_name( $template_name, $plain_text = false ) {
+		$file_name_parts = array( 'emails' );
+		if ( $plain_text ) {
+			$file_name_parts[] = 'plain';
+		}
+
+		$file_name_parts[] = $template_name . '.php';
+
+		return implode( '/', $file_name_parts );
+	}
+
+	/**
+	 * Returns the total number of deferred notifications to be sent.
+	 *
+	 * @access private
+	 *
+	 * @return int
+	 */
+	public static function _get_deferred_notification_count() {
+		return count( self::$deferred_notifications );
+	}
+
+	/**
+	 * Confirms an email notification is valid.
+	 *
+	 * @access private
+	 *
+	 * @param string $email_class
+	 * @return bool
+	 */
+	private static function is_email_notification_valid( $email_class ) {
+		return is_string( $email_class )
+				&& class_exists( $email_class )
+				&& is_subclass_of( $email_class, 'WP_Job_Manager_Email' )
+				&& false !== $email_class::get_key()
+				&& false !== $email_class::get_name();
+	}
+
+	/**
+	 * Sends an email notification.
+	 *
+	 * @access private
+	 *
+	 * @param string               $email_notification_key
+	 * @param WP_Job_Manager_Email $email
+	 * @return bool
+	 */
+	private static function send_email( $email_notification_key, WP_Job_Manager_Email $email ) {
+		if ( ! $email->is_valid() ) {
+			return false;
+		}
+
+		$fields = array( 'to', 'from', 'subject', 'rich_content', 'plain_content', 'attachments', 'cc', 'headers' );
+		$args = array();
+		foreach ( $fields as $field ) {
+			$method = 'get_' . $field;
+
+			/**
+			 * Filter email values for job manager notifications.
+			 *
+			 * @since 1.31.0
+			 *
+			 * @param mixed                $email_field_value Value to be filtered.
+			 * @param WP_Job_Manager_Email $email             Email notification object.
+			 */
+			$args[ $field ] = apply_filters( "job_manager_email_{$email_notification_key}_{$field}", $email->$method(), $email );
+		}
+
+		$headers = is_array( $args['headers'] ) ? $args['headers'] : array();
+
+		if ( ! empty( $args['from'] ) ) {
+			$headers[] = 'From: ' . $args['from'];
+		}
+
+		if ( ! self::send_as_plain_text( $email_notification_key ) ) {
+			$headers[] = 'Content-Type: text/html';
+		}
+
+		$content = self::get_email_content( $email_notification_key, $args );
+
+		return wp_mail( $args['to'], $args['subject'], $content, $headers, $args['attachments'] );
+	}
+
+	/**
+	 * Generates the content for an email.
+	 *
+	 * @access private
+	 *
+	 * @param string $email_notification_key
+	 * @param array  $args
+	 * @return string
+	 */
+	private static function get_email_content( $email_notification_key, $args ) {
+		$plain_text = self::send_as_plain_text( $email_notification_key );
+
+		ob_start();
+
+		/**
+		 * Output the header for all job manager emails.
+		 *
+		 * @since 1.31.0
+		 *
+		 * @param string $email_notification_key Unique email notification key.
+		 * @param array  $args                   Arguments passed for generating email.
+		 * @param bool   $plain_text             True if sending plain text email.
+		 */
+		do_action( 'job_manager_email_header', $email_notification_key, $args, $plain_text );
+
+		if ( $plain_text ) {
+			echo wptexturize( $args['plain_content'] );
+		} else {
+			echo wpautop( wptexturize( $args['rich_content'] ) );
+		}
+
+		/**
+		 * Output the footer for all job manager emails.
+		 *
+		 * @since 1.31.0
+		 *
+		 * @param string $email_notification_key Unique email notification key.
+		 * @param array  $args                   Arguments passed for generating email.
+		 * @param bool   $plain_text             True if sending plain text email.
+		 */
+		do_action( 'job_manager_email_footer', $email_notification_key, $args, $plain_text );
+
+		$content = ob_get_clean();
+		return $content;
+	}
+
+	/**
+	 * Checks if a particular notification is enabled or not.
+	 *
+	 * @access private
+	 *
+	 * @param string $email_notification_key
+	 * @return bool
+	 */
+	private static function is_email_notification_enabled( $email_notification_key ) {
+		/**
+		 * Filter whether to send a notification email.
+		 *
+		 * @since 1.31.0
+		 *
+		 * @param bool   $send_notification
+		 * @param string $email_notification_key
+		 */
+		return apply_filters( 'job_manager_emails_is_email_notification_enabled', true, $email_notification_key );
+	}
+
+	/**
+	 * Checks if we should send emails using plain text.
+	 *
+	 * @access private
+	 *
+	 * @param string $email_notification_key
+	 * @return bool
+	 */
+	private static function send_as_plain_text( $email_notification_key ) {
+		/**
+		 * Filter whether to send emails as plain text.
+		 *
+		 * @since 1.31.0
+		 *
+		 * @param bool   $send_as_plain_text
+		 * @param string $email_notification_key
+		 */
+		return apply_filters( 'job_manager_emails_send_as_plain_text', false, $email_notification_key );
+	}
+}

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -140,7 +140,8 @@ final class WP_Job_Manager_Email_Notifications {
 				continue;
 			}
 
-			$email_notification_key = $email_class::get_key();
+			// PHP 5.2: Using `call_user_func()` but `$email_class::get_key()` preferred.
+			$email_notification_key = call_user_func( array( $email_class, 'get_key') );
 			if (
 				isset( $email_notifications[ $email_notification_key ] )
 				|| ( $enabled_notifications_only && ! self::is_email_notification_enabled( $email_notification_key ) )
@@ -192,11 +193,12 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @return bool
 	 */
 	private static function is_email_notification_valid( $email_class ) {
+		// PHP 5.2: Using `call_user_func()` but `$email_class::get_key()` preferred.
 		return is_string( $email_class )
 				&& class_exists( $email_class )
 				&& is_subclass_of( $email_class, 'WP_Job_Manager_Email' )
-				&& false !== $email_class::get_key()
-				&& false !== $email_class::get_name();
+				&& false !== call_user_func( array( $email_class, 'get_key') )
+				&& false !== call_user_func( array( $email_class, 'get_name') );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -324,7 +324,7 @@ final class WP_Job_Manager_Email_Notifications {
 		 * @param bool   $send_notification
 		 * @param string $email_notification_key
 		 */
-		return apply_filters( 'job_manager_emails_is_email_notification_enabled', true, $email_notification_key );
+		return apply_filters( 'job_manager_email_is_email_notification_enabled', true, $email_notification_key );
 	}
 
 	/**
@@ -344,6 +344,6 @@ final class WP_Job_Manager_Email_Notifications {
 		 * @param bool   $send_as_plain_text
 		 * @param string $email_notification_key
 		 */
-		return apply_filters( 'job_manager_emails_send_as_plain_text', false, $email_notification_key );
+		return apply_filters( 'job_manager_email_send_as_plain_text', false, $email_notification_key );
 	}
 }

--- a/includes/emails/class-wp-job-manager-email-admin-new-job.php
+++ b/includes/emails/class-wp-job-manager-email-admin-new-job.php
@@ -1,0 +1,99 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Email notification to administrator when a new job is submitted.
+ *
+ * @package wp-job-manager
+ * @since 1.31.0
+ * @extends WP_Job_Manager_Email
+ */
+class WP_Job_Manager_Email_Admin_New_Job extends WP_Job_Manager_Email_Template {
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return 'admin-notice-new-listing';
+	}
+
+	/**
+	 * Get the friendly name for this email notification.
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return __( 'Admin Notice of New Listing', 'wp-job-manager' );
+	}
+
+	/**
+	 * Expand arguments as necessary for the generation of the email.
+	 *
+	 * @param $args
+	 * @return mixed
+	 */
+	protected function prepare_args( $args ) {
+		if ( isset( $args['job_id'] ) ) {
+			$job = get_post( $args['job_id'] );
+			if ( $job instanceof WP_Post ) {
+				$args['job'] = $job;
+			}
+		}
+		if ( ! empty( $args['user_id'] ) ) {
+			$user = get_user_by( 'ID', $args['user_id'] );
+			if ( $user instanceof WP_User ) {
+				$args['user'] = $user;
+			}
+		}
+		return parent::prepare_args( $args );
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		$args = $this->get_args();
+
+		/**
+		 * @var WP_Post $job
+		 */
+		$job = $args['job'];
+		return sprintf( __( 'New Job Listing Submitted: %s', 'wp-job-manager' ), $job->post_title );
+	}
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	public function get_from() {
+		return false;
+	}
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	public function get_to() {
+		return get_option( 'admin_email', false );
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		$args = $this->get_args();
+		return isset( $args['job'] )
+				&& $args['job'] instanceof WP_Post
+				&& $this->get_to();
+	}
+}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -829,6 +829,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 */
 	public function done() {
 		do_action( 'job_manager_job_submitted', $this->job_id );
+		do_action( 'job_manager_send_notification', 'admin-notice-new-listing', array( 'job_id' => $this->job_id, 'user_id' => get_current_user_id() ) );
 		get_job_manager_template( 'job-submitted.php', array( 'job' => get_post( $this->job_id ) ) );
 	}
 }

--- a/templates/emails/admin-notice-new-listing.php
+++ b/templates/emails/admin-notice-new-listing.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Email content when notifying admin of a new job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/admin-notice-new-listing.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+/**
+ * @var WP_Post $job
+ */
+$job = $args['job'];
+?>
+	<p><?php
+		printf( __( 'A new job listing has been submitted titled <em>%s</em>.', 'wp-job-manager' ), esc_html( $job->post_title ) );
+		switch ( $job->post_status ) {
+			case 'publish':
+				printf( ' ' . __( 'It has been published and is now available to the public.', 'wp-job-manager' ) );
+				break;
+			case 'pending':
+				printf( ' ' . __( 'It is awaiting approval by an administrator in <a href="%s">WordPress admin</a>.', 'wp-job-manager' ), esc_url( admin_url( 'edit.php?post_type=job_listing' ) ) );
+				break;
+		}
+		?></p>
+<?php
+
+/**
+ * Show details about the job listing.
+ *
+ * @param WP_Post              $job            The job listing to show details for.
+ * @param WP_Job_Manager_Email $email          Email object for the notification.
+ * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
+ * @param bool                 $plain_text     True if the email is being sent as plain text.
+ */
+do_action( 'job_manager_email_job_details', $job, $email, true, $plain_text );

--- a/templates/emails/plain/admin-notice-new-listing.php
+++ b/templates/emails/plain/admin-notice-new-listing.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Email content when notifying admin of a new job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/admin-notice-new-listing.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+/**
+ * @var WP_Post $job
+ */
+$job = $args['job'];
+?>
+<?php
+printf( __( 'A new job listing has been submitted titled "%s".', 'wp-job-manager' ), esc_html( $job->post_title ) );
+switch ( $job->post_status ) {
+	case 'publish':
+		printf( ' ' . __( 'It has been published and is now available to the public.', 'wp-job-manager' ) );
+		break;
+	case 'pending':
+		printf( ' ' . __( 'It is awaiting approval by an administrator in WordPress admin (%s).', 'wp-job-manager' ), esc_url( admin_url( 'edit.php?post_type=job_listing' ) ) );
+		break;
+}
+
+/**
+ * Show details about the job listing.
+ *
+ * @param WP_Post              $job            The job listing to show details for.
+ * @param WP_Job_Manager_Email $email          Email object for the notification.
+ * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
+ * @param bool                 $plain_text     True if the email is being sent as plain text.
+ */
+do_action( 'job_manager_email_job_details', $job, $email, true, $plain_text );

--- a/tests/php/includes/stubs/class-wp-job-manager-email-invalid.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-email-invalid.php
@@ -1,0 +1,58 @@
+<?php
+class WP_Job_Manager_Email_Invalid extends WP_Job_Manager_Email {
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return 'invalid-email';
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		return 'Test Subject';
+	}
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	public function get_from() {
+		return 'From Name <from@example.com>';
+	}
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	public function get_to() {
+		return 'to@example.com';
+	}
+
+	/**
+	 * Get the rich text version of the email content.
+	 *
+	 * @return string
+	 */
+	public function get_rich_content() {
+		$args = $this->get_args();
+		return "<strong>{$args['test']}</strong>";
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		$args = $this->get_args();
+		return isset( $args['test'] );
+	}
+}

--- a/tests/php/includes/stubs/class-wp-job-manager-email-template-valid.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-email-template-valid.php
@@ -1,0 +1,58 @@
+<?php
+class WP_Job_Manager_Email_Template_Valid extends WP_Job_Manager_Email_Template {
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return 'test';
+	}
+
+	/**
+	 * Get the friendly name for this email notification.
+	 *
+	 * @return string
+	 * @throws Exception When it hasn't been implemented in a subclass.
+	 */
+	public static function get_name() {
+		return 'Test Email Notification';
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		return 'Test Subject';
+	}
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	public function get_from() {
+		return 'From Name <from@example.com>';
+	}
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	public function get_to() {
+		return 'to@example.com';
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		$args = $this->get_args();
+		return isset( $args['test'] );
+	}
+}

--- a/tests/php/includes/stubs/class-wp-job-manager-email-valid.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-email-valid.php
@@ -1,0 +1,68 @@
+<?php
+class WP_Job_Manager_Email_Valid extends WP_Job_Manager_Email {
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return 'valid-email';
+	}
+
+	/**
+	 * Get the friendly name for this email notification.
+	 *
+	 * @return string
+	 * @throws Exception When it hasn't been implemented in a subclass.
+	 */
+	public static function get_name() {
+		return 'Test Email Notification';
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		return 'Test Subject';
+	}
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	public function get_from() {
+		return 'From Name <from@example.com>';
+	}
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	public function get_to() {
+		return 'to@example.com';
+	}
+
+	/**
+	 * Get the rich text version of the email content.
+	 *
+	 * @return string
+	 */
+	public function get_rich_content() {
+		$args = $this->get_args();
+		return "<strong>{$args['test']}</strong>";
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		$args = $this->get_args();
+		return isset( $args['test'] );
+	}
+}

--- a/tests/php/includes/stubs/plain-test-template.php
+++ b/tests/php/includes/stubs/plain-test-template.php
@@ -1,0 +1,1 @@
+Plain Test Email: <?php echo $args['job']->post_title; ?>

--- a/tests/php/includes/stubs/test-template.php
+++ b/tests/php/includes/stubs/test-template.php
@@ -1,0 +1,1 @@
+<strong>Rich Test Email: <?php echo $args['job']->post_title; ?></strong>

--- a/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email-template.php
+++ b/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email-template.php
@@ -1,0 +1,109 @@
+<?php
+include_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-email-template-valid.php';
+
+/**
+ * Tests for WP_Job_Manager_Email_Template.
+ *
+ * @group email
+ */
+class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
+	private $fake_pass = 0;
+
+	/**
+	 * @covers WP_Job_Manager_Email_Template::has_template()
+	 * @covers WP_Job_Manager_Email_Template::locate_template()
+	 * @covers WP_Job_Manager_Email_Template::get_template_file_name()
+	 * @covers WP_Job_Manager_Email_Template::get_rich_content()
+	 */
+	public function test_get_rich_content() {
+		$job = get_post( $this->factory->job_listing->create() );
+		$args =  array( 'job' => $job );
+		$test = new WP_Job_Manager_Email_Template_Valid( $args );
+		$test_expected = "<strong>Rich Test Email: {$job->post_title}</strong>";
+
+		add_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		$test_value = $test->get_rich_content();
+		remove_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		$this->assertStringStartsWith( $test_expected, $test_value );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Template::has_template()
+	 * @covers WP_Job_Manager_Email_Template::locate_template()
+	 * @covers WP_Job_Manager_Email_Template::get_plain_content()
+	 * @covers WP_Job_Manager_Email_Template::get_template()
+	 */
+	public function test_get_plain_content() {
+		$job = get_post( $this->factory->job_listing->create() );
+		$args =  array( 'job' => $job );
+		$test = new WP_Job_Manager_Email_Template_Valid( $args );
+		$test_expected = "Plain Test Email: {$job->post_title}";
+		add_filter( 'job_manager_locate_template', array( $this, 'use_plain_test_template' ) );
+		$test_value = $test->get_plain_content();
+		remove_filter( 'job_manager_locate_template', array( $this, 'use_plain_test_template' ) );
+		$this->assertStringStartsWith( $test_expected, $test_value );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Template::has_template()
+	 * @covers WP_Job_Manager_Email_Template::locate_template()
+	 * @covers WP_Job_Manager_Email_Template::get_rich_content()
+	 * @covers WP_Job_Manager_Email_Template::get_plain_content()
+	 * @covers WP_Job_Manager_Email_Template::get_template()
+	 */
+	public function test_get_plain_content_rich_fallback() {
+		$this->fake_pass = 0;
+		$job = get_post( $this->factory->job_listing->create() );
+		$args =  array( 'job' => $job );
+		$test = new WP_Job_Manager_Email_Template_Valid( $args );
+		$test_expected = "Rich Test Email: {$job->post_title}";
+		add_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		$test_value = $test->get_plain_content();
+		remove_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		$this->assertStringStartsWith( $test_expected, $test_value );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Template::has_template()
+	 * @covers WP_Job_Manager_Email_Template::locate_template()
+	 */
+	public function test_has_template_rich() {
+		$this->fake_pass = 0;
+		$args =  array( 'job' => '' );
+		$test = new WP_Job_Manager_Email_Template_Valid( $args );
+		add_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		$test_value = $test->has_template();
+		remove_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		$this->assertTrue( $test_value );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Template::has_template()
+	 * @covers WP_Job_Manager_Email_Template::locate_template()
+	 */
+	public function test_has_template_plain_fake() {
+		$this->fake_pass = 0;
+		$args =  array( 'job' => '' );
+		$test = new WP_Job_Manager_Email_Template_Valid( $args );
+		add_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		$test_value = $test->has_template( true );
+		remove_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		$this->assertFalse( $test_value );
+	}
+
+	public function use_rich_test_template( $template ) {
+		return WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/test-template.php';
+	}
+
+	public function use_plain_test_template( $template ) {
+		return WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/plain-test-template.php';
+	}
+
+	public function use_fake_test_template( $template ) {
+		$this->fake_pass++;
+		if ( 1 === $this->fake_pass ) {
+			return WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/fake-test-template.php';
+		}
+		return WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/test-template.php';
+	}
+}

--- a/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email.php
+++ b/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email.php
@@ -1,0 +1,42 @@
+<?php
+include_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-email-valid.php';
+
+/**
+ * Tests for WP_Job_Manager_Email.
+ *
+ * @group email
+ */
+class WP_Test_WP_Job_Manager_Email extends WPJM_BaseTest {
+	/**
+	 * @covers WP_Job_Manager_Email::get_attachments()
+	 */
+	public function test_get_attachments() {
+		$test = new WP_Job_Manager_Email_Valid( array() );
+		$this->assertEquals( array(), $test->get_attachments() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email::get_cc()
+	 */
+	public function test_get_cc() {
+		$test = new WP_Job_Manager_Email_Valid( array() );
+		$this->assertNull( $test->get_cc() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email::get_headers()
+	 */
+	public function test_get_headers() {
+		$test = new WP_Job_Manager_Email_Valid( array() );
+		$this->assertEquals( array(), $test->get_headers() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email::get_plain_content()
+	 */
+	public function test_get_plain_contents() {
+		$args =  array( 'test' => md5( microtime( true ) ) );
+		$test = new WP_Job_Manager_Email_Valid( $args );
+		$this->assertEquals( $args['test'], $test->get_plain_content() );
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -1,0 +1,223 @@
+<?php
+include_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-email-valid.php';
+include_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-email-invalid.php';
+
+/**
+ * Tests for WP_Job_Manager_Email_Notifications.
+ *
+ * @group email
+ */
+class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
+	public function setUp() {
+		parent::setUp();
+		reset_phpmailer_instance();
+		WP_Job_Manager_Email_Notifications::_clear_deferred_notifications();
+	}
+
+	public function tearDown() {
+		reset_phpmailer_instance();
+		WP_Job_Manager_Email_Notifications::_clear_deferred_notifications();
+		remove_action( 'shutdown', array( 'WP_Job_Manager_Email_Notifications', '_send_deferred_notifications' ) );
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::_lazy_init()
+	 * @covers WP_Job_Manager_Email_Notifications::_schedule_notification()
+	 * @runInSeparateProcess
+	 */
+	public function test_lazy_init() {
+		$this->assertFalse( class_exists( 'WP_Job_Manager_Email_Admin_New_Job' ) );
+		$this->assertEquals( 0, did_action( 'job_manager_email_init' ) );
+		$this->assertFalse( has_action( 'shutdown', array( 'WP_Job_Manager_Email_Notifications', '_send_deferred_notifications' ) ) );
+
+		WP_Job_Manager_Email_Notifications::_schedule_notification( 'test-notification' );
+
+		$this->assertTrue( class_exists( 'WP_Job_Manager_Email_Admin_New_Job' ) );
+		$this->assertEquals( 1, did_action( 'job_manager_email_init' ) );
+		$this->assertEquals( 10, has_action( 'shutdown', array( 'WP_Job_Manager_Email_Notifications', '_send_deferred_notifications' ) ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::_schedule_notification()
+	 * @covers WP_Job_Manager_Email_Notifications::_get_deferred_notification_count()
+	 */
+	public function test_schedule_notification() {
+		$this->assertEquals( 0, WP_Job_Manager_Email_Notifications::_get_deferred_notification_count() );
+		$this->assertEquals( 0, did_action( 'job_manager_email_init' ) );
+
+		WP_Job_Manager_Email_Notifications::_schedule_notification( 'test-notification' );
+		$this->assertEquals( 1, did_action( 'job_manager_email_init' ) );
+		$this->assertEquals( 1, WP_Job_Manager_Email_Notifications::_get_deferred_notification_count() );
+
+		WP_Job_Manager_Email_Notifications::_schedule_notification( 'test-notification', array( 'test' => 'test' ) );
+		$this->assertEquals( 1, did_action( 'job_manager_email_init' ) );
+		$this->assertEquals( 2, WP_Job_Manager_Email_Notifications::_get_deferred_notification_count() );
+
+		do_action( 'job_manager_send_notification', 'test-notification-action', array( 'test' => 'test' ) );
+		$this->assertEquals( 1, did_action( 'job_manager_email_init' ) );
+		$this->assertEquals( 3, WP_Job_Manager_Email_Notifications::_get_deferred_notification_count() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::_send_deferred_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_deferred_notifications_valid_email() {
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertFalse( $mailer->get_sent() );
+		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		do_action( 'job_manager_send_notification', 'valid-email', array( 'test' => 'test' ) );
+		WP_Job_Manager_Email_Notifications::_send_deferred_notifications();
+		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+
+		$sent_email = $mailer->get_sent();
+		$this->assertNotFalse( $sent_email );
+		$this->assertInternalType( 'array', $sent_email->to );
+		$this->assertTrue( isset( $sent_email->to[0][0] ) );
+		$this->assertEquals( 'to@example.com', $sent_email->to[0][0] );
+		$this->assertEmpty( $sent_email->cc );
+		$this->assertEmpty( $sent_email->bcc );
+		$this->assertEquals( 'Test Subject', $sent_email->subject );
+		$this->assertEquals( "<p><strong>test</strong></p>\n", $sent_email->body );
+		$this->assertContains( 'From: From Name <from@example.com>', $sent_email->header );
+		$this->assertContains( 'Content-Type: text/html;', $sent_email->header );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::_send_deferred_notifications()
+	 */
+	public function test_send_deferred_notifications_unknown_email() {
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertFalse( $mailer->get_sent() );
+		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
+		do_action( 'job_manager_send_notification', 'invalid-email', array( 'test' => 'test' ) );
+		WP_Job_Manager_Email_Notifications::_send_deferred_notifications();
+		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
+		$this->assertFalse( $mailer->get_sent() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::_send_deferred_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_deferred_notifications_invalid_args() {
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertFalse( $mailer->get_sent() );
+		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		do_action( 'job_manager_send_notification', 'valid-email', array( 'nope' => 'test' ) );
+		WP_Job_Manager_Email_Notifications::_send_deferred_notifications();
+		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		$this->assertFalse( $mailer->get_sent() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::get_email_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
+	 */
+	public function test_get_email_notifications() {
+		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
+		$core_email_notifications = array( 'admin-notice-new-listing' );
+		$this->assertEquals( count( $core_email_notifications ), count( $emails ) );
+
+		foreach ( $core_email_notifications as $email_notification_key ) {
+			$this->assertArrayHasKey( $email_notification_key, $emails );
+			$this->assertValidEmailNotificationConfig( $emails[ $email_notification_key ] );
+		}
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::get_email_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
+	 */
+	public function test_get_email_notifications_inject_bad_ordinary_class() {
+		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
+		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
+		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
+		$this->assertArrayNotHasKey( 'invalid-email', $emails );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::get_email_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
+	 */
+	public function test_get_email_notifications_inject_bad_class_unknown() {
+		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_unknown' ) );
+		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
+		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_unknown' ) );
+		$this->assertArrayNotHasKey( 'invalid-email', $emails );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::get_email_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
+	 */
+	public function test_get_email_notifications_inject_malformed_class() {
+		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_setup' ) );
+		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
+		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_setup' ) );
+		$this->assertArrayNotHasKey( 'invalid-email', $emails );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::get_email_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
+	 */
+	public function test_get_email_notifications_inject_valid_email() {
+		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
+		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		$this->assertArrayHasKey( 'valid-email', $emails );
+		$this->assertValidEmailNotificationConfig( $emails['valid-email'] );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::get_template_file_name()
+	 */
+	public function test_get_template_file_name_plain() {
+		$template_name = md5( microtime( true ) );
+		$this->assertEquals( "emails/plain/{$template_name}.php", WP_Job_Manager_Email_Notifications::get_template_file_name( $template_name, true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::get_template_file_name()
+	 */
+	public function test_get_template_file_name_rich() {
+		$template_name = md5( microtime( true ) );
+		$this->assertEquals( "emails/{$template_name}.php", WP_Job_Manager_Email_Notifications::get_template_file_name( $template_name, false ) );
+	}
+
+	/**
+	 * Helper Methods
+	 */
+	public function inject_email_config_invalid_class_unknown( $emails ) {
+		$emails[] = 'WP_Job_Manager_BoopBeepBoop';
+		return $emails;
+	}
+
+	public function inject_email_config_invalid_class_ordinary( $emails ) {
+		$emails[] = 'WP_Job_Manager';
+		return $emails;
+	}
+
+	public function inject_email_config_invalid_class_setup( $emails ) {
+		$emails[] = 'WP_Job_Manager_Email_Invalid';
+		return $emails;
+	}
+
+	public function inject_email_config_valid_email( $emails ) {
+		$emails[] = 'WP_Job_Manager_Email_Valid';
+		return $emails;
+	}
+
+	/**
+	 * @param array $core_email_class
+	 */
+	protected function assertValidEmailNotificationConfig( $core_email_class ) {
+		$this->assertTrue( is_string( $core_email_class ) );
+		$this->assertTrue( class_exists( $core_email_class ) );
+		$this->assertTrue( is_subclass_of( $core_email_class, 'WP_Job_Manager_Email' ) );
+		$this->assertTrue( is_string( $core_email_class::get_key() ) );
+		$this->assertTrue( is_string( $core_email_class::get_name() ) );
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -9,6 +9,7 @@ include_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class
  */
 class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	public function setUp() {
+		defined( 'PHPUNIT_WPJM_TESTSUITE' ) || define( 'PHPUNIT_WPJM_TESTSUITE', true );
 		parent::setUp();
 		reset_phpmailer_instance();
 		WP_Job_Manager_Email_Notifications::_clear_deferred_notifications();
@@ -217,7 +218,9 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		$this->assertTrue( is_string( $core_email_class ) );
 		$this->assertTrue( class_exists( $core_email_class ) );
 		$this->assertTrue( is_subclass_of( $core_email_class, 'WP_Job_Manager_Email' ) );
-		$this->assertTrue( is_string( $core_email_class::get_key() ) );
-		$this->assertTrue( is_string( $core_email_class::get_name() ) );
+
+		// // PHP 5.2: Using `call_user_func()` but `$core_email_class::get_key()` preferred.
+		$this->assertTrue( is_string( call_user_func( array( $core_email_class, 'get_key') ) ) );
+		$this->assertTrue( is_string( call_user_func( array( $core_email_class, 'get_name') ) ) );
 	}
 }

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -74,6 +74,9 @@ class WP_Job_Manager {
 		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-geocode.php' );
 		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-cache-helper.php' );
 		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-helper.php' );
+		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-email.php' );
+		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-email-template.php' );
+		include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-email-notifications.php' );
 
 		add_action( 'rest_api_init', array( $this, 'rest_api' ) );
 
@@ -106,6 +109,7 @@ class WP_Job_Manager {
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
 		add_action( 'admin_init', array( $this, 'updater' ) );
 		add_action( 'wp_logout', array( $this, 'cleanup_job_posting_cookies' ) );
+		add_action( 'init', array( 'WP_Job_Manager_Email_Notifications', 'init' ) );
 
 		add_action( 'init', array( $this, 'usage_tracking_init' ) );
 		register_deactivation_hook( __FILE__, array( $this, 'usage_tracking_cleanup' ) );


### PR DESCRIPTION
This is a large chunk of functionality that I'm adding. This is the largest/first PR that just adds an MVP and starts resolving #672 (as well as others later).

Additional PRs will be added to:
- Show job details in notification to admin when new jobs are created. 
- Finish the actual notification for #672.
- Add an administration interface for enabling/disabling each notification in settings.
- Add additional notifications for editing job listings and notice of expiring job listings (#446).
- I'm also going to create a PR for the Resume's plugin to test compatibility with a WPJM extension plugin.

This PR:
- Adds the core functionality for sending notifications in WPJM.
- Includes a very minimal version of a notification that will be sent to admins when a new job listing is created.
- Adds unit tests functionality included so-far.

## Testing Instructions
- Verify unit tests pass.
- On submitting a new job listing from the `[submit_job_form]` shortcode, verify a very basic email is sent to the WordPress admin when submitted.