### PR TITLE
Hide filled and expired positions from native WP search

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -479,11 +479,11 @@ class WP_Job_Manager_Post_Types {
 				$meta_query = array();
 			}
 
-			$meta_query[] = [
+			$meta_query[] = array(
 				'key'     => '_filled',
 				'value'   => '1',
 				'compare' => '!=',
-			];
+			);
 
 			if ( ! empty( $meta_query ) ) {
 				$query->set( 'meta_query', $meta_query );

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -330,13 +330,7 @@ class WP_Job_Manager_Shortcodes {
 			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], array( 1, '1', 'true', 'yes' ), true );
 		}
 
-		// Array handling.
-		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
-		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
-		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
-		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
-
-		// Get keywords and location from querystring if set.
+		// Get keywords, location, category and type from querystring if set.
 		if ( ! empty( $_GET['search_keywords'] ) ) {
 			$atts['keywords'] = sanitize_text_field( $_GET['search_keywords'] );
 		}
@@ -346,6 +340,15 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $_GET['search_category'] ) ) {
 			$atts['selected_category'] = sanitize_text_field( $_GET['search_category'] );
 		}
+		if ( ! empty( $_GET['search_job_type'] ) ) {
+			$atts['selected_job_types'] = sanitize_text_field( $_GET['search_job_type'] );
+		}
+
+		// Array handling.
+		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
+		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
+		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
+		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
 
 		$data_attributes = array(
 			'location'        => $atts['location'],

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -330,7 +330,13 @@ class WP_Job_Manager_Shortcodes {
 			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], array( 1, '1', 'true', 'yes' ), true );
 		}
 
-		// Get keywords, location, category and type from querystring if set.
+		// Array handling.
+		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
+		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
+		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
+		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
+
+		// Get keywords and location from querystring if set.
 		if ( ! empty( $_GET['search_keywords'] ) ) {
 			$atts['keywords'] = sanitize_text_field( $_GET['search_keywords'] );
 		}
@@ -340,15 +346,6 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $_GET['search_category'] ) ) {
 			$atts['selected_category'] = sanitize_text_field( $_GET['search_category'] );
 		}
-		if ( ! empty( $_GET['search_job_type'] ) ) {
-			$atts['selected_job_types'] = sanitize_text_field( $_GET['search_job_type'] );
-		}
-
-		// Array handling.
-		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
-		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
-		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
-		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
 
 		$data_attributes = array(
 			'location'        => $atts['location'],


### PR DESCRIPTION
Fixes #833

#### Changes proposed in this Pull Request:

Configurations for Hiding filled or expired positions aren't respected in core search.

This PR introduces a method (`WP_Job_Manager_Post_Types::public_search_handler()`) to insert the necessary `meta_query` parameter to deal with filled positions.

To solve expired positions, currently, a bit hacky solution is needed. Although the `expired` post status is created with the `exclude_from_search` set to true, WordPress will ignore it if the WP_Query `post_status` parameter is empty, using only the post status `public` value. That way, this PR suggests setting `'public' => ! isset( $_GET['s'] )`.

I've already reported the problem with a [ticket in core](https://core.trac.wordpress.org/ticket/44737).

#### Testing instructions:

1. Install Wordpress
1. Install WP Job Manager
1. Setup WP Job Manager (enable: "Hide filled positions" and "Hide content within expired listings")
1. Create 2 Jobs
1. Expire that job first one and mark the second one as filled
1. Do search with WordPress own search function using the name of the expired job or the filled job

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Hide filled and expired positions from native WP search

p.s.: Please ignore 3ed0288 and 1bd7465 commits. I've messed up my files with another branch :grimacing: 