### PR TITLE
Update `get_terms()` calls for new format

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -282,13 +282,14 @@ class WP_Job_Manager_CPT {
 	    include_once( JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-category-walker.php' );
 
 		$r                 = array();
+		$r['taxonomy']     = 'job_listing_category';
 		$r['pad_counts']   = 1;
 		$r['hierarchical'] = 1;
 		$r['hide_empty']   = 0;
 		$r['show_count']   = 1;
 		$r['selected']     = ( isset( $wp_query->query['job_listing_category'] ) ) ? $wp_query->query['job_listing_category'] : '';
 		$r['menu_order']   = false;
-		$terms             = get_terms( 'job_listing_category', $r );
+		$terms             = get_terms( $r );
 		$walker            = new WP_Job_Manager_Category_Walker;
 
 		if ( ! $terms ) {

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -181,12 +181,12 @@ class WP_Job_Manager_Writepanels {
 		$name = 'tax_input[' . $taxonomy . ']';
 
 		// Get all the terms for this taxonomy
-		$terms = get_terms( $taxonomy, array( 'hide_empty' => 0 ) );
+		$terms = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => 0 ) );
 		$postterms = get_the_terms( $post->ID, $taxonomy );
 		$current = ( $postterms ? array_pop( $postterms ) : false );
 		$current = ( $current ? $current->term_id : 0 );
 		// Get current and popular terms
-		$popular = get_terms( $taxonomy, array( 'orderby' => 'count', 'order' => 'DESC', 'number' => 10, 'hierarchical' => false ) );
+		$popular = get_terms( array( 'taxonomy' => $taxonomy, 'orderby' => 'count', 'order' => 'DESC', 'number' => 10, 'hierarchical' => false ) );
 		$postterms = get_the_terms( $post->ID,$taxonomy );
 		$current = ($postterms ? array_pop($postterms) : false);
 		$current = ($current ? $current->term_id : 0);

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -102,7 +102,8 @@ class WP_Job_Manager_Usage_Tracking_Data {
 
 		$count = 0;
 		$terms = get_terms(
-			'job_listing_category', array(
+			array(
+				'taxonomy'   => 'job_listing_category',
 				'hide_empty' => false,
 			)
 		);
@@ -128,7 +129,8 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_job_type_has_description_count() {
 		$count = 0;
 		$terms = get_terms(
-			'job_listing_type', array(
+			array(
+				'taxonomy'   => 'job_listing_type',
 				'hide_empty' => false,
 			)
 		);

--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -40,7 +40,7 @@ do_action( 'job_manager_job_filters_before', $atts );
 			<?php foreach ( $categories as $category ) : ?>
 				<input type="hidden" name="search_categories[]" value="<?php echo sanitize_title( $category ); ?>" />
 			<?php endforeach; ?>
-		<?php elseif ( $show_categories && ! is_tax( 'job_listing_category' ) && get_terms( 'job_listing_category' ) ) : ?>
+		<?php elseif ( $show_categories && ! is_tax( 'job_listing_category' ) && get_terms( array( 'taxonomy' => 'job_listing_category' ) ) ) : ?>
 			<div class="search_categories">
 				<label for="search_categories"><?php _e( 'Category', 'wp-job-manager' ); ?></label>
 				<?php if ( $show_category_multiselect ) : ?>

--- a/tests/php/tests/includes/test_class.wp-job-manager-category-walker.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-category-walker.php
@@ -41,12 +41,13 @@ class WP_Test_WP_Job_Manager_Cache_Walker extends WPJM_BaseTest {
 	private function get_terms() {
 		$terms = $this->setup_terms();
 		$args                 = array();
+		$args['taxonomy']     = WP_UnitTest_Factory_For_Term::DEFAULT_TAXONOMY;
 		$args['pad_counts']   = 1;
 		$args['hierarchical'] = 1;
 		$args['hide_empty']   = 0;
 		$args['show_count']   = 1;
 		$args['selected']     = array_pop( $terms );
 		$args['menu_order']   = false;
-		return get_terms( WP_UnitTest_Factory_For_Term::DEFAULT_TAXONOMY, $args );
+		return get_terms( $args );
 	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -382,11 +382,25 @@ function get_job_listing_categories() {
 		return array();
 	}
 
-	return get_terms( "job_listing_category", array(
+	$args = array(
 		'orderby'       => 'name',
-	    'order'         => 'ASC',
-	    'hide_empty'    => false,
-	) );
+		'order'         => 'ASC',
+		'hide_empty'    => false,
+	);
+
+	/**
+	 * Change the category query arguments.
+	 *
+	 * @since 1.31.0
+	 *
+	 * @param array $args
+	 */
+	$args = apply_filters( 'get_job_listing_category_args', $args );
+
+	// Prevent users from filtering the taxonomy
+	$args['taxonomy'] = 'job_listing_category';
+
+	return get_terms( $args );
 }
 endif;
 
@@ -1046,14 +1060,15 @@ function job_manager_dropdown_categories( $args = '' ) {
 	$categories      = get_transient( $categories_hash );
 
 	if ( empty( $categories ) ) {
-		$categories = get_terms( $taxonomy, array(
+		$categories = get_terms( array(
+			'taxonomy'        => $r['taxonomy'],
 			'orderby'         => $r['orderby'],
 			'order'           => $r['order'],
 			'hide_empty'      => $r['hide_empty'],
 			'parent'          => $r['parent'],
 			'child_of'        => $r['child_of'],
 			'exclude'         => $r['exclude'],
-			'hierarchical'    => $r['hierarchical']
+			'hierarchical'    => $r['hierarchical'],
 		) );
 		set_transient( $categories_hash, $categories, DAY_IN_SECONDS * 7 );
 	}


### PR DESCRIPTION
Fixes #825

#### Testing instructions:
* Make sure unit tests pass.
* Test where call is used:
  * Filters form on `[jobs]`.
  * Submit job form.
  * Filter on Job Listings screen in WP Admin.
  * Usage tracking.
