### PR TITLE
Optimize DB query for searching meta

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -711,15 +711,18 @@ class WP_Job_Manager_CPT {
 			array_merge(
 				$wpdb->get_col(
 					$wpdb->prepare(
-						"
-					SELECT posts.ID
-					FROM {$wpdb->posts} posts
-					INNER JOIN {$wpdb->postmeta} p1 ON posts.ID = p1.post_id
-					WHERE p1.meta_value LIKE %s
-					OR posts.post_title LIKE %s
-					OR posts.post_content LIKE %s
-					AND posts.post_type = 'job_listing'
-					",
+						"SELECT posts.ID
+						FROM {$wpdb->posts} posts
+						WHERE (
+							posts.ID IN (
+								SELECT post_id
+								FROM {$wpdb->postmeta}
+								WHERE meta_value LIKE %s
+							)
+							OR posts.post_title LIKE %s
+							OR posts.post_content LIKE %s
+						)
+						AND posts.post_type = 'job_listing'",
 						'%' . $wpdb->esc_like( $wp->query_vars['s'] ) . '%',
 						'%' . $wpdb->esc_like( $wp->query_vars['s'] ) . '%',
 						'%' . $wpdb->esc_like( $wp->query_vars['s'] ) . '%'


### PR DESCRIPTION
Fixes #1693 

This PR introduces the updated SQL query given by the issue referenced above. The old SQL query was creating a PHP array that was much larger than it needed to be because of duplication.

I was not personally able to reproduce the performance problems to the extent that the issue suggests (50 seconds down to 5) but I saw some performance improvement in the updated query. Plus, the updated query is more correct.

## Testing Instructions

See the issue. To add several posts, use `wp post generate --count=<number>` and `wp post generate --post_type=job_listing --count=<number>`. (When I tried this, the generic posts took much longer to create. I got around this by creating `job_listing` posts and then running a DB query to change their `post_type` to `"post"`)

Also, try several searches in WP Admin and ensure that the results are as expected.