### PR TITLE
Remove target attribute on links

### DIFF
--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -248,9 +248,9 @@ class WP_Job_Manager_Setup {
 					<?php
 					echo wp_kses_post( sprintf(
 						// translators: %1$s is URL to WordPress core shortcode documentation. %2$s is URL to WPJM specific shortcode reference.
-						__( '(These pages are created using <a href="%1$s" title="What is a shortcode?" target="_blank" class="help-page-link">shortcodes</a>, 
-								which we take care of in this step. If you\'d like to build these pages yourself or want to add one of these options to an existing 
-								page on your site, you can skip this step and take a look at <a href="%2$s" target="_blank" class="help-page-link">shortcode documentation</a> for detailed instructions.)', 'wp-job-manager' ),
+						__( '(These pages are created using <a href="%1$s" title="What is a shortcode?" class="help-page-link">shortcodes</a>,
+								which we take care of in this step. If you\'d like to build these pages yourself or want to add one of these options to an existing
+								page on your site, you can skip this step and take a look at <a href="%2$s" class="help-page-link">shortcode documentation</a> for detailed instructions.)', 'wp-job-manager' ),
 						'http://codex.wordpress.org/Shortcode',
 						'https://wpjobmanager.com/document/shortcode-reference/'
 					) );
@@ -346,7 +346,7 @@ class WP_Job_Manager_Setup {
 					echo wp_kses_post(
 						sprintf(
 							// translators: %1$s is the URL to WPJM support documentation; %2$s is the URL to WPJM support forums.
-							__( 'If you need help, you can find more detail in our 
+							__( 'If you need help, you can find more detail in our
 							<a href="%1$s">support documentation</a> or post your question on the
 							<a href="%2$s">WP Job Manager support forums</a>. Happy hiring!', 'wp-job-manager' ),
 							'https://wpjobmanager.com/documentation/',

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -107,7 +107,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			// translators: Placeholder %s is a URL to the document on wpjobmanager.com with info on usage tracking.
 			__(
 				'We\'d love if you helped us make WP Job Manager better by allowing us to collect
-				<a href="%s" target="_blank">usage tracking data</a>. No sensitive information is 
+				<a href="%s">usage tracking data</a>. No sensitive information is
 				collected, and you can opt out at any time.',
 				'wp-job-manager'
 			), self::WPJM_TRACKING_INFO_URL
@@ -174,7 +174,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			 */
 			__(
 				'Help us make WP Job Manager better by allowing us to collect
-				<a href="%s" target="_blank">usage tracking data</a>.
+				<a href="%s">usage tracking data</a>.
 				No sensitive information is collected.', 'wp-job-manager'
 			), self::WPJM_TRACKING_INFO_URL
 		);

--- a/templates/content-single-job_listing-company.php
+++ b/templates/content-single-job_listing-company.php
@@ -27,7 +27,7 @@ if ( ! get_the_company_name() ) {
 
 	<p class="name">
 		<?php if ( $website = get_the_company_website() ) : ?>
-			<a class="website" href="<?php echo esc_url( $website ); ?>" target="_blank" rel="nofollow"><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
+			<a class="website" href="<?php echo esc_url( $website ); ?>" rel="nofollow"><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
 		<?php endif; ?>
 		<?php the_company_twitter(); ?>
 		<?php the_company_name( '<strong>', '</strong>' ); ?>

--- a/templates/job-application-url.php
+++ b/templates/job-application-url.php
@@ -15,4 +15,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
-<p><?php esc_html_e( 'To apply for this job please visit', 'wp-job-manager' ); ?> <a href="<?php echo esc_url( $apply->url ); ?>" target="_blank" rel="nofollow"><?php echo esc_html( wp_parse_url( $apply->url, PHP_URL_HOST ) ); ?></a>.</p>
+<p><?php esc_html_e( 'To apply for this job please visit', 'wp-job-manager' ); ?> <a href="<?php echo esc_url( $apply->url ); ?>" rel="nofollow"><?php echo esc_html( wp_parse_url( $apply->url, PHP_URL_HOST ) ); ?></a>.</p>

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -785,7 +785,7 @@ function the_job_location( $map_link = true, $post = null ) {
 			echo wp_kses_post(
 				apply_filters(
 					'the_job_location_map_link',
-					'<a class="google_map_link" href="' . esc_url( 'http://maps.google.com/maps?q=' . rawurlencode( wp_strip_all_tags( $location ) ) . '&zoom=14&size=512x512&maptype=roadmap&sensor=false' ) . '" target="_blank">' . esc_html( wp_strip_all_tags( $location ) ) . '</a>',
+					'<a class="google_map_link" href="' . esc_url( 'http://maps.google.com/maps?q=' . rawurlencode( wp_strip_all_tags( $location ) ) . '&zoom=14&size=512x512&maptype=roadmap&sensor=false' ) . '">' . esc_html( wp_strip_all_tags( $location ) ) . '</a>',
 					$location, $post
 				)
 			);
@@ -1098,7 +1098,7 @@ function the_company_twitter( $before = '', $after = '', $echo = true, $post = n
 		return null;
 	}
 
-	$company_twitter = $before . '<a href="' . esc_url( 'https://twitter.com/' . $company_twitter ) . '" class="company_twitter" target="_blank">' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
+	$company_twitter = $before . '<a href="' . esc_url( 'https://twitter.com/' . $company_twitter ) . '" class="company_twitter">' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
 
 	if ( $echo ) {
 		echo wp_kses_post( $company_twitter );


### PR DESCRIPTION
Fixes #1473.

#### Changes proposed in this Pull Request:
This PR removes the `target` attributes on links so that they open in the current tab.

#### Testing instructions:

- Run the following query:
```
UPDATE wp_options
SET option_value = '0'
WHERE option_name = 'job_manager_usage_tracking_opt_in_hide'
```
  - In WP admin, ensure the link in the usage tracking notice opens in the current tab.
- Navigate to http://yourdomain/wp-admin/index.php?page=job-manager-setup&step=2.
  - Check that the _shortcodes_ and _shortcode documentation_ links open in the current tab.
- Navigate to _Job Listings_ > _Settings_ > _General_.
  - Ensure the _usage tracking data_ link opens in the current tab.
- Create a job listing and fill out the _Location_, _Company Website_ and _Company Twitter_ fields.
  - Browse to that job on the front-end and verify that the location, website and Twitter links open in the current tab.
- Activate the WPJM - Applications plugin and ensure that both _Email Application Method_ and _Website URL Application Method_ checkboxes are unchecked.
  - Add a URL to the _Application Email or URL_ of the job listing.
  - Browse to that job on the front-end and click the _Apply for job_ button.
  - Ensure that the link to apply for the job opens in the current tab.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Open links in current tab