### PR TITLE
Fix: Undefined index in class-wp-job-manager-cpt.php

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -686,7 +686,7 @@ class WP_Job_Manager_CPT {
 	public function filter_meta( $wp ) {
 		global $pagenow;
 
-		if ( 'edit.php' !== $pagenow || 'job_listing' !== $wp->query_vars['post_type'] ) {
+		if ( 'edit.php' !== $pagenow || empty( $wp->query_vars['post_type'] ) || 'job_listing' !== $wp->query_vars['post_type'] ) {
 			return;
 		}
 


### PR DESCRIPTION
The following error happens on admin screens when `post_type` isn't set in `$wp->query_vars`:
```
Notice: Undefined index: post_type in \plugins\wp-job-manager\includes\admin\class-wp-job-manager-cpt.php on line 689
```
I've added an additional check to avoid this.
