### PR TITLE
Send notice to employers of expiring job listings

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -122,7 +122,7 @@ abstract class WP_Job_Manager_Email {
 				$args['job'] = $job;
 			}
 		}
-		if ( $args['job'] instanceof WP_Post ) {
+		if ( isset( $args['job'] ) && $args['job'] instanceof WP_Post ) {
 			$author = get_user_by( 'ID', $args['job']->post_author );
 			if ( $author instanceof WP_User ) {
 				$args['author'] = $author;

--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -116,6 +116,19 @@ abstract class WP_Job_Manager_Email {
 	 * @return mixed
 	 */
 	protected function prepare_args( $args ) {
+		if ( isset( $args['job_id'] ) ) {
+			$job = get_post( $args['job_id'] );
+			if ( $job instanceof WP_Post ) {
+				$args['job'] = $job;
+			}
+		}
+		if ( $args['job'] instanceof WP_Post ) {
+			$author = get_user_by( 'ID', $args['job']->post_author );
+			if ( $author instanceof WP_User ) {
+				$args['author'] = $author;
+			}
+		}
+
 		return $args;
 	}
 

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -651,8 +651,9 @@ class WP_Job_Manager_Settings {
 	 * @param string $placeholder
 	 */
 	protected function input_number( $option, $attributes, $value, $placeholder ) {
-		?><input id="setting-<?php echo $option['name']; ?>" class="regular-text" type="number" name="<?php echo $option['name']; ?>" value="<?php echo esc_attr( $value ); ?>" <?php echo implode( ' ', $attributes ); ?> <?php echo $placeholder; ?> /><?php
-
+		echo isset( $option['before'] ) ? $option['before'] : '';
+		?><input id="setting-<?php echo $option['name']; ?>" class="small-text" type="number" name="<?php echo $option['name']; ?>" value="<?php echo esc_attr( $value ); ?>" <?php echo implode( ' ', $attributes ); ?> <?php echo $placeholder; ?> /><?php
+		echo isset( $option['after'] ) ? $option['after'] : '';
 		if ( ! empty( $option['desc'] ) ) {
 			echo ' <p class="description">' . $option['desc'] . '</p>';
 		}

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -432,6 +432,8 @@ final class WP_Job_Manager_Email_Notifications {
 	 * Sending notices to employers for expiring job listings.
 	 */
 	public static function send_employer_expiring_notice() {
+		self::maybe_init();
+
 		$email_key   = call_user_func( array( 'WP_Job_Manager_Email_Employer_Expiring_Job', 'get_key' ) );
 		if ( ! self::is_email_notification_enabled( $email_key ) ) {
 			return;

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -274,6 +274,15 @@ final class WP_Job_Manager_Email_Notifications {
 			);
 		}
 
+		$job_expires = get_post_meta( $job->ID, '_job_expires', true );
+		if ( ! empty( $job_expires ) ) {
+			$job_expires_str = date_i18n( get_option( 'date_format' ), strtotime( $job_expires ) );
+			$fields['job_expires'] = array(
+				'label' => __( 'Listing expires', 'wp-job-manager' ),
+				'value' => $job_expires_str,
+			);
+		}
+
 		if ( $sent_to_admin ) {
 			$author = get_user_by( 'ID', $job->post_author );
 			if ( $author instanceof WP_User ) {

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -434,7 +434,7 @@ final class WP_Job_Manager_Email_Notifications {
 	public static function send_employer_expiring_notice() {
 		self::maybe_init();
 
-		$email_key   = call_user_func( array( 'WP_Job_Manager_Email_Employer_Expiring_Job', 'get_key' ) );
+		$email_key   = WP_Job_Manager_Email_Employer_Expiring_Job::get_key();
 		if ( ! self::is_email_notification_enabled( $email_key ) ) {
 			return;
 		}

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -31,6 +31,7 @@ final class WP_Job_Manager_Email_Notifications {
 		add_action( 'job_manager_email_job_details', array( __CLASS__, 'output_job_details'), 10, 4 );
 		add_action( 'job_manager_email_header', array( __CLASS__, 'output_header' ), 10, 3 );
 		add_action( 'job_manager_email_footer', array( __CLASS__, 'output_footer' ), 10, 3 );
+		add_action( 'job_manager_email_daily_notices', array( __CLASS__, 'send_employer_expiring_notice' ) );
 		add_filter( 'job_manager_settings', array( __CLASS__, 'add_email_settings' ), 1 );
 	}
 
@@ -43,6 +44,7 @@ final class WP_Job_Manager_Email_Notifications {
 		return array(
 			'WP_Job_Manager_Email_Admin_New_Job',
 			'WP_Job_Manager_Email_Admin_Updated_Job',
+			'WP_Job_Manager_Email_Employer_Expiring_Job',
 		);
 	}
 
@@ -110,6 +112,7 @@ final class WP_Job_Manager_Email_Notifications {
 
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-new-job.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-updated-job.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-employer-expiring-job.php';
 
 		if ( ! class_exists( 'Emogrifier' ) && class_exists( 'DOMDocument' ) ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/lib/emogrifier/class-emogrifier.php';
@@ -423,6 +426,46 @@ final class WP_Job_Manager_Email_Notifications {
 		 * @param string $email_notification_key
 		 */
 		return apply_filters( 'job_manager_email_send_as_plain_text', $send_as_plain_text, $email_notification_key );
+	}
+
+	/**
+	 * Sending notices to employers for expiring job listings.
+	 */
+	public static function send_employer_expiring_notice() {
+		$email_key   = call_user_func( array( 'WP_Job_Manager_Email_Employer_Expiring_Job', 'get_key' ) );
+		if ( ! self::is_email_notification_enabled( $email_key ) ) {
+			return;
+		}
+		$settings    = self::get_email_settings( $email_key );
+		$days_notice = WP_Job_Manager_Email_Employer_Expiring_Job::get_notice_period( $settings );
+		self::send_expiring_notice( $email_key, $days_notice );
+	}
+
+	/**
+	 * Send notice based on job expiration date.
+	 *
+	 * @param string $email_notification_key
+	 * @param int    $days_notice
+	 */
+	private static function send_expiring_notice( $email_notification_key, $days_notice ) {
+		global $wpdb;
+
+		$notice_before_ts = current_time( 'timestamp' ) + ( DAY_IN_SECONDS * $days_notice );
+		$job_ids_sql      = $wpdb->prepare( "
+			SELECT postmeta.post_id FROM {$wpdb->postmeta} as postmeta
+			LEFT JOIN {$wpdb->posts} as posts ON postmeta.post_id = posts.ID
+			WHERE postmeta.meta_key = '_job_expires'
+			AND postmeta.meta_value = %s
+			AND posts.post_status = 'publish'
+			AND posts.post_type = 'job_listing'
+		", date( 'Y-m-d', $notice_before_ts ) );
+		$job_ids = $wpdb->get_col( $job_ids_sql );
+
+		if ( $job_ids ) {
+			foreach ( $job_ids as $job_id ) {
+				do_action( 'job_manager_send_notification', $email_notification_key, array( 'job_id' => $job_id ) );
+			}
+		}
 	}
 
 	/**

--- a/includes/emails/class-wp-job-manager-email-admin-new-job.php
+++ b/includes/emails/class-wp-job-manager-email-admin-new-job.php
@@ -41,28 +41,6 @@ class WP_Job_Manager_Email_Admin_New_Job extends WP_Job_Manager_Email_Template {
 	}
 
 	/**
-	 * Expand arguments as necessary for the generation of the email.
-	 *
-	 * @param $args
-	 * @return mixed
-	 */
-	protected function prepare_args( $args ) {
-		if ( isset( $args['job_id'] ) ) {
-			$job = get_post( $args['job_id'] );
-			if ( $job instanceof WP_Post ) {
-				$args['job'] = $job;
-			}
-		}
-		if ( ! empty( $args['user_id'] ) ) {
-			$user = get_user_by( 'ID', $args['user_id'] );
-			if ( $user instanceof WP_User ) {
-				$args['user'] = $user;
-			}
-		}
-		return parent::prepare_args( $args );
-	}
-
-	/**
 	 * Get the email subject.
 	 *
 	 * @return string

--- a/includes/emails/class-wp-job-manager-email-admin-updated-job.php
+++ b/includes/emails/class-wp-job-manager-email-admin-updated-job.php
@@ -41,28 +41,6 @@ class WP_Job_Manager_Email_Admin_Updated_Job extends WP_Job_Manager_Email_Templa
 	}
 
 	/**
-	 * Expand arguments as necessary for the generation of the email.
-	 *
-	 * @param $args
-	 * @return mixed
-	 */
-	protected function prepare_args( $args ) {
-		if ( isset( $args['job_id'] ) ) {
-			$job = get_post( $args['job_id'] );
-			if ( $job instanceof WP_Post ) {
-				$args['job'] = $job;
-			}
-		}
-		if ( ! empty( $args['user_id'] ) ) {
-			$user = get_user_by( 'ID', $args['user_id'] );
-			if ( $user instanceof WP_User ) {
-				$args['user'] = $user;
-			}
-		}
-		return parent::prepare_args( $args );
-	}
-
-	/**
 	 * Get the email subject.
 	 *
 	 * @return string

--- a/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
+++ b/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Email notification to employers when a job is updated.
+ * Email notification to employers when a job is expiring.
  *
  * @package wp-job-manager
  * @since 1.31.0
@@ -97,18 +97,9 @@ class WP_Job_Manager_Email_Employer_Expiring_Job extends WP_Job_Manager_Email_Te
 	 * @return mixed
 	 */
 	protected function prepare_args( $args ) {
-		if ( isset( $args['job_id'] ) ) {
-			$job = get_post( $args['job_id'] );
-			if ( $job instanceof WP_Post ) {
-				$args['job'] = $job;
-			}
-		}
-		if ( isset( $args['job'] ) ) {
-			$author = get_user_by( 'ID', $job->post_author );
-			if ( $author instanceof WP_User ) {
-				$args['author'] = $author;
-			}
+		$args = parent::prepare_args( $args );
 
+		if ( isset( $args['job'] ) ) {
 			$args['expiring_today'] = false;
 			$today         = date( 'Y-m-d', current_time( 'timestamp' ) );
 			$expiring_date = date( 'Y-m-d', strtotime( $args['job']->_job_expires ) );
@@ -116,7 +107,8 @@ class WP_Job_Manager_Email_Employer_Expiring_Job extends WP_Job_Manager_Email_Te
 				$args['expiring_today'] = true;
 			}
 		}
-		return parent::prepare_args( $args );
+
+		return $args;
 	}
 
 	/**
@@ -154,10 +146,10 @@ class WP_Job_Manager_Email_Employer_Expiring_Job extends WP_Job_Manager_Email_Te
 	public function is_valid() {
 		$args = $this->get_args();
 		return isset( $args['job'] )
-			   && $args['job'] instanceof WP_Post
-			   && isset( $args['author'] )
-			   && $args['author'] instanceof WP_User
-			   && ! empty( $args['author']->user_email );
+					&& $args['job'] instanceof WP_Post
+					&& isset( $args['author'] )
+					&& $args['author'] instanceof WP_User
+					&& ! empty( $args['author']->user_email );
 	}
 
 }

--- a/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
+++ b/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
@@ -1,0 +1,163 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Email notification to employers when a job is updated.
+ *
+ * @package wp-job-manager
+ * @since 1.31.0
+ * @extends WP_Job_Manager_Email
+ */
+class WP_Job_Manager_Email_Employer_Expiring_Job extends WP_Job_Manager_Email_Template {
+	const SETTING_NOTICE_PERIOD_NAME = 'notice_period_days';
+	const SETTING_NOTICE_PERIOD_DEFAULT = '1';
+
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return 'employer_expiring_job';
+	}
+
+	/**
+	 * Get the friendly name for this email notification.
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return __( 'Employer Notice of Expiring Job Listings', 'wp-job-manager' );
+	}
+
+	/**
+	 * Get the description for this email notification.
+	 *
+	 * @type abstract
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'Send notices to employers before a job listing expires.', 'wp-job-manager' );
+	}
+
+	/**
+	 * Get the notice period in days from the notification settings.
+	 *
+	 * @param array $settings
+	 * @return int
+	 */
+	public static function get_notice_period( $settings ) {
+		if ( isset( $settings[ self::SETTING_NOTICE_PERIOD_NAME ] ) ) {
+			return absint( $settings[ self::SETTING_NOTICE_PERIOD_NAME ] );
+		}
+		return absint( self::SETTING_NOTICE_PERIOD_DEFAULT );
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		$args = $this->get_args();
+
+		/**
+		 * @var WP_Post $job
+		 */
+		$job = $args['job'];
+		return sprintf( __( 'Job Listing Expiring: %s', 'wp-job-manager' ), $job->post_title );
+	}
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	public function get_from() {
+		return false;
+	}
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	public function get_to() {
+		$args = $this->get_args();
+		return $args['author']->user_email;
+	}
+
+	/**
+	 * Expand arguments as necessary for the generation of the email.
+	 *
+	 * @param $args
+	 * @return mixed
+	 */
+	protected function prepare_args( $args ) {
+		if ( isset( $args['job_id'] ) ) {
+			$job = get_post( $args['job_id'] );
+			if ( $job instanceof WP_Post ) {
+				$args['job'] = $job;
+			}
+		}
+		if ( isset( $args['job'] ) ) {
+			$author = get_user_by( 'ID', $job->post_author );
+			if ( $author instanceof WP_User ) {
+				$args['author'] = $author;
+			}
+
+			$args['expiring_today'] = false;
+			$today         = date( 'Y-m-d', current_time( 'timestamp' ) );
+			$expiring_date = date( 'Y-m-d', strtotime( $args['job']->_job_expires ) );
+			if ( ! empty( $args['job']->_job_expires ) && $today === $expiring_date ) {
+				$args['expiring_today'] = true;
+			}
+		}
+		return parent::prepare_args( $args );
+	}
+
+	/**
+	 * Get the settings for this email notifications.
+	 *
+	 * @return array
+	 */
+	public static function get_setting_fields() {
+		$fields = parent::get_setting_fields();
+		$fields[] = array(
+			'name'       => self::SETTING_NOTICE_PERIOD_NAME,
+			'std'        => self::SETTING_NOTICE_PERIOD_DEFAULT,
+			'label'      => __( 'Notice Period', 'wp-job-manager' ),
+			'type'       => 'number',
+			'after'      => ' ' . __( 'days', 'wp-job-manager' ),
+			'attributes' => array( 'min' => 0 ),
+		);
+		return $fields;
+	}
+
+	/**
+	 * Is this email notification enabled by default?
+	 *
+	 * @return bool
+	 */
+	public static function is_default_enabled() {
+		return false;
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		$args = $this->get_args();
+		return isset( $args['job'] )
+			   && $args['job'] instanceof WP_Post
+			   && isset( $args['author'] )
+			   && $args['author'] instanceof WP_User
+			   && ! empty( $args['author']->user_email );
+	}
+
+}

--- a/templates/emails/employer-expiring-job.php
+++ b/templates/emails/employer-expiring-job.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Email content when notifying employers of an expiring job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/employer-expiring-job.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * @var WP_Post $job
+ */
+$job = $args['job'];
+
+/**
+ * @var bool
+ */
+$expiring_today = $args['expiring_today'];
+
+echo '<p>';
+if ( $expiring_today ) {
+	printf( __( 'The following job listing is expiring today from <a href="%s">%s</a>.', 'wp-job-manager' ), home_url(), get_bloginfo( 'name' ) );
+} else {
+	printf( __( 'The following job listing is expiring soon from <a href="%s">%s</a>.', 'wp-job-manager' ), home_url(), get_bloginfo( 'name' ) );
+}
+printf( ' ' . __( 'Visit the <a href="%s">job listing dashboard</a> to manage the listing.', 'wp-job-manager' ), esc_url( job_manager_get_permalink( 'job_dashboard' ) ) );
+echo '</p>';
+
+/**
+ * Show details about the job listing.
+ *
+ * @param WP_Post              $job            The job listing to show details for.
+ * @param WP_Job_Manager_Email $email          Email object for the notification.
+ * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
+ * @param bool                 $plain_text     True if the email is being sent as plain text.
+ */
+do_action( 'job_manager_email_job_details', $job, $email, false, $plain_text );

--- a/templates/emails/plain/employer-expiring-job.php
+++ b/templates/emails/plain/employer-expiring-job.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Email content when notifying employers of an expiring job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/emails/plain/employer-expiring-job.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     WP Job Manager
+ * @category    Template
+ * @version     1.31.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * @var WP_Post $job
+ */
+$job = $args['job'];
+
+/**
+ * @var bool
+ */
+$expiring_today = $args['expiring_today'];
+
+if ( $expiring_today ) {
+	printf( __( 'The following job listing is expiring today from %s (%s).', 'wp-job-manager' ), get_bloginfo( 'name' ), home_url() );
+} else {
+	printf( __( 'The following job listing is expiring soon from %s (%s).', 'wp-job-manager' ), get_bloginfo( 'name' ), home_url() );
+}
+printf( ' ' . __( 'Visit the job listing dashboard (%s) to manage the listing.', 'wp-job-manager' ), esc_url( job_manager_get_permalink( 'job_dashboard' ) ) );
+
+/**
+ * Show details about the job listing.
+ *
+ * @param WP_Post              $job            The job listing to show details for.
+ * @param WP_Job_Manager_Email $email          Email object for the notification.
+ * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
+ * @param bool                 $plain_text     True if the email is being sent as plain text.
+ */
+do_action( 'job_manager_email_job_details', $job, $email, false, $plain_text );

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -245,7 +245,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 			$email_settings           = call_user_func( array( $email_class, 'get_setting_fields' ) );
 			$email_is_default_enabled = call_user_func( array( $email_class, 'is_default_enabled' ) );
 			$defaults = array(
-				'enabled'    => $email_is_default_enabled,
+				'enabled'    => $email_is_default_enabled ? '1' : '0',
 				'plain_text' => '0',
 			);
 			foreach ( $email_settings as $email_setting ) {

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -217,6 +217,9 @@ class WP_Job_Manager {
 		if ( ! wp_next_scheduled( 'job_manager_clear_expired_transients' ) ) {
 			wp_schedule_event( time(), 'twicedaily', 'job_manager_clear_expired_transients' );
 		}
+		if ( ! wp_next_scheduled( 'job_manager_email_daily_notices' ) ) {
+			wp_schedule_event( time(), 'daily', 'job_manager_email_daily_notices' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #446 

Depends on #1448 (~rebase~ rebased)

#### Changes proposed in this Pull Request:

* Send a notice to employers when job listing is about to expire.

#### Testing instructions:

* Create a job listing that expires tomorrow. 
* Enable the notification and have it notify 1 day away.
* Run `do_action( 'job_manager_email_daily_notices' );` and verify the email is sent. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Notify employers when their listings are expiring.