### PR TITLE
List unsubmitted job listings in job dashboard and allow completion

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -150,7 +150,7 @@ class WP_Job_Manager_Shortcodes {
 
 						break;
 					case 'relist':
-					case 'resume':
+					case 'continue':
 						if ( ! job_manager_get_permalink( 'submit_job_form' ) ) {
 							throw new Exception( __( 'Missing submission page.', 'wp-job-manager' ) );
 						}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -150,6 +150,7 @@ class WP_Job_Manager_Shortcodes {
 
 						break;
 					case 'relist':
+					case 'resume':
 						if ( ! job_manager_get_permalink( 'submit_job_form' ) ) {
 							throw new Exception( __( 'Missing submission page.', 'wp-job-manager' ) );
 						}
@@ -226,7 +227,7 @@ class WP_Job_Manager_Shortcodes {
 			'job_manager_get_dashboard_jobs_args',
 			array(
 				'post_type'           => 'job_listing',
-				'post_status'         => array( 'publish', 'expired', 'pending' ),
+				'post_status'         => array( 'publish', 'expired', 'pending', 'draft', 'preview' ),
 				'ignore_sticky_posts' => 1,
 				'posts_per_page'      => $posts_per_page,
 				'offset'              => ( max( 1, get_query_var( 'paged' ) ) - 1 ) * $posts_per_page,

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -121,7 +121,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					$this->job_id = 0;
 					$this->step   = 0;
 				}
-			} elseif ( ! in_array( $job_status, apply_filters( 'job_manager_valid_submit_job_statuses', array( 'preview' ) ), true ) ) {
+			} elseif ( ! in_array( $job_status, apply_filters( 'job_manager_valid_submit_job_statuses', array( 'preview', 'draft' ) ), true ) ) {
 				$this->job_id = 0;
 				$this->step   = 0;
 			}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -599,8 +599,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				throw new Exception( __( 'You must be signed in to post a new listing.', 'wp-job-manager' ) );
 			}
 
+			$post_status = '';
+			if ( ! $this->job_id || 'draft' === get_post_status( $this->job_id ) ) {
+				$post_status = 'preview';
+			}
+
 			// Update the job.
-			$this->save_job( $values['job']['job_title'], $values['job']['job_description'], $this->job_id ? '' : 'preview', $values );
+			$this->save_job( $values['job']['job_title'], $values['job']['job_description'], $post_status, $values );
 			$this->update_job_data( $values );
 
 			// Successful, show next step.

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -70,6 +70,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 														$actions['edit'] = array( 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false );
 													}
 												break;
+												case 'draft' :
+												case 'preview' :
+													$actions['resume'] = array( 'label' => __( 'Resume Submission', 'wp-job-manager' ), 'nonce' => true );
+													break;
 											}
 
 											$actions['delete'] = array( 'label' => __( 'Delete', 'wp-job-manager' ), 'nonce' => true );

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -72,7 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 												break;
 												case 'draft' :
 												case 'preview' :
-													$actions['resume'] = array( 'label' => __( 'Resume Submission', 'wp-job-manager' ), 'nonce' => true );
+													$actions['continue'] = array( 'label' => __( 'Continue Submission', 'wp-job-manager' ), 'nonce' => true );
 													break;
 											}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -146,7 +146,9 @@ function get_the_job_status( $post = null ) {
 	$post     = get_post( $post );
 	$status   = $post->post_status;
 	$statuses = get_job_listing_post_statuses();
-
+	if ( 'preview' === $status ) {
+		$status = 'draft';
+	}
 	if ( isset( $statuses[ $status ] ) ) {
 		$status = $statuses[ $status ];
 	} else {


### PR DESCRIPTION
Fixes #1644

#### Changes proposed in this Pull Request:
I thought this was going to be more difficult. Maybe I'm overlooking something, but this seems to work for me. Have just done some testing but will do more later.

* For `draft` (started in WP Admin) and `preview` (started in frontend) job listings, list them in the `[job_dashboard]` and allow users to continue their submission.
* This does not allow for continuation of listings stuck in `pending_payment` (WC Paid Listings). We'll need to build off this PR in that plugin.
* It shows the post status of `preview` as `Preview`, but that might be confusing. We could map the human readable label for `preview` to `draft`'s label in `get_the_job_status()`. 
* Folks who want to disable this can filter `job_manager_get_dashboard_jobs_args` and remove the post statuses. 

#### Testing instructions:

* Using both WP admin and then again through `[submit_job_listing]` form, start some listings. In WP admin, just save draft. In frontend, stop at Preview stage.
* Visit `[job_dashboard]` page. 
* Click `Continue Submission` under either listing. 
* Should allow you to move to Preview stage and post (assuming no WCPL or similar plugin is active).
