### PR TITLE
Cleans up build scripts and updates path of built blocks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,8 @@ module.exports = function( grunt ) {
 					'!assets/css/*.less',
 					'!*.log', // Log Files
 					'!assets/blocks/**', // Block source files
-					'!node_modules/**', '!Gruntfile.js', '!package.json','!package-lock.json', '!webpack.config.js', // JS build/package files
+					'!node_modules/**', '!Gruntfile.js', '!package.json', '!jest.config.json',
+					'!package-lock.json', '!webpack.config.js', // JS build/package files
 					'!.git/**', '!.github/**', // Git / Github
 					'!tests/**', '!bin/**', '!phpunit.xml', '!phpunit.xml.dist', // Unit Tests
 					'!vendor/**', '!composer.lock', '!composer.phar', '!composer.json', // Composer

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,16 +82,20 @@ module.exports = function( grunt ) {
 			main: {
 				src: [
 					'**',
+					'!assets/js/**/*.js', 'assets/js/**/*.min.js', 'assets/js/jquery-fileupload/*.js', 'assets/js/jquery-deserialize/*.js',
+					'!assets/css/*.less',
 					'!*.log', // Log Files
-					'!node_modules/**', '!Gruntfile.js', '!package.json','!package-lock.json', // NPM/Grunt
+					'!assets/blocks/**', // Block source files
+					'!node_modules/**', '!Gruntfile.js', '!package.json','!package-lock.json', '!webpack.config.js', // JS build/package files
 					'!.git/**', '!.github/**', // Git / Github
 					'!tests/**', '!bin/**', '!phpunit.xml', '!phpunit.xml.dist', // Unit Tests
 					'!vendor/**', '!composer.lock', '!composer.phar', '!composer.json', // Composer
 					'!.*', '!**/*~', '!tmp/**', //hidden/tmp files
+					'!*.code-workspace', // IDE files
 					'!docs/**',
 					'!CONTRIBUTING.md',
 					'!readme.md',
-					'!phpcs.ruleset.xml',
+					'!phpcs.xml.dist',
 					'!tools/**',
 					'!mixtape.json'
 				],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ const webpackConfig = ( env, argv ) => {
 	return {
 		entry: entryObject,
 		output: {
-			filename: 'build/[name]/index.js',
+			filename: 'build/blocks/[name]/index.js',
 			path: __dirname,
 		},
 		module: {
@@ -39,10 +39,10 @@ const webpackConfig = ( env, argv ) => {
 			],
 		},
 		plugins: [
-			new cleanWebpackPlugin( [ 'build' ] ),
+			new cleanWebpackPlugin( [ 'build/blocks' ] ),
 			new lodashModuleReplacementPlugin(),
 			new miniCssExtractPlugin( {
-				filename: 'build/[name]/style.css'
+				filename: 'build/blocks/[name]/style.css'
 			} ),
 		],
 	};


### PR DESCRIPTION
This PR cleans up the files that are packaged in the released plugin and also moves the built block directory to `build/blocks`. Ideally, we'll move all built assets to `build/[css|js|blocks|...]` and it'd be nice to have it be ready for that.

To test build, run `grunt build` and see the `tmp/build` directory.