### PR TITLE
Tests: Adds REST API endpoint authorization checks

### DIFF
--- a/tests/php/includes/class-wpjm-rest-testcase.php
+++ b/tests/php/includes/class-wpjm-rest-testcase.php
@@ -17,13 +17,6 @@ class WPJM_REST_TestCase extends WPJM_BaseTest {
 	 */
 	protected $admin_id;
 
-	/**
-	 * Default User ID
-	 *
-	 * @var int
-	 */
-	protected $default_user_id;
-
 	public static function setUpBeforeClass() {
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
@@ -71,39 +64,9 @@ class WPJM_REST_TestCase extends WPJM_BaseTest {
 		wp_roles()->init_roles();
 		wp_cache_flush();
 
-		$admin = get_user_by( 'email', 'rest_api_admin_user@test.com' );
-		if ( false === $admin ) {
-			$this->admin_id = wp_create_user(
-				'rest_api_admin_user',
-				'rest_api_admin_user',
-				'rest_api_admin_user@test.com'
-			);
-			$admin          = get_user_by( 'ID', $this->admin_id );
-			$admin->set_role( 'administrator' );
-		}
-
 		$this->default_user_id = get_current_user_id();
 		$this->login_as_admin();
 		$this->rest_server = $wp_rest_server;
-	}
-
-	function login_as_admin() {
-		return $this->login_as( $this->admin_id );
-	}
-
-	function login_as_default_user() {
-		return $this->login_as( $this->default_user_id );
-	}
-
-	function login_as( $user_id ) {
-		wp_set_current_user( $user_id );
-		return $this;
-	}
-
-	function logout() {
-		$this->login_as( 0 );
-		wp_logout();
-		return $this;
 	}
 
 	/**

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -40,6 +40,7 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 		if ( ! empty( $args['meta_input']['_featured'] ) ) {
 			$args['menu_order'] = -1;
 		}
+
 		$post = wp_insert_post( $args );
 		if ( isset( $args['age'] ) ) {
 			$this->set_post_age( $post, $args['age'] );

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
@@ -4,6 +4,11 @@ require JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-writepane
 
 class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 
+	public function setUp() {
+		parent::setUp();
+		$this->enable_manage_job_listings_cap();
+	}
+
 	public function data_provider_test_save_job_data_auto_expire() {
 		$expired_date = date( 'Y-m-d', strtotime( '-2 months', current_time( 'timestamp' ) ) );
 		$future_date  = date( 'Y-m-d', strtotime( '+2 months', current_time( 'timestamp' ) ) );

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
@@ -16,6 +16,94 @@
  * @group rest
  */
 class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
+	
+	public function test_guest_get_job_categories_success() {
+		$this->logout();
+		$response = $this->get( '/wp/v2/job-categories' );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_guest_get_job_category_success() {
+		$this->logout();
+		$term_id  = $this->get_job_category();
+		$response = $this->get( sprintf( '/wp/v2/job-categories/%d', $term_id ) );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_guest_delete_job_categories_fail() {
+		$this->logout();
+		$term_id  = $this->get_job_category();
+		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), array( 'force' => 1 ) );
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_guest_post_job_categories_fail() {
+		$this->logout();
+		$response = $this->post(
+			'/wp/v2/job-categories', array(
+				'name'   => 'Software Engineer',
+				'slug'   => 'software-engineer',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_guest_put_job_categories_fail() {
+		$term_id  = $this->get_job_category();
+		$this->logout();
+		$response = $this->put(
+			sprintf( '/wp/v2/job-categories/%d', $term_id ), array(
+				'name'   => 'Software Engineer 2',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_employer_get_job_categories_success() {
+		$this->login_as_employer();
+		$response = $this->get( '/wp/v2/job-categories' );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_employer_get_job_category_success() {
+		$this->login_as_employer();
+		$term_id  = $this->get_job_category();
+		$response = $this->get( sprintf( '/wp/v2/job-categories/%d', $term_id ) );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_employer_delete_job_categories_fail() {
+		$this->login_as_employer();
+		$term_id  = $this->get_job_category();
+		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), array( 'force' => 1 ) );
+		$this->assertResponseStatus( $response, 403 );
+	}
+
+	public function test_employer_post_job_categories_fail() {
+		$this->login_as_employer();
+		$response = $this->post(
+			'/wp/v2/job-categories', array(
+				'name'   => 'Software Engineer',
+				'slug'   => 'software-engineer',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 403 );
+	}
+
+	public function test_employer_put_job_categories_fail() {
+		$term_id  = $this->get_job_category();
+		$this->login_as_employer();
+		$response = $this->put(
+			sprintf( '/wp/v2/job-categories/%d', $term_id ), array(
+				'name'   => 'Software Engineer 2',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 403 );
+	}
 
 	public function test_get_success_when_guest() {
 		$this->logout();

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -17,6 +17,94 @@
  */
 class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
+	public function test_guest_get_job_listings_success() {
+		$this->logout();
+		$response = $this->get( '/wp/v2/job-listings' );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_guest_get_job_listing_success() {
+		$this->logout();
+		$post_id  = $this->get_job_listing();
+		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_guest_delete_job_listings_fail() {
+		$this->logout();
+		$post_id  = $this->get_job_listing();
+		$response = $this->delete( sprintf( '/wp/v2/job-listings/%d', $post_id ), array( 'force' => 1 ) );
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_guest_post_job_listings_fail() {
+		$this->logout();
+		$response = $this->post(
+			'/wp/v2/job-listings', array(
+				'post_title' => 'Software Engineer',
+				'post_name'  => 'software-engineer',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_guest_put_job_listings_fail() {
+		$post_id  = $this->get_job_listing();
+		$this->logout();
+		$response = $this->put(
+			sprintf( '/wp/v2/job-listings/%d', $post_id ), array(
+				'post_title' => 'Software Engineer 2',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_employer_get_job_listings_success() {
+		$this->login_as_employer();
+		$response = $this->get( '/wp/v2/job-listings' );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_employer_get_job_listing_success() {
+		$this->login_as_employer();
+		$post_id  = $this->get_job_listing();
+		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_employer_delete_job_listings_fail() {
+		$this->login_as_employer();
+		$post_id  = $this->get_job_listing();
+		$response = $this->delete( sprintf( '/wp/v2/job-listings/%d', $post_id ), array( 'force' => 1 ) );
+		$this->assertResponseStatus( $response, 403 );
+	}
+
+	public function test_employer_post_job_listings_fail() {
+		$this->login_as_employer();
+		$response = $this->post(
+			'/wp/v2/job-listings', array(
+				'post_title' => 'Software Engineer',
+				'post_name'  => 'software-engineer',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 403 );
+	}
+
+	public function test_employer_put_job_listings_fail() {
+		$term_id  = $this->get_job_listing();
+		$this->login_as_employer();
+		$response = $this->put(
+			sprintf( '/wp/v2/job-listings/%d', $term_id ), array(
+				'name'   => 'Software Engineer 2',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 403 );
+	}
+	
 	/**
 	 * @covers WP_Job_Manager_Registrable_Job_Listings::get_fields
 	 */
@@ -30,5 +118,9 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->get( '/wp/v2/job-listings' );
 		$this->assertResponseStatus( $response, 200 );
+	}
+
+	private function get_job_listing() {
+		return $this->factory()->job_listing->create_and_get()->ID;
 	}
 }

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
@@ -27,6 +27,94 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		$this->assertTrue( in_array( '/wp/v2/job-types', $routes ) );
 	}
 
+	public function test_guest_get_job_types_success() {
+		$this->logout();
+		$response = $this->get( '/wp/v2/job-types' );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_guest_get_job_type_success() {
+		$this->logout();
+		$term_id  = $this->get_job_type();
+		$response = $this->get( sprintf( '/wp/v2/job-types/%d', $term_id ) );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_guest_delete_job_types_fail() {
+		$this->logout();
+		$term_id  = $this->get_job_type();
+		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), array( 'force' => 1 ) );
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_guest_post_job_types_fail() {
+		$this->logout();
+		$response = $this->post(
+			'/wp/v2/job-types', array(
+				'name'   => 'Software Engineer',
+				'slug'   => 'software-engineer',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_guest_put_job_types_fail() {
+		$term_id  = $this->get_job_type();
+		$this->logout();
+		$response = $this->put(
+			sprintf( '/wp/v2/job-types/%d', $term_id ), array(
+				'name'   => 'Software Engineer 2',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 401 );
+	}
+
+	public function test_employer_get_job_types_success() {
+		$this->login_as_employer();
+		$response = $this->get( '/wp/v2/job-types' );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_employer_get_job_type_success() {
+		$this->login_as_employer();
+		$term_id  = $this->get_job_type();
+		$response = $this->get( sprintf( '/wp/v2/job-types/%d', $term_id ) );
+		$this->assertResponseStatus( $response, 200 );
+	}
+
+	public function test_employer_delete_job_types_fail() {
+		$this->login_as_employer();
+		$term_id  = $this->get_job_type();
+		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), array( 'force' => 1 ) );
+		$this->assertResponseStatus( $response, 403 );
+	}
+
+	public function test_employer_post_job_types_fail() {
+		$this->login_as_employer();
+		$response = $this->post(
+			'/wp/v2/job-types', array(
+				'name'   => 'Software Engineer',
+				'slug'   => 'software-engineer',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 403 );
+	}
+
+	public function test_employer_put_job_types_fail() {
+		$term_id  = $this->get_job_type();
+		$this->login_as_employer();
+		$response = $this->put(
+			sprintf( '/wp/v2/job-types/%d', $term_id ), array(
+				'name'   => 'Software Engineer 2',
+			)
+		);
+
+		$this->assertResponseStatus( $response, 403 );
+	}
+
 	public function test_get_job_types_success() {
 		$this->login_as_default_user();
 		$response = $this->get( '/wp/v2/job-types' );

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -12,6 +12,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		defined( 'PHPUNIT_WPJM_TESTSUITE' ) || define( 'PHPUNIT_WPJM_TESTSUITE', true );
 		parent::setUp();
 		reset_phpmailer_instance();
+		$this->enable_manage_job_listings_cap();
 		update_option( 'job_manager_enable_categories', 1 );
 		update_option( 'job_manager_enable_types', 1 );
 		add_theme_support( 'job-manager-templates' );

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -3,6 +3,7 @@
 class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function setUp() {
 		parent::setUp();
+		$this->enable_manage_job_listings_cap();
 		update_option( 'job_manager_enable_categories', 1 );
 		update_option( 'job_manager_enable_types', 1 );
 		unregister_post_type( 'job_listing' );

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -3,6 +3,7 @@
 class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	public function setUp() {
 		parent::setUp();
+		$this->enable_manage_job_listings_cap();
 		update_option( 'job_manager_enable_categories', 1 );
 		update_option( 'job_manager_enable_types', 1 );
 		add_theme_support( 'job-manager-templates' );


### PR DESCRIPTION
Further Fixes #1625 

Essentially, guests and employers can `GET` [published] job listings and job listing taxonomies but can't do any other actions (`DELETE`, `POST`, `PUT`, etc). 