### PR TITLE
Allow job listing archive slug to be customized

### DIFF
--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -76,6 +76,24 @@ class WP_Job_Manager_Permalink_Settings {
 			'permalink',
 			'optional'
 		);
+		if ( current_theme_supports( 'job-manager-templates' ) ) {
+			add_settings_field(
+				'wpjm_job_listings_archive_slug',
+				__( 'Job listing archive page', 'wp-job-manager' ),
+				array( $this, 'job_listings_archive_slug_input' ),
+				'permalink',
+				'optional'
+			);
+		}
+	}
+
+	/**
+	 * Show a slug input box for job listing archive slug.
+	 */
+	public function job_listings_archive_slug_input() {
+		?>
+		<input name="wpjm_job_listings_archive_slug" type="text" class="regular-text code" value="<?php echo esc_attr( $this->permalinks['jobs_archive'] ); ?>" placeholder="<?php echo esc_attr( $this->permalinks['jobs_archive_rewrite_slug'] ); ?>" />
+		<?php
 	}
 
 	/**
@@ -129,6 +147,10 @@ class WP_Job_Manager_Permalink_Settings {
 			$permalink_settings['job_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );
 			$permalink_settings['category_base'] = sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] );
 			$permalink_settings['type_base']     = sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] );
+
+			if ( isset( $_POST['wpjm_job_listings_archive_slug'] ) ) {
+				$permalinks['jobs_archive'] = sanitize_title_with_dashes( $_POST['wpjm_job_listings_archive_slug'] );
+			}
 
 			update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
 

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -118,12 +118,17 @@ class WP_Job_Manager_Permalink_Settings {
 				switch_to_locale( get_locale() );
 			}
 
-			$permalinks                  = (array) get_option( 'wpjm_permalinks', array() );
+			/**
+			 * Option `wpjm_permalink` was renamed to match other options in 1.32.0.
+			 *
+			 * Reference to the old option will be removed in 1.34.0.
+			 */
+			$permalinks                  = (array) get_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, get_option( 'wpjm_permalink', array() ) );
 			$permalinks['job_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );
 			$permalinks['category_base'] = sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] );
 			$permalinks['type_base']     = sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] );
 
