### PR TITLE
Force classic block on job listings

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -34,6 +34,7 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_post_types' ), 0 );
+		add_action( 'init', array( $this, 'prepare_block_editor' ) );
 		add_filter( 'admin_head', array( $this, 'admin_head' ) );
 		add_action( 'job_manager_check_for_expired_jobs', array( $this, 'check_for_expired_jobs' ) );
 		add_action( 'job_manager_delete_old_previews', array( $this, 'delete_old_previews' ) );
@@ -71,6 +72,28 @@ class WP_Job_Manager_Post_Types {
 
 		// Single job content.
 		$this->job_content_filter( true );
+	}
+
+	/**
+	 * Prepare CPTs for special block editor situations.
+	 */
+	public function prepare_block_editor() {
+		add_filter( 'allowed_block_types', array( $this, 'force_classic_block' ), 10, 2 );
+	}
+
+	/**
+	 * Forces job listings to just have the classic block. This is necessary with the use of the classic editor on
+	 * the frontend.
+	 *
+	 * @param array   $allowed_block_types
+	 * @param WP_Post $post
+	 * @return array
+	 */
+	public function force_classic_block( $allowed_block_types, $post ) {
+		if ( 'job_listing' === $post->post_type ) {
+			return array( 'core/freeform' );
+		}
+		return $allowed_block_types;
 	}
 
 	/**
@@ -304,6 +327,8 @@ class WP_Job_Manager_Post_Types {
 					'show_in_rest'          => true,
 					'rest_base'             => 'job-listings',
 					'rest_controller_class' => 'WP_REST_Posts_Controller',
+					'template'              => array( array( 'core/freeform' ) ),
+					'template_lock'         => 'all',
 				)
 			)
 		);


### PR DESCRIPTION
Fixes #1626

#### Changes proposed in this Pull Request:

* Forces the classic block on job listings. This is due to potential conflicts between frontend rich text editor and block editor.

#### Testing instructions:

* Make sure job listings edited in classic block appear the same as when they are edited with the classic editor.

#### Known Issues
* Due to a bug in the block editor (TODO: Find issue on Gutenberg 😉), the classic block context menu still allows for converting classic to blocks. This shouldn't happen because no other blocks are allowed. When they go back into the job listing editor things explode because it doesn't follow the template.