### PR TITLE
Fix issue when exporting personal data and no email exists

### DIFF
--- a/includes/class-wp-job-manager-data-exporter.php
+++ b/includes/class-wp-job-manager-data-exporter.php
@@ -38,12 +38,15 @@ class WP_Job_Manager_Data_Exporter {
 	 * @return array
 	 */
 	public static function user_data_exporter( $email_address ) {
-		$user = get_user_by( 'email', $email_address );
+		$export_items = array();
+		$user         = get_user_by( 'email', $email_address );
 		if ( false === $user ) {
-			return;
+			return array(
+				'data' => $export_items,
+				'done' => true,
+			);
 		}
 
-		$export_items        = array();
 		$user_data_to_export = array();
 		$user_meta_keys      = array(
 			'_company_logo'    => __( 'Company Logo', 'wp-job-manager' ),

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
@@ -48,7 +48,10 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 		$result = WP_Job_Manager_Data_Exporter::user_data_exporter( 'this-is-an-invalid-email' );
 
 		// ASSERT.
-		$this->assertEmpty( $result );
+		$this->assertTrue( is_array( $result ) );
+		$this->assertArrayHasKey( 'data', $result );
+		$this->assertArrayHasKey( 'done', $result );
+		$this->assertEmpty( $result['data'] );
 	}
 
 	/**


### PR DESCRIPTION
This fixes a bug when exporting personal data and no email exists.

## Testing Instructions
1) Run a Personal Data Export request for `doesnotexist@example.com` (as long as that doesn't exist in your dev env 😉)
2) Verify the export runs and no errors are produced. 