### PR TITLE
When deleting users without merging delete their job listings

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -244,7 +244,8 @@ class WP_Job_Manager_Post_Types {
 				'query_var' 			=> true,
 				'supports' 				=> array( 'title', 'editor', 'custom-fields', 'publicize', 'thumbnail' ),
 				'has_archive' 			=> $has_archive,
-				'show_in_nav_menus' 	=> false
+				'show_in_nav_menus' 	=> false,
+				'delete_with_user'		=> true,
 			) )
 		);
 


### PR DESCRIPTION
While deleting a user and `Delete all content` is selected, job manager will now allow job listings to be deleted as well.

## Testing Instructions
- In Incognito, post several job listings as a new user.
- Delete that user and choose `Delete all content`. 
- Verify job listings are deleted.

<img width="634" alt="screen shot 2018-04-26 at 4 30 17 pm" src="https://user-images.githubusercontent.com/68693/39316053-2377d78a-4970-11e8-95f1-514ab57f0364.png">
