### PR TITLE
Fix issues around job types sidebar on block editor

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -176,15 +176,8 @@ class WP_Job_Manager_Writepanels {
 	 * @param int|WP_Post $post
 	 */
 	public function job_type_single_meta_box( $post ) {
-		$is_block_editor = false;
-		$current_screen = get_current_screen();
-		if ( method_exists( $current_screen, 'is_block_editor' ) ) {
-			$is_block_editor = $current_screen->is_block_editor();
-		}
-
 		// Set up the taxonomy object and get terms.
 		$taxonomy_name = 'job_listing_type';
-		$tax           = get_taxonomy( $taxonomy_name );// This is the taxonomy object.
 
 		// Get all the terms for this taxonomy.
 		$terms     = get_terms(
@@ -197,22 +190,6 @@ class WP_Job_Manager_Writepanels {
 		$current   = $postterms ? array_pop( $postterms ) : false;
 		$current   = $current ? $current->term_id : 0;
 
-		if ( $is_block_editor ) {
-			$this->output_job_type_single_meta_box_block( $tax, $terms, $current );
-		} else {
-			$this->output_job_type_single_meta_box_classic( $tax, $terms, $current );
-		}
-	}
-
-	/**
-	 * Output single taxonomy meta box formatted for the block editor.
-	 *
-	 * @param WP_Taxonomy $taxonomy
-	 * @param WP_Term[]   $terms
-	 * @param int         $current
-	 */
-	protected function output_job_type_single_meta_box_block( $taxonomy, $terms, $current ) {
-		$taxonomy_name = $taxonomy->name;
 		$field_name = 'tax_input[' . $taxonomy_name . ']';
 		?>
 		<div id="taxonomy-<?php echo esc_attr( $taxonomy_name ); ?>" class="categorydiv">
@@ -224,66 +201,6 @@ class WP_Job_Manager_Writepanels {
 						$id = $taxonomy_name . '-' . $term->term_id;
 						echo '<li id="' . esc_attr( $id ) . '"><label class="selectit">';
 						echo '<input type="radio" id="in-' . esc_attr( $id ) . '" name="' . esc_attr( $field_name ) . '" ' . checked( $current, $term->term_id, false ) . ' value="' . esc_attr( $term->term_id ) . '" />' . esc_attr( $term->name ) . '<br />';
-						echo '</label></li>';
-					}
-					?>
-				</ul>
-			</div>
-
-		</div>
-		<?php
-	}
-
-	/**
-	 * Output single taxonomy meta box formatted for the classic editor.
-	 *
-	 * @param WP_Taxonomy $taxonomy
-	 * @param WP_Term[]   $terms
-	 * @param int         $current
-	 */
-	protected function output_job_type_single_meta_box_classic( $taxonomy, $terms, $current ) {
-		$taxonomy_name = $taxonomy->name;
-		$field_name = 'tax_input[' . $taxonomy_name . ']';
-		$popular   = get_terms(
-			array(
-				'taxonomy'     => $taxonomy_name,
-				'orderby'      => 'count',
-				'order'        => 'DESC',
-				'number'       => 10,
-				'hierarchical' => false,
-			)
-		);
-		?>
-		<div id="taxonomy-<?php echo esc_attr( $taxonomy_name ); ?>" class="categorydiv">
-
-			<!-- Display tabs-->
-			<ul id="<?php echo esc_attr( $taxonomy_name ); ?>-tabs" class="category-tabs">
-				<li class="tabs"><a href="#<?php echo esc_attr( $taxonomy_name ); ?>-all" tabindex="3"><?php echo esc_html( $taxonomy->labels->all_items ); ?></a></li>
-				<li class="hide-if-no-js"><a href="#<?php echo esc_attr( $taxonomy_name ); ?>-pop" tabindex="3"><?php esc_html_e( 'Most Used', 'wp-job-manager' ); ?></a></li>
-			</ul>
-
-			<!-- Display taxonomy terms -->
-			<div id="<?php echo esc_attr( $taxonomy_name ); ?>-all" class="tabs-panel">
-				<ul id="<?php echo esc_attr( $taxonomy_name ); ?>checklist" class="list:<?php echo esc_attr( $taxonomy_name ); ?> categorychecklist form-no-clear">
-					<?php
-					foreach ( $terms as $term ) {
-						$id = $taxonomy_name . '-' . $term->term_id;
-						echo '<li id="' . esc_attr( $id ) . '"><label class="selectit">';
-						echo '<input type="radio" id="in-' . esc_attr( $id ) . '" name="' . esc_attr( $field_name ) . '" ' . checked( $current, $term->term_id, false ) . ' value="' . esc_attr( $term->term_id ) . '" />' . esc_attr( $term->name ) . '<br />';
-						echo '</label></li>';
-					}
-					?>
-				</ul>
-			</div>
-
-			<!-- Display popular taxonomy terms -->
-			<div id="<?php echo esc_attr( $taxonomy_name ); ?>-pop" class="tabs-panel" style="display: none;">
-				<ul id="<?php echo esc_attr( $taxonomy_name ); ?>checklist-pop" class="categorychecklist form-no-clear" >
-					<?php
-					foreach ( $popular as $term ) {
-						$id = 'popular-' . $taxonomy_name . '-' . $term->term_id;
-						echo '<li id="' . esc_attr( $id ) . '"><label class="selectit">';
-						echo '<input type="radio" id="in-' . esc_attr( $id ) . '" ' . checked( $current, $term->term_id, false ) . ' value="' . esc_attr( $term->term_id ) . '" />' . esc_attr( $term->name ) . '<br />';
 						echo '</label></li>';
 					}
 					?>

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -194,12 +194,8 @@ class WP_Job_Manager_Writepanels {
 			)
 		);
 		$postterms = get_the_terms( $post->ID, $taxonomy_name );
-		$current   = ( $postterms ? array_pop( $postterms ) : false );
-		$current   = ( $current ? $current->term_id : 0 );
-
-		$postterms = get_the_terms( $post->ID, $taxonomy_name );
-		$current   = ( $postterms ? array_pop( $postterms ) : false );
-		$current   = ( $current ? $current->term_id : 0 );
+		$current   = $postterms ? array_pop( $postterms ) : false;
+		$current   = $current ? $current->term_id : 0;
 
 		if ( $is_block_editor ) {
 			$this->output_job_type_single_meta_box_block( $tax, $terms, $current );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -112,7 +112,10 @@ class WP_Job_Manager_Post_Types {
 	 * @return WP_REST_Response
 	 */
 	public function hide_job_type_block_editor_selector( $response, $taxonomy, $request ) {
-		if ( 'job_listing_type' === $taxonomy->name && 'edit' === $request->get_param( 'context' ) ) {
+		if (
+			'job_listing_type' === $taxonomy->name
+			 && 'edit' === $request->get_param( 'context' )
+		) {
 			$response->data['visibility']['show_ui'] = false;
 		}
 		return $response;

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -79,6 +79,10 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function prepare_block_editor() {
 		add_filter( 'allowed_block_types', array( $this, 'force_classic_block' ), 10, 2 );
+
+		if ( false === job_manager_multi_job_type() ) {
+			add_filter( 'rest_prepare_taxonomy', array( $this, 'hide_job_type_block_editor_selector' ), 10, 3 );
+		}
 	}
 
 	/**
@@ -94,6 +98,24 @@ class WP_Job_Manager_Post_Types {
 			return array( 'core/freeform' );
 		}
 		return $allowed_block_types;
+	}
+
+	/**
+	 * Filters a taxonomy returned from the REST API.
+	 *
+	 * Allows modification of the taxonomy data right before it is returned.
+	 *
+	 * @param WP_REST_Response $response  The response object.
+	 * @param object           $taxonomy  The original taxonomy object.
+	 * @param WP_REST_Request  $request   Request used to generate the response.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function hide_job_type_block_editor_selector( $response, $taxonomy, $request ) {
+		if ( 'job_listing_type' === $taxonomy->name && 'edit' === $request->get_param( 'context' ) ) {
+			$response->data['visibility']['show_ui'] = false;
+		}
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1374

#### Changes proposed in this Pull Request:

When Job Types are enabled and the option to allow multiple job types is NOT enabled:
* On the classic editor, use the original meta box from 1.31.x.
* On the block editor, use the modified meta box that matches styling from core block editor. 
* When using block editor, hint that the UI shouldn't be showing in REST API so that it is hidden.

#### Testing instructions:
* Enable and disable multiple job type setting and make sure correct sidebar is shown in block and classic editor.
* Switch between classic editor and block editor and make sure the correct sidebar is shown.
* Make sure there are never two Job Type sidebars on either editor.

#### Known Issues
* On the block editor, I can't find a way to move Job Types up near Job Categories. We would need to build a new component for the editor, which I propose doing in a future version.
* For me (Chrome), there is a funny styling issue with the radio buttons being cut off on the left. The same thing is happening in core block editor for the term selector.
