### PR TITLE
Add setting to control whether data should be deleted

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -102,7 +102,7 @@ class WP_Job_Manager_Settings {
 						array(
 							'name'       => 'job_manager_delete_data_on_uninstall',
 							'std'        => '0',
-							'label'      => __( 'Delete data on uninstall', 'wp-job-manager' ),
+							'label'      => __( 'Delete Data On Uninstall', 'wp-job-manager' ),
 							'cb_label'   => __( 'Delete WP Job Manager data when the plugin is deleted. Once removed, this data cannot be restored.', 'wp-job-manager' ),
 							'desc'       => '',
 							'type'       => 'checkbox',

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -99,6 +99,15 @@ class WP_Job_Manager_Settings {
 							'desc'       => sprintf( __( 'Google requires an API key to retrieve location information for job listings. Acquire an API key from the <a href="%s">Google Maps API developer site</a>.', 'wp-job-manager' ), 'https://developers.google.com/maps/documentation/geocoding/get-api-key' ),
 							'attributes' => array()
 						),
+						array(
+							'name'       => 'job_manager_delete_data_on_uninstall',
+							'std'        => '0',
+							'label'      => __( 'Delete data on uninstall', 'wp-job-manager' ),
+							'cb_label'   => __( 'Delete WP Job Manager data when the plugin is deleted. Once removed, this data cannot be restored.', 'wp-job-manager' ),
+							'desc'       => '',
+							'type'       => 'checkbox',
+							'attributes' => array()
+						),
 					),
 				),
 				'job_listings' => array(

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -80,6 +80,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_jobs_page_id',
 		'job_manager_submit_page_slug',
 		'job_manager_job_dashboard_page_slug',
+		'job_manager_delete_data_on_uninstall',
 	);
 
 	/**

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -123,7 +123,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			'std'      => '0',
 			'type'     => 'checkbox',
 			'desc'     => '',
-			'label'    => __( 'Enable usage tracking', 'wp-job-manager' ),
+			'label'    => __( 'Enable Usage Tracking', 'wp-job-manager' ),
 			'cb_label' => $this->opt_in_checkbox_text(),
 		);
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,7 +7,12 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 require 'includes/class-wp-job-manager-data-cleaner.php';
 
 if ( ! is_multisite() ) {
-	WP_Job_Manager_Data_Cleaner::cleanup_all();
+
+	// Only do deletion if the setting is true.
+	$do_deletion = get_option( 'job_manager_delete_data_on_uninstall' );
+	if ( $do_deletion ) {
+		WP_Job_Manager_Data_Cleaner::cleanup_all();
+	}
 } else {
 	global $wpdb;
 
@@ -16,7 +21,12 @@ if ( ! is_multisite() ) {
 
 	foreach ( $blog_ids as $blog_id ) {
 		switch_to_blog( $blog_id );
-		WP_Job_Manager_Data_Cleaner::cleanup_all();
+
+		// Only do deletion if the setting is true.
+		$do_deletion = get_option( 'job_manager_delete_data_on_uninstall' );
+		if ( $do_deletion ) {
+			WP_Job_Manager_Data_Cleaner::cleanup_all();
+		}
 	}
 
 	switch_to_blog( $original_blog_id );


### PR DESCRIPTION
Contributes to #1362

Adds a setting (unchecked by default) so a user may specify whether the plugin data should be deleted when the plugin is deleted.

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure the Job Manager setting "Delete data on uninstall" is unchecked and saved.

- Delete and then reinstall the WPJM plugin.

- Verify that the plugin data is still intact.

- Now, check the checkbox for "Delete data on uninstall" and save.

- Delete and then reinstall the WPJM plugin.

- Verify that the plugin data has been deleted/trashed (including the new setting).

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the WPJM data should only be removed from the sites with the setting checked.