### PR TITLE
Pre-fill widget instance array with defaults

### DIFF
--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -183,6 +183,24 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Gets the instance with the default values for all settings.
+	 *
+	 * @return array
+	 */
+	protected function get_default_instance() {
+		$defaults = array();
+		if ( ! empty( $this->settings ) ) {
+			foreach ( $this->settings as $key => $setting ) {
+				$defaults[ $key ] = null;
+				if ( isset( $setting['std'] ) ) {
+					$defaults[ $key ] = $setting['std'];
+				}
+			}
+		}
+		return $defaults;
+	}
+
+	/**
 	 * Echoes the widget content.
 	 *
 	 * @see    WP_Widget

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -73,13 +73,15 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 			return;
 		}
 
+		$instance = array_merge( $this->get_default_instance(), $instance );
+
 		ob_start();
 
 		extract( $args );
-		$titleInstance = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-		$number  = isset( $instance['number'] ) ? absint( $instance['number'] ) : '';
-		$orderby = isset( $instance['orderby'] ) ? esc_attr( $instance['orderby'] ) : 'date';
-		$order   = isset( $instance['order'] ) ? esc_attr( $instance['order'] ) : 'DESC';
+		$titleInstance = esc_attr( $instance['title'] );
+		$number  = absint( $instance['number'] );
+		$orderby = esc_attr( $instance['orderby'] );
+		$order   = esc_attr( $instance['order'] );
 		$title   = apply_filters( 'widget_title', $titleInstance, $instance, $this->id_base );
 		$jobs    = get_job_listings( array(
 			'posts_per_page' => $number,

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -63,6 +63,8 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 			return;
 		}
 
+		$instance = array_merge( $this->get_default_instance(), $instance );
+
 		ob_start();
 
 		extract( $args );
@@ -70,8 +72,8 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 		$title  = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 		$number = absint( $instance['number'] );
 		$jobs   = get_job_listings( array(
-			'search_location'   => isset( $instance['location'] ) ? $instance['location'] : '',
-			'search_keywords'   => isset( $instance['keyword'] ) ? $instance['keyword'] : '',
+			'search_location'   => $instance['location'],
+			'search_keywords'   => $instance['keyword'],
 			'posts_per_page'    => $number,
 			'orderby'           => 'date',
 			'order'             => 'DESC',


### PR DESCRIPTION
Fixes #1444

#### Changes proposed in this Pull Request:

* For widget instances, merge the passed instance array with the defaults for the widget.

#### Testing instructions:

* Ensure `define( 'WP_DEBUG', true );` and `define( 'WP_DEBUG_LOG', true );` are in your `wp-config.php`.
* Create both featured and non-featured listings.
* Add both WPJM widgets from the Customizer but don't save any values.
* Load a page with those widgets.
* Verify no errors from the widget files are entered into `debug.log`.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fix: Issue with errors appearing when widgets were added from Customizer.