### PR TITLE
Fix: Email subject line contains incorrect characters

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -244,7 +244,7 @@ function get_the_job_application_method( $post = null ) {
 		$method->email     = antispambot( $apply );
 
 		// translators: %1$s is the job listing title; %2$s is the URL for the current WordPress instance.
-		$method->subject = apply_filters( 'job_manager_application_email_subject', sprintf( esc_html__( 'Application via "%1$s" listing on %2$s', 'wp-job-manager' ), esc_html( $post->post_title ), esc_url( home_url() ) ), $post );
+		$method->subject = apply_filters( 'job_manager_application_email_subject', sprintf( esc_html__( 'Application via %1$s listing on %2$s', 'wp-job-manager' ), esc_html( $post->post_title ), esc_url( home_url() ) ), $post );
 	} else {
 		if ( strpos( $apply, 'http' ) !== 0 ) {
 			$apply = 'http://' . $apply;


### PR DESCRIPTION
Fixes #1605 

#### Changes proposed in this Pull Request:

Change the line in code that sets email subjects so no special entity markup shows up on the email subject line when applying for a job.

#### Testing instructions:

1. Setup: Settings > Job Listings >Job Submisstions-> Set Application Method to "email addresses only'.
2. View and apply for a job
3. See email subject line (should be correctly displayed).

<img width="313" alt="applicationemail" src="https://user-images.githubusercontent.com/31791243/48723064-9d027680-ec60-11e8-855b-8b86e5ce7d3d.png">

