### PR TITLE
Preselect job types by slug in query string on `[jobs]` page

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -330,13 +330,7 @@ class WP_Job_Manager_Shortcodes {
 			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], array( 1, '1', 'true', 'yes' ), true );
 		}
 
-		// Array handling.
-		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
-		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
-		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
-		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
-
-		// Get keywords and location from querystring if set.
+		// Get keywords, location, category and type from querystring if set.
 		if ( ! empty( $_GET['search_keywords'] ) ) {
 			$atts['keywords'] = sanitize_text_field( $_GET['search_keywords'] );
 		}
@@ -346,6 +340,15 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $_GET['search_category'] ) ) {
 			$atts['selected_category'] = sanitize_text_field( $_GET['search_category'] );
 		}
+		if ( ! empty( $_GET['search_job_type'] ) ) {
+			$atts['selected_job_types'] = sanitize_text_field( $_GET['search_job_type'] );
+		}
+
+		// Array handling.
+		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
+		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
+		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
+		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
 
 		$data_attributes = array(
 			'location'        => $atts['location'],


### PR DESCRIPTION
Fixes #1474 

#### Changes proposed in this Pull Request:

* Allow job types pre-selection by query string, similar to what is already possible with categories.

#### Testing instructions:

* Access the page with `[jobs]` shortcode
* Append `?search_job_type=<types-slugs-separated-by-comma>`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Allow job types pre-selection by query string