### PR TITLE
Check if `wp_job_manager_create_account` exists

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -502,7 +502,7 @@ if ( ! function_exists( 'wp_job_manager_notify_new_user' ) ) :
 	}
 endif;
 
-if ( ! function_exists( 'job_manager_create_account' ) ) :
+if ( ! function_exists( 'wp_job_manager_create_account' ) ) :
 /**
  * Handles account creation.
  *


### PR DESCRIPTION
Fixes #1492

#### Changes proposed in this Pull Request:

* Makes `wp_job_manager_create_account()` pluggable