### PR TITLE
Track job submission and approval events

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1028,7 +1028,7 @@ class WP_Job_Manager_Post_Types {
 			WP_Job_Manager_Usage_Tracking::track_job_approval(
 				$post->ID,
 				array(
-					'source'     => $source,
+					'source' => $source,
 				)
 			);
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -69,6 +69,8 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'update_post_meta', array( $this, 'update_post_meta' ), 10, 4 );
 		add_action( 'wp_insert_post', array( $this, 'maybe_add_default_meta_data' ), 10, 2 );
 
+		add_action( 'transition_post_status', array( $this, 'track_job_submission' ), 10, 3 );
+
 		add_action( 'parse_query', array( $this, 'add_feed_query_args' ) );
 
 		// Single job content.
@@ -988,14 +990,58 @@ class WP_Job_Manager_Post_Types {
 	/**
 	 * Maybe sets default meta data for job listings.
 	 *
-	 * @param  int            $post_id
-	 * @param  WP_Post|string $post
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
 	 */
-	public function maybe_add_default_meta_data( $post_id, $post = '' ) {
+	public function maybe_add_default_meta_data( $post_id, $post ) {
 		if ( empty( $post ) || 'job_listing' === $post->post_type ) {
 			add_post_meta( $post_id, '_filled', 0, true );
 			add_post_meta( $post_id, '_featured', 0, true );
 		}
+	}
+
+	/**
+	 * Track job submission from the backend.
+	 *
+	 * @param string  $new_status  New post status.
+	 * @param string  $old_status  Old status.
+	 * @param WP_Post $post        Post object.
+	 */
+	public function track_job_submission( $new_status, $old_status, $post ) {
+		if ( empty( $post ) || 'job_listing' !== get_post_type( $post ) ) {
+			return;
+		}
+
+		if ( $new_status === $old_status || 'publish' !== $new_status ) {
+			return;
+		}
+
+		// For the purpose of this event, we only care about admin requests and REST API requests.
+		if ( ! is_admin() && ! WP_Job_Manager_Usage_Tracking::is_rest_request() ) {
+			return;
+		}
+
+		$source = WP_Job_Manager_Usage_Tracking::is_rest_request() ? 'rest_api' : 'admin';
+
+		if ( 'pending' === $old_status ) {
+			// Track approving a new job listing.
+			WP_Job_Manager_Usage_Tracking::track_job_approval(
+				$post->ID,
+				array(
+					'source'     => $source,
+				)
+			);
+
+			return;
+		}
+
+		WP_Job_Manager_Usage_Tracking::track_job_submission(
+			$post->ID,
+			array(
+				'source'     => $source,
+				'old_status' => $old_status,
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -312,4 +312,24 @@ class WP_Job_Manager_Usage_Tracking_Data {
 
 		return $query->found_posts;
 	}
+
+	/**
+	 * Get the base fields to be sent for event logging.
+	 *
+	 * @since 1.33.0
+	 *
+	 * @return array
+	 */
+	public static function get_event_logging_base_fields() {
+		$base_fields = array(
+			'job_listings' => wp_count_posts( 'job_listing' )->publish,
+		);
+
+		/**
+		 * Filter the fields that should be sent with every event that is logged.
+		 *
+		 * @param array $base_fields The default base fields.
+		 */
+		return apply_filters( 'job_manager_event_logging_base_fields', $base_fields );
+	}
 }

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -31,13 +31,115 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	/**
+	 * Track a WP Job Manager event.
+	 *
+	 * @since 1.33.0
+	 *
+	 * @param string $event_name The name of the event, without the `wpjm` prefix.
+	 * @param array  $properties The event properties to be sent.
+	 */
+	public static function log_event( $event_name, $properties = array() ) {
+		$properties = array_merge(
+			WP_Job_Manager_Usage_Tracking_Data::get_event_logging_base_fields(),
+			$properties
+		);
+
+		self::get_instance()->send_event( $event_name, $properties );
+	}
+
+	/**
+	 * Get the current user's primary role.
+	 *
+	 * @return string
+	 */
+	private static function get_current_role() {
+		$current_user = wp_get_current_user();
+		$roles        = $current_user->roles;
+
+		if ( empty( $roles ) ) {
+			return 'guest';
+		}
+
+		if ( in_array( 'administrator', $roles, true ) ) {
+			return 'administrator';
+		}
+
+		if ( in_array( 'employer', $roles, true ) ) {
+			return 'employer';
+		}
+
+		return array_shift( $roles );
+	}
+
+
+	/**
+	 * Check if current request is a REST API request.
+	 *
+	 * @todo move this to WP_Job_Manager_REST_API
+	 * @return bool
+	 */
+	public static function is_rest_request() {
+		return defined( 'REST_REQUEST' ) && REST_REQUEST;
+	}
+
+	/**
+	 * Track the job submission event.
+	 *
+	 * @param int   $post_id    Post ID.
+	 * @param array $properties Default properties to use.
+	 */
+	public static function track_job_submission( $post_id, $properties = array() ) {
+		// Only track the first time a job is submitted.
+		if ( get_post_meta( $post_id, '_tracked_submitted' ) ) {
+			return;
+		}
+		update_post_meta( $post_id, '_tracked_submitted', time() );
+
+		$properties['job_id']      = intval( $post_id );
+		$properties['post_status'] = get_post_status( $post_id );
+
+		$user_role  = self::get_current_role();
+		if ( $user_role ) {
+			$properties['user_role'] = $user_role;
+		}
+
+		WP_Job_Manager_Usage_Tracking::log_event( 'job_listing_submitted', $properties );
+	}
+
+	/**
+	 * Track the job approval event.
+	 *
+	 * @param int   $post_id    Post ID.
+	 * @param array $properties Default properties to use.
+	 */
+	public static function track_job_approval( $post_id, $properties = array() ) {
+		// Only track the first time a job is approved.
+		if ( get_post_meta( $post_id, '_tracked_approved' ) ) {
+			return;
+		}
+		update_post_meta( $post_id, '_tracked_approved', time() );
+
+		$post = get_post( $post_id );
+
+		$properties['job_id'] = intval( $post_id );
+		$properties['age']    = time() - strtotime( $post->post_date_gmt );
+
+		$user_role  = self::get_current_role();
+		if ( $user_role ) {
+			$properties['user_role'] = $user_role;
+		}
+
+		WP_Job_Manager_Usage_Tracking::log_event( 'job_listing_approved', $properties );
+	}
+
+	/**
 	 * Implementation for abstract functions.
 	 */
 
 	/**
 	 * Return the instance of this class.
 	 *
-	 * @return object
+	 * @return self
 	 */
 	public static function get_instance() {
 		return self::get_instance_for_subclass( get_class() );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -59,6 +59,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		add_action( 'wp', array( $this, 'process' ) );
 		add_action( 'submit_job_form_start', array( $this, 'output_submit_form_nonce_field' ) );
 		add_action( 'preview_job_form_start', array( $this, 'output_preview_form_nonce_field' ) );
+		add_action( 'job_manager_job_submitted', array( $this, 'track_job_submission' ) );
 
 		if ( $this->use_recaptcha_field() ) {
 			add_action( 'submit_job_form_end', array( $this, 'display_recaptcha_field' ) );
@@ -952,5 +953,20 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 */
 	public function done_before() {
 		do_action( 'job_manager_job_submitted', $this->job_id );
+	}
+
+	/**
+	 * Send usage tracking event for job submission.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function track_job_submission( $post_id ) {
+		WP_Job_Manager_Usage_Tracking::track_job_submission(
+			$post_id,
+			array(
+				'source'     => 'frontend',
+				'old_status' => 'preview',
+			)
+		);
 	}
 }


### PR DESCRIPTION
Fixes #1738

#### Changes proposed in this Pull Request:

* Fires usage tracking event when job is submitted from frontend or created in WP admin.
* Fires usage tracking event when job is approved from WP admin.

#### Testing instructions:

* See issue for expected property values.
* Enable event tracking in Job Manager > Settings.
* Submit job from frontend and verify the `wpjm_job_listing_submitted` event fires with `source` set to `frontend`.
* Create job from WP admin (both in classic and block editors) and verify `wpjm_job_listing_submitted` fires with `source` set to `admin` or `rest_api`.
* Approve job from WP admin (that was submitted from frontend) and verify the event `wpjm_job_listing_approved` is fired with appropriate `age` value.
