### PR TITLE
Fix submit of empty multiselect fields

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -482,6 +482,7 @@ class WP_Job_Manager_Writepanels {
 				<span class="tips" data-tip="<?php echo esc_attr( $field['description'] ); ?>">[?]</span>
 			<?php endif; ?>
 			</label>
+			<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="">
 			<select multiple="multiple" name="<?php echo esc_attr( $name ); ?>[]" id="<?php echo esc_attr( $key ); ?>">
 				<?php foreach ( $field['options'] as $key => $value ) : ?>
 				<option value="<?php echo esc_attr( $key ); ?>"


### PR DESCRIPTION
Fixes #1494 

#### Changes proposed in this Pull Request:

* This PR just adds an empty hidden input for each multiselect field. That way even without any selected option the $_POST variable will be set.

It has a different approach of that one suggested by @tripflex in the original issue. If we empty not sent vars, we can break the expected behavior of codes that just want to update some metadata.

#### Testing instructions:

1. Add multiselect field using admin area fields filter
2. Add listing (from admin) selecting at least 1 option(s) from multiselect
3. Remove all selected options in multiselect and save listing (in admin)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Fix submit of empty multiselect fields