### PR TITLE
Fix category selction bug in wp-admin.

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -307,16 +307,16 @@ class WP_Job_Manager_CPT {
 		}
 
 		$allowed_html = array(
-    		'option' => array(
-    			'value'=> array(),
-    			'selected' => array(),
-    			'class' => array()
-    		)
+			'option' => array(
+				'value' => array(),
+				'selected' => array(),
+				'class' => array(),
+			),
 		);
 
 		echo "<select name='job_listing_category' id='dropdown_job_listing_category'>";
 		echo '<option value="" ' . selected( isset( $_GET['job_listing_category'] ) ? $_GET['job_listing_category'] : '', '', false ) . '>' . esc_html__( 'Select category', 'wp-job-manager' ) . '</option>';
-		echo  wp_kses($walker->walk( $terms, 0, $r ), $allowed_html);
+		echo wp_kses( $walker->walk( $terms, 0, $r ), $allowed_html );
 		echo '</select>';
 
 	}

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -306,9 +306,17 @@ class WP_Job_Manager_CPT {
 			return;
 		}
 
+		$allowed_html = array(
+    		'option' => array(
+    			'value'=> array(),
+    			'selected' => array(),
+    			'class' => array()
+    		)
+		);
+
 		echo "<select name='job_listing_category' id='dropdown_job_listing_category'>";
 		echo '<option value="" ' . selected( isset( $_GET['job_listing_category'] ) ? $_GET['job_listing_category'] : '', '', false ) . '>' . esc_html__( 'Select category', 'wp-job-manager' ) . '</option>';
-		echo  $walker->walk( $terms, 0, $r );
+		echo  wp_kses($walker->walk( $terms, 0, $r ), $allowed_html);
 		echo '</select>';
 
 	}

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -308,7 +308,7 @@ class WP_Job_Manager_CPT {
 
 		echo "<select name='job_listing_category' id='dropdown_job_listing_category'>";
 		echo '<option value="" ' . selected( isset( $_GET['job_listing_category'] ) ? $_GET['job_listing_category'] : '', '', false ) . '>' . esc_html__( 'Select category', 'wp-job-manager' ) . '</option>';
-		echo wp_kses_post( $walker->walk( $terms, 0, $r ) );
+		echo  $walker->walk( $terms, 0, $r );
 		echo '</select>';
 
 	}


### PR DESCRIPTION
Fixes #1564

#### Changes proposed in this Pull Request:

* Fix the broken sort-by-category dropdown in Job Listings > All Jobs

#### Testing instructions:

* Open wp-admin and go to Job Listings > All Jobs.
* Click on the Select Category drop down.
* Job categories and there corresponding job counts should be listed as expected.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix dropdown to sort by category in wp-admin