### PR TITLE
Add data deletion for WPJM Cron Jobs

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -342,7 +342,8 @@ class WP_Job_Manager_Data_Cleaner {
 	}
 
 	/**
-	 * Cleanup cron jobs.
+	 * Cleanup cron jobs. Note that this should be done on deactivation, but
+	 * doing it here as well for safety.
 	 *
 	 * @access private
 	 */

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -38,6 +38,17 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_listing_type',
 	);
 
+	/** Cron jobs to be unscheduled.
+	 *
+	 * @var $cron_jobs
+	 */
+	private static $cron_jobs = array(
+		'job_manager_check_for_expired_jobs',
+		'job_manager_delete_old_previews',
+		'job_manager_clear_expired_transients',
+		'job_manager_usage_tracking_send_usage_data',
+	);
+
 	/**
 	 * Options to be deleted.
 	 *
@@ -159,6 +170,7 @@ class WP_Job_Manager_Data_Cleaner {
 		self::cleanup_custom_post_types();
 		self::cleanup_taxonomies();
 		self::cleanup_pages();
+		self::cleanup_cron_jobs();
 		self::cleanup_roles_and_caps();
 		self::cleanup_transients();
 		self::cleanup_user_meta();
@@ -326,6 +338,17 @@ class WP_Job_Manager_Data_Cleaner {
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
 			$wpdb->delete( $wpdb->usermeta, array( 'meta_key' => $meta_key ) );
+		}
+	}
+
+	/**
+	 * Cleanup cron jobs.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_cron_jobs() {
+		foreach ( self::$cron_jobs as $job ) {
+			wp_clear_scheduled_hook( $job );
 		}
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,35 +22,5 @@ if ( ! is_multisite() ) {
 	switch_to_blog( $original_blog_id );
 }
 
-wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
-wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
-
-$options = array(
-	'wp_job_manager_version',
-	'job_manager_per_page',
-	'job_manager_hide_filled_positions',
-	'job_manager_enable_categories',
-	'job_manager_enable_default_category_multiselect',
-	'job_manager_category_filter_type',
-	'job_manager_user_requires_account',
-	'job_manager_enable_registration',
-	'job_manager_registration_role',
-	'job_manager_submission_requires_approval',
-	'job_manager_user_can_edit_pending_submissions',
-	'job_manager_submission_duration',
-	'job_manager_allowed_application_method',
-	'job_manager_submit_job_form_page_id',
-	'job_manager_job_dashboard_page_id',
-	'job_manager_jobs_page_id',
-	'job_manager_installed_terms',
-	'job_manager_submit_page_slug',
-	'job_manager_job_dashboard_page_slug',
-	'job_manager_google_maps_api_key',
-);
-
-foreach ( $options as $option ) {
-	delete_option( $option );
-}
-
 include dirname( __FILE__ ) . '/includes/class-wp-job-manager-usage-tracking.php';
 WP_Job_Manager_Usage_Tracking::get_instance()->clear_options();

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -115,6 +115,9 @@ class WP_Job_Manager {
 		add_action( 'init', array( $this, 'usage_tracking_init' ) );
 		register_deactivation_hook( __FILE__, array( $this, 'usage_tracking_cleanup' ) );
 
+		// Other cleanup
+		register_deactivation_hook( __FILE__, array( $this, 'unschedule_cron_jobs' ) );
+
 		// Defaults for WPJM core actions
 		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );
 	}
@@ -214,6 +217,15 @@ class WP_Job_Manager {
 		if ( ! wp_next_scheduled( 'job_manager_clear_expired_transients' ) ) {
 			wp_schedule_event( time(), 'twicedaily', 'job_manager_clear_expired_transients' );
 		}
+	}
+
+	/**
+	 * Unschedule cron jobs. This is run on plugin deactivation.
+	 */
+	public static function unschedule_cron_jobs() {
+		wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
+		wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
+		wp_clear_scheduled_hook( 'job_manager_clear_expired_transients' );
 	}
 
 	/**


### PR DESCRIPTION
Contributes to #1362

This PR, on plugin deletion, deletes the cron jobs associated with WPJM. The following cron jobs are deleted:

- `job_manager_check_for_expired_jobs`
- `job_manager_delete_old_previews`
- `job_manager_clear_expired_transients`
- `job_manager_usage_tracking_send_usage_data`

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- With WPJM installed, inspect the cron jobs. The ones listed above should be scheduled. You can use a plugin such as WP Crontrol for this.

- Deactivate the WPJM plugin.

- Verify the WPJM cron jobs have been unscheduled.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin OR deactivated from an individual site, the WPJM cron jobs should be removed.