### PR TITLE
Delete options on plugin deletion

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -83,6 +83,15 @@ class WP_Job_Manager_Data_Cleaner {
 	);
 
 	/**
+	 * Site options to be deleted.
+	 *
+	 * @var $site_options
+	 */
+	private static $site_options = array(
+		'job_manager_helper',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -92,6 +101,7 @@ class WP_Job_Manager_Data_Cleaner {
 		self::cleanup_taxonomies();
 		self::cleanup_pages();
 		self::cleanup_options();
+		self::cleanup_site_options();
 	}
 
 	/**
@@ -173,6 +183,17 @@ class WP_Job_Manager_Data_Cleaner {
 	private static function cleanup_options() {
 		foreach ( self::$options as $option ) {
 			delete_option( $option );
+		}
+	}
+
+	/**
+	 * Cleanup data for site options.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_site_options() {
+		foreach ( self::$site_options as $option ) {
+			delete_site_option( $option );
 		}
 	}
 }

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -39,6 +39,50 @@ class WP_Job_Manager_Data_Cleaner {
 	);
 
 	/**
+	 * Options to be deleted.
+	 *
+	 * @var $options
+	 */
+	private static $options = array(
+		'wp_job_manager_version',
+		'job_manager_installed_terms',
+		'wpjm_permalinks',
+		'job_manager_helper',
+		'job_manager_date_format',
+		'job_manager_google_maps_api_key',
+		'job_manager_usage_tracking_enabled',
+		'job_manager_usage_tracking_opt_in_hide',
+		'job_manager_per_page',
+		'job_manager_hide_filled_positions',
+		'job_manager_hide_expired',
+		'job_manager_hide_expired_content',
+		'job_manager_enable_categories',
+		'job_manager_enable_default_category_multiselect',
+		'job_manager_category_filter_type',
+		'job_manager_enable_types',
+		'job_manager_multi_job_type',
+		'job_manager_user_requires_account',
+		'job_manager_enable_registration',
+		'job_manager_generate_username_from_email',
+		'job_manager_use_standard_password_setup_email',
+		'job_manager_registration_role',
+		'job_manager_submission_requires_approval',
+		'job_manager_user_can_edit_pending_submissions',
+		'job_manager_user_edit_published_submissions',
+		'job_manager_submission_duration',
+		'job_manager_allowed_application_method',
+		'job_manager_recaptcha_label',
+		'job_manager_recaptcha_site_key',
+		'job_manager_recaptcha_secret_key',
+		'job_manager_enable_recaptcha_job_submission',
+		'job_manager_submit_job_form_page_id',
+		'job_manager_job_dashboard_page_id',
+		'job_manager_jobs_page_id',
+		'job_manager_submit_page_slug',
+		'job_manager_job_dashboard_page_slug',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -47,6 +91,7 @@ class WP_Job_Manager_Data_Cleaner {
 		self::cleanup_custom_post_types();
 		self::cleanup_taxonomies();
 		self::cleanup_pages();
+		self::cleanup_options();
 	}
 
 	/**
@@ -117,6 +162,17 @@ class WP_Job_Manager_Data_Cleaner {
 		$jobs_page_id = get_option( 'job_manager_jobs_page_id' );
 		if ( $jobs_page_id ) {
 			wp_trash_post( $jobs_page_id );
+		}
+	}
+
+	/**
+	 * Cleanup data for options.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_options() {
+		foreach ( self::$options as $option ) {
+			delete_option( $option );
 		}
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -329,6 +329,32 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Ensure the WPJM options are deleted and the others aren't.
+	 *
+	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_all
+	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_options
+	 */
+	public function testJobManagerOptionsDeleted() {
+		// Set a couple WPJM options.
+		update_option( 'job_manager_usage_tracking_opt_in_hide', '1' );
+		update_option( 'wp_job_manager_version', '1.10.0' );
+
+		// Set a couple other options.
+		update_option( 'my_option_1', 'Value 1' );
+		update_option( 'my_option_2', 'Value 2' );
+
+		WP_Job_Manager_Data_Cleaner::cleanup_all();
+
+		// Ensure the WPJM options are deleted.
+		$this->assertFalse( get_option( 'job_manager_usage_tracking_opt_in_hide' ), 'Option job_manager_usage_tracking_opt_in_hide should be deleted' );
+		$this->assertFalse( get_option( 'wp_job_manager_version' ), 'Option wp_job_manager_version should be deleted' );
+
+		// Ensure the non-WPJM options are intact.
+		$this->assertEquals( 'Value 1', get_option( 'my_option_1' ), 'Option my_option_1 should not be deleted' );
+		$this->assertEquals( 'Value 2', get_option( 'my_option_2' ), 'Option my_option_2 should not be deleted' );
+	}
+
 	/* Helper functions. */
 
 	private function getPostIdsWithTerm( $term_id, $taxonomy ) {

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -317,7 +317,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_all
 	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_pages
 	 */
-	public function testSenseiPagesTrashed() {
+	public function testJobManagerPagesTrashed() {
 		WP_Job_Manager_Data_Cleaner::cleanup_all();
 
 		$this->assertEquals( 'trash', get_post_status( $this->submit_job_form_page_id ), 'Submit Job page should be trashed' );

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -339,6 +339,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		// Set a couple WPJM options.
 		update_option( 'job_manager_usage_tracking_opt_in_hide', '1' );
 		update_option( 'wp_job_manager_version', '1.10.0' );
+		update_site_option( 'job_manager_helper', '{}' );
 
 		// Set a couple other options.
 		update_option( 'my_option_1', 'Value 1' );
@@ -349,6 +350,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		// Ensure the WPJM options are deleted.
 		$this->assertFalse( get_option( 'job_manager_usage_tracking_opt_in_hide' ), 'Option job_manager_usage_tracking_opt_in_hide should be deleted' );
 		$this->assertFalse( get_option( 'wp_job_manager_version' ), 'Option wp_job_manager_version should be deleted' );
+		$this->assertFalse( get_site_option( 'job_manager_helper' ), 'Site option job_manager_helper should be deleted' );
 
 		// Ensure the non-WPJM options are intact.
 		$this->assertEquals( 'Value 1', get_option( 'my_option_1' ), 'Option my_option_1 should not be deleted' );


### PR DESCRIPTION
Contributes to #1362

This PR, on plugin deletion, deletes all options in the database associated with WPJM. This includes the following regular options:

- `wp_job_manager_version`
- `job_manager_installed_terms`
- `wpjm_permalinks`
- `job_manager_helper`
- `job_manager_date_format`
- `job_manager_google_maps_api_key`
- `job_manager_usage_tracking_enabled`
- `job_manager_usage_tracking_opt_in_hide`
- `job_manager_per_page`
- `job_manager_hide_filled_positions`
- `job_manager_hide_expired`
- `job_manager_hide_expired_content`
- `job_manager_enable_categories`
- `job_manager_enable_default_category_multiselect`
- `job_manager_category_filter_type`
- `job_manager_enable_types`
- `job_manager_multi_job_type`
- `job_manager_user_requires_account`
- `job_manager_enable_registration`
- `job_manager_generate_username_from_email`
- `job_manager_use_standard_password_setup_email`
- `job_manager_registration_role`
- `job_manager_submission_requires_approval`
- `job_manager_user_can_edit_pending_submissions`
- `job_manager_user_edit_published_submissions`
- `job_manager_submission_duration`
- `job_manager_allowed_application_method`
- `job_manager_recaptcha_label`
- `job_manager_recaptcha_site_key`
- `job_manager_recaptcha_secret_key`
- `job_manager_enable_recaptcha_job_submission`
- `job_manager_submit_job_form_page_id`
- `job_manager_job_dashboard_page_id`
- `job_manager_jobs_page_id`
- `job_manager_submit_page_slug`
- `job_manager_job_dashboard_page_slug`

And the following Site Option:

- `job_manager_helper`

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Delete the WPJM plugin.

- Inspect the database and look at the `wp_options` table. All options should be intact except for the ones listed above. Those should be deleted.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the options should be deleted across all sites.

- To test the site options on a multisite installation, activate a WPJM extension using your license key on any of the sites in the network. That will create the site option in the `wp_sitemeta` table in the DB. Then you can ensure that deleting WPJM removes that site option.