### PR TITLE
Grunt deploy improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -210,7 +210,8 @@ module.exports = function( grunt ) {
 			'main': {
 				cwd: '<%= dirs.build %>/',
 				src: [ '<%= dirs.build %>/**' ],
-				dest: 'tmp/wp-job-manager.zip'
+				dest: 'tmp/wp-job-manager.zip',
+				compression: 'DEFLATE'
 			}
 		},
 
@@ -225,7 +226,7 @@ module.exports = function( grunt ) {
 		},
 
 		clean: {
-			main: [ 'tmp/', 'lib/wpjm_rest' ], //Clean up build folder
+			main: [ 'tmp/*.zip', 'lib/wpjm_rest', '<%= dirs.build %>' ], //Clean up build folder
 		},
 
 		jshint: {
@@ -294,11 +295,13 @@ module.exports = function( grunt ) {
 	grunt.registerTask( 'build-blocks:dev', [ 'shell:webpackDev' ] );
 
 	grunt.registerTask( 'build', [ 'gitinfo', 'clean', 'check-mixtape', 'check-mixtape-fatal', 'test', 'build-blocks', 'copy' ] );
+	grunt.registerTask( 'build-unsafe', [ 'clean', 'check-mixtape', 'check-mixtape-fatal', 'build-blocks', 'copy' ] );
 
 	grunt.registerTask( 'deploy', [ 'checkbranch:master', 'checkrepo', 'build', 'wp_deploy' ] );
 	grunt.registerTask( 'deploy-unsafe', [ 'build', 'wp_deploy' ] );
 
 	grunt.registerTask( 'package', [ 'build', 'zip' ] );
+	grunt.registerTask( 'package-unsafe', [ 'build-unsafe', 'zip' ] );
 
 	// Register tasks
 	grunt.registerTask( 'default', [


### PR DESCRIPTION
- Use ZIP compression
- Maintain SVN repo to speed up deployment
