### PR TITLE
Fix issue with escaped strings on setting checkbox labels

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -531,7 +531,7 @@ class WP_Job_Manager_Settings {
 			echo implode( ' ', $attributes ) . ' '; // WPCS: XSS ok.
 			checked( '1', $value );
 			?>
-		/> <?php echo esc_html( $option['cb_label'] ); ?></label>
+		/> <?php echo wp_kses_post( $option['cb_label'] ); ?></label>
 		<?php
 		if ( ! empty( $option['desc'] ) ) {
 			echo ' <p class="description">' . wp_kses_post( $option['desc'] ) . '</p>';


### PR DESCRIPTION
Fixes issue with checkbox labels being escaped entirely from WP admin settings.