### PR TITLE
Point admins to WP admin for expiring job notices

### DIFF
--- a/templates/emails/admin-expiring-job.php
+++ b/templates/emails/admin-expiring-job.php
@@ -31,7 +31,8 @@ if ( $expiring_today ) {
 } else {
 	printf( __( 'The following job listing is expiring soon from <a href="%s">%s</a>.', 'wp-job-manager' ), home_url(), get_bloginfo( 'name' ) );
 }
-printf( ' ' . __( 'Visit the <a href="%s">job listing dashboard</a> to manage the listing.', 'wp-job-manager' ), esc_url( job_manager_get_permalink( 'job_dashboard' ) ) );
+$edit_post_link = admin_url( sprintf( 'post.php?post=%d&amp;action=edit', $job->ID ) );
+printf( ' ' . __( 'Visit <a href="%s">WordPress admin</a> to manage the listing.', 'wp-job-manager' ), esc_url( $edit_post_link ) );
 echo '</p>';
 
 /**

--- a/templates/emails/plain/admin-expiring-job.php
+++ b/templates/emails/plain/admin-expiring-job.php
@@ -30,7 +30,8 @@ if ( $expiring_today ) {
 } else {
 	printf( __( 'The following job listing is expiring soon from %s (%s).', 'wp-job-manager' ), get_bloginfo( 'name' ), home_url() );
 }
-printf( ' ' . __( 'Visit the job listing dashboard (%s) to manage the listing.', 'wp-job-manager' ), esc_url( job_manager_get_permalink( 'job_dashboard' ) ) );
+$edit_post_link = admin_url( sprintf( 'post.php?post=%d&amp;action=edit', $job->ID ) );
+printf( ' ' . __( 'Visit WordPress admin (%s) to manage the listing.', 'wp-job-manager' ), esc_url( $edit_post_link ) );
 
 /**
  * Show details about the job listing.


### PR DESCRIPTION
Minor change to point admins to WP admin instead of the job dashboard for expiring job notices.