-			update_option( 'wpjm_permalinks', $permalinks );
+			update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, $permalinks );
 
 			if ( function_exists( 'restore_current_locale' ) ) {
 				restore_current_locale();

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -137,11 +137,11 @@ class WP_Job_Manager_Permalink_Settings {
 			}
 
 			/**
-			 * Option `wpjm_permalink` was renamed to match other options in 1.32.0.
+			 * Option `wpjm_permalinks` was renamed to match other options in 1.32.0.
 			 *
 			 * Reference to the old option will be removed in 1.34.0.
 			 */
-			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalink', array() ) );
+			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
 			$permalink_settings = (array) json_decode( get_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
 
 			$permalink_settings['job_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -149,7 +149,7 @@ class WP_Job_Manager_Permalink_Settings {
 			$permalink_settings['type_base']     = sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] );
 
 			if ( isset( $_POST['wpjm_job_listings_archive_slug'] ) ) {
-				$permalinks['jobs_archive'] = sanitize_title_with_dashes( $_POST['wpjm_job_listings_archive_slug'] );
+				$permalink_settings['jobs_archive'] = sanitize_title_with_dashes( $_POST['wpjm_job_listings_archive_slug'] );
 			}
 
 			update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -123,12 +123,14 @@ class WP_Job_Manager_Permalink_Settings {
 			 *
 			 * Reference to the old option will be removed in 1.34.0.
 			 */
-			$permalinks                  = (array) get_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, get_option( 'wpjm_permalink', array() ) );
-			$permalinks['job_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );
-			$permalinks['category_base'] = sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] );
-			$permalinks['type_base']     = sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] );
+			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalink', array() ) );
+			$permalink_settings = (array) json_decode( get_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
 
-			update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, $permalinks );
+			$permalink_settings['job_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );
+			$permalink_settings['category_base'] = sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] );
+			$permalink_settings['type_base']     = sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] );
+
+			update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
 
 			if ( function_exists( 'restore_current_locale' ) ) {
 				restore_current_locale();

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -136,13 +136,7 @@ class WP_Job_Manager_Permalink_Settings {
 				switch_to_locale( get_locale() );
 			}
 
-			/**
-			 * Option `wpjm_permalinks` was renamed to match other options in 1.32.0.
-			 *
-			 * Reference to the old option will be removed in 1.34.0.
-			 */
-			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
-			$permalink_settings = (array) json_decode( get_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
+			$permalink_settings = WP_Job_Manager_Post_Types::get_raw_permalink_settings();
 
 			$permalink_settings['job_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );
 			$permalink_settings['category_base'] = sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] );

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -59,6 +59,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'wp_job_manager_version',
 		'job_manager_installed_terms',
 		'wpjm_permalinks',
+		'job_manager_permalinks',
 		'job_manager_helper',
 		'job_manager_date_format',
 		'job_manager_google_maps_api_key',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -50,6 +50,16 @@ class WP_Job_Manager_Install {
 			update_option( 'job_manager_permalinks', wp_json_encode( (array) get_option( 'wpjm_permalinks', array() ) ) );
 		}
 
+		$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
+		if ( ! array_key_exists( 'jobs_archive', $permalink_options ) ) {
+			if ( current_theme_supports( 'job-manager-templates' ) ) {
+				$permalink_options['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
+			} else {
+				$permalink_options['jobs_archive'] = '';
+			}
+		}
+		update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
+
 		delete_transient( 'wp_job_manager_addons_html' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );
 	}

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -47,7 +47,7 @@ class WP_Job_Manager_Install {
 			update_option( 'job_manager_job_dashboard_page_id', $page_id );
 		}
 		if ( false === get_option( 'job_manager_permalinks', false ) && get_option( 'wpjm_permalinks' ) ) {
-			update_option( 'job_manager_permalinks', (array) get_option( 'wpjm_permalinks', array() ) );
+			update_option( 'job_manager_permalinks', wp_json_encode( (array) get_option( 'wpjm_permalinks', array() ) ) );
 		}
 
 		delete_transient( 'wp_job_manager_addons_html' );

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -57,8 +57,8 @@ class WP_Job_Manager_Install {
 			} else {
 				$permalink_options['jobs_archive'] = '';
 			}
+			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
 		}
