### PR TITLE
Hook new/updated job email notifications to their action hooks

### DIFF
--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -34,6 +34,8 @@ final class WP_Job_Manager_Email_Notifications {
 		add_action( 'job_manager_email_daily_notices', array( __CLASS__, 'send_employer_expiring_notice' ) );
 		add_action( 'job_manager_email_daily_notices', array( __CLASS__, 'send_admin_expiring_notice' ) );
 		add_filter( 'job_manager_settings', array( __CLASS__, 'add_email_settings' ), 1 );
+		add_action( 'job_manager_job_submitted', array( __CLASS__, 'send_new_job_notification' ) );
+		add_action( 'job_manager_user_edit_job_listing', array( __CLASS__, 'send_updated_job_notification' ) );
 	}
 
 	/**
@@ -459,6 +461,24 @@ final class WP_Job_Manager_Email_Notifications {
 		$settings    = self::get_email_settings( $email_key );
 		$days_notice = WP_Job_Manager_Email_Admin_Expiring_Job::get_notice_period( $settings );
 		self::send_expiring_notice( $email_key, $days_notice );
+	}
+
+	/**
+	 * Fire the action to send a new job notification to the admin.
+	 *
+	 * @param int $job_id
+	 */
+	public static function send_new_job_notification( $job_id ) {
+		do_action( 'job_manager_send_notification', 'admin_new_job', array( 'job_id' => $job_id ) );
+	}
+
+	/**
+	 * Fire the action to send a updated job notification to the admin.
+	 *
+	 * @param int $job_id
+	 */
+	public static function send_updated_job_notification( $job_id ) {
+		do_action( 'job_manager_send_notification', 'admin_updated_job', array( 'job_id' => $job_id ) );
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -173,8 +173,6 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 			$save_message = __( 'Your changes have been saved.', 'wp-job-manager' );
 			$post_status = get_post_status( $this->job_id );
 
-			do_action( 'job_manager_send_notification', 'admin_updated_job', array( 'job_id' => $this->job_id ) );
-
 			update_post_meta( $this->job_id, '_job_edited', time() );
 
 			if ( 'publish' === $post_status ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -829,7 +829,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 */
 	public function done() {
 		do_action( 'job_manager_job_submitted', $this->job_id );
-		do_action( 'job_manager_send_notification', 'admin_new_job', array( 'job_id' => $this->job_id ) );
 		get_job_manager_template( 'job-submitted.php', array( 'job' => get_post( $this->job_id ) ) );
 	}
 }


### PR DESCRIPTION
Changes the admin email notifications to hook onto the `job_manager_job_submitted` and `job_manager_user_edit_job_listing` actions. This will allow for better control in WCPL and plugins that might not get to the `done()` step.