### PR TITLE
Allow listings to be moved to draft without change to expiration

### DIFF
--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -148,4 +148,17 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $post );
 		$this->assertNotEquals( $expected_post_type, $post->post_status );
 	}
+
+	protected function login_as_admin() {
+		$admin = get_user_by( 'email', 'wpjm_admin_user@test.com' );
+		if ( false === $admin ){
+			$admin_id = wp_create_user(
+				'wpjm_admin_user',
+				'wpjm_admin_user',
+				'wpjm_admin_user@example.com' );
+			$admin = get_user_by( 'ID', $admin_id );
+			$admin->set_role( 'administrator' );
+		}
+		wp_set_current_user( $admin->ID );
+	}
 }

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -150,7 +150,7 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	}
 
 	protected function login_as_admin() {
-		$admin = get_user_by( 'email', 'wpjm_admin_user@test.com' );
+		$admin = get_user_by( 'email', 'wpjm_admin_user@example.com' );
 		if ( false === $admin ){
 			$admin_id = wp_create_user(
 				'wpjm_admin_user',

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -8,6 +8,7 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 		$this->default_job_listing_meta = array(
 			'_job_location' => '',
 			'_job_type' => 'full-time',
+			'_application' => 'test@example.com',
 			'_company_name' => new WP_UnitTest_Generator_Sequence( 'Job Listing company name %s' ),
 			'_company_website' => new WP_UnitTest_Generator_Sequence( 'Job Listing company website %s' ),
 			'_company_tagline' => new WP_UnitTest_Generator_Sequence( 'Job Listing company tagline %s' ),

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
@@ -1,0 +1,226 @@
+<?php
+
+require JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-writepanels.php';
+
+class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
+
+	public function data_provider_test_save_job_data_auto_expire() {
+		$expired_date = date( 'Y-m-d', strtotime( '-2 months', current_time( 'timestamp' ) ) );
+		$future_date  = date( 'Y-m-d', strtotime( '+2 months', current_time( 'timestamp' ) ) );
+		$duration     = absint( get_option( 'job_manager_submission_duration' ) );
+		$auto_date    = date( 'Y-m-d', strtotime( "+{$duration} days", current_time( 'timestamp' ) ) );
+
+		return array(
+			/**
+			 * Tests to make sure auto-expiring works.
+			 */
+			'autoexpire_publish_future_publish' => array(
+				// On published post, set to future date and expect published.
+				array(
+					'original' => 'publish',
+					'new'      => null,
+					'expected' => 'publish',
+				),
+				array(
+					'original' => $future_date,
+					'new'      => $future_date,
+					'expected' => $future_date,
+				),
+			),
+			'autoexpire_publish_past_expired' => array(
+				// On published post, set to past date and expect expired.
+				array(
+					'original' => 'publish',
+					'new'      => 'publish',
+					'expected' => 'expired',
+				),
+				array(
+					'original' => $future_date,
+					'new'      => $expired_date,
+					'expected' => $expired_date,
+				),
+			),
+			'autoexpire_draft_past_expired' => array(
+				// On draft post, set to past date and expect expired.
+				array(
+					'original' => 'draft',
+					'new'      => 'publish',
+					'expected' => 'expired',
+				),
+				array(
+					'original' => $future_date,
+					'new'      => $expired_date,
+					'expected' => $expired_date,
+				),
+			),
+			'autoexpire_draft_future_publish' => array(
+				// On draft post, set to future date and expect expired.
+				array(
+					'original' => 'draft',
+					'new'      => 'publish',
+					'expected' => 'publish',
+				),
+				array(
+					'original' => $future_date,
+					'new'      => $future_date,
+					'expected' => $future_date,
+				),
+			),
+			'autoexpire_expired_future_keep_expired' => array(
+				// On expired post, set to future date and expect expired to be preserved.
+				array(
+					'original' => 'expired',
+					'new'      => null,
+					'expected' => 'expired',
+				),
+				array(
+					'original' => $expired_date,
+					'new'      => $future_date,
+					'expected' => $future_date,
+				),
+			),
+
+			/**
+			 * Tests to make sure changes to draft is preserved.
+			*/
+			'draft_publish_draft' => array(
+				// From publish to draft (not touching expiration date) we should get a draft
+				array(
+					'original' => 'publish',
+					'new'      => 'draft',
+					'expected' => 'draft',
+				),
+				null
+			),
+			'draft_expired_draft' => array(
+				// From expired to draft (not touching expiration date) we should get a draft
+				array(
+					'original' => 'expired',
+					'new'      => 'draft',
+					'expected' => 'draft',
+				),
+				null
+			),
+			'draft_publish_draft_set_expired_date' => array(
+				// From publish to draft (setting an expired expiration date) we should get a draft
+				array(
+					'original' => 'publish',
+					'new'      => 'draft',
+					'expected' => 'draft',
+				),
+				array(
+					'original' => $future_date,
+					'new'      => $expired_date,
+					'expected' => $expired_date,
+				),
+			),
+			'draft_publish_draft_keep_expired_date' => array(
+				// From publish to draft (keeping an expired expiration date) we should get a draft
+				array(
+					'original' => 'publish',
+					'new'      => 'draft',
+					'expected' => 'draft',
+				),
+				array(
+					'original' => $expired_date,
+					'new'      => $expired_date,
+					'expected' => $expired_date,
+				),
+			),
+			'draft_expired_draft_set_expired' => array(
+				// From expired to draft (setting an expired expiration date) we should get a draft
+				array(
+					'original' => 'expired',
+					'new'      => 'draft',
+					'expected' => 'draft',
+				),
+				array(
+					'original' => $future_date,
+					'new'      => $expired_date,
+					'expected' => $expired_date,
+				),
+			),
+			'draft_expired_draft_keep_expired' => array(
+				// From expired to draft (keeping an expired expiration date) we should get a draft
+				array(
+					'original' => 'expired',
+					'new'      => 'draft',
+					'expected' => 'draft',
+				),
+				array(
+					'original' => $expired_date,
+					'new'      => $expired_date,
+					'expected' => $expired_date,
+				),
+			),
+		);
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::save_job_listing_data
+	 * @dataProvider data_provider_test_save_job_data_auto_expire
+	 */
+	public function test_save_job_data_auto_expire( $status_data = null, $expires_data = null ) {
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$this->login_as_admin();
+		$original_job_data = array();
+		if ( null !== $status_data && null !== $status_data['original'] ) {
+			$original_job_data['post_status'] = $status_data['original'];
+		}
+		if ( null !== $expires_data && null !== $expires_data['original'] ) {
+			$original_job_data['meta_input']  = array( '_job_expires' => $expires_data['original'] );
+		}
+		if ( null !== $status_data ) {
+			$new_job_data = array(
+				'original_post_status' => $status_data['original'],
+				'post_status'          => $status_data['new'],
+			);
+		}
+		if ( null !== $expires_data && null !== $expires_data['new'] ) {
+			$new_job_data['_job_expires'] = $expires_data['new'];
+		}
+		$job = $this->mock_writepanel_save_request( $new_job_data, $original_job_data );
+		if ( null !== $status_data && null !== $status_data['new'] ) {
+			wp_update_post( array(
+				'ID'          => $job->ID,
+				'post_status' => $status_data['new'],
+			) );
+		}
+
+		$writepanels->save_job_listing_data( $job->ID, $job );
+		if ( $status_data ) {
+			$this->assertEquals( $status_data['expected'], get_post_status( $job->ID ), sprintf( 'Expected post status of %s after emulating a save where the original post status was %s and new post status was %s', $status_data['expected'], $status_data['original'], $status_data['new'] ) );
+		}
+		if ( $expires_data ) {
+			$this->assertEquals( $expires_data['expected'], get_post_meta( $job->ID, '_job_expires', true ), sprintf( 'Expected job expiration of %s after emulating a save where the original expiration was %s and the new expiration is %s', $expires_data['expected'], $expires_data['original'], $expires_data['new'] ) );
+		}
+	}
+
+	private function mock_writepanel_save_request( $new_job_data = array(), $original_job_data = array() ) {
+		global $post;
+		$job_id = $this->factory->job_listing->create( $original_job_data );
+		$job    = get_post( $job_id );
+		$post   = $job;
+
+		$_POST                     = array();
+		$_POST['_job_expires']     = $job->_job_expires;
+		$_POST['_job_location']    = $job->_job_location;
+		$_POST['_job_author']      = $job->_job_author;
+		$_POST['_application']     = $job->_application;
+		$_POST['_company_name']    = $job->_company_name;
+		$_POST['_company_website'] = $job->_company_website;
+		$_POST['_company_tagline'] = $job->_company_tagline;
+		$_POST['_company_twitter'] = $job->_company_twitter;
+		$_POST['_company_video']   = $job->_company_video;
+		$_POST['_filled']          = $job->_filled;
+		$_POST['_featured']        = $job->_featured;
+
+		$_POST['post_status']          = 'publish';
+		$_POST['original_post_status'] = $job->post_status;
+
+		$_POST = array_merge( $_POST, $new_job_data );
+
+		return $job;
+	}
+}

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -24,12 +24,12 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_keywords() {
-		$keywords = array( 'saurkraut' => array(), 'dinosaur' => array(), 'saur' => array(), 'test' => array() );
-		$keywords['saurkraut'][] = $keywords['saur'][] = $keywords['test'][] = $this->factory->job_listing->create( array(
-			'post_title' => 'A Saurkraut Test',
+		$keywords = array( 'saurkraut' => array(), 'dinosaur' => array(), 'saur' => array(), 'boom' => array() );
+		$keywords['saurkraut'][] = $keywords['saur'][] = $keywords['boom'][] = $this->factory->job_listing->create( array(
+			'post_title' => 'A Saurkraut Boom',
 		) );
-		$keywords['dinosaur'][] = $keywords['saur'][] = $keywords['test'][] = $this->factory->job_listing->create( array(
-			'post_title' => 'Dinosaur Test',
+		$keywords['dinosaur'][] = $keywords['saur'][] = $keywords['boom'][] = $this->factory->job_listing->create( array(
+			'post_title' => 'Dinosaur Boom',
 		) );
 		$keywords['dinosaur'][] = $keywords['saur'][] = $this->factory->job_listing->create( array(
 			'post_title' => 'Dinosaur',
@@ -37,11 +37,11 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 
 		$dinosaur_job_listings = get_job_listings( array( 'search_keywords' => 'Dinosaur' ) );
 		$saur_job_listings = get_job_listings( array( 'search_keywords' => 'Saur' ) );
-		$test_job_listings = get_job_listings( array( 'search_keywords' => 'Test' ) );
+		$boom_job_listings = get_job_listings( array( 'search_keywords' => 'Boom' ) );
 
 		$this->assertEqualSets( $keywords['dinosaur'], wp_list_pluck( $dinosaur_job_listings->posts, 'ID' ) );
 		$this->assertEqualSets( $keywords['saur'], wp_list_pluck( $saur_job_listings->posts, 'ID' ) );
-		$this->assertEqualSets( $keywords['test'], wp_list_pluck( $test_job_listings->posts, 'ID' ) );
+		$this->assertEqualSets( $keywords['boom'], wp_list_pluck( $boom_job_listings->posts, 'ID' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1515

#### Changes proposed in this Pull Request:

* Skips logic to auto-expire if new post status is draft.

#### Testing instructions:

See #1515