### PR TITLE
Warn users of upcoming requirement for PHP 5.6.20+

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -64,43 +64,7 @@ class WP_Job_Manager_Admin {
 	 * Set up actions during admin initialization.
 	 */
 	public function admin_init() {
-		global $wp_version;
-
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-taxonomy-meta.php';
-
-		if ( version_compare( $wp_version, JOB_MANAGER_MINIMUM_WP_VERSION, '<' ) ) {
-			add_action( 'admin_notices', array( $this, 'wp_version_admin_notice' ) );
-			add_filter( 'plugin_action_links_' . JOB_MANAGER_PLUGIN_BASENAME, array( $this, 'wp_version_plugin_action_notice' ) );
-		}
-	}
-
-	/**
-	 * Display notice if WordPress core is out-of-date in admin notice section.
-	 */
-	public function wp_version_admin_notice() {
-		// We only want to show the notices on the plugins page and WPJM admin pages.
-		$screen        = get_current_screen();
-		$valid_screens = array( 'plugins', 'edit-job_listing', 'job_listing_page_job-manager-settings', 'edit-job_listing_type', 'edit-job_listing_category', 'job_listing' );
-		if ( null === $screen || ! in_array( $screen->id, $valid_screens, true ) ) {
-			return;
-		}
-
-		echo '<div class="error">';
-		// translators: %s is the URL for the page where users can go to update WordPress.
-		echo '<p>' . wp_kses_post( sprintf( __( '<strong>WP Job Manager</strong> requires a more recent version of WordPress. <a href="%s">Please update WordPress</a> to avoid issues.', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) ) . '</p>';
-		echo '</div>';
-	}
-
-	/**
-	 * Add admin notice when WP upgrade is required.
-	 *
-	 * @param array $actions
-	 * @return array
-	 */
-	public function wp_version_plugin_action_notice( $actions ) {
-		// translators: Placeholder (%s) is the URL where users can go to update WordPress.
-		$actions[] = wp_kses_post( sprintf( __( '<a href="%s" style="color: red">WordPress Update Required</a>', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) );
-		return $actions;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-dependency-checker.php
+++ b/includes/class-wp-job-manager-dependency-checker.php
@@ -53,9 +53,9 @@ class WP_Job_Manager_Dependency_Checker {
 	 */
 	public static function add_php_notice() {
 		$screen        = get_current_screen();
-		$valid_screens = array( 'dashboard', 'plugins', 'plugins-network', 'edit-job_listing', 'job_listing_page_job-manager-settings' );
+		$valid_screens = self::get_critical_screen_ids();
 
-		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
+		if ( null === $screen || ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
 			return;
 		}
 
@@ -95,16 +95,21 @@ class WP_Job_Manager_Dependency_Checker {
 	 * @access private
 	 */
 	public static function add_wp_notice() {
-		// We only want to show the notices on the plugins page and WPJM admin pages.
 		$screen        = get_current_screen();
-		$valid_screens = array( 'dashboard', 'plugins', 'plugins-network', 'edit-job_listing', 'job_listing_page_job-manager-settings' );
+		$valid_screens = self::get_critical_screen_ids();
+
 		if ( null === $screen || ! in_array( $screen->id, $valid_screens, true ) ) {
 			return;
 		}
 
+		$update_action_link = '';
+		if ( current_user_can( 'update_core' ) ) {
+			// translators: %s is the URL for the page where users can go to update WordPress.
+			$update_action_link = ' ' . sprintf( 'Please <a href="%s">update WordPress</a> to avoid issues.', esc_url( self_admin_url( 'update-core.php' ) ) );
+		}
+
 		echo '<div class="error">';
-		// translators: %s is the URL for the page where users can go to update WordPress.
-		echo '<p>' . wp_kses_post( sprintf( __( '<strong>WP Job Manager</strong> requires a more recent version of WordPress. <a href="%s">Please update WordPress</a> to avoid issues.', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) ) . '</p>';
+		echo '<p>' . wp_kses_post( __( '<strong>WP Job Manager</strong> requires a more recent version of WordPress.', 'wp-job-manager' ) . $update_action_link ) . '</p>';
 		echo '</div>';
 	}
 
@@ -117,8 +122,20 @@ class WP_Job_Manager_Dependency_Checker {
 	 * @return array
 	 */
 	public static function wp_version_plugin_action_notice( $actions ) {
-		// translators: Placeholder (%s) is the URL where users can go to update WordPress.
-		$actions[] = wp_kses_post( sprintf( __( '<a href="%s" style="color: red">WordPress Update Required</a>', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) );
+		if ( ! current_user_can( 'update_core' ) ) {
+			$actions[] = '<strong style="color: red">' . esc_html__( 'WordPress Update Required', 'wp-job-manager' ) . '</strong>';
+		} else {
+			$actions[] = '<a href="' . esc_url( self_admin_url( 'update-core.php' ) ) . '" style="color: red">' . esc_html__( 'WordPress Update Required', 'wp-job-manager' ) . '</a>';
+		}
 		return $actions;
+	}
+
+	/**
+	 * Returns the screen IDs where dependency notices should be displayed.
+	 *
+	 * @return array
+	 */
+	private static function get_critical_screen_ids() {
+		return array( 'dashboard', 'plugins', 'plugins-network', 'edit-job_listing', 'job_listing_page_job-manager-settings' );
 	}
 }

--- a/includes/class-wp-job-manager-dependency-checker.php
+++ b/includes/class-wp-job-manager-dependency-checker.php
@@ -25,8 +25,13 @@ class WP_Job_Manager_Dependency_Checker {
 	 * @return bool True if we should continue to load the plugin.
 	 */
 	public static function check_dependencies() {
-		if ( self::check_php() ) {
+		if ( ! self::check_php() ) {
 			add_action( 'admin_notices', array( 'WP_Job_Manager_Dependency_Checker', 'add_php_notice' ) );
+		}
+
+		if ( ! self::check_wp() ) {
+			add_action( 'admin_notices', array( 'WP_Job_Manager_Dependency_Checker', 'add_wp_notice' ) );
+			add_filter( 'plugin_action_links_' . JOB_MANAGER_PLUGIN_BASENAME, array( 'WP_Job_Manager_Dependency_Checker', 'wp_version_plugin_action_notice' ) );
 		}
 
 		return true;
@@ -73,16 +78,15 @@ class WP_Job_Manager_Dependency_Checker {
 		echo '</p></div>';
 	}
 
-
 	/**
-	 * Checks for our PHP version requirement.
+	 * Checks for our WordPress version requirement.
 	 *
 	 * @return bool
 	 */
-	public static function check_wp() {
+	private static function check_wp() {
 		global $wp_version;
 
-		return version_compare( $wp_version, self::MINIMUM_PHP_VERSION, '>=' );
+		return version_compare( $wp_version, self::MINIMUM_WP_VERSION, '>=' );
 	}
 
 	/**
@@ -107,10 +111,12 @@ class WP_Job_Manager_Dependency_Checker {
 	/**
 	 * Add admin notice when WP upgrade is required.
 	 *
-	 * @param array $actions
+	 * @access private
+	 *
+	 * @param array $actions Actions to show in WordPress admin's plugin list.
 	 * @return array
 	 */
-	public function wp_version_plugin_action_notice( $actions ) {
+	public static function wp_version_plugin_action_notice( $actions ) {
 		// translators: Placeholder (%s) is the URL where users can go to update WordPress.
 		$actions[] = wp_kses_post( sprintf( __( '<a href="%s" style="color: red">WordPress Update Required</a>', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) );
 		return $actions;

--- a/includes/class-wp-job-manager-dependency-checker.php
+++ b/includes/class-wp-job-manager-dependency-checker.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager_Dependency_Checker.
+ *
+ * @package wp-job-manager
+ * @since   1.33.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles checking for WP Job Manager's dependencies.
+ *
+ * @since 1.33.0
+ */
+class WP_Job_Manager_Dependency_Checker {
+	const MINIMUM_PHP_VERSION = '5.6.20';
+	const MINIMUM_WP_VERSION  = '4.7.0';
+
+	/**
+	 * Check if WP Job Manager's dependencies have been met.
+	 *
+	 * @return bool True if we should continue to load the plugin.
+	 */
+	public static function check_dependencies() {
+		if ( self::check_php() ) {
+			add_action( 'admin_notices', array( 'WP_Job_Manager_Dependency_Checker', 'add_php_notice' ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks for our PHP version requirement.
+	 *
+	 * @return bool
+	 */
+	private static function check_php() {
+		return version_compare( phpversion(), self::MINIMUM_PHP_VERSION, '>=' );
+	}
+
+	/**
+	 * Adds notice in WP Admin that minimum version of PHP is not met.
+	 *
+	 * @access private
+	 */
+	public static function add_php_notice() {
+		$screen        = get_current_screen();
+		$valid_screens = array( 'dashboard', 'plugins', 'plugins-network', 'edit-job_listing', 'job_listing_page_job-manager-settings' );
+
+		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
+			return;
+		}
+
+		// translators: %1$s is version of PHP that WP Job Manager requires; %2$s is the version of PHP WordPress is running on.
+		$message = sprintf( __( 'The next release of <strong>WP Job Manager</strong> will require a minimum PHP version of %1$s, but you are running %2$s. Please update PHP to continue using this plugin.', 'wp-job-manager' ), self::MINIMUM_PHP_VERSION, phpversion() );
+
+		echo '<div class="error"><p>';
+		echo wp_kses( $message, array( 'strong' => array() ) );
+		$php_update_url = 'https://wordpress.org/support/update-php/';
+		if ( function_exists( 'wp_get_update_php_url' ) ) {
+			$php_update_url = wp_get_update_php_url();
+		}
+		printf(
+			'<p><a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
+			esc_url( $php_update_url ),
+			esc_html__( 'Learn more about updating PHP', 'wp-job-manager' ),
+			/* translators: accessibility text */
+			esc_html__( '(opens in a new tab)', 'wp-job-manager' )
+		);
+		echo '</p></div>';
+	}
+
+
+	/**
+	 * Checks for our PHP version requirement.
+	 *
+	 * @return bool
+	 */
+	public static function check_wp() {
+		global $wp_version;
+
+		return version_compare( $wp_version, self::MINIMUM_PHP_VERSION, '>=' );
+	}
+
+	/**
+	 * Adds notice in WP Admin that minimum version of WordPress is not met.
+	 *
+	 * @access private
+	 */
+	public static function add_wp_notice() {
+		// We only want to show the notices on the plugins page and WPJM admin pages.
+		$screen        = get_current_screen();
+		$valid_screens = array( 'dashboard', 'plugins', 'plugins-network', 'edit-job_listing', 'job_listing_page_job-manager-settings' );
+		if ( null === $screen || ! in_array( $screen->id, $valid_screens, true ) ) {
+			return;
+		}
+
+		echo '<div class="error">';
+		// translators: %s is the URL for the page where users can go to update WordPress.
+		echo '<p>' . wp_kses_post( sprintf( __( '<strong>WP Job Manager</strong> requires a more recent version of WordPress. <a href="%s">Please update WordPress</a> to avoid issues.', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) ) . '</p>';
+		echo '</div>';
+	}
+
+	/**
+	 * Add admin notice when WP upgrade is required.
+	 *
+	 * @param array $actions
+	 * @return array
+	 */
+	public function wp_version_plugin_action_notice( $actions ) {
+		// translators: Placeholder (%s) is the URL where users can go to update WordPress.
+		$actions[] = wp_kses_post( sprintf( __( '<a href="%s" style="color: red">WordPress Update Required</a>', 'wp-job-manager' ), esc_url( self_admin_url( 'update-core.php' ) ) ) );
+		return $actions;
+	}
+}

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -26,6 +26,11 @@ define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ )
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
+require_once dirname( __FILE__ ) . '/includes/class-wp-job-manager-dependency-checker.php';
+if ( ! WP_Job_Manager_Dependency_Checker::check_dependencies() ) {
+	return;
+}
+
 require_once dirname( __FILE__ ) . '/includes/class-wp-job-manager.php';
 
 /**

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -21,7 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Define constants.
 define( 'JOB_MANAGER_VERSION', '1.32.3' );
-define( 'JOB_MANAGER_MINIMUM_WP_VERSION', '4.7.0' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Fixes #1728 

#### Changes proposed in this Pull Request:

* Creates new class in charge of checking dependencies before the plugin is loaded.
* Moves WordPress version check to this class.

#### Testing instructions:

* Using PHP 5.2-5.5, try loading the plugin. Verify notice shows on admin dashboard, plugins page, job listing page in WP admin, and Job Manager settings.
* Using a version of WordPress older than 4.7.0, try loading the plugin. Verify notice shows on admin dashboard, plugins page, job listing page in WP admin, and Job Manager settings.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Warns admins of upcoming requirement for PHP 5.6.20+.