### PR TITLE
Use strict sanitization for usernames

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -532,7 +532,7 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
 		extract( $args );
 	}
 
-	$username = sanitize_user( $username );
+	$username = sanitize_user( $username, true );
 	$email    = apply_filters( 'user_registration_email', sanitize_email( $email ) );
 
 	if ( empty( $email ) ) {
@@ -540,7 +540,7 @@ function wp_job_manager_create_account( $args, $deprecated = '' ) {
 	}
 
 	if ( empty( $username ) ) {
-		$username = sanitize_user( current( explode( '@', $email ) ) );
+		$username = sanitize_user( current( explode( '@', $email ) ), true );
 	}
 
 	if ( ! is_email( $email ) ) {


### PR DESCRIPTION
In order to accurately check if the username exists we have to use the same level of strictness as the WP core function `wp_insert_user()`, which is to say `$strict = true`.

Fixes #1490

#### Changes proposed in this Pull Request:

* Set strict sanitization for usernames

#### Testing instructions:

1. Enable the setting for account creation during job submission
2. Create a job using the front end form with the email mike+test2@domain.com
3. Create a second job using the front end form with the email mike+test2@anotherdomain.com
4. There should no longer be an error message upon submission

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix bug where new user could not be created due to conflicting user name