### PR TITLE
Emails should have contexts and use template paths for their context

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -82,6 +82,16 @@ abstract class WP_Job_Manager_Email {
 	}
 
 	/**
+	 * Get the context for where this email notification is used. Used to direct which admin settings to show.
+	 *
+	 * @type abstract
+	 * @return string
+	 */
+	public static function get_context() {
+		return 'job_manager';
+	}
+
+	/**
 	 * Get the email subject.
 	 *
 	 * @return string
@@ -210,5 +220,4 @@ abstract class WP_Job_Manager_Email {
 	final protected function get_settings() {
 		return $this->settings;
 	}
-
 }

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -394,7 +394,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * Add email notification settings for a context.
 	 *
 	 * @param array  $settings
-	 * @param string $context (Defaults to Job Manager core)
+	 * @param string $context
 	 * @return array
 	 */
 	public static function add_email_settings( $settings, $context ) {

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -28,12 +28,12 @@ final class WP_Job_Manager_Email_Notifications {
 	public static function init() {
 		add_action( 'job_manager_send_notification', array( __CLASS__, '_schedule_notification' ), 10, 2 );
 		add_action( 'job_manager_email_init', array( __CLASS__, '_lazy_init' ) );
-		add_action( 'job_manager_email_job_details', array( __CLASS__, 'output_job_details'), 10, 4 );
+		add_action( 'job_manager_email_job_details', array( __CLASS__, 'output_job_details' ), 10, 4 );
 		add_action( 'job_manager_email_header', array( __CLASS__, 'output_header' ), 10, 3 );
 		add_action( 'job_manager_email_footer', array( __CLASS__, 'output_footer' ), 10, 3 );
 		add_action( 'job_manager_email_daily_notices', array( __CLASS__, 'send_employer_expiring_notice' ) );
 		add_action( 'job_manager_email_daily_notices', array( __CLASS__, 'send_admin_expiring_notice' ) );
-		add_filter( 'job_manager_settings', array( __CLASS__, 'add_email_settings' ), 1 );
+		add_filter( 'job_manager_settings', array( __CLASS__, 'add_job_manager_email_settings' ), 1 );
 	}
 
 	/**
@@ -180,24 +180,6 @@ final class WP_Job_Manager_Email_Notifications {
 	}
 
 	/**
-	 * Generate the file name for the email template.
-	 *
-	 * @param string $template_name
-	 * @param bool   $plain_text
-	 * @return string
-	 */
-	public static function get_template_file_name( $template_name, $plain_text = false ) {
-		$file_name_parts = array( 'emails' );
-		if ( $plain_text ) {
-			$file_name_parts[] = 'plain';
-		}
-
-		$file_name_parts[] = $template_name . '.php';
-
-		return implode( '/', $file_name_parts );
-	}
-
-	/**
 	 * Show details about the job listing.
 	 *
 	 * @param WP_Post              $job            The job listing to show details for.
@@ -206,7 +188,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @param bool                 $plain_text     True if the email is being sent as plain text.
 	 */
 	public static function output_job_details( $job, $email, $sent_to_admin, $plain_text = false ) {
-		$template_segment = locate_job_manager_template( self::get_template_file_name( 'email-job-details', $plain_text ) );
+		$template_segment = self::locate_template_file( 'email-job-details', $plain_text );
 		if ( ! file_exists( $template_segment ) ) {
 			return;
 		}
@@ -323,13 +305,16 @@ final class WP_Job_Manager_Email_Notifications {
 	/**
 	 * Output email header.
 	 *
-	 * @param WP_Job_Manager_Email $email          Email object for the notification.
-	 * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
-	 * @param bool                 $plain_text     True if the email is being sent as plain text.
+	 * @param string $email_notification_key  Email object for the notification.
+	 * @param bool   $sent_to_admin           True if this is being sent to an administrator.
+	 * @param bool   $plain_text              True if the email is being sent as plain text.
 	 */
-	public static function output_header( $email, $sent_to_admin, $plain_text = false ) {
-		$template_segment = locate_job_manager_template( self::get_template_file_name( 'email-header', $plain_text ) );
-		if ( ! file_exists( $template_segment ) ) {
+	public static function output_header( $email_notification_key, $sent_to_admin, $plain_text = false ) {
+		$template_segment = self::email_template_path_alternative( $email_notification_key, 'email-header', $plain_text );
+		if ( false === $template_segment ) {
+			$template_segment = self::locate_template_file( 'email-header', $plain_text );
+		}
+		if ( ! $template_segment || ! file_exists( $template_segment ) ) {
 			return;
 		}
 		include $template_segment;
@@ -338,29 +323,88 @@ final class WP_Job_Manager_Email_Notifications {
 	/**
 	 * Output email footer.
 	 *
-	 * @param WP_Job_Manager_Email $email          Email object for the notification.
-	 * @param bool                 $sent_to_admin  True if this is being sent to an administrator.
-	 * @param bool                 $plain_text     True if the email is being sent as plain text.
+	 * @param string $email_notification_key  Email object for the notification.
+	 * @param bool   $sent_to_admin           True if this is being sent to an administrator.
+	 * @param bool   $plain_text              True if the email is being sent as plain text.
 	 */
-	public static function output_footer( $email, $sent_to_admin, $plain_text = false ) {
-		$template_segment = locate_job_manager_template( self::get_template_file_name( 'email-footer', $plain_text ) );
-		if ( ! file_exists( $template_segment ) ) {
+	public static function output_footer( $email_notification_key, $sent_to_admin, $plain_text = false ) {
+		$template_segment = self::email_template_path_alternative( $email_notification_key, 'email-footer', $plain_text );
+		if ( false === $template_segment ) {
+			$template_segment = self::locate_template_file( 'email-footer', $plain_text );
+		}
+		if ( ! $template_segment || ! file_exists( $template_segment ) ) {
 			return;
 		}
 		include $template_segment;
 	}
 
 	/**
-	 * Add email notification settings.
+	 * Checks for an alternative email template segment in the template path specified by the current email.
+	 * Useful to provide alternative email headers and footers for a specific WPJM extension plugin.
 	 *
-	 * @param array $settings
+	 * @param string  $email_notification_key  Email object for the notification.
+	 * @param string  $template_name           Name of the template to check
+	 * @param bool    $plain_text              True if the email is being sent as plain text.
+	 * @return bool|string Returns path to template path alternative or false if none exists.
+	 */
+	private static function email_template_path_alternative( $email_notification_key, $template_name, $plain_text ) {
+		$email_class = self::get_email_class( $email_notification_key );
+		if ( ! $email_class || ! is_subclass_of( $email_class, 'WP_Job_Manager_Email_Template' ) ) {
+			return false;
+		}
+
+		$template_default_path = call_user_func( array( $email_class, 'get_template_default_path' ) );
+		if ( '' === $template_default_path ) {
+			return false;
+		}
+
+		$template_path = call_user_func( array( $email_class, 'get_template_path' ) );
+		$template = self::locate_template_file( $template_name, $plain_text, $template_path, $template_default_path );
+		if ( '' === $template ) {
+			return false;
+		}
+
+		return $template;
+	}
+
+	/**
+	 * Locate template file.
+	 *
+	 * @param string $template_name
+	 * @param bool   $plain_text
+	 * @param string $template_path
+	 * @param string $default_path
+	 * @return string
+	 */
+	public static function locate_template_file( $template_name, $plain_text = false, $template_path = 'job_manager', $default_path = '' ) {
+		return locate_job_manager_template( WP_Job_Manager_Email_Template::generate_template_file_name( $template_name, $plain_text ), $template_path, $default_path );
+	}
+
+	/**
+	 * Add email notification settings for the job manager context.
+	 *
+	 * @param array  $settings
 	 * @return array
 	 */
-	public static function add_email_settings( $settings ) {
+	public static function add_job_manager_email_settings( $settings ) {
+		return self::add_email_settings( $settings, WP_Job_Manager_Email::get_context() );
+	}
+
+	/**
+	 * Add email notification settings for a context.
+	 *
+	 * @param array  $settings
+	 * @param string $context (Defaults to Job Manager core)
+	 * @return array
+	 */
+	public static function add_email_settings( $settings, $context ) {
 		$email_notifications = self::get_email_notifications( false );
 		$email_settings = array();
 
 		foreach ( $email_notifications as $email_notification_key => $email_class ) {
+			$email_notification_context = call_user_func( array( $email_class, 'get_context' ) );
+			if ( $context !== $email_notification_context ) { continue; }
+
 			$email_settings[] = array(
 				'type'           => 'multi_enable_expand',
 				'class'          => 'email-setting-row no-separator',
@@ -376,13 +420,15 @@ final class WP_Job_Manager_Email_Notifications {
 			);
 		}
 
-		$settings['email_notifications'] = array(
-			__( 'Email Notifications', 'wp-job-manager' ),
-			$email_settings,
-			array(
-				'before' => __( 'Select the email notifications to enable.', 'wp-job-manager' ),
-			),
-		);
+		if ( ! empty( $email_settings ) ) {
+			$settings['email_notifications'] = array(
+				__( 'Email Notifications', 'wp-job-manager' ),
+				$email_settings,
+				array(
+					'before' => __( 'Select the email notifications to enable.', 'wp-job-manager' ),
+				),
+			);
+		}
 
 		return $settings;
 	}
@@ -736,7 +782,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @return bool|string
 	 */
 	private static function get_styles() {
-		$email_styles_template = locate_job_manager_template( self::get_template_file_name( 'email-styles' ) );
+		$email_styles_template = self::locate_template_file( 'email-styles' );
 		if ( ! file_exists( $email_styles_template ) ) {
 			return false;
 		}

--- a/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email-template.php
+++ b/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email-template.php
@@ -91,6 +91,22 @@ class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
 		$this->assertFalse( $test_value );
 	}
 
+	/**
+	 * @covers WP_Job_Manager_Email_Template::generate_template_file_name()
+	 */
+	public function test_get_template_file_name_plain() {
+		$template_name = md5( microtime( true ) );
+		$this->assertEquals( "emails/plain/{$template_name}.php", WP_Job_Manager_Email_Template::generate_template_file_name( $template_name, true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Template::generate_template_file_name()
+	 */
+	public function test_get_template_file_name_rich() {
+		$template_name = md5( microtime( true ) );
+		$this->assertEquals( "emails/{$template_name}.php", WP_Job_Manager_Email_Template::generate_template_file_name( $template_name, false ) );
+	}
+
 	public function use_rich_test_template( $template ) {
 		return WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/test-template.php';
 	}

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -158,22 +158,6 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @covers WP_Job_Manager_Email_Notifications::get_template_file_name()
-	 */
-	public function test_get_template_file_name_plain() {
-		$template_name = md5( microtime( true ) );
-		$this->assertEquals( "emails/plain/{$template_name}.php", WP_Job_Manager_Email_Notifications::get_template_file_name( $template_name, true ) );
-	}
-
-	/**
-	 * @covers WP_Job_Manager_Email_Notifications::get_template_file_name()
-	 */
-	public function test_get_template_file_name_rich() {
-		$template_name = md5( microtime( true ) );
-		$this->assertEquals( "emails/{$template_name}.php", WP_Job_Manager_Email_Notifications::get_template_file_name( $template_name, false ) );
-	}
-
-	/**
 	 * @covers WP_Job_Manager_Email_Notifications::output_job_details()
 	 * @covers WP_Job_Manager_Email_Notifications::get_job_detail_fields()
 	 */
@@ -223,7 +207,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 
 		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
 		$emails   = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
-		$settings = WP_Job_Manager_Email_Notifications::add_email_settings( array() );
+		$settings = WP_Job_Manager_Email_Notifications::add_email_settings( array(), WP_Job_Manager_Email::get_context() );
 		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
 
 		$this->assertArrayHasKey( 'email_notifications', $settings );


### PR DESCRIPTION
As I started thinking about how we'd implement this in our extension plugins, I realized we want to give emails a context so they can appear in different setting screens _and_ they should follow a template path and default template path for overriding in plugins.

@alexsanford  I also closed that circular dependency for the template file name method 😉 