### PR TITLE
Allow embed `<iframe>` in job description content

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -421,6 +421,52 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
+	 * Filter the post content of job listings.
+	 *
+	 * @since 1.33.0
+	 * @param string $post_content Post content to filter.
+	 */
+	public static function output_kses_post( $post_content ) {
+		echo wp_kses( $post_content, self::kses_allowed_html() );
+	}
+
+	/**
+	 * Returns the expanded set of tags allowed in job listing content.
+	 *
+	 * @since 1.33.0
+	 * @return string
+	 */
+	private static function kses_allowed_html() {
+		/**
+		 * Change the allowed tags in job listing content.
+		 *
+		 * @since 1.33.0
+		 *
+		 * @param array $allowed_html Tags allowed in job listing posts.
+		 */
+		return apply_filters(
+			'job_manager_kses_allowed_html',
+			array_replace_recursive( // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.array_replace_recursiveFound
+				wp_kses_allowed_html( 'post' ),
+				array(
+					'iframe' => array(
+						'src'             => true,
+						'width'           => true,
+						'height'          => true,
+						'frameborder'     => true,
+						'marginwidth'     => true,
+						'marginheight'    => true,
+						'scrolling'       => true,
+						'title'           => true,
+						'allow'           => true,
+						'allowfullscreen' => true,
+					),
+				)
+			)
+		);
+	}
+
+	/**
 	 * Sanitize job type meta box input data from WP admin.
 	 *
 	 * @param WP_Taxonomy $taxonomy  Taxonomy being sterilized.
@@ -824,7 +870,7 @@ class WP_Job_Manager_Post_Types {
 			update_option( self::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
 		}
 
-		$permalinks         = wp_parse_args(
+		$permalinks = wp_parse_args(
 			$permalink_settings,
 			array(
 				'job_base'      => '',

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -16,6 +16,44 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @since 1.33.0
+	 * @covers WP_Job_Manager_Post_Types::output_kses_post
+	 */
+	public function test_output_kses_post_simple() {
+		$job_id = $this->factory->job_listing->create( array(
+			'post_content' => '<p>This is a simple job listing</p>',
+		) );
+
+		$test_content = wpjm_get_the_job_description( $job_id );
+
+		ob_start();
+		WP_Job_Manager_Post_Types::output_kses_post( $test_content );
+		$actual_content = ob_get_clean();
+
+		$this->assertEquals( $test_content, $actual_content, 'No HTML should have been removed from this test.' );
+	}
+
+	/**
+	 * @since 1.33.0
+	 * @covers WP_Job_Manager_Post_Types::output_kses_post
+	 */
+	public function test_output_kses_post_allow_embeds() {
+		$job_id = $this->factory->job_listing->create( array(
+			'post_content' => '<p>This is a simple job listing</p><p>https://www.youtube.com/watch?v=S_GVbuddri8</p>',
+		) );
+
+		$test_content = wpjm_get_the_job_description( $job_id );
+
+		ob_start();
+		WP_Job_Manager_Post_Types::output_kses_post( $test_content );
+		$actual_content = ob_get_clean();
+
+		$this->assertFalse( strpos( $actual_content, '<p>https://www.youtube.com/watch?v=S_GVbuddri8</p>' ), 'The YouTube link should have been expanded to an iframe' );
+		$this->assertGreaterThan( 0, strpos( $actual_content, '<iframe ' ), 'The iframe should not have been filtered out' );
+		$this->assertGreaterThan( 0, strpos( $actual_content, 'src="https://www.youtube.com' ), 'The iframe source should not have been filtered out' );
+	}
+
+	/**
 	 * Tests the WP_Job_Manager_Post_Types::instance() always returns the same `WP_Job_Manager_API` instance.
 	 *
 	 * @since 1.28.0

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -548,13 +548,13 @@ function wpjm_get_the_job_description( $post = null ) {
 		return null;
 	}
 
-	$description = apply_filters( 'the_job_description', $post->post_content );
+	$description = apply_filters( 'the_job_description', wp_kses_post( $post->post_content ) );
 
 	/**
 	 * Filter for the job description.
 	 *
 	 * @since 1.28.0
-	 * @param string      $title Title to be filtered.
+	 * @param string      $job_description Job description to be filtered.
 	 * @param int|WP_Post $post
 	 */
 	return apply_filters( 'wpjm_the_job_description', $description, $post );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -548,7 +548,7 @@ function wpjm_get_the_job_description( $post = null ) {
 		return null;
 	}
 
-	$description = apply_filters( 'the_job_description', get_the_content( $post ) );
+	$description = apply_filters( 'the_job_description', $post->post_content );
 
 	/**
 	 * Filter for the job description.

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -531,7 +531,7 @@ function wpjm_get_the_job_title( $post = null ) {
 function wpjm_the_job_description( $post = null ) {
 	$job_description = wpjm_get_the_job_description( $post );
 	if ( $job_description ) {
-		echo wp_kses_post( $job_description );
+		WP_Job_Manager_Post_Types::output_kses_post( $job_description );
 	}
 }
 


### PR DESCRIPTION
Fixes issue of embeds getting removed from job description content. Introduced by #1495 in 1.31.1 (July 2018).

Fixes #1584
Fixes #1718 

#### Changes proposed in this Pull Request:

* Allows iframe in job description content.

#### Testing instructions:

* Add YouTube link in job description.
* Verify embed works correctly on frontend.

### To  Do
- [x] Add tests