### PR TITLE
[WIP] Allow users to relist a job listing before expiry

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -112,7 +112,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		// Load job details
 		if ( $this->job_id ) {
 			$job_status = get_post_status( $this->job_id );
-			if ( 'expired' === $job_status || 'publish' === $job_status && job_manager_job_expiring_soon( $this->job_id ) ) {
+			if ( 'expired' === $job_status || job_manager_job_can_be_relisted( $this->job_id ) ) {
 				if ( ! job_manager_user_can_edit_job( $this->job_id ) ) {
 					$this->job_id = 0;
 					$this->step   = 0;

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -112,7 +112,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		// Load job details
 		if ( $this->job_id ) {
 			$job_status = get_post_status( $this->job_id );
-			if ( 'expired' === $job_status ) {
+			if ( 'expired' === $job_status || 'publish' === $job_status && job_manager_job_expiring_soon( $this->job_id ) ) {
 				if ( ! job_manager_user_can_edit_job( $this->job_id ) ) {
 					$this->job_id = 0;
 					$this->step   = 0;

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -73,7 +73,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 											}
 
 											// Add relist action if the job is going to expire soon.
-											if ( ! isset( $actions['relist'] ) && job_manager_job_expiring_soon( $job ) ) {
+											if ( ! isset( $actions['relist'] ) && job_manager_job_can_be_relisted( $job ) ) {
 												$actions['relist'] = array( 'label' => __( 'Relist', 'wp-job-manager' ), 'nonce' => true );
 											}
 

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -73,10 +73,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 											}
 
 											// Add relist action if the job is going to expire soon.
-											$expiry = strtotime( wpjm_get_job_listing_structured_data( $job )['validThrough'] );
-											$early_relisting_period_days =
-												apply_filters( 'job_manager_early_relisting_period_days', 5 );
-											if ( ! isset( $actions['relist'] ) && $expiry - current_time( 'timestamp' ) < $early_relisting_period_days * DAY_IN_SECONDS ) {
+											if ( ! isset( $actions['relist'] ) && job_manager_job_expiring_soon( $job ) ) {
 												$actions['relist'] = array( 'label' => __( 'Relist', 'wp-job-manager' ), 'nonce' => true );
 											}
 

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -72,6 +72,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 												break;
 											}
 
+											// Add relist action if the job is going to expire soon.
+											$expiry = strtotime( wpjm_get_job_listing_structured_data( $job )['validThrough'] );
+											$early_relisting_period_days =
+												apply_filters( 'job_manager_early_relisting_period_days', 5 );
+											if ( ! isset( $actions['relist'] ) && $expiry - current_time( 'timestamp' ) < $early_relisting_period_days * DAY_IN_SECONDS ) {
+												$actions['relist'] = array( 'label' => __( 'Relist', 'wp-job-manager' ), 'nonce' => true );
+											}
+
 											$actions['delete'] = array( 'label' => __( 'Delete', 'wp-job-manager' ), 'nonce' => true );
 											$actions           = apply_filters( 'job_manager_my_job_actions', $actions, $job );
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -666,18 +666,19 @@ function job_manager_user_can_edit_job( $job_id ) {
 }
 
 /**
- * Checks if the job is expiring soon. By default this is true if the job
- * expires within 5 days.
+ * Checks if the job can be relisted. By default this is true if the job
+ * is public and expires within 5 days.
  *
  * @since 1.31.0
  * @param int|WP_Post $job_id
  * @return bool
  */
-function job_manager_job_expiring_soon( $job ) {
-	$expiry             = strtotime( wpjm_get_job_listing_structured_data( $job )['validThrough'] );
+function job_manager_job_can_be_relisted( $job ) {
+	$status             = get_post_status( $job );
+	$expiry             = strtotime( get_post_meta( $job, '_job_expires', true ) );
 	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', 5 );
 
-	return $expiry - current_time( 'timestamp' ) < $expiring_soon_days * DAY_IN_SECONDS;
+	return 'publish' === $status && $expiry - current_time( 'timestamp' ) < $expiring_soon_days * DAY_IN_SECONDS;
 }
 
 /**

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -683,6 +683,13 @@ function job_manager_job_can_be_relisted( $job ) {
 		return false;
 	}
 
+	/**
+	 * Number of days before a job expires to allow relisting it.
+	 *
+	 * @since 1.31.0
+	 *
+	 * @param int $expiring_soon_days The default number of days.
+	 */
 	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', 5 );
 
 	return 'publish' === $status && $expiry - current_time( 'timestamp' ) < $expiring_soon_days * DAY_IN_SECONDS;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -674,8 +674,15 @@ function job_manager_user_can_edit_job( $job_id ) {
  * @return bool
  */
 function job_manager_job_can_be_relisted( $job ) {
-	$status             = get_post_status( $job );
-	$expiry             = strtotime( get_post_meta( $job, '_job_expires', true ) );
+	$job    = get_post( $job );
+	$status = get_post_status( $job );
+	$expiry = strtotime( get_post_meta( $job->ID, '_job_expires', true ) );
+
+	// If there is no expiry, then relisting is not necessary.
+	if ( ! $expiry ) {
+		return false;
+	}
+
 	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', 5 );
 
 	return 'publish' === $status && $expiry - current_time( 'timestamp' ) < $expiring_soon_days * DAY_IN_SECONDS;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -666,6 +666,21 @@ function job_manager_user_can_edit_job( $job_id ) {
 }
 
 /**
+ * Checks if the job is expiring soon. By default this is true if the job
+ * expires within 5 days.
+ *
+ * @since 1.31.0
+ * @param int|WP_Post $job_id
+ * @return bool
+ */
+function job_manager_job_expiring_soon( $job ) {
+	$expiry             = strtotime( wpjm_get_job_listing_structured_data( $job )['validThrough'] );
+	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', 5 );
+
+	return $expiry - current_time( 'timestamp' ) < $expiring_soon_days * DAY_IN_SECONDS;
+}
+
+/**
  * Checks if the visitor is currently on a WPJM page, job listing, or taxonomy.
  *
  * @since 1.30.0

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1332,9 +1332,10 @@ function job_manager_get_allowed_mime_types( $field = '' ){
  *
  * @since 1.22.0
  * @param  int $job_id
+ * @param  int $from_timestamp
  * @return string
  */
-function calculate_job_expiry( $job_id ) {
+function calculate_job_expiry( $job_id, $from_timestamp = null ) {
 	// Get duration from the product if set...
 	$duration = get_post_meta( $job_id, '_job_duration', true );
 
@@ -1344,7 +1345,10 @@ function calculate_job_expiry( $job_id ) {
 	}
 
 	if ( $duration ) {
-		return date( 'Y-m-d', strtotime( "+{$duration} days", current_time( 'timestamp' ) ) );
+		if ( ! $from_timestamp ) {
+			$from_timestamp = current_time( 'timestamp' );
+		}
+		return date( 'Y-m-d', strtotime( "+{$duration} days", $from_timestamp ) );
 	}
 
 	return '';


### PR DESCRIPTION
Fixes #848

#### Changes proposed in this Pull Request:

* Gives users an option on the Job Dashboard to Relist a job when it is within 5 days of expiry.
* The option is only available for Job listings whose status is `publish`.

#### Issue

When the job is relisted, and the Moderate New Listings setting is enabled, the listing's status will be changed to `pending` and will no longer be public until approved. We may want to discuss a better implementation for this.

#### Testing instructions:

* Set the expiry date of a job listing to a date within 5 days from now.
* Ensure the Job Manager pages and shortcodes are set up.
* Go to the Job Dashboard page. Notice the option to Relist the job listing even though it is not expired.
* Relist the listing. The new expiry date should be calculated based on the old expiry date, not the current date.
* [WIP] Test with the WooCommerce Paid Listings add-on. The flow should be the same, and relisting the job listing should use up one listing in a purchased Job Package Product. _(Currently this does not seem to be working)_

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Add ability to re-list a job listing before it is expired.