### PR TITLE
Freeze WP version for PHP 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     env: WP_TRAVISCI="phpcs"
   - php: "5.2"
     dist: precise
-    env: WP_VERSION=latest
+    env: WP_VERSION=5.1.1
   - php: "5.6"
     env: WP_VERSION=latest
   - php: "5.6"


### PR DESCRIPTION
Until we bump the PHP version, we need to freeze the WordPress version Travis runs PHP 5.2 tests on to 5.1.1.