### PR TITLE
Allow users to relist expired jobs in bulk

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -208,6 +208,13 @@ class WP_Job_Manager_CPT {
 		}
 		return false;
 	}
+	
+	/**
+	 * Performs bulk action to relist a single expired job.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
 	public function bulk_action_handle_relist_job( $post_id ) {
 		$job_data = array(
 			'ID'          => $post_id,
@@ -221,6 +228,7 @@ class WP_Job_Manager_CPT {
 		}
 		return false;
 	}
+
 	/**
 	 * Performs bulk action to mark a single job listing as filled.
 	 *

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -86,6 +86,13 @@ class WP_Job_Manager_CPT {
 			'notice'  => __( '%s expired', 'wp-job-manager' ),
 			'handler' => array( $this, 'bulk_action_handle_expire_job' ),
 		);
+		$actions_handled['relist_jobs']          = array(
+			// translators: Placeholder (%s) is the plural name of the job listings post type.
+			'label'   => __( 'Relist Expired %s', 'wp-job-manager' ),
+			// translators: Placeholder (%s) is the plural name of the job listings post type.
+			'notice'  => __( '%s has been relisted', 'wp-job-manager' ),
+			'handler' => array( $this, 'bulk_action_handle_relist_job' ),
+		);
 		$actions_handled['mark_jobs_filled']     = array(
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'label'   => __( 'Mark %s Filled', 'wp-job-manager' ),
@@ -201,7 +208,19 @@ class WP_Job_Manager_CPT {
 		}
 		return false;
 	}
-
+	public function bulk_action_handle_relist_job( $post_id ) {
+		$job_data = array(
+			'ID'          => $post_id,
+			'post_status' => 'publish',
+		);
+		if ( in_array( get_post_status( $post_id ), array( 'expired' ), true )
+			 && current_user_can( 'publish_post', $post_id )
+			 && wp_update_post( $job_data )
+		) {
+			return true;
+		}
+		return false;
+	}
 	/**
 	 * Performs bulk action to mark a single job listing as filled.
 	 *

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -208,7 +208,7 @@ class WP_Job_Manager_CPT {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Performs bulk action to relist a single expired job.
 	 *


### PR DESCRIPTION
Fixes #1555

#### Changes proposed in this Pull Request:

*Allow users to relist expired entries in bulk from wp-admin. If a user relist's an entry it is set to published, and if the expiry date of that entry has passed it has no new expiry date (however, I can alter these as needed).

#### Testing instructions:

* Open the Job Listings in wp-admin
* Add two jobs, giving one an 'expired' status, and one a 'preview' status (or any status that is not 'Active' or 'Expired')
* Select both jobs in the 'All Jobs' subsection
* Select 'Relist Expired Jobs' from the 'Bulk Actions' dropdown, and hit 'Apply'
* The job that was set to expired should now be 'Active' and the job that was set to 'Preview' should still be inactive.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Add bulk relist option to job listings from wp-admin