### PR TITLE
Fix description for multiple categories setting

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -165,7 +165,7 @@ class WP_Job_Manager_Settings {
 							'std'        => '0',
 							'label'      => __( 'Multi-select Categories', 'wp-job-manager' ),
 							'cb_label'   => __( 'Default to category multiselect', 'wp-job-manager' ),
-							'desc'       => __( 'The category selection box will default to allowing multiple selections on the [jobs] shortcode. Without this, users will only be able to select a single category when submitting jobs.', 'wp-job-manager' ),
+							'desc'       => __( 'The category selection box will default to allowing multiple selections on the [jobs] shortcode. Without this, visitors will only be able to select a single category when filtering jobs.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => array(),
 						),


### PR DESCRIPTION
Fixes #1517

#### Changes proposed in this Pull Request:

* The setting is under `Job Listings` and only applies to the filtering within the `[jobs]` shortcode. This updates the language to make that clearer.
