### PR TITLE
Adds setting to show logo on Featured Jobs widget

### DIFF
--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -181,8 +181,8 @@ class WP_Job_Manager_Widget extends WP_Widget {
 				case 'checkbox':
 					?>
 					<p>
-						<label for="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>"><?php echo esc_html( $setting['label'] ); ?></label>
 						<input class="checkbox" id="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( $key ) ); ?>" type="checkbox" value="1" <?php checked( $value, 1 ); ?> />
+						<label for="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>"><?php echo esc_html( $setting['label'] ); ?></label>
 					</p>
 					<?php
 					break;

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -23,13 +23,13 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 		$this->widget_description = __( 'Display a list of featured listings on your site.', 'wp-job-manager' );
 		$this->widget_id          = 'widget_featured_jobs';
 		$this->settings           = array(
-			'title'   => array(
+			'title'     => array(
 				'type'  => 'text',
 				// translators: Placeholder %s is the plural label for the job listing post type.
 				'std'   => sprintf( __( 'Featured %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name ),
 				'label' => __( 'Title', 'wp-job-manager' ),
 			),
-			'number'  => array(
+			'number'    => array(
 				'type'  => 'number',
 				'step'  => 1,
 				'min'   => 1,
@@ -37,7 +37,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 				'std'   => 10,
 				'label' => __( 'Number of listings to show', 'wp-job-manager' ),
 			),
-			'orderby' => array(
+			'orderby'   => array(
 				'type'    => 'select',
 				'std'     => 'date',
 				'label'   => __( 'Sort By', 'wp-job-manager' ),
@@ -48,7 +48,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 					'rand_featured' => __( 'Random', 'wp-job-manager' ),
 				),
 			),
-			'order'   => array(
+			'order'     => array(
 				'type'    => 'select',
 				'std'     => 'DESC',
 				'label'   => __( 'Sort Direction', 'wp-job-manager' ),
@@ -56,6 +56,11 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 					'ASC'  => __( 'Ascending', 'wp-job-manager' ),
 					'DESC' => __( 'Descending', 'wp-job-manager' ),
 				),
+			),
+			'show_logo' => array(
+				'type'  => 'checkbox',
+				'std'   => 0,
+				'label' => esc_html__( 'Show Company Logo', 'wp-job-manager' ),
 			),
 		);
 		parent::__construct();
@@ -84,6 +89,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 		$orderby        = esc_attr( $instance['orderby'] );
 		$order          = esc_attr( $instance['order'] );
 		$title          = apply_filters( 'widget_title', $title_instance, $instance, $this->id_base );
+		$show_logo      = absint( $instance['show_logo'] );
 		$jobs           = get_job_listings(
 			array(
 				'posts_per_page' => $number,
@@ -110,7 +116,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 					$jobs->the_post();
 					?>
 
-					<?php get_job_manager_template_part( 'content-widget', 'job_listing' ); ?>
+					<?php get_job_manager_template( 'content-widget-job_listing.php', array( 'show_logo' => $show_logo ) ); ?>
 
 				<?php endwhile; ?>
 
@@ -122,7 +128,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 			<?php get_job_manager_template_part( 'content-widget', 'no-jobs-found' ); ?>
 
-		<?php
+			<?php
 		endif;
 
 		wp_reset_postdata();

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -116,7 +116,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 					$jobs->the_post();
 					?>
 
-					<?php get_job_manager_template( 'content-widget-job_listing.php', array( 'show_logo' => $instance['show_logo'] ) ); ?>
+					<?php get_job_manager_template( 'content-widget-job_listing.php', array( 'show_logo' => $show_logo ) ); ?>
 
 				<?php endwhile; ?>
 
@@ -128,7 +128,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 			<?php get_job_manager_template_part( 'content-widget', 'no-jobs-found' ); ?>
 
-		<?php
+			<?php
 		endif;
 
 		/**


### PR DESCRIPTION
Fixes #1700

#### Changes proposed in this Pull Request:

* Adds setting for Featured Jobs widget to show logo. Matches behavior with Recent Jobs widget.

#### Testing instructions:

* Add Featured Job widget. Try enabling and disabling the **Show Company Logo** setting for the widget.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- New: Adds option to show company logo on Featured Jobs widget.