### PR TITLE
Simplify the application URL

### DIFF
--- a/templates/job-application-url.php
+++ b/templates/job-application-url.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     WP Job Manager
  * @category    Template
- * @version     1.9.0
+ * @version     1.31.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/job-application-url.php
+++ b/templates/job-application-url.php
@@ -15,4 +15,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 ?>
-<p><?php _e( 'To apply for this job please visit the following URL:', 'wp-job-manager' ); ?> <a href="<?php echo esc_url( $apply->url ); ?>" target="_blank" rel="nofollow"><?php echo esc_html( $apply->url ); ?> &rarr;</a></p>
+<p><?php esc_html_e( 'To apply for this job please visit', 'wp-job-manager' ); ?> <a href="<?php echo esc_url( $apply->url ); ?>" target="_blank" rel="nofollow"><?php echo esc_html( wp_parse_url( $apply->url, PHP_URL_HOST ) ); ?></a>.</p>


### PR DESCRIPTION
Fixes #635

#### Changes proposed in this Pull Request:

* Simplify the displayed application URL to just the host.

#### Testing instructions:

* Ensure the Applications extension is not activated.
* Set the Application URL on a job listing.
* View that job listing on the frontend and click Apply For Job.
* Inspect the simplified link. Ensure that clicking the link takes you to the correct page in a new tab.