### PR TITLE
Add functionality for filtering job listings on Filled and Featured in WP Admin

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -322,15 +322,15 @@ class WP_Job_Manager_CPT {
 		$this->jobs_filter_dropdown( 'job_listing_filled', array(
 			array(
 				'value' => '',
-				'text'  => 'Select Filled',
+				'text'  => __( 'Select Filled', 'wp-job-manager' ),
 			),
 			array(
 				'value' => '1',
-				'text'  => 'Filled',
+				'text'  => __( 'Filled', 'wp-job-manager' ),
 			),
 			array(
 				'value' => '0',
-				'text'  => 'Not Filled',
+				'text'  => __( 'Not Filled', 'wp-job-manager' ),
 			),
 		) );
 
@@ -338,15 +338,15 @@ class WP_Job_Manager_CPT {
 		$this->jobs_filter_dropdown( 'job_listing_featured', array(
 			array(
 				'value' => '',
-				'text'  => 'Select Featured',
+				'text'  => __( 'Select Featured', 'wp-job-manager' ),
 			),
 			array(
 				'value' => '1',
-				'text'  => 'Featured',
+				'text'  => __( 'Featured', 'wp-job-manager' ),
 			),
 			array(
 				'value' => '0',
-				'text'  => 'Not Featured',
+				'text'  => __( 'Not Featured', 'wp-job-manager' ),
 			),
 		) );
 	}

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -44,6 +44,7 @@ class WP_Job_Manager_CPT {
 		add_filter( 'manage_edit-job_listing_sortable_columns', array( $this, 'sortable_columns' ) );
 		add_filter( 'request', array( $this, 'sort_columns' ) );
 		add_action( 'parse_query', array( $this, 'search_meta' ) );
+		add_action( 'parse_query', array( $this, 'filter_meta' ) );
 		add_filter( 'get_search_query', array( $this, 'search_meta_label' ) );
 		add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
 		add_action( 'bulk_actions-edit-job_listing', array( $this, 'add_bulk_actions' ) );
@@ -55,6 +56,7 @@ class WP_Job_Manager_CPT {
 		if ( get_option( 'job_manager_enable_categories' ) ) {
 			add_action( "restrict_manage_posts", array( $this, "jobs_by_category" ) );
 		}
+		add_action( "restrict_manage_posts", array( $this, "jobs_meta_filters" ) );
 
 		foreach ( array( 'post', 'post-new' ) as $hook ) {
 			add_action( "admin_footer-{$hook}.php", array( $this,'extend_submitdiv_post_status' ) );
@@ -299,6 +301,84 @@ class WP_Job_Manager_CPT {
 		$output .= '<option value="" ' . selected( isset( $_GET['job_listing_category'] ) ? $_GET['job_listing_category'] : '', '', false ) . '>' . __( 'Select category', 'wp-job-manager' ) . '</option>';
 		$output .= $walker->walk( $terms, 0, $r );
 		$output .= "</select>";
+
+		echo $output;
+	}
+
+	/**
+	 * Output dropdowns for filters based on post meta.
+	 *
+	 * @since 1.31.0
+	 */
+	public function jobs_meta_filters() {
+		global $typenow;
+
+		// Only add the filters for job_listings
+		if ( 'job_listing' !== $typenow  ) {
+			return;
+		}
+
+		// Filter by Filled.
+		$this->jobs_filter_dropdown( 'job_listing_filled', array(
+			array(
+				'value' => '',
+				'text'  => 'Select Filled',
+			),
+			array(
+				'value' => '1',
+				'text'  => 'Filled',
+			),
+			array(
+				'value' => '0',
+				'text'  => 'Not Filled',
+			),
+		) );
+
+		// Filter by Featured.
+		$this->jobs_filter_dropdown( 'job_listing_featured', array(
+			array(
+				'value' => '',
+				'text'  => 'Select Featured',
+			),
+			array(
+				'value' => '1',
+				'text'  => 'Featured',
+			),
+			array(
+				'value' => '0',
+				'text'  => 'Not Featured',
+			),
+		) );
+	}
+
+	/**
+	 * Shows dropdown to filter by the given URL parameter. The dropdown will
+	 * have three options: "Select $name", "$name", and "Not $name".
+	 *
+	 * The $options element should be an array of arrays, each with the
+	 * attributes needed to create an <option> HTML element. The attributes are
+	 * as follows:
+	 *
+	 * $options[i]['value']  The value for the <option> HTML element.
+	 * $options[i]['text']   The text for the <option> HTML element.
+	 *
+	 * @since 1.31.0
+	 *
+	 * @param string $param        The URL parameter.
+	 * @param array  $options      The options for the dropdown. See the
+	 *                             description above.
+	 */
+	private function jobs_filter_dropdown( $param, $options ) {
+		$selected = isset( $_GET[ $param ] ) ? $_GET[ $param ] : '';
+
+		$output = "<select name=\"$param\" id=\"dropdown_$param\">";
+
+		foreach ( $options as $option ) {
+			$output .= '<option value="' . esc_attr( $option['value'] ) . '"'
+				. ( $selected === $option['value'] ? ' selected' : '' )
+				. '>' . esc_html( $option['text'] ) . '</option>';
+		}
+		$output .= '</select>';
 
 		echo $output;
 	}
@@ -595,6 +675,45 @@ class WP_Job_Manager_CPT {
 		unset( $wp->query_vars['s'] );
 		$wp->query_vars['job_listing_search'] = true;
 		$wp->query_vars['post__in'] = $post_ids;
+	}
+
+	/**
+	 * Filters by meta fields.
+	 *
+	 * @param WP_Query $wp
+	 */
+	public function filter_meta( $wp ) {
+		global $pagenow;
+
+		if ( 'edit.php' !== $pagenow || 'job_listing' !== $wp->query_vars['post_type'] ) {
+			return;
+		}
+
+		$meta_query = $wp->get( 'meta_query' );
+		if ( ! is_array( $meta_query ) ) {
+			$meta_query = array();
+		}
+
+		// Filter on _filled meta.
+		if ( isset( $_GET['job_listing_filled'] ) && '' !== $_GET['job_listing_filled'] ) {
+			$meta_query[] = array(
+				'key' => '_filled',
+				'value' => $_GET['job_listing_filled'],
+			);
+		}
+
+		// Filter on _featured meta.
+		if ( isset( $_GET['job_listing_featured'] ) && '' !== $_GET['job_listing_featured'] ) {
+			$meta_query[] = array(
+				'key' => '_featured',
+				'value' => $_GET['job_listing_featured'],
+			);
+		}
+
+		// Set new meta query.
+		if ( ! empty( $meta_query ) ) {
+			$wp->set( 'meta_query', $meta_query );
+		}
 	}
 
 	/**

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
@@ -1,0 +1,103 @@
+<?php
+
+require 'includes/admin/class-wp-job-manager-cpt.php';
+
+class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
+	public function setUp() {
+		parent::setUp();
+
+		// Ensure the hooks are set up.
+		$this->job_manager_cpt = new WP_Job_Manager_CPT();
+	}
+
+	/**
+	 * Ensure that filter_meta adds the correct filters to the query based on
+	 * the URL parameters.
+	 *
+	 * @since 1.31.0
+	 * @covers WP_Job_Manager_CPT::filter_meta
+	 */
+	public function test_filter_meta() {
+		global $pagenow;
+
+		// Create some listings.
+		$listing_notfilled_notfeatured_id = $this->create_listing_with_meta(
+			array( '_filled' => '0', '_featured' => '0' )
+		);
+		$listing_notfilled_featured_id    = $this->create_listing_with_meta(
+			array( '_filled' => '0', '_featured' => '1' )
+		);
+		$listing_filled_notfeatured_id    = $this->create_listing_with_meta(
+			array( '_filled' => '1', '_featured' => '0' )
+		);
+		$listing_filled_featured_id       = $this->create_listing_with_meta(
+			array( '_filled' => '1', '_featured' => '1' )
+		);
+
+		// Simulate viewing the edit.php page.
+		$pagenow = 'edit.php';
+
+		// When no filters are given.
+		$query = new WP_Query( array( 'post_type' => 'job_listing', 'fields' => 'ids' ) );
+		$this->assertContains( $listing_notfilled_notfeatured_id, $query->posts );
+		$this->assertContains( $listing_notfilled_featured_id, $query->posts );
+		$this->assertContains( $listing_filled_notfeatured_id, $query->posts );
+		$this->assertContains( $listing_filled_featured_id, $query->posts );
+
+		// Filtering on Filled.
+		$_GET['job_listing_filled'] = '1';
+		$query = new WP_Query( array( 'post_type' => 'job_listing', 'fields' => 'ids' ) );
+		$this->assertNotContains( $listing_notfilled_notfeatured_id, $query->posts );
+		$this->assertNotContains( $listing_notfilled_featured_id, $query->posts );
+		$this->assertContains( $listing_filled_notfeatured_id, $query->posts );
+		$this->assertContains( $listing_filled_featured_id, $query->posts );
+
+		// Filtering on Featured.
+		$_GET['job_listing_filled']   = '';
+		$_GET['job_listing_featured'] = '0';
+		$query = new WP_Query( array( 'post_type' => 'job_listing', 'fields' => 'ids' ) );
+		$this->assertContains( $listing_notfilled_notfeatured_id, $query->posts );
+		$this->assertNotContains( $listing_notfilled_featured_id, $query->posts );
+		$this->assertContains( $listing_filled_notfeatured_id, $query->posts );
+		$this->assertNotContains( $listing_filled_featured_id, $query->posts );
+	}
+
+	/**
+	 * Ensure that filter_meta adds the correct filters to the query only on
+	 * edit.php page.
+	 *
+	 * @since 1.31.0
+	 * @covers WP_Job_Manager_CPT::filter_meta
+	 */
+	public function test_filter_meta_only_on_edit() {
+		global $pagenow;
+
+		// Create some listings.
+		$listing_id = $this->factory->post->create(
+			array( 'post_type' => 'job_listing' )
+		);
+
+		// Simulate viewing some other page.
+		$pagenow = 'index.php';
+
+		// Filter should do nothing
+		$_GET['job_listing_filled']   = '1';
+		$_GET['job_listing_featured'] = '1';
+		$query = new WP_Query( array( 'post_type' => 'job_listing', 'fields' => 'ids' ) );
+		$this->assertContains( $listing_id, $query->posts );
+	}
+
+	/* Helper methods. */
+
+	private function create_listing_with_meta( $meta ) {
+		$id = $this->factory->post->create(
+			array( 'post_type' => 'job_listing' )
+		);
+
+		foreach ( $meta as $meta_key => $meta_value ) {
+			update_post_meta( $id, $meta_key, $meta_value );
+		}
+
+		return $id;
+	}
+}


### PR DESCRIPTION
Fixes #980 

#### Changes proposed in this Pull Request:

* Adds filter dropdowns to the Job Listings page in WP Admin for Filled and Featured jobs.

#### Testing instructions:

* Go to the Job Listings page in WP Admin.
* Choose values from the new dropdowns at the top of the table. Their initial values will be "Select Filled" and "Select Featured".
* Press "Filter".
* When the page reloads, the visible job listings should be filtered based on the values of the dropdowns.
* The dropdowns should retain their selected values.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Add filters in WP Admin for Filled and Featured jobs.