### PR TITLE
Add basic job details to email notifications

### DIFF
--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -262,6 +262,17 @@ final class WP_Job_Manager_Email_Notifications {
 			);
 		}
 
+		if ( $sent_to_admin ) {
+			$author = get_user_by( 'ID', $job->post_author );
+			if ( $author instanceof WP_User ) {
+				$fields[ 'author' ] = array(
+					'label' => __( 'Posted by', 'wp-job-manager' ),
+					'value' => $author->user_nicename,
+					'url'   => 'mailto:' . $author->user_email,
+				);
+			}
+		}
+
 		/**
 		 * Modify the fields shown in email notifications in the details summary a job listing.
 		 *

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -29,6 +29,7 @@ final class WP_Job_Manager_Email_Notifications {
 	public static function init() {
 		add_action( 'job_manager_send_notification', array( __CLASS__, '_schedule_notification' ), 10, 2 );
 		add_action( 'job_manager_email_init', array( __CLASS__, '_lazy_init' ) );
+		add_action( 'job_manager_email_job_details', array( __CLASS__, 'output_job_details'), 10, 4 );
 		add_action( 'job_manager_email_header', array( __CLASS__, 'output_header' ), 10, 3 );
 		add_action( 'job_manager_email_footer', array( __CLASS__, 'output_footer' ), 10, 3 );
 	}
@@ -176,6 +177,104 @@ final class WP_Job_Manager_Email_Notifications {
 		$file_name_parts[] = $template_name . '.php';
 
 		return implode( '/', $file_name_parts );
+	}
+
+	/**
+	 * Show details about the job listing.
+	 *
+	 * @param WP_Post              $job            The job listing to show details for.
+	 * @param WP_Job_Manager_Email $email          Email object for the notification.
+	 * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
+	 * @param bool                 $plain_text     True if the email is being sent as plain text.
+	 */
+	static public function output_job_details( $job, $email, $sent_to_admin, $plain_text = false ) {
+		$template_segment = locate_job_manager_template( self::get_template_file_name( 'email-job-details', $plain_text ) );
+		if ( ! file_exists( $template_segment ) ) {
+			return;
+		}
+
+		$fields = self::get_job_detail_fields( $job, $sent_to_admin, $plain_text );
+
+		include $template_segment;
+	}
+
+	/**
+	 * Get the job fields to show in email templates.
+	 *
+	 * @param WP_Post $job
+	 * @param bool    $sent_to_admin
+	 * @param bool    $plain_text
+	 * @return array
+	 */
+	static private function get_job_detail_fields( WP_Post $job, $sent_to_admin, $plain_text = false ) {
+		$fields = array();
+
+		$fields['job_title'] = array(
+			'label' => __( 'Job title', 'wp-job-manager' ),
+			'value' => $job->post_title,
+		);
+
+		$job_location = get_the_job_location( $job );
+		if ( ! empty( $job_location ) ) {
+			$fields['job_location'] = array(
+				'label' => __( 'Location', 'wp-job-manager' ),
+				'value' => $job_location,
+			);
+		}
+
+		if ( get_option( 'job_manager_enable_types' ) && wp_count_terms( 'job_listing_type' ) > 0 ) {
+			$job_types = wpjm_get_the_job_types( $job );
+			if ( ! empty( $job_types ) ) {
+				$fields[ 'job_type' ] = array(
+					'label' => __( 'Job type', 'wp-job-manager' ),
+					'value' => implode( ', ', wp_list_pluck( $job_types, 'name' ) ),
+				);
+			}
+		}
+
+		if ( get_option( 'job_manager_enable_categories' ) && wp_count_terms( 'job_listing_category' ) > 0 ) {
+			$job_categories = wpjm_get_the_job_categories( $job );
+			if ( ! empty( $job_categories ) ) {
+				$fields[ 'job_category' ] = array(
+					'label' => __( 'Job category', 'wp-job-manager' ),
+					'value' => implode( ', ', wp_list_pluck( $job_categories, 'name' ) ),
+				);
+			}
+		}
+
+		$company_name = get_the_company_name( $job );
+		if ( ! empty( $company_name ) ) {
+			$fields['company_name'] = array(
+				'label' => __( 'Company name', 'wp-job-manager' ),
+				'value' => $company_name,
+			);
+		}
+
+		$company_website = get_the_company_website( $job );
+		if ( ! empty( $company_website ) ) {
+			$fields['company_website'] = array(
+				'label' => __( 'Company website', 'wp-job-manager' ),
+				'value' => $plain_text ? $company_website : sprintf( '<a href="%1$s">%1$s</a>', esc_url( $company_website, array( 'http', 'https' ) ) ),
+			);
+		}
+
+		/**
+		 * Modify the fields shown in email notifications in the details summary a job listing.
+		 *
+		 * @since 1.31.0
+		 *
+		 * @param array   $fields         {
+		 *     Array of fields. Each field is keyed with a unique identifier.
+		 *     {
+		 *          @type string $label Label to show next to field.
+		 *          @type string $value Value for field.
+		 *     }
+		 * }
+		 * @param WP_Post $job            Job listing.
+		 * @param bool    $sent_to_admin  True if being sent in an admin notification.
+		 * @param bool    $plain_text     True if being sent as plain text.
+		 */
+		return apply_filters( 'job_manager_emails_job_detail_fields', $fields, $job, $sent_to_admin, $plain_text );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -214,6 +214,10 @@ final class WP_Job_Manager_Email_Notifications {
 			'value' => $job->post_title,
 		);
 
+		if ( $sent_to_admin || 'publish' === $job->post_status ) {
+			$fields['job_title']['url'] = get_permalink( $job );
+		}
+
 		$job_location = get_the_job_location( $job );
 		if ( ! empty( $job_location ) ) {
 			$fields['job_location'] = array(
@@ -268,6 +272,7 @@ final class WP_Job_Manager_Email_Notifications {
 		 *     {
 		 *          @type string $label Label to show next to field.
 		 *          @type string $value Value for field.
+		 *          @type string $url   URL to provide with the value (optional).
 		 *     }
 		 * }
 		 * @param WP_Post $job            Job listing.

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -421,7 +421,7 @@ final class WP_Job_Manager_Email_Notifications {
 		do_action( 'job_manager_email_header', $email_notification_key, $args, $plain_text );
 
 		if ( $plain_text ) {
-			echo wptexturize( $args['plain_content'] );
+			echo html_entity_decode( wptexturize( $args['plain_content'] ) );
 		} else {
 			echo wpautop( wptexturize( $args['rich_content'] ) );
 		}

--- a/templates/emails/admin-notice-new-listing.php
+++ b/templates/emails/admin-notice-new-listing.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $job = $args['job'];
 ?>
 	<p><?php
-		printf( __( 'A new job listing has been submitted titled <em>%s</em>.', 'wp-job-manager' ), esc_html( $job->post_title ) );
+		printf( __( 'A new job listing has been submitted to <a href="%s">%s</a>.', 'wp-job-manager' ), home_url(), get_bloginfo( 'name' ) );
 		switch ( $job->post_status ) {
 			case 'publish':
 				printf( ' ' . __( 'It has been published and is now available to the public.', 'wp-job-manager' ) );

--- a/templates/emails/email-job-details.php
+++ b/templates/emails/email-job-details.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Email content for showing job details.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/plain/email-job-details.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+$text_align = is_rtl() ? 'right' : 'left';
+
+if ( ! empty( $fields ) ) : ?>
+	<div style="margin-bottom: 20px;" class="job-manager-email-job-details-container job-manager-email-container">
+		<table border="0" cellpadding="10" cellspacing="0" width="600" class="job-manager-email-job-details">
+			<?php foreach ( $fields as $field ) : ?>
+			<tr>
+				<td width="30%" style="text-align:<?php echo $text_align; ?>; vertical-align: middle; border: 1px solid #eee; word-wrap: break-word;">
+					<?php echo wp_kses_post( $field['label'] ); ?>
+				</td>
+				<td class="td" style="text-align:<?php echo $text_align; ?>; vertical-align: middle; border: 1px solid #eee;">
+					<?php echo wp_kses_post( $field['value'] ); ?>
+				</td>
+			</tr>
+			<?php endforeach; ?>
+		</table>
+	</div>
+<?php endif; ?>

--- a/templates/emails/email-job-details.php
+++ b/templates/emails/email-job-details.php
@@ -2,7 +2,7 @@
 /**
  * Email content for showing job details.
  *
- * This template can be overridden by copying it to yourtheme/job_manager/emails/plain/email-job-details.php.
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/email-job-details.php.
  *
  * @see         https://wpjobmanager.com/document/template-overrides/
  * @author      Automattic

--- a/templates/emails/email-job-details.php
+++ b/templates/emails/email-job-details.php
@@ -18,14 +18,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 $text_align = is_rtl() ? 'right' : 'left';
 
 if ( ! empty( $fields ) ) : ?>
-	<div style="margin-bottom: 20px;" class="job-manager-email-job-details-container job-manager-email-container">
-		<table border="0" cellpadding="10" cellspacing="0" width="600" class="job-manager-email-job-details">
+	<div class="job-manager-email-job-details-container email-container">
+		<table border="0" cellpadding="10" cellspacing="0" width="100%" class="job-manager-email-job-details details">
 			<?php foreach ( $fields as $field ) : ?>
 			<tr>
-				<td width="30%" style="text-align:<?php echo $text_align; ?>; vertical-align: middle; border: 1px solid #eee; word-wrap: break-word;">
+				<td class="detail-label" style="text-align:<?php echo $text_align; ?>;">
 					<?php echo wp_kses_post( $field['label'] ); ?>
 				</td>
-				<td class="td" style="text-align:<?php echo $text_align; ?>; vertical-align: middle; border: 1px solid #eee;">
+				<td class="detail-value" style="text-align:<?php echo $text_align; ?>;">
 					<?php echo wp_kses_post( $field['value'] ); ?>
 				</td>
 			</tr>

--- a/templates/emails/email-job-details.php
+++ b/templates/emails/email-job-details.php
@@ -26,7 +26,13 @@ if ( ! empty( $fields ) ) : ?>
 					<?php echo wp_kses_post( $field['label'] ); ?>
 				</td>
 				<td class="detail-value" style="text-align:<?php echo $text_align; ?>;">
-					<?php echo wp_kses_post( $field['value'] ); ?>
+					<?php
+					if ( ! empty( $field['url'] ) ) {
+						echo sprintf( '<a href="%s">%s</a>', esc_url( $field['url'] ), wp_kses_post( $field['value'] ) );
+					} else {
+						echo wp_kses_post( $field['value'] );
+					}
+					?>
 				</td>
 			</tr>
 			<?php endforeach; ?>

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -57,7 +57,7 @@ a {
 	text-decoration: underline;
 }
 
-.job-manager-email-container {
+.email-container {
 	margin-bottom: 10px;
 }
 

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -38,7 +38,7 @@ $style_vars = apply_filters( 'job_manager_email_style_vars', $style_vars );
  *
  * @param array $style_vars Variables used in style generation.
  */
-do_action( 'job_manager_email_style_pre', $style_vars );
+do_action( 'job_manager_email_style_before', $style_vars );
 ?>
 
 #wrapper {
@@ -80,5 +80,5 @@ td.detail-label {
  *
  * @param array $style_vars Variables used in style generation.
  */
-do_action( 'job_manager_email_style_post', $style_vars );
+do_action( 'job_manager_email_style_after', $style_vars );
 ?>

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -81,4 +81,3 @@ td.detail-label {
  * @param array $style_vars Variables used in style generation.
  */
 do_action( 'job_manager_email_style_after', $style_vars );
-?>

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -15,24 +15,70 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-$color_bg       = apply_filters( 'job_manager_email_style_background_color', '#fff');
-$color_fg       = apply_filters( 'job_manager_email_style_foreground_color', '#000');
-$color_link     = apply_filters( 'job_manager_email_style_link_color', '#036fa9');
-$font_family    = apply_filters( 'job_manager_email_style_font_family', '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif' );
+$style_vars                   = array();
+$style_vars['color_bg']       = '#fff';
+$style_vars['color_fg']       = '#000';
+$style_vars['color_light']    = '#eee';
+$style_vars['color_link']     = '#036fa9';
+$style_vars['font_family']    = '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif';
+
+/**
+ * Change the style vars used in email generation stylesheet.
+ *
+ * @since 1.31.0
+ *
+ * @param array $style_vars  Variables used in style generation.
+ */
+$style_vars = apply_filters( 'job_manager_email_style_vars', $style_vars );
+
+/**
+ * Inject styles before the core styles.
+ *
+ * @since 1.31.0
+ *
+ * @param array $style_vars Variables used in style generation.
+ */
+do_action( 'job_manager_email_style_pre', $style_vars );
 ?>
 
 #wrapper {
-	background-color: <?php echo esc_attr( $color_bg ); ?>;
-	color: <?php echo esc_attr( $color_fg ); ?>;
+	background-color: <?php echo esc_attr( $style_vars['color_bg'] ); ?>;
+	color: <?php echo esc_attr( $style_vars['color_fg'] ); ?>;
 	margin: 0;
 	padding: 70px 0 70px 0;
 	-webkit-text-size-adjust: none !important;
 	width: 100%;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo esc_attr( $style_vars['font_family'] ); ?>;
 }
 
 a {
-	color: <?php echo esc_attr( $color_link ); ?>;
+	color: <?php echo esc_attr( $style_vars['color_link'] ); ?>;
 	font-weight: normal;
 	text-decoration: underline;
 }
+
+.job-manager-email-container {
+	margin-bottom: 10px;
+}
+
+td.detail-label,
+td.detail-value {
+	vertical-align: middle;
+	border: 1px solid  <?php echo esc_attr( $style_vars['color_light'] ); ?>;
+}
+
+td.detail-label {
+	word-wrap: break-word;
+	width: 40%;
+}
+
+<?php
+/**
+ * Inject styles after the core styles.
+ *
+ * @since 1.31.0
+ *
+ * @param array $style_vars Variables used in style generation.
+ */
+do_action( 'job_manager_email_style_post', $style_vars );
+?>

--- a/templates/emails/plain/admin-notice-new-listing.php
+++ b/templates/emails/plain/admin-notice-new-listing.php
@@ -18,9 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @var WP_Post $job
  */
 $job = $args['job'];
-?>
-<?php
-printf( __( 'A new job listing has been submitted titled "%s".', 'wp-job-manager' ), esc_html( $job->post_title ) );
+
+printf( __( 'A new job listing has been submitted to %s (%s).', 'wp-job-manager' ), get_bloginfo( 'name' ), home_url() );
 switch ( $job->post_status ) {
 	case 'publish':
 		printf( ' ' . __( 'It has been published and is now available to the public.', 'wp-job-manager' ) );

--- a/templates/emails/plain/email-job-details.php
+++ b/templates/emails/plain/email-job-details.php
@@ -19,6 +19,10 @@ echo "\n\n";
 
 if ( ! empty( $fields ) ) {
 	foreach ( $fields as $field ) {
-		echo strip_tags( $field[ 'label' ] )  .': '. strip_tags( $field[ 'value' ] ) . "\n";
+		echo strip_tags( $field[ 'label' ] )  .': '. strip_tags( $field[ 'value' ] );
+		if ( ! empty( $field['url'] ) ) {
+			echo ' (' . esc_url( $field['url'] ) . ')';
+		}
+		echo "\n";
 	}
 }

--- a/templates/emails/plain/email-job-details.php
+++ b/templates/emails/plain/email-job-details.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Email content for showing job details.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/plain/email-job-details.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+echo "\n\n";
+
+if ( ! empty( $fields ) ) {
+	foreach ( $fields as $field ) {
+		echo strip_tags( $field[ 'label' ] )  .': '. strip_tags( $field[ 'value' ] ) . "\n";
+	}
+}

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -601,6 +601,60 @@ function wpjm_get_the_job_types( $post = null ) {
 }
 
 /**
+ * Displays job categories for the listing.
+ *
+ * @since 1.31.0
+ *
+ * @param int|WP_Post $post      Current post object.
+ * @param string      $separator String to join the term names with.
+ */
+function wpjm_the_job_categories( $post = null, $separator = ', ' ) {
+	if ( ! get_option( 'job_manager_enable_categories' ) ) {
+		return;
+	}
+
+	$job_categories = wpjm_get_the_job_categories( $post );
+
+	if ( $job_categories ) {
+		$names = wp_list_pluck( $job_categories, 'name' );
+
+		echo esc_html( implode( $separator, $names ) );
+	}
+}
+
+/**
+ * Gets the job type for the listing.
+ *
+ * @since 1.31.0
+ *
+ * @param int|WP_Post $post (default: null).
+ * @return bool|array
+ */
+function wpjm_get_the_job_categories( $post = null ) {
+	$post = get_post( $post );
+
+	if ( ! $post || 'job_listing' !== $post->post_type ) {
+		return false;
+	}
+
+	$categories = get_the_terms( $post->ID, 'job_listing_category' );
+
+	if ( empty( $categories ) || is_wp_error( $categories ) ) {
+		$categories = array();
+	}
+
+	/**
+	 * Filter the returned job categories for a post.
+	 *
+	 * @since 1.31.0
+	 *
+	 * @param array   $types
+	 * @param WP_Post $post
+	 */
+	return apply_filters( 'wpjm_the_job_categories', $categories, $post );
+}
+
+/**
  * Returns the registration fields used when an account is required.
  *
  * @since 1.27.0


### PR DESCRIPTION
Fixes #672
Builds off of #1422

#### Changes proposed in this Pull Request:

* Adds basic job details to email notifications. I chose just a few of the fields to put in for now, but we can add more later if desired.

<img width="588" alt="screen shot 2018-04-12 at 11 09 51 am" src="https://user-images.githubusercontent.com/68693/38671003-346fb7bc-3e42-11e8-954d-446ae5d877d5.png">

* Refactored a bit of what I just did in #1436 to ease future complexity with filters and hooks (cdde24fe676d9edd06510ebf9864cb9df315bd52).

* Uses new stylesheet functionality from #1436.

* Cleans up new job listing email notification.

* Adds `wpjm_get_the_job_categories()` and `wpjm_the_job_categories ()` in support of this objective.


#### Testing instructions:

* Ensure all tests pass.
* Submit a job listing using the `[submit_job_form]` shortcode and verify the admin gets an email with the correct job details.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
