### PR TITLE
Notify administrator when employer updates job listing

### DIFF
--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -42,6 +42,7 @@ final class WP_Job_Manager_Email_Notifications {
 	private static function core_email_notifications() {
 		return array(
 			'WP_Job_Manager_Email_Admin_New_Job',
+			'WP_Job_Manager_Email_Admin_Updated_Job',
 		);
 	}
 
@@ -101,6 +102,8 @@ final class WP_Job_Manager_Email_Notifications {
 		add_action( 'shutdown', array( __CLASS__, '_send_deferred_notifications' ) );
 
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-new-job.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-updated-job.php';
+
 		if ( ! class_exists( 'Emogrifier' ) && class_exists( 'DOMDocument' ) ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/lib/emogrifier/class-emogrifier.php';
 		}

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -39,7 +39,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 *
 	 * @return array
 	 */
-	private static function core_email_notifications() {
+	public static function core_email_notifications() {
 		return array(
 			'WP_Job_Manager_Email_Admin_New_Job',
 			'WP_Job_Manager_Email_Admin_Updated_Job',

--- a/includes/emails/class-wp-job-manager-email-admin-updated-job.php
+++ b/includes/emails/class-wp-job-manager-email-admin-updated-job.php
@@ -1,0 +1,99 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Email notification to administrator when a job is updated.
+ *
+ * @package wp-job-manager
+ * @since 1.31.0
+ * @extends WP_Job_Manager_Email
+ */
+class WP_Job_Manager_Email_Admin_Updated_Job extends WP_Job_Manager_Email_Template {
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return 'admin-notice-updated-listing';
+	}
+
+	/**
+	 * Get the friendly name for this email notification.
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return __( 'Admin Notice of Updated Listing', 'wp-job-manager' );
+	}
+
+	/**
+	 * Expand arguments as necessary for the generation of the email.
+	 *
+	 * @param $args
+	 * @return mixed
+	 */
+	protected function prepare_args( $args ) {
+		if ( isset( $args['job_id'] ) ) {
+			$job = get_post( $args['job_id'] );
+			if ( $job instanceof WP_Post ) {
+				$args['job'] = $job;
+			}
+		}
+		if ( ! empty( $args['user_id'] ) ) {
+			$user = get_user_by( 'ID', $args['user_id'] );
+			if ( $user instanceof WP_User ) {
+				$args['user'] = $user;
+			}
+		}
+		return parent::prepare_args( $args );
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		$args = $this->get_args();
+
+		/**
+		 * @var WP_Post $job
+		 */
+		$job = $args['job'];
+		return sprintf( __( 'Job Listing Updated: %s', 'wp-job-manager' ), $job->post_title );
+	}
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	public function get_from() {
+		return false;
+	}
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	public function get_to() {
+		return get_option( 'admin_email', false );
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		$args = $this->get_args();
+		return isset( $args['job'] )
+				&& $args['job'] instanceof WP_Post
+				&& $this->get_to();
+	}
+}

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -173,6 +173,8 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 			$save_message = __( 'Your changes have been saved.', 'wp-job-manager' );
 			$post_status = get_post_status( $this->job_id );
 
+			do_action( 'job_manager_send_notification', 'admin-notice-updated-listing', array( 'job_id' => $this->job_id, 'user_id' => get_current_user_id() ) );
+
 			update_post_meta( $this->job_id, '_job_edited', time() );
 
 			if ( 'publish' === $post_status ) {

--- a/templates/emails/admin-notice-updated-listing.php
+++ b/templates/emails/admin-notice-updated-listing.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Email content when notifying admin of an updated job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/admin-notice-updated-listing.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * @var WP_Post $job
+ */
+$job = $args['job'];
+?>
+	<p><?php
+		printf( __( 'A job listing has been updated on <a href="%s">%s</a>.', 'wp-job-manager' ), home_url(), get_bloginfo( 'name' ) );
+		switch ( $job->post_status ) {
+			case 'publish':
+				printf( ' ' . __( 'The changes have been published and are now available to the public.', 'wp-job-manager' ) );
+				break;
+			case 'pending':
+				printf( ' ' . __( 'The job listing is not publicly available until the changes are approved by an administrator in the site\'s <a href="%s">WordPress admin</a>.', 'wp-job-manager' ), esc_url( admin_url( 'edit.php?post_type=job_listing' ) ) );
+				break;
+		}
+		?></p>
+<?php
+
+/**
+ * Show details about the job listing.
+ *
+ * @param WP_Post              $job            The job listing to show details for.
+ * @param WP_Job_Manager_Email $email          Email object for the notification.
+ * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
+ * @param bool                 $plain_text     True if the email is being sent as plain text.
+ */
+do_action( 'job_manager_email_job_details', $job, $email, true, $plain_text );

--- a/templates/emails/plain/admin-notice-updated-listing.php
+++ b/templates/emails/plain/admin-notice-updated-listing.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Email content when notifying admin of an updated job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/admin-notice-new-listing.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+/**
+ * @var WP_Post $job
+ */
+$job = $args['job'];
+
+printf( __( 'A job listing has been updated on %s (%s).', 'wp-job-manager' ), get_bloginfo( 'name' ), home_url() );
+switch ( $job->post_status ) {
+	case 'publish':
+		printf( ' ' . __( 'The changes have been published and are now available to the public.', 'wp-job-manager' ) );
+		break;
+	case 'pending':
+		printf( ' ' . __( 'The job listing is not publicly available until the changes are approved by an administrator in the site\'s WordPress admin (%s).', 'wp-job-manager' ), esc_url( admin_url( 'edit.php?post_type=job_listing' ) ) );
+		break;
+}
+
+/**
+ * Show details about the job listing.
+ *
+ * @param WP_Post              $job            The job listing to show details for.
+ * @param WP_Job_Manager_Email $email          Email object for the notification.
+ * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
+ * @param bool                 $plain_text     True if the email is being sent as plain text.
+ */
+do_action( 'job_manager_email_job_details', $job, $email, true, $plain_text );

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -124,10 +124,11 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 */
 	public function test_get_email_notifications() {
 		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
-		$core_email_notifications = array( 'admin-notice-new-listing' );
+		$core_email_notifications = WP_Job_Manager_Email_Notifications::core_email_notifications();
 		$this->assertEquals( count( $core_email_notifications ), count( $emails ) );
 
-		foreach ( $core_email_notifications as $email_notification_key ) {
+		foreach ( $core_email_notifications as $email_notification_class ) {
+			$email_notification_key = call_user_func( array( $email_notification_class, 'get_key' ) );
 			$this->assertArrayHasKey( $email_notification_key, $emails );
 			$this->assertValidEmailNotificationConfig( $emails[ $email_notification_key ] );
 		}


### PR DESCRIPTION
Fixes #1437 
Based from #1434 (~must be merged first~ -- rebased)

#### Changes proposed in this Pull Request:

* Sends a new notification when a job is updated by an employer.

#### Testing instructions:

* Update a job from the `[job_dashboard]` shortcode and verify the admin is sent a notice.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Notify site administrators when a job has been updated by an employer. 