### PR TITLE
Provide our own callback to sanitize job type meta box input

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -223,9 +223,9 @@ class WP_Job_Manager_Post_Types {
 				apply_filters(
 					'register_taxonomy_job_listing_type_args',
 					array(
-						'hierarchical'  => true,
-						'label'         => $plural,
-						'labels'        => array(
+						'hierarchical'         => true,
+						'label'                => $plural,
+						'labels'               => array(
 							'name'              => $plural,
 							'singular_name'     => $singular,
 							'menu_name'         => ucwords( $plural ),
@@ -246,18 +246,19 @@ class WP_Job_Manager_Post_Types {
 							// translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
 							'new_item_name'     => sprintf( __( 'New %s Name', 'wp-job-manager' ), $singular ),
 						),
-						'show_ui'       => true,
-						'show_tagcloud' => false,
-						'public'        => $public,
-						'capabilities'  => array(
+						'show_ui'              => true,
+						'show_tagcloud'        => false,
+						'public'               => $public,
+						'capabilities'         => array(
 							'manage_terms' => $admin_capability,
 							'edit_terms'   => $admin_capability,
 							'delete_terms' => $admin_capability,
 							'assign_terms' => $admin_capability,
 						),
-						'rewrite'       => $rewrite,
-						'show_in_rest'  => true,
-						'rest_base'     => 'job-types',
+						'rewrite'              => $rewrite,
+						'show_in_rest'         => true,
+						'rest_base'            => 'job-types',
+						'meta_box_sanitize_cb' => array( $this, 'sanitize_job_type_meta_box_input' ),
 					)
 				)
 			);
@@ -417,6 +418,20 @@ class WP_Job_Manager_Post_Types {
 				break;
 			}
 		}
+	}
+
+	/**
+	 * Sanitize job type meta box input data from WP admin.
+	 *
+	 * @param WP_Taxonomy $taxonomy  Taxonomy being sterilized.
+	 * @param mixed       $input     Raw term data from the 'tax_input' field.
+	 * @return int[]|int
+	 */
+	public function sanitize_job_type_meta_box_input( $taxonomy, $input ) {
+		if ( is_array( $input ) ) {
+			return array_map( 'intval', $input );
+		}
+		return intval( $input );
 	}
 
 	/**


### PR DESCRIPTION
Fixes bug introduced in WP 5.1 

Fixes #1687.

#### Changes proposed in this Pull Request:

* Provide our callback for job type metabox input that can sanitize an array of integers (multiple job type setting enabled) or a single integer (single job type allowed). 

#### Testing instructions:

* With `Allow multiple types for listings` enabled: In both classic editor and block editor, save a job listing in WP admin and select multiple job types. Once saved, refresh edit page and make sure selected categories are saved.
* With `Allow multiple types for listings` disabled: In both classic editor and block editor, save a job listing in WP admin and select a job type. Once saved, refresh edit page and make sure selected category is saved.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fix: Saving job types in WordPress admin after WordPress 5.1 update.