### PR TITLE
Allow for handlers to be called before a form view is processed

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -97,6 +97,11 @@ abstract class WP_Job_Manager_Form {
 
 		$next_step_key = $this->get_step_key( $this->step );
 
+		// If the next step has a handler to call before going to the view, run it now.
+		if ( $next_step_key && $step_key !== $next_step_key && is_callable( $this->steps[ $next_step_key ]['before'] ) ) {
+			call_user_func( $this->steps[ $next_step_key ]['before'] );
+		}
+
 		// if the step changed, but the next step has no 'view', call the next handler in sequence.
 		if ( $next_step_key && $step_key !== $next_step_key && ! is_callable( $this->steps[ $next_step_key ]['view'] ) ) {
 			$this->process();

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -79,6 +79,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				),
 				'done'    => array(
 					'name'     => __( 'Done', 'wp-job-manager' ),
+					'before'   => array( $this, 'done_before' ),
 					'view'     => array( $this, 'done' ),
 					'priority' => 30,
 				),
@@ -876,7 +877,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * Displays the final screen after a job listing has been submitted.
 	 */
 	public function done() {
-		do_action( 'job_manager_job_submitted', $this->job_id );
 		get_job_manager_template( 'job-submitted.php', array( 'job' => get_post( $this->job_id ) ) );
+	}
+
+	/**
+	 * Handles the job submissions before the view is called.
+	 */
+	public function done_before() {
+		do_action( 'job_manager_job_submitted', $this->job_id );
 	}
 }


### PR DESCRIPTION
Fixes an issue that prevents users from redirecting without duplicating logic needed to handle email notifications etc.

#### Changes proposed in this Pull Request:

* Introduces a new handler to run before the next step is processed. 

#### Testing instructions:
**_All Cases_**
Make sure email notifications are enabled for new job listings.

Case 1:
* Submit a new job and make sure the email notifications work. 

Case 2:
1) Add this snippet:
```
add_filter( 'job_manager_job_submitted', function() {
    if ( wp_redirect( job_manager_get_permalink( 'job_dashboard' ) ) ) {
	  exit;
	}
}, 20 );
```
2) Submit job listing. Make sure email notification gets sent _and_ on the last step the user gets redirected to the job dashboard.