-		update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
 
 		delete_transient( 'wp_job_manager_addons_html' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -48,6 +48,7 @@ class WP_Job_Manager_Install {
 		}
 		if ( false === get_option( 'job_manager_permalinks', false ) && get_option( 'wpjm_permalinks' ) ) {
 			update_option( 'job_manager_permalinks', wp_json_encode( (array) get_option( 'wpjm_permalinks', array() ) ) );
+			delete_option( 'wpjm_permalinks' );
 		}
 
 		$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -46,10 +46,6 @@ class WP_Job_Manager_Install {
 			$page_id = get_page_by_path( get_option( 'job_manager_job_dashboard_page_slug' ) )->ID;
 			update_option( 'job_manager_job_dashboard_page_id', $page_id );
 		}
-		if ( false === get_option( 'job_manager_permalinks', false ) && get_option( 'wpjm_permalinks' ) ) {
-			update_option( 'job_manager_permalinks', wp_json_encode( (array) get_option( 'wpjm_permalinks', array() ) ) );
-			delete_option( 'wpjm_permalinks' );
-		}
 
 		$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
 		if ( ! array_key_exists( 'jobs_archive', $permalink_options ) ) {

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -46,6 +46,9 @@ class WP_Job_Manager_Install {
 			$page_id = get_page_by_path( get_option( 'job_manager_job_dashboard_page_slug' ) )->ID;
 			update_option( 'job_manager_job_dashboard_page_id', $page_id );
 		}
+		if ( false === get_option( 'job_manager_permalinks', false ) && get_option( 'wpjm_permalinks' ) ) {
+			update_option( 'job_manager_permalinks', (array) get_option( 'wpjm_permalinks', array() ) );
+		}
 
 		delete_transient( 'wp_job_manager_addons_html' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -47,16 +47,6 @@ class WP_Job_Manager_Install {
 			update_option( 'job_manager_job_dashboard_page_id', $page_id );
 		}
 
-		$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
-		if ( ! array_key_exists( 'jobs_archive', $permalink_options ) ) {
-			if ( current_theme_supports( 'job-manager-templates' ) ) {
-				$permalink_options['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
-			} else {
-				$permalink_options['jobs_archive'] = '';
-			}
-			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
-		}
-
 		delete_transient( 'wp_job_manager_addons_html' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );
 	}

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -21,7 +21,7 @@ class WP_Job_Manager_Install {
 		self::init_user_roles();
 		self::default_terms();
 
-		$is_fresh_install = false;
+		$is_new_install = false;
 
 		// Redirect to setup screen for new installs.
 		if ( ! get_option( 'wp_job_manager_version' ) ) {

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -21,8 +21,11 @@ class WP_Job_Manager_Install {
 		self::init_user_roles();
 		self::default_terms();
 
+		$is_fresh_install = false;
+
 		// Redirect to setup screen for new installs.
 		if ( ! get_option( 'wp_job_manager_version' ) ) {
+			$is_new_install = true;
 			set_transient( '_job_manager_activation_redirect', 1, HOUR_IN_SECONDS );
 		}
 
@@ -47,13 +50,9 @@ class WP_Job_Manager_Install {
 			update_option( 'job_manager_job_dashboard_page_id', $page_id );
 		}
 
-		$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
-		if ( ! array_key_exists( 'jobs_archive', $permalink_options ) ) {
-			if ( current_theme_supports( 'job-manager-templates' ) ) {
-				$permalink_options['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
-			} else {
-				$permalink_options['jobs_archive'] = '';
-			}
+		if ( $is_new_install ) {
+			$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
+			$permalink_options['jobs_archive'] = '';
 			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
 		}
 

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -54,7 +54,6 @@ class WP_Job_Manager_Install {
 			$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
 			$permalink_options['jobs_archive'] = '';
 			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
-			flush_rewrite_rules();
 		}
 
 		delete_transient( 'wp_job_manager_addons_html' );

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -47,6 +47,16 @@ class WP_Job_Manager_Install {
 			update_option( 'job_manager_job_dashboard_page_id', $page_id );
 		}
 
+		$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
+		if ( ! array_key_exists( 'jobs_archive', $permalink_options ) ) {
+			if ( current_theme_supports( 'job-manager-templates' ) ) {
+				$permalink_options['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
+			} else {
+				$permalink_options['jobs_archive'] = '';
+			}
+			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
+		}
+
 		delete_transient( 'wp_job_manager_addons_html' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );
 	}

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -54,6 +54,7 @@ class WP_Job_Manager_Install {
 			$permalink_options = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
 			$permalink_options['jobs_archive'] = '';
 			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
+			flush_rewrite_rules();
 		}
 
 		delete_transient( 'wp_job_manager_addons_html' );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -811,8 +811,11 @@ class WP_Job_Manager_Post_Types {
 		 *
 		 * Reference to the old option will be removed in 1.34.0.
 		 */
-		$permalinks = wp_parse_args(
-			(array) get_option( self::PERMALINK_OPTION_NAME, get_option( 'wpjm_permalink', array() ) ),
+		$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalink', array() ) );
+		$permalink_settings = (array) json_decode( get_option( self::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
+
+		$permalinks         = wp_parse_args(
+			$permalink_settings,
 			array(
 				'job_base'      => '',
 				'category_base' => '',
@@ -820,7 +823,7 @@ class WP_Job_Manager_Post_Types {
 			)
 		);
 
-		// Ensure rewrite slugs are set.
+		// Ensure rewrite slugs are set. Use legacy translation options if not.
 		$permalinks['job_rewrite_slug']      = untrailingslashit( empty( $permalinks['job_base'] ) ? _x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['job_base'] );
 		$permalinks['category_rewrite_slug'] = untrailingslashit( empty( $permalinks['category_base'] ) ? _x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['category_base'] );
 		$permalinks['type_rewrite_slug']     = untrailingslashit( empty( $permalinks['type_base'] ) ? _x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['type_base'] );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -288,7 +288,7 @@ class WP_Job_Manager_Post_Types {
 		 * @param bool $enable_job_archive_page
 		 */
 		if ( apply_filters( 'job_manager_enable_job_archive_page', current_theme_supports( 'job-manager-templates' ) ) ) {
-			$has_archive = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
+			$has_archive = $permalink_structure['jobs_archive_rewrite_slug'];
 		} else {
 			$has_archive = false;
 		}
@@ -809,10 +809,21 @@ class WP_Job_Manager_Post_Types {
 		/**
 		 * Option `wpjm_permalink` was renamed to match other options in 1.32.0.
 		 *
-		 * Reference to the old option will be removed in 1.34.0.
+		 * Reference to the old option and support for non-standard plugin updates will be removed in 1.34.0.
 		 */
 		$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalink', array() ) );
 		$permalink_settings = (array) json_decode( get_option( self::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
+
+		// Check if migration happened on upgrade, if not, do it manually.
+		if ( ! array_key_exists( 'jobs_archive', $permalink_settings ) ) {
+			// Create entry to prevent future checks.
+			$permalink_settings['jobs_archive'] = '';
+			if ( current_theme_supports( 'job-manager-templates' ) ) {
+				// If the user has a theme that declares support, assume they are using the old archive page from the translation.
+				$permalink_settings['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
+			}
+			update_option( self::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
+		}
 
 		$permalinks         = wp_parse_args(
 			$permalink_settings,
@@ -820,13 +831,15 @@ class WP_Job_Manager_Post_Types {
 				'job_base'      => '',
 				'category_base' => '',
 				'type_base'     => '',
+				'jobs_archive'  => '',
 			)
 		);
 
 		// Ensure rewrite slugs are set. Use legacy translation options if not.
-		$permalinks['job_rewrite_slug']      = untrailingslashit( empty( $permalinks['job_base'] ) ? _x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['job_base'] );
-		$permalinks['category_rewrite_slug'] = untrailingslashit( empty( $permalinks['category_base'] ) ? _x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['category_base'] );
-		$permalinks['type_rewrite_slug']     = untrailingslashit( empty( $permalinks['type_base'] ) ? _x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['type_base'] );
+		$permalinks['job_rewrite_slug']          = untrailingslashit( empty( $permalinks['job_base'] ) ? _x( 'job', 'Job permalink - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['job_base'] );
+		$permalinks['category_rewrite_slug']     = untrailingslashit( empty( $permalinks['category_base'] ) ? _x( 'job-category', 'Job category slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['category_base'] );
+		$permalinks['type_rewrite_slug']         = untrailingslashit( empty( $permalinks['type_base'] ) ? _x( 'job-type', 'Job type slug - resave permalinks after changing this', 'wp-job-manager' ) : $permalinks['type_base'] );
+		$permalinks['jobs_archive_rewrite_slug'] = untrailingslashit( empty( $permalinks['jobs_archive'] ) ? 'job-listings' : $permalinks['jobs_archive'] );
 
 		// Restore the original locale.
 		if ( function_exists( 'restore_current_locale' ) && did_action( 'admin_init' ) ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -828,7 +828,6 @@ class WP_Job_Manager_Post_Types {
 				$permalink_settings['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
 			}
 			update_option( self::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
-			flush_rewrite_rules();
 		}
 
 		$permalinks         = wp_parse_args(

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -794,6 +794,26 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
+	 * Get the permalink settings directly from the option.
+	 *
+	 * @return array Permalink settings option.
+	 */
+	public static function get_raw_permalink_settings() {
+		/**
+		 * Option `wpjm_permalinks` was renamed to match other options in 1.32.0.
+		 *
+		 * Reference to the old option and support for non-standard plugin updates will be removed in 1.34.0.
+		 */
+		$legacy_permalink_settings = '[]';
+		if ( false !== get_option( 'wpjm_permalinks', false ) ) {
+			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
+			delete_option( 'wpjm_permalinks' );
+		}
+
+		return (array) json_decode( get_option( self::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
+	}
+
+	/**
 	 * Retrieves permalink settings.
 	 *
 	 * @see https://github.com/woocommerce/woocommerce/blob/3.0.8/includes/wc-core-functions.php#L1573
@@ -806,18 +826,7 @@ class WP_Job_Manager_Post_Types {
 			switch_to_locale( get_locale() );
 		}
 
-		/**
-		 * Option `wpjm_permalinks` was renamed to match other options in 1.32.0.
-		 *
-		 * Reference to the old option and support for non-standard plugin updates will be removed in 1.34.0.
-		 */
-		$legacy_permalink_settings = '[]';
-		if ( false !== get_option( 'wpjm_permalinks', false ) ) {
-			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
-			delete_option( 'wpjm_permalinks' );
-		}
-
-		$permalink_settings = (array) json_decode( get_option( self::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
+		$permalink_settings = self::get_raw_permalink_settings();
 
 		// First-time activations will get this cleared on activation.
 		if ( ! array_key_exists( 'jobs_archive', $permalink_settings ) ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -807,11 +807,11 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		/**
-		 * Option `wpjm_permalink` was renamed to match other options in 1.32.0.
+		 * Option `wpjm_permalinks` was renamed to match other options in 1.32.0.
 		 *
 		 * Reference to the old option and support for non-standard plugin updates will be removed in 1.34.0.
 		 */
-		$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalink', array() ) );
+		$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
 		$permalink_settings = (array) json_decode( get_option( self::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
 
 		// Check if migration happened on upgrade, if not, do it manually.

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -828,6 +828,7 @@ class WP_Job_Manager_Post_Types {
 				$permalink_settings['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
 			}
 			update_option( self::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
+			flush_rewrite_rules();
 		}
 
 		$permalinks         = wp_parse_args(

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -819,12 +819,12 @@ class WP_Job_Manager_Post_Types {
 
 		$permalink_settings = (array) json_decode( get_option( self::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
 
-		// Check if migration happened on upgrade, if not, do it manually.
+		// First-time activations will get this cleared on activation.
 		if ( ! array_key_exists( 'jobs_archive', $permalink_settings ) ) {
 			// Create entry to prevent future checks.
 			$permalink_settings['jobs_archive'] = '';
 			if ( current_theme_supports( 'job-manager-templates' ) ) {
-				// If the user has a theme that declares support, assume they are using the old archive page from the translation.
+				// This isn't the first activation and the theme supports it. Set the default to legacy value.
 				$permalink_settings['jobs_archive'] = _x( 'jobs', 'Post type archive slug - resave permalinks after changing this', 'wp-job-manager' );
 			}
 			update_option( self::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -811,7 +811,12 @@ class WP_Job_Manager_Post_Types {
 		 *
 		 * Reference to the old option and support for non-standard plugin updates will be removed in 1.34.0.
 		 */
-		$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
+		$legacy_permalink_settings = '[]';
+		if ( false !== get_option( 'wpjm_permalinks', false ) ) {
+			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
+			delete_option( 'wpjm_permalinks' );
+		}
+
 		$permalink_settings = (array) json_decode( get_option( self::PERMALINK_OPTION_NAME, $legacy_permalink_settings ), true );
 
 		// Check if migration happened on upgrade, if not, do it manually.

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -7,6 +7,8 @@
  */
 class WP_Job_Manager_Post_Types {
 
+	const PERMALINK_OPTION_NAME = 'job_manager_permalinks';
+
 	/**
 	 * The single instance of the class.
 	 *
@@ -804,8 +806,13 @@ class WP_Job_Manager_Post_Types {
 			switch_to_locale( get_locale() );
 		}
 
+		/**
+		 * Option `wpjm_permalink` was renamed to match other options in 1.32.0.
+		 *
+		 * Reference to the old option will be removed in 1.34.0.
+		 */
 		$permalinks = wp_parse_args(
-			(array) get_option( 'wpjm_permalinks', array() ),
+			(array) get_option( self::PERMALINK_OPTION_NAME, get_option( 'wpjm_permalink', array() ) ),
 			array(
 				'job_base'      => '',
 				'category_base' => '',

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -509,7 +509,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 			'category_base' => 'job-cat-b',
 			'type_base'     => 'job-type-c',
 		);
-		update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, $permalink_test );
+		update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_test ) );
 		$permalinks = WP_Job_Manager_Post_Types::get_permalink_structure();
 		delete_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME );
 		$this->assertEquals( 'job-test-a', $permalinks['job_rewrite_slug'] );

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -509,9 +509,9 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 			'category_base' => 'job-cat-b',
 			'type_base'     => 'job-type-c',
 		);
-		update_option( 'wpjm_permalinks', $permalink_test );
+		update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, $permalink_test );
 		$permalinks = WP_Job_Manager_Post_Types::get_permalink_structure();
-		delete_option( 'wpjm_permalinks' );
+		delete_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME );
 		$this->assertEquals( 'job-test-a', $permalinks['job_rewrite_slug'] );
 		$this->assertEquals( 'job-cat-b', $permalinks['category_rewrite_slug'] );
 		$this->assertEquals( 'job-type-c', $permalinks['type_rewrite_slug'] );


### PR DESCRIPTION
Fixes #1486

#### Changes proposed in this Pull Request:

* Rename the `wpjm_permalinks` option to `job_manager_permalinks` for consistency.
* Along with the rename, I also shifted it to store the settings in JSON. JSON encoding/decoding is a bit faster and more secure.
* Add option for people to change Job Listings archive page from Permalink Settings _if_ their theme declares support for `job-manager-templates`. 
* Before this customization was allowed, the default would be `/jobs`. This often conflicted with the standard permalink for the `[jobs]` shortcode. For _new_ installations, the default will be `/job-listings`.

#### Testing instructions:

Three scenarios should be tested:
* New install with theme support: 
  * On a fresh instance with the active theme declaring support (`add_theme_support( 'job-manager-templates' );`) , activate job manager (this branch). 
  * Go to WP Admin > Settings > Permalinks.
  * Ensure the `Job listing archive page` option shows up with a default for `job-listings`.
  * Change setting to another valid slug (e.g. `fancy-job-listings`). 
  * Save settings. 
  * Visit `http://example.com/fancy-job-listings` and verify it works and is an archive of published job listings.
* New install without theme support: 
  * On a fresh instance without the active theme declaring support, activate job manager (this branch). 
  * Go to WP Admin > Settings > Permalinks.
  * Ensure the `Job listing archive page` option does not show up.
  * In MySQL, verify `job_manager_permalinks` option in `{prefix_}options` contains `"jobs_archive":""`.
  * Both `http://example.com/job-listings` and `http://example.com/jobs` should not be the jobs archive page.
* Old install with theme support: 
  * On an instance that already has job manager with the active theme declaring support (`add_theme_support( 'job-manager-templates' );`), make sure the plugin is on `master` or the last release.
  * Go to WP Admin > Settings > Permalinks; save permalinks as-is at the bottom.
  * In MySQL `{prefix_}options`, verify `job_manager_permalinks` option doesn't exist.
  * Switch to this branch.
  * Refresh the permalink settings page.
  * In MySQL `{prefix_}options`, verify `job_manager_permalinks` option exists that is the current representation of the old `wpjm_permalinks` _and_ `wpjm_permalinks` has been removed.
  * Ensure the `Job listing archive page` option shows up with a default for `jobs`.
  * Change setting to another valid slug (e.g. `fancy-job-listings`). 
  * Save settings. 
  * Visit `http://example.com/fancy-job-listings` and verify it works and is an archive of published job listings.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Enhancement: Allow jobs archive page slug to be customized in Permalink Settings.