### PR TITLE
Fixing quote issue in subject line produced by apply-for-job button

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -244,7 +244,7 @@ function get_the_job_application_method( $post = null ) {
 		$method->email     = antispambot( $apply );
 
 		// translators: %1$s is the job listing title; %2$s is the URL for the current WordPress instance.
-		$method->subject = apply_filters( 'job_manager_application_email_subject', sprintf( esc_html__( 'Application via "%1$s" listing on %2$s', 'wp-job-manager' ), esc_html( $post->post_title ), esc_url( home_url() ) ), $post );
+		$method->subject = apply_filters( 'job_manager_application_email_subject', sprintf( esc_html__( 'Application via %1$s listing on %2$s', 'wp-job-manager' ), esc_html( $post->post_title ), esc_url( home_url() ) ), $post );
 	} else {
 		if ( strpos( $apply, 'http' ) !== 0 ) {
 			$apply = 'http://' . $apply;


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Removed quotes "" from that particular line which was producing `&quot;` in the subject line.
* This is a fix for https://github.com/Automattic/WP-Job-Manager/issues/1605

#### Testing instructions:

* Create a job, go to the single job page
* Click on apply for job 
* Hit the email id 
* You should no longer see `&quot;` in the subject line.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Fix for subject line issue in apply-for-job feature
