### PR TITLE
Add data deletion for WPJM transients

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -92,6 +92,18 @@ class WP_Job_Manager_Data_Cleaner {
 	);
 
 	/**
+	 * Transient names (as MySQL regexes) to be deleted. The prefixes
+	 * "_transient_" and "_transient_timeout_" will be prepended.
+	 *
+	 * @var $transients
+	 */
+	private static $transients = array(
+		'_job_manager_activation_redirect',
+		'get_job_listings-transient-version',
+		'jm_.*',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -100,6 +112,7 @@ class WP_Job_Manager_Data_Cleaner {
 		self::cleanup_custom_post_types();
 		self::cleanup_taxonomies();
 		self::cleanup_pages();
+		self::cleanup_transients();
 		self::cleanup_options();
 		self::cleanup_site_options();
 	}
@@ -194,6 +207,26 @@ class WP_Job_Manager_Data_Cleaner {
 	private static function cleanup_site_options() {
 		foreach ( self::$site_options as $option ) {
 			delete_site_option( $option );
+		}
+	}
+
+	/**
+	 * Cleanup transients from the database.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_transients() {
+		global $wpdb;
+
+		foreach ( array( '_transient_', '_transient_timeout_' ) as $prefix ) {
+			foreach ( self::$transients as $transient ) {
+				$wpdb->query(
+					$wpdb->prepare(
+						"DELETE FROM $wpdb->options WHERE option_name RLIKE %s",
+						$prefix . $transient
+					)
+				);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Contributes to #1362 

This PR, on plugin deletion, deletes the transients associated with WPJM from the database. The following transients (as regular expressions) should be deleted:

- `_job_manager_activation_redirect`
- `get_job_listings-transient-version`
- `jm_.*`

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Add some of the above transients to the database.

- Delete the WPJM plugin.

- Inspect the database to ensure that those transients have been deleted. You can use this query to see all the transients in the DB: `SELECT option_id, option_name from wp_options WHERE option_name LIKE "_transient_%"`. You can also use a plugin like "Transients Manager" to check them.

- Ensure that the transient itself and it's timeout value have been deleted (e.g. both `_transient__job_manager_activation_redirect` and `_transient_timeout__job_manager_activation_redirect`).

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the transients should be deleted across all sites.