### PR TITLE
Fix Polylang always loading the default language in ajax requests

### DIFF
--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -65,3 +65,16 @@ function polylang_wpjm_page_id( $page_id ) {
 	return absint( $page_id );
 }
 
+/**
+ * Tells Polylang about ajax requests
+ * The filter is applied *before* the action 'pll_init'
+ *
+ * @since 1.32.0
+ *
+ * @param bool $is_ajax
+ * @return bool
+ */
+function polylang_wpjm_doing_ajax( $is_ajax ) {
+	return false === strpos( $_SERVER['REQUEST_URI'], '/jm-ajax/' ) ? $is_ajax : true;
+}
+add_filter( 'pll_is_ajax_on_front', 'polylang_wpjm_doing_ajax' );


### PR DESCRIPTION
Fixes a compatiility issue with Polylang.

#### Changes proposed in this Pull Request:

Polylang is able to load the correct translations during an ajax request (based on the 'lang' parameter or the cookie if it's empty). However WP Job Manager ajax requests don't use the standard admin-ajax.php and thus Polylang does not recognize the WP Job Manager ajax requests as ajax. Setting the constant `DOING_AJAX` or filtering `wp_doing_ajax()` may be sufficient but it's currently done in a function hooked to 'template_redirect' which is far too late for the language to be defined. Polylang usually defines it in a function hooked to `plugins_loaded` with priority 1.

I propose to use an available filter of Polylang to inform it about the ajax request. Note that filtering `wp_doing_ajax()` would be as efficient for Polylang. The important thing is to do it before the `plugins_loaded` action is fired. 

#### Testing instructions:

* Activate WP Job Manager (run the wizard).
* Activate Polylang and create 2 languages English (default) and French
* Translate the Jobs page in French
* Create a new job in French
* Visit the French jobs page on frontend
=> The text "Posted %s ago" is displayed in English instead of French 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix Polylang always loading the default language in ajax requests