### PR TITLE
Run Javascript tests on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ branches:
 # Next we define our matrix of additional build configurations to test against.
 matrix:
   include:
+  - env: WP_TRAVISCI="npm test"
   - php: "5.2"
     dist: precise
     env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ branches:
 # Next we define our matrix of additional build configurations to test against.
 matrix:
   include:
-  - env: WP_TRAVISCI="npm test"
+  # Uncomment this once there are JavaScript tests.
+  # - env: WP_TRAVISCI="npm test"
   - php: "5.2"
     dist: precise
     env: WP_VERSION=latest

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -32,10 +32,9 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	done
 else
 
-    gem install less
-    rm -rf ~/.yarn
-    curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.20.3
-    yarn
+	npm install npm -g
+	npm install
+	npm test
 
     if $WP_TRAVISCI; then
 	# Everything is fine

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -34,7 +34,6 @@ else
 
 	npm install npm -g
 	npm install
-	npm test
 
 		if $WP_TRAVISCI; then
 	# Everything is fine

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -5,19 +5,19 @@ set -e
 source ~/.nvm/nvm.sh
 
 run_phpunit_for() {
-  test_branch="$1";
-  echo "Testing on $test_branch..."
-  export WP_TESTS_DIR="/tmp/$test_branch/tests/phpunit"
-  cd "/tmp/$test_branch/src/wp-content/plugins/$PLUGIN_SLUG"
-  nvm use 6
-  npm install >/dev/null
-  ./node_modules/.bin/mixtape build >/dev/null
+	test_branch="$1";
+	echo "Testing on $test_branch..."
+	export WP_TESTS_DIR="/tmp/$test_branch/tests/phpunit"
+	cd "/tmp/$test_branch/src/wp-content/plugins/$PLUGIN_SLUG"
+	nvm use 6
+	npm install >/dev/null
+	./node_modules/.bin/mixtape build >/dev/null
 
-  phpunit
+	phpunit
 
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
+	if [ $? -ne 0 ]; then
+		exit 1
+	fi
 }
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
@@ -36,12 +36,12 @@ else
 	npm install
 	npm test
 
-    if $WP_TRAVISCI; then
+		if $WP_TRAVISCI; then
 	# Everything is fine
 	:
-    else
-        exit 1
-    fi
+		else
+				exit 1
+		fi
 fi
 
 exit 0


### PR DESCRIPTION
This PR configures TravisCI to run JavaScript tests. Since there are currently no JS tests, and to prevent TravisCI from [returning an error](https://travis-ci.org/Automattic/WP-Job-Manager/jobs/400019368) in that scenario, the command is commented out in `.travis.yml`, but can easily be turned back on once we have some tests.