### PR TITLE
Don't escape sign in template message entirely of HTML

### DIFF
--- a/templates/account-signin.php
+++ b/templates/account-signin.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="field account-sign-in">
 			<?php
 				$user = wp_get_current_user();
-				printf( esc_html__( 'You are currently signed in as <strong>%s</strong>.', 'wp-job-manager' ), esc_html( $user->user_login ) );
+				printf( wp_kses_post( __( 'You are currently signed in as <strong>%s</strong>.', 'wp-job-manager' ) ), esc_html( $user->user_login ) );
 			?>
 
 			<a class="button" href="<?php echo esc_url( apply_filters( 'submit_job_form_logout_url', wp_logout_url( get_permalink() ) ) ); ?>"><?php esc_html_e( 'Sign out', 'wp-job-manager' ); ?></a>


### PR DESCRIPTION
Fixes an escaping bug that popped up in #1495