### PR TITLE
Fix company logo extending outside parent

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,1 +1,1257 @@
-.clearfix{zoom:1}.clearfix:after,.clearfix:before{content:"";display:table}.clearfix:after{clear:both}@font-face{font-family:job-manager;src:url(../font/job-manager.eot?4963673);src:url(../font/job-manager.eot?4963673#iefix) format('embedded-opentype'),url(../font/job-manager.woff?4963673) format('woff'),url(../font/job-manager.ttf?4963673) format('truetype'),url(../font/job-manager.svg?4963673#job-manager) format('svg');font-weight:400;font-style:normal}@font-face{font-family:jm-logo;src:url(../font/jm-logo/jm.eot?ycsbky);src:url(../font/jm-logo/jm.eot?#iefixycsbky) format('embedded-opentype'),url(../font/jm-logo/jm.woff?ycsbky) format('woff'),url(../font/jm-logo/jm.ttf?ycsbky) format('truetype'),url(../font/jm-logo/jm.svg?ycsbky#icomoon) format('svg');font-weight:400;font-style:normal}.jm-icon{font-family:job-manager!important;font-style:normal;font-weight:400;speak:none;display:inline-block;text-decoration:inherit;width:1em;text-align:center;font-variant:normal;text-transform:none;line-height:1em}.rp4wp-related-job_listing>ul,ul.job_listings{padding:0;margin:0;border-top:1px solid #eee}.rp4wp-related-job_listing>ul.loading,ul.job_listings.loading{min-height:96px;border-bottom:1px solid #eee;background:url(../images/ajax-loader.gif) no-repeat center 32px}.rp4wp-related-job_listing>ul li.job_listing,.rp4wp-related-job_listing>ul li.no_job_listings_found,ul.job_listings li.job_listing,ul.job_listings li.no_job_listings_found{list-style:none outside;padding:0;margin:0;border-bottom:1px solid #eee}.rp4wp-related-job_listing>ul li.job_listing.job_position_filled a,.rp4wp-related-job_listing>ul li.no_job_listings_found.job_position_filled a,ul.job_listings li.job_listing.job_position_filled a,ul.job_listings li.no_job_listings_found.job_position_filled a{opacity:.25}.rp4wp-related-job_listing>ul li.job_listing.no_job_listings_found,.rp4wp-related-job_listing>ul li.no_job_listings_found.no_job_listings_found,ul.job_listings li.job_listing.no_job_listings_found,ul.job_listings li.no_job_listings_found.no_job_listings_found{padding:1em;border-bottom:1px solid #eee}.rp4wp-related-job_listing>ul li.job_listing a,.rp4wp-related-job_listing>ul li.no_job_listings_found a,ul.job_listings li.job_listing a,ul.job_listings li.no_job_listings_found a{display:block;padding:1em 1em 1em 2em;border:0;overflow:hidden;zoom:1;position:relative;line-height:1.5em;text-decoration:none}.rp4wp-related-job_listing>ul li.job_listing a:focus,.rp4wp-related-job_listing>ul li.job_listing a:hover,.rp4wp-related-job_listing>ul li.no_job_listings_found a:focus,.rp4wp-related-job_listing>ul li.no_job_listings_found a:hover,ul.job_listings li.job_listing a:focus,ul.job_listings li.job_listing a:hover,ul.job_listings li.no_job_listings_found a:focus,ul.job_listings li.no_job_listings_found a:hover{background-color:#fcfcfc}.rp4wp-related-job_listing>ul li.job_listing a img.company_logo,.rp4wp-related-job_listing>ul li.no_job_listings_found a img.company_logo,ul.job_listings li.job_listing a img.company_logo,ul.job_listings li.no_job_listings_found a img.company_logo{width:42px;height:42px;position:absolute;left:1em;float:left;margin-right:1em;vertical-align:middle;box-shadow:none}.rp4wp-related-job_listing>ul li.job_listing a div.location,.rp4wp-related-job_listing>ul li.job_listing a div.position,.rp4wp-related-job_listing>ul li.job_listing a ul.meta,.rp4wp-related-job_listing>ul li.no_job_listings_found a div.location,.rp4wp-related-job_listing>ul li.no_job_listings_found a div.position,.rp4wp-related-job_listing>ul li.no_job_listings_found a ul.meta,ul.job_listings li.job_listing a div.location,ul.job_listings li.job_listing a div.position,ul.job_listings li.job_listing a ul.meta,ul.job_listings li.no_job_listings_found a div.location,ul.job_listings li.no_job_listings_found a div.position,ul.job_listings li.no_job_listings_found a ul.meta{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.rp4wp-related-job_listing>ul li.job_listing a div.position,.rp4wp-related-job_listing>ul li.no_job_listings_found a div.position,ul.job_listings li.job_listing a div.position,ul.job_listings li.no_job_listings_found a div.position{float:left;width:55%;padding:0 0 0 42px;line-height:1.5em}.rp4wp-related-job_listing>ul li.job_listing a div.position h3,.rp4wp-related-job_listing>ul li.no_job_listings_found a div.position h3,ul.job_listings li.job_listing a div.position h3,ul.job_listings li.no_job_listings_found a div.position h3{margin:0;padding:0;line-height:inherit;font-size:inherit}.rp4wp-related-job_listing>ul li.job_listing a div.position .company,.rp4wp-related-job_listing>ul li.no_job_listings_found a div.position .company,ul.job_listings li.job_listing a div.position .company,ul.job_listings li.no_job_listings_found a div.position .company{color:#999}.rp4wp-related-job_listing>ul li.job_listing a div.position .company .tagline,.rp4wp-related-job_listing>ul li.no_job_listings_found a div.position .company .tagline,ul.job_listings li.job_listing a div.position .company .tagline,ul.job_listings li.no_job_listings_found a div.position .company .tagline{margin-left:.5em}.rp4wp-related-job_listing>ul li.job_listing a div.location,.rp4wp-related-job_listing>ul li.no_job_listings_found a div.location,ul.job_listings li.job_listing a div.location,ul.job_listings li.no_job_listings_found a div.location{float:left;text-align:left;width:25%;padding:0 0 0 1em;color:#999;line-height:1.5em}.rp4wp-related-job_listing>ul li.job_listing a .meta,.rp4wp-related-job_listing>ul li.no_job_listings_found a .meta,ul.job_listings li.job_listing a .meta,ul.job_listings li.no_job_listings_found a .meta{float:right;text-align:right;width:20%;padding:0 0 0 1em;margin:0;line-height:1.5em;color:#999;list-style:none outside}.rp4wp-related-job_listing>ul li.job_listing a .meta li,.rp4wp-related-job_listing>ul li.no_job_listings_found a .meta li,ul.job_listings li.job_listing a .meta li,ul.job_listings li.no_job_listings_found a .meta li{list-style:none outside;display:block;margin:0}.rp4wp-related-job_listing>ul li.job_listing a .meta .job-type,.rp4wp-related-job_listing>ul li.no_job_listings_found a .meta .job-type,ul.job_listings li.job_listing a .meta .job-type,ul.job_listings li.no_job_listings_found a .meta .job-type{font-weight:700}.rp4wp-related-job_listing>ul li.job_listing.job_position_featured a,.rp4wp-related-job_listing>ul li.no_job_listings_found.job_position_featured a,ul.job_listings li.job_listing.job_position_featured a,ul.job_listings li.no_job_listings_found.job_position_featured a{background:#fefee5}.rp4wp-related-job_listing>ul li.job_listing.job_position_featured a:focus,.rp4wp-related-job_listing>ul li.job_listing.job_position_featured a:hover,.rp4wp-related-job_listing>ul li.no_job_listings_found.job_position_featured a:focus,.rp4wp-related-job_listing>ul li.no_job_listings_found.job_position_featured a:hover,ul.job_listings li.job_listing.job_position_featured a:focus,ul.job_listings li.job_listing.job_position_featured a:hover,ul.job_listings li.no_job_listings_found.job_position_featured a:focus,ul.job_listings li.no_job_listings_found.job_position_featured a:hover{background-color:#fefed8}.widget ul.job_listings li.job_listing a{padding:1em 0}.widget ul.job_listings li.job_listing .image{float:left}.widget ul.job_listings li.job_listing .image img{left:0;position:relative}.widget ul.job_listings li.job_listing .content{overflow:hidden}.widget ul.job_listings li.job_listing .position{float:none;width:auto;padding:0}.widget ul.job_listings li.job_listing ul.meta{float:none;width:auto;padding:0;margin:0;text-align:left}.widget ul.job_listings li.job_listing ul.meta li{float:none;display:inline;padding:0;margin:0 .5em 0 0;font-weight:400}.widget ul.job_listings li.job_listing ul.meta li:after{padding:0 0 0 .5em;content:"\2023"}.widget ul.job_listings li.job_listing ul.meta li:last-child:after{content:''}.job-manager .job-type,.job-types .job-type,.job_listing .job-type{color:#f08d3c}.job-manager .full-time,.job-types .full-time,.job_listing .full-time{color:#90da36}.job-manager .part-time,.job-types .part-time,.job_listing .part-time{color:#f08d3c}.job-manager .temporary,.job-types .temporary,.job_listing .temporary{color:#d93674}.job-manager .freelance,.job-types .freelance,.job_listing .freelance{color:#39c}.job-manager .internship,.job-types .internship,.job_listing .internship{color:#6033cc}@media only screen and (max-width:767px){ul.job_listings li.job_listing a,ul.job_listings li.no_job_listings_found a{padding:1em}ul.job_listings li.job_listing a img.company_logo,ul.job_listings li.no_job_listings_found a img.company_logo{visibility:hidden}ul.job_listings li.job_listing a div.position,ul.job_listings li.no_job_listings_found a div.position{float:left;width:60%;padding:0}ul.job_listings li.job_listing a div.location,ul.job_listings li.no_job_listings_found a div.location{float:right;width:40%;line-height:2em;font-size:.75em;padding:0 0 0 1em;text-align:right}ul.job_listings li.job_listing a .meta,ul.job_listings li.no_job_listings_found a .meta{float:right;width:40%;line-height:2em;font-size:.75em}ul.job_listings li.job_listing a .meta li,ul.job_listings li.no_job_listings_found a .meta li{font-size:1em}}.twenty-eleven ul.job_listings li.job_listing,.twenty-eleven ul.job_listings li.no_job_listings_found{padding:0!important}.display-icon{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0}.job-manager-error,.job-manager-info,.job-manager-message{padding:1em 2em 1em 3.5em!important;margin:0 0 2em!important;position:relative;background-color:#fff;color:#666;border-top:3px solid #999;list-style:none outside!important;width:auto;zoom:1;box-shadow:0 1px 1px rgba(0,0,0,.2)}.job-manager-error:after,.job-manager-error:before,.job-manager-info:after,.job-manager-info:before,.job-manager-message:after,.job-manager-message:before{content:"";display:table}.job-manager-error:after,.job-manager-info:after,.job-manager-message:after{clear:both}.job-manager-error:before,.job-manager-info:before,.job-manager-message:before{content:"";font-family:sans-serif;display:inline-block;position:absolute;top:1em;left:1.5em}.job-manager-error li,.job-manager-info li,.job-manager-message li{list-style:none outside!important;padding-left:0!important;margin-left:0!important}.job-manager-error.job-manager-message,.job-manager-info.job-manager-message,.job-manager-message.job-manager-message{border-top-color:#8fae1b}.job-manager-error.job-manager-message:before,.job-manager-info.job-manager-message:before,.job-manager-message.job-manager-message:before{color:#8fae1b;content:"\2713"}.job-manager-error.job-manager-info,.job-manager-info.job-manager-info,.job-manager-message.job-manager-info{border-top-color:#1e85be}.job-manager-error.job-manager-info:before,.job-manager-info.job-manager-info:before,.job-manager-message.job-manager-info:before{color:#1e85be;content:"i";font-family:Times,Georgia,serif;font-style:italic}.job-manager-error.job-manager-error,.job-manager-info.job-manager-error,.job-manager-message.job-manager-error{border-top-color:#b81c23}.job-manager-error.job-manager-error:before,.job-manager-info.job-manager-error:before,.job-manager-message.job-manager-error:before{color:#b81c23;content:"\00d7";font-weight:700}.job-manager-form fieldset{margin:0 0 1em 0;padding:0 0 1em 0;line-height:2em;border:0;border-bottom:1px solid #eee;zoom:1}.job-manager-form fieldset:after,.job-manager-form fieldset:before{content:"";display:table}.job-manager-form fieldset:after{clear:both}.job-manager-form fieldset label{display:block;margin:0;width:29%;float:left;vertical-align:middle}.job-manager-form fieldset label small{opacity:.75;font-size:.83em}.job-manager-form fieldset div.field{width:70%;float:right;vertical-align:middle}.job-manager-form fieldset .wp-editor-container{border:1px solid #ccc;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}.job-manager-form fieldset .account-sign-in .button{margin-right:.5em}.job-manager-form fieldset .account-sign-in .button:before{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0;content:'\e808'}.job-manager-form fieldset abbr.required{color:red;font-weight:700;border:0}.job-manager-form fieldset input.input-text,.job-manager-form fieldset select,.job-manager-form fieldset textarea{margin:0;vertical-align:middle;width:100%;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.job-manager-form fieldset small.description{opacity:.75;font-size:.83em;margin:1.2em 0 0 0;display:block;line-height:1.2em}.job-manager-form fieldset .job-manager-uploaded-files{display:table}.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file{line-height:2em;font-style:italic;margin-bottom:1em;display:block}.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file .job-manager-uploaded-file-preview img{height:64px;margin:0;vertical-align:top}.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file .job-manager-uploaded-file-preview a{line-height:64px;display:inline-block;padding:0 0 0 1em}.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file .job-manager-uploaded-file-name{display:block}.job-manager-form .submit-job{padding:1em 0}.job-manager-form .job-manager-term-checklist{list-style:none outside;max-height:200px;overflow:auto;margin:0}.job-manager-form .job-manager-term-checklist li{list-style:none outside;margin:0;display:block;float:none}.job-manager-form .job-manager-term-checklist li label{width:auto;float:none}.job-manager-form .job-manager-term-checklist li li{margin:0 0 0 2em}.job-manager-form input[type=submit].disabled,.job-manager-form input[type=submit]:disabled{opacity:.5;cursor:not-allowed}.job-manager-form .spinner{background-repeat:no-repeat;background-size:20px 20px;display:inline-block;visibility:hidden;width:20px;height:20px;margin:0;vertical-align:middle}.job-manager-form .spinner.is-active{visibility:visible}div.job_listings{margin-bottom:1em}div.job_listings ul.job_listings{margin:0}.single_job_listing .company{position:relative;border:1px solid #eee;padding:1em;margin:0 0 2em;display:block;clear:both;min-height:3em;box-shadow:0 1px 1px rgba(0,0,0,.1)}.single_job_listing .company img{width:3em;height:3em;position:absolute;left:1em;float:left;vertical-align:middle;box-shadow:none}.single_job_listing .company .name{margin:0 0 0 3em;padding:0 0 0 1em;line-height:1.5em}.single_job_listing .company .name a{float:right;margin-left:1em}.single_job_listing .company .tagline{display:block;margin:0 0 0 3em;padding:0 0 0 1em;line-height:1.5em;font-style:italic;color:#999}.single_job_listing .company .website:before{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0;content:'\e809'}.single_job_listing .company .company_twitter:before{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0;content:'\e80a'}.single_job_listing .company .company_video{border-top:1px solid #eee;padding:1em 0 0;margin:1em 0 0 0;position:relative;padding-bottom:56.25%;padding-top:30px;height:0;overflow:hidden}.single_job_listing .company .company_video embed,.single_job_listing .company .company_video iframe,.single_job_listing .company .company_video object{position:absolute;top:0;left:0;width:100%;height:100%;margin:0;display:block}.single_job_listing .meta{list-style:none outside;padding:0;margin:0 0 1.5em;overflow:hidden;zoom:1;clear:both}.single_job_listing .meta li{margin:0 1em 0 0;padding:.5em;float:left;line-height:1em;color:#999}.single_job_listing .meta .job-type{color:#fff;background-color:#f08d3c}.single_job_listing .meta .full-time{background-color:#90da36}.single_job_listing .meta .part-time{background-color:#f08d3c}.single_job_listing .meta .temporary{background-color:#d93674}.single_job_listing .meta .freelance{background-color:#39c}.single_job_listing .meta .internship{background-color:#6033cc}.single_job_listing .meta .listing-expired,.single_job_listing .meta .position-filled{color:#b81c23}.single_job_listing .meta .location:before{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0;content:'\e81d'}.single_job_listing .meta .date-posted:before{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0;content:'\e80f'}.single_job_listing .meta .listing-expired:before,.single_job_listing .meta .position-filled:before{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0;content:'\e80e'}.single_job_listing .job_description{margin:0 0 1.5em}.job-manager-application-wrapper{clear:both;border:1px solid #eee;padding:.75em 1em 0;margin:1em 0;line-height:1.5em;display:block;position:relative;box-shadow:0 1px 1px rgba(0,0,0,.1)}.job-manager-application-wrapper .application,.single_job_listing .application{padding:0;margin:0 0 1em;overflow:hidden}.job-manager-application-wrapper .application .application_button,.job-manager-application-wrapper .application .application_details,.single_job_listing .application .application_button,.single_job_listing .application .application_details{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.job-manager-application-wrapper .application .application_button,.single_job_listing .application .application_button{text-align:center;font-size:1.1em;line-height:1em;display:inline-block;margin:0 .5em 0 0;padding:.90909091em 2em;outline:0}.job-manager-application-wrapper .application .application_details,.single_job_listing .application .application_details{clear:both;border:1px solid #eee;padding:.75em 1em 0;margin:1em 0;line-height:1.5em;display:block;position:relative;box-shadow:0 1px 1px rgba(0,0,0,.1)}.job-manager-application-wrapper .application .application_details p,.single_job_listing .application .application_details p{margin:0 0 .75em}.job-manager-application-wrapper .application .application_details:before,.single_job_listing .application .application_details:before{content:"";position:absolute;margin:-10px 0 0 0;top:0;left:5em;width:0;height:0;border-left:10px solid transparent;border-right:10px solid transparent;border-bottom:10px solid #eee}.job-manager-application-wrapper .application .application_details:after,.single_job_listing .application .application_details:after{content:"";position:absolute;margin:-9px 0 0 1px;left:5em;top:0;width:0;height:0;border-left:9px solid transparent;border-right:9px solid transparent;border-bottom:9px solid #fff}.job_filters{background:#eee;zoom:1}.job_filters:after,.job_filters:before{content:"";display:table}.job_filters:after{clear:both}.job_filters .search_jobs{padding:1em;zoom:1}.job_filters .search_jobs:after,.job_filters .search_jobs:before{content:"";display:table}.job_filters .search_jobs:after{clear:both}.job_filters .search_jobs div{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.job_filters .search_jobs div label{display:none}.job_filters .search_jobs div.filter_first,.job_filters .search_jobs div.search_keywords{float:left;padding-right:.5em;width:50%}.job_filters .search_jobs div.filter_last,.job_filters .search_jobs div.search_location{float:right;padding-left:.5em;width:50%}.job_filters .search_jobs div.filter_wide,.job_filters .search_jobs div.search_categories{padding-top:.5em;clear:both;width:100%}.job_filters .search_jobs div.search_submit{padding-top:.5em}.job_filters .search_jobs div .showing_jobs a{padding:.25em}.job_filters .search_jobs div .showing_jobs a.active{background:#ddd;text-decoration:none}.job_filters .search_jobs input,.job_filters .search_jobs select{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;width:100%}.job_filters .job_types{list-style:none outside;margin:0;padding:0;font-size:.83em;background:#f9f9f9;border-top:1px solid #e5e5e5;zoom:1}.job_filters .job_types:after,.job_filters .job_types:before{content:"";display:table}.job_filters .job_types:after{clear:both}.job_filters .job_types li{margin:0;padding:.5em 1em;float:left;border-right:1px solid #eee}.job_filters .job_types li:last-child{border-right:0}.job_filters .showing_jobs{padding:.5em 1em;display:none;font-size:.83em;background:#f9f9f9;border-top:1px solid #e5e5e5}.job_filters .showing_jobs a{float:right;padding-left:10px;border:0}div.job_listings .job-manager-pagination{text-align:center;display:block;padding:1em 0 1em 0;border-bottom:1px solid #eee;line-height:1}div.job_listings .load_previous{border-top:1px solid #eee}div.job_listings .load_more_jobs+ul.job_listings{border-top:0}div.job_listings .load_more_jobs{text-align:center;display:block;padding:1em 1em 1em 2em;border-bottom:1px solid #eee;font-weight:700}div.job_listings .load_more_jobs.loading{background:url(../images/ajax-loader.gif) no-repeat center}div.job_listings .load_more_jobs.loading strong{visibility:hidden}div.job_listings .load_more_jobs:focus,div.job_listings .load_more_jobs:hover{background-color:#fcfcfc;border-bottom:1px solid #eee}.job_listing_preview{padding:0 1em 1em;border:5px solid #eee}.single-job_listing .entry-header .attachment-post-thumbnail,.single-job_listing .job_listing.has-post-thumbnail .post-thumbnail{display:none}.entry-content .job_listing_preview_title,.job_listing_preview_title{padding:.5em 1em;vertical-align:middle;position:relative;background:#eee}.entry-content .job_listing_preview_title h2,.job_listing_preview_title h2{margin:0;clear:none}.entry-content .job_listing_preview_title .button,.job_listing_preview_title .button{float:right;margin-left:.25em}.job_summary_shortcode{border:1px solid #ccc;-moz-border-radius:4px;-webkit-border-radius:4px;border-radius:4px;text-align:center;position:relative;box-shadow:0 2px 4px rgba(0,0,0,.1),inset 0 1px 0 rgba(255,255,255,.4);-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.job_summary_shortcode.aligncenter{display:block;margin:2em auto 2em}.job_summary_shortcode.alignleft{float:left;margin:0 2em 2em 0}.job_summary_shortcode.alignright{float:right;margin:0 0 2em 2em}.job_summary_shortcode a{text-decoration:none;color:inherit}.job_summary_shortcode img{margin:0;padding:0;display:block;width:100%;-moz-border-radius:0;-webkit-border-radius:0;-moz-border-top-left-radius:3px;-moz-border-top-right-radius:3px;-webkit-border-top-left-radius:3px;-webkit-border-top-right-radius:3px;border-radius:0;border-top-left-radius:3px;border-top-right-radius:3px;box-shadow:inset 0 1px 0 rgba(255,255,255,.4)}.job_summary_shortcode .job_summary_content{padding:0 1em}.job_summary_shortcode .meta{font-style:italic;color:#777}.job_summary_shortcode .job-type{-moz-border-radius:1em;-webkit-border-radius:1em;border-radius:1em;color:#fff;text-shadow:0 1px 0 rgba(255,255,255,.5);box-shadow:0 2px 4px rgba(0,0,0,.1),inset 0 1px 0 rgba(255,255,255,.4);position:absolute;top:0;right:0;padding:.5em;height:1em;width:auto;min-width:1em;font-size:1em;text-align:center;vertical-align:middle;line-height:1em;margin:-.5em -.5em 0 0}.job_summary_shortcode .job-type.full-time{background-color:#90da36}.job_summary_shortcode .job-type.part-time{background-color:#f08d3c}.job_summary_shortcode .job-type.temporary{background-color:#d93674}.job_summary_shortcode .job-type.freelance{background-color:#39c}.job_summary_shortcode .job-type.internship{background-color:#6033cc}#job-manager-job-dashboard .account-sign-in .button{margin-right:.5em}#job-manager-job-dashboard .account-sign-in .button:before{display:inline-block;width:16px;height:16px;-webkit-font-smoothing:antialiased;font-family:job-manager!important;text-decoration:none;font-weight:400;font-style:normal;vertical-align:top;font-size:16px;margin:0 2px 0 0;content:'\e808'}#job-manager-job-dashboard table ul.job-dashboard-actions{margin:0;padding:0;visibility:hidden;font-size:.92em}#job-manager-job-dashboard table ul.job-dashboard-actions li{float:none;display:inline;padding:0;margin:0 .5em 0 0;font-weight:400;list-style:none outside}#job-manager-job-dashboard table ul.job-dashboard-actions li:after{padding:0 0 0 .5em;content:"\2023"}#job-manager-job-dashboard table ul.job-dashboard-actions li:last-child:after{content:''}#job-manager-job-dashboard table ul.job-dashboard-actions li .job-dashboard-action-delete{color:red}#job-manager-job-dashboard table tr:focus ul.job-dashboard-actions,#job-manager-job-dashboard table tr:hover ul.job-dashboard-actions{visibility:visible}#job-manager-job-dashboard table td,#job-manager-job-dashboard table th{padding:.5em 1em .5em 0}#job-manager-job-dashboard table .job_title small{color:#999}#job-manager-job-dashboard table .featured-job-icon:before{content:'\e803';font-family:job-manager!important;font-style:normal;font-weight:400;speak:none;display:inline-block;text-decoration:inherit;width:1em;text-align:center;font-variant:normal;text-transform:none;line-height:1em}#job-manager-job-dashboard table .applications,#job-manager-job-dashboard table .expires,#job-manager-job-dashboard table .filled{text-align:center}#content nav.job-manager-pagination,nav.job-manager-pagination{text-align:center}#content nav.job-manager-pagination ul,nav.job-manager-pagination ul{display:inline-block;white-space:nowrap;padding:0;clear:both;border-left:1px solid #eee;margin:1px}#content nav.job-manager-pagination ul li,nav.job-manager-pagination ul li{border-right:1px solid #eee;border-top:1px solid #eee;border-bottom:1px solid #eee;padding:0;margin:0;float:left;display:inline;overflow:hidden}#content nav.job-manager-pagination ul li a,#content nav.job-manager-pagination ul li span,nav.job-manager-pagination ul li a,nav.job-manager-pagination ul li span{margin:0;text-decoration:none;padding:0;line-height:1em;font-size:1em;font-weight:400;padding:.5em;min-width:1em;display:block;border:0}#content nav.job-manager-pagination ul li a:focus,#content nav.job-manager-pagination ul li a:hover,#content nav.job-manager-pagination ul li span.current,nav.job-manager-pagination ul li a:focus,nav.job-manager-pagination ul li a:hover,nav.job-manager-pagination ul li span.current{background:#eee;color:#888}.chosen-container{width:100%!important}.twenty-ten .chosen-choices,.twenty-ten .job_types{margin:0!important}.rtl .job-manager-form label{float:right}.rtl .job-manager-form div.field{float:left}.rtl .entry-content .job_listing_preview_title .button,.rtl .job_listing_preview_title .button{float:left}.rtl .single_job_listing .meta li{float:right;margin:0 0 0 1em}
+.clearfix {
+  zoom: 1;
+  /* For IE 6/7 (trigger hasLayout) */
+}
+.clearfix:before,
+.clearfix:after {
+  content: "";
+  display: table;
+}
+.clearfix:after {
+  clear: both;
+}
+@font-face {
+  font-family: 'job-manager';
+  src: url('../font/job-manager.eot?4963673');
+  src: url('../font/job-manager.eot?4963673#iefix') format('embedded-opentype'), url('../font/job-manager.woff?4963673') format('woff'), url('../font/job-manager.ttf?4963673') format('truetype'), url('../font/job-manager.svg?4963673#job-manager') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'jm-logo';
+  src: url('../font/jm-logo/jm.eot?ycsbky');
+  src: url('../font/jm-logo/jm.eot?#iefixycsbky') format('embedded-opentype'), url('../font/jm-logo/jm.woff?ycsbky') format('woff'), url('../font/jm-logo/jm.ttf?ycsbky') format('truetype'), url('../font/jm-logo/jm.svg?ycsbky#icomoon') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+.jm-icon {
+  font-family: "job-manager" !important;
+  font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  text-align: center;
+  /* For safety - reset parent styles, that can break glyph codes*/
+  font-variant: normal;
+  text-transform: none;
+  /* fix buttons height, for twitter bootstrap */
+  line-height: 1em;
+}
+.rp4wp-related-job_listing > ul,
+ul.job_listings {
+  padding: 0;
+  margin: 0;
+  border-top: 1px solid #eee;
+}
+.rp4wp-related-job_listing > ul.loading,
+ul.job_listings.loading {
+  min-height: 96px;
+  border-bottom: 1px solid #eee;
+  background: url(../images/ajax-loader.gif) no-repeat center 32px;
+}
+.rp4wp-related-job_listing > ul li.job_listing,
+ul.job_listings li.job_listing,
+.rp4wp-related-job_listing > ul li.no_job_listings_found,
+ul.job_listings li.no_job_listings_found {
+  list-style: none outside;
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px solid #eee;
+}
+.rp4wp-related-job_listing > ul li.job_listing.job_position_filled a,
+ul.job_listings li.job_listing.job_position_filled a,
+.rp4wp-related-job_listing > ul li.no_job_listings_found.job_position_filled a,
+ul.job_listings li.no_job_listings_found.job_position_filled a {
+  opacity: 0.25;
+}
+.rp4wp-related-job_listing > ul li.job_listing.no_job_listings_found,
+ul.job_listings li.job_listing.no_job_listings_found,
+.rp4wp-related-job_listing > ul li.no_job_listings_found.no_job_listings_found,
+ul.job_listings li.no_job_listings_found.no_job_listings_found {
+  padding: 1em;
+  border-bottom: 1px solid #eee;
+}
+.rp4wp-related-job_listing > ul li.job_listing a,
+ul.job_listings li.job_listing a,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a,
+ul.job_listings li.no_job_listings_found a {
+  display: block;
+  padding: 1em 1em 1em 2em;
+  border: 0;
+  overflow: hidden;
+  zoom: 1;
+  position: relative;
+  line-height: 1.5em;
+  text-decoration: none;
+}
+.rp4wp-related-job_listing > ul li.job_listing a:hover,
+ul.job_listings li.job_listing a:hover,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a:hover,
+ul.job_listings li.no_job_listings_found a:hover,
+.rp4wp-related-job_listing > ul li.job_listing a:focus,
+ul.job_listings li.job_listing a:focus,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a:focus,
+ul.job_listings li.no_job_listings_found a:focus {
+  background-color: #fcfcfc;
+}
+.rp4wp-related-job_listing > ul li.job_listing a img.company_logo,
+ul.job_listings li.job_listing a img.company_logo,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a img.company_logo,
+ul.job_listings li.no_job_listings_found a img.company_logo {
+  width: 42px;
+  height: 42px;
+  position: absolute;
+  left: 1em;
+  float: left;
+  margin-right: 1em;
+  vertical-align: middle;
+  box-shadow: none;
+}
+.rp4wp-related-job_listing > ul li.job_listing a div.position,
+ul.job_listings li.job_listing a div.position,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a div.position,
+ul.job_listings li.no_job_listings_found a div.position,
+.rp4wp-related-job_listing > ul li.job_listing a div.location,
+ul.job_listings li.job_listing a div.location,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a div.location,
+ul.job_listings li.no_job_listings_found a div.location,
+.rp4wp-related-job_listing > ul li.job_listing a ul.meta,
+ul.job_listings li.job_listing a ul.meta,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a ul.meta,
+ul.job_listings li.no_job_listings_found a ul.meta {
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+}
+.rp4wp-related-job_listing > ul li.job_listing a div.position,
+ul.job_listings li.job_listing a div.position,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a div.position,
+ul.job_listings li.no_job_listings_found a div.position {
+  float: left;
+  width: 55%;
+  padding: 0 0 0 42px;
+  line-height: 1.5em;
+}
+.rp4wp-related-job_listing > ul li.job_listing a div.position h3,
+ul.job_listings li.job_listing a div.position h3,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a div.position h3,
+ul.job_listings li.no_job_listings_found a div.position h3 {
+  margin: 0;
+  padding: 0;
+  line-height: inherit;
+  font-size: inherit;
+}
+.rp4wp-related-job_listing > ul li.job_listing a div.position .company,
+ul.job_listings li.job_listing a div.position .company,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a div.position .company,
+ul.job_listings li.no_job_listings_found a div.position .company {
+  color: #999;
+}
+.rp4wp-related-job_listing > ul li.job_listing a div.position .company .tagline,
+ul.job_listings li.job_listing a div.position .company .tagline,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a div.position .company .tagline,
+ul.job_listings li.no_job_listings_found a div.position .company .tagline {
+  margin-left: .5em;
+}
+.rp4wp-related-job_listing > ul li.job_listing a div.location,
+ul.job_listings li.job_listing a div.location,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a div.location,
+ul.job_listings li.no_job_listings_found a div.location {
+  float: left;
+  text-align: left;
+  width: 25%;
+  padding: 0 0 0 1em;
+  color: #999;
+  line-height: 1.5em;
+}
+.rp4wp-related-job_listing > ul li.job_listing a .meta,
+ul.job_listings li.job_listing a .meta,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a .meta,
+ul.job_listings li.no_job_listings_found a .meta {
+  float: right;
+  text-align: right;
+  width: 20%;
+  padding: 0 0 0 1em;
+  margin: 0;
+  line-height: 1.5em;
+  color: #999;
+  list-style: none outside;
+}
+.rp4wp-related-job_listing > ul li.job_listing a .meta li,
+ul.job_listings li.job_listing a .meta li,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a .meta li,
+ul.job_listings li.no_job_listings_found a .meta li {
+  list-style: none outside;
+  display: block;
+  margin: 0;
+}
+.rp4wp-related-job_listing > ul li.job_listing a .meta .job-type,
+ul.job_listings li.job_listing a .meta .job-type,
+.rp4wp-related-job_listing > ul li.no_job_listings_found a .meta .job-type,
+ul.job_listings li.no_job_listings_found a .meta .job-type {
+  font-weight: bold;
+}
+.rp4wp-related-job_listing > ul li.job_listing.job_position_featured a,
+ul.job_listings li.job_listing.job_position_featured a,
+.rp4wp-related-job_listing > ul li.no_job_listings_found.job_position_featured a,
+ul.job_listings li.no_job_listings_found.job_position_featured a {
+  background: #fefee5;
+}
+.rp4wp-related-job_listing > ul li.job_listing.job_position_featured a:hover,
+ul.job_listings li.job_listing.job_position_featured a:hover,
+.rp4wp-related-job_listing > ul li.no_job_listings_found.job_position_featured a:hover,
+ul.job_listings li.no_job_listings_found.job_position_featured a:hover,
+.rp4wp-related-job_listing > ul li.job_listing.job_position_featured a:focus,
+ul.job_listings li.job_listing.job_position_featured a:focus,
+.rp4wp-related-job_listing > ul li.no_job_listings_found.job_position_featured a:focus,
+ul.job_listings li.no_job_listings_found.job_position_featured a:focus {
+  background-color: #fefed8;
+}
+.widget ul.job_listings li.job_listing a {
+  padding: 1em 0;
+}
+.widget ul.job_listings li.job_listing .image {
+  float: left;
+}
+.widget ul.job_listings li.job_listing .image img {
+  left: 0;
+  position: relative;
+}
+.widget ul.job_listings li.job_listing .content {
+  overflow: hidden;
+}
+.widget ul.job_listings li.job_listing .position {
+  float: none;
+  width: auto;
+  padding: 0;
+}
+.widget ul.job_listings li.job_listing ul.meta {
+  float: none;
+  width: auto;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+}
+.widget ul.job_listings li.job_listing ul.meta li {
+  float: none;
+  display: inline;
+  padding: 0;
+  margin: 0 .5em 0 0;
+  font-weight: normal;
+}
+.widget ul.job_listings li.job_listing ul.meta li:after {
+  padding: 0 0 0 .5em;
+  content: "\2023";
+}
+.widget ul.job_listings li.job_listing ul.meta li:last-child:after {
+  content: '';
+}
+.job-manager .job-type,
+.job_listing .job-type,
+.job-types .job-type {
+  color: #f08d3c;
+}
+.job-manager .full-time,
+.job_listing .full-time,
+.job-types .full-time {
+  color: #90da36;
+}
+.job-manager .part-time,
+.job_listing .part-time,
+.job-types .part-time {
+  color: #f08d3c;
+}
+.job-manager .temporary,
+.job_listing .temporary,
+.job-types .temporary {
+  color: #d93674;
+}
+.job-manager .freelance,
+.job_listing .freelance,
+.job-types .freelance {
+  color: #3399cc;
+}
+.job-manager .internship,
+.job_listing .internship,
+.job-types .internship {
+  color: #6033cc;
+}
+/**
+ * Mobile styles
+ */
+@media only screen and (max-width: 767px) {
+  ul.job_listings li.job_listing a,
+  ul.job_listings li.no_job_listings_found a {
+    padding: 1em;
+  }
+  ul.job_listings li.job_listing a img.company_logo,
+  ul.job_listings li.no_job_listings_found a img.company_logo {
+    visibility: hidden;
+  }
+  ul.job_listings li.job_listing a div.position,
+  ul.job_listings li.no_job_listings_found a div.position {
+    float: left;
+    width: 60%;
+    padding: 0;
+  }
+  ul.job_listings li.job_listing a div.location,
+  ul.job_listings li.no_job_listings_found a div.location {
+    float: right;
+    width: 40%;
+    line-height: 2em;
+    font-size: .75em;
+    padding: 0 0 0 1em;
+    text-align: right;
+  }
+  ul.job_listings li.job_listing a .meta,
+  ul.job_listings li.no_job_listings_found a .meta {
+    float: right;
+    width: 40%;
+    line-height: 2em;
+    font-size: .75em;
+  }
+  ul.job_listings li.job_listing a .meta li,
+  ul.job_listings li.no_job_listings_found a .meta li {
+    font-size: 1em;
+  }
+}
+/**
+ * Default theme fixes
+ */
+.twenty-eleven ul.job_listings li.job_listing,
+.twenty-eleven ul.job_listings li.no_job_listings_found {
+  padding: 0 !important;
+}
+/* Primary colour for buttons (alt) */
+/* Text on primary colour bg */
+/* Secondary buttons */
+/* Text on secondary colour bg */
+/* Prices, In stock labels, sales flash */
+/* Text on highlight colour bg */
+/* Content BG - Tabs (active state) */
+/* small, breadcrumbs etc */
+.display-icon {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+}
+/* =Global styles/layout
+-------------------------------------------------------------- */
+.job-manager-message,
+.job-manager-error,
+.job-manager-info {
+  padding: 1em 2em 1em 3.5em !important;
+  margin: 0 0 2em !important;
+  position: relative;
+  background-color: #ffffff;
+  color: #666666;
+  border-top: 3px solid #999999;
+  list-style: none outside !important;
+  width: auto;
+  zoom: 1;
+  /* For IE 6/7 (trigger hasLayout) */
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+.job-manager-message:before,
+.job-manager-error:before,
+.job-manager-info:before,
+.job-manager-message:after,
+.job-manager-error:after,
+.job-manager-info:after {
+  content: "";
+  display: table;
+}
+.job-manager-message:after,
+.job-manager-error:after,
+.job-manager-info:after {
+  clear: both;
+}
+.job-manager-message:before,
+.job-manager-error:before,
+.job-manager-info:before {
+  content: "";
+  font-family: sans-serif;
+  display: inline-block;
+  position: absolute;
+  top: 1em;
+  left: 1.5em;
+}
+.job-manager-message li,
+.job-manager-error li,
+.job-manager-info li {
+  list-style: none outside !important;
+  padding-left: 0 !important;
+  margin-left: 0 !important;
+}
+.job-manager-message.job-manager-message,
+.job-manager-error.job-manager-message,
+.job-manager-info.job-manager-message {
+  border-top-color: #8fae1b;
+}
+.job-manager-message.job-manager-message:before,
+.job-manager-error.job-manager-message:before,
+.job-manager-info.job-manager-message:before {
+  color: #8fae1b;
+  content: "\2713";
+}
+.job-manager-message.job-manager-info,
+.job-manager-error.job-manager-info,
+.job-manager-info.job-manager-info {
+  border-top-color: #1e85be;
+}
+.job-manager-message.job-manager-info:before,
+.job-manager-error.job-manager-info:before,
+.job-manager-info.job-manager-info:before {
+  color: #1e85be;
+  content: "i";
+  font-family: Times, Georgia, serif;
+  font-style: italic;
+}
+.job-manager-message.job-manager-error,
+.job-manager-error.job-manager-error,
+.job-manager-info.job-manager-error {
+  border-top-color: #b81c23;
+}
+.job-manager-message.job-manager-error:before,
+.job-manager-error.job-manager-error:before,
+.job-manager-info.job-manager-error:before {
+  color: #b81c23;
+  content: "\00d7";
+  font-weight: 700;
+}
+.job-manager-form fieldset {
+  margin: 0 0 1em 0;
+  padding: 0 0 1em 0;
+  line-height: 2em;
+  border: 0;
+  border-bottom: 1px solid #eee;
+  zoom: 1;
+  /* For IE 6/7 (trigger hasLayout) */
+}
+.job-manager-form fieldset:before,
+.job-manager-form fieldset:after {
+  content: "";
+  display: table;
+}
+.job-manager-form fieldset:after {
+  clear: both;
+}
+.job-manager-form fieldset label {
+  display: block;
+  margin: 0;
+  width: 29%;
+  float: left;
+  vertical-align: middle;
+}
+.job-manager-form fieldset label small {
+  opacity: .75;
+  font-size: 0.83em;
+}
+.job-manager-form fieldset div.field {
+  width: 70%;
+  float: right;
+  vertical-align: middle;
+}
+.job-manager-form fieldset .wp-editor-container {
+  border: 1px solid #ccc;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+}
+.job-manager-form fieldset .account-sign-in .button {
+  margin-right: .5em;
+}
+.job-manager-form fieldset .account-sign-in .button:before {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+  content: '\e808';
+}
+.job-manager-form fieldset abbr.required {
+  color: red;
+  font-weight: bold;
+  border: 0;
+}
+.job-manager-form fieldset input.input-text,
+.job-manager-form fieldset textarea,
+.job-manager-form fieldset select {
+  margin: 0;
+  vertical-align: middle;
+  width: 100%;
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+}
+.job-manager-form fieldset small.description {
+  opacity: .75;
+  font-size: 0.83em;
+  margin: 1.2em 0 0 0;
+  display: block;
+  line-height: 1.2em;
+}
+.job-manager-form fieldset .job-manager-uploaded-files {
+  display: table;
+}
+.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file {
+  line-height: 2em;
+  font-style: italic;
+  margin-bottom: 1em;
+  display: block;
+}
+.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file .job-manager-uploaded-file-preview img {
+  height: 64px;
+  margin: 0;
+  vertical-align: top;
+}
+.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file .job-manager-uploaded-file-preview a {
+  line-height: 64px;
+  display: inline-block;
+  padding: 0 0 0 1em;
+}
+.job-manager-form fieldset .job-manager-uploaded-files .job-manager-uploaded-file .job-manager-uploaded-file-name {
+  display: block;
+}
+.job-manager-form .submit-job {
+  padding: 1em 0;
+}
+.job-manager-form .job-manager-term-checklist {
+  list-style: none outside;
+  max-height: 200px;
+  overflow: auto;
+  margin: 0;
+}
+.job-manager-form .job-manager-term-checklist li {
+  list-style: none outside;
+  margin: 0;
+  display: block;
+  float: none;
+}
+.job-manager-form .job-manager-term-checklist li label {
+  width: auto;
+  float: none;
+}
+.job-manager-form .job-manager-term-checklist li li {
+  margin: 0 0 0 2em;
+}
+.job-manager-form input[type=submit]:disabled,
+.job-manager-form input[type=submit].disabled {
+  opacity: .5;
+  filter: alpha(opacity=50);
+  cursor: not-allowed;
+}
+.job-manager-form .spinner {
+  background-repeat: no-repeat;
+  background-size: 20px 20px;
+  display: inline-block;
+  visibility: hidden;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  vertical-align: middle;
+}
+.job-manager-form .spinner.is-active {
+  visibility: visible;
+}
+div.job_listings {
+  margin-bottom: 1em;
+}
+div.job_listings ul.job_listings {
+  margin: 0;
+}
+.single_job_listing .company {
+  position: relative;
+  border: 1px solid #eee;
+  padding: 1em;
+  margin: 0 0 2em;
+  display: block;
+  clear: both;
+  min-height: 3em;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+  box-sizing: content-box;
+}
+.single_job_listing .company img {
+  width: 3em;
+  height: 3em;
+  position: absolute;
+  left: 1em;
+  float: left;
+  vertical-align: middle;
+  box-shadow: none;
+}
+.single_job_listing .company .name {
+  margin: 0 0 0 3em;
+  padding: 0 0 0 1em;
+  line-height: 1.5em;
+}
+.single_job_listing .company .name a {
+  float: right;
+  margin-left: 1em;
+}
+.single_job_listing .company .tagline {
+  display: block;
+  margin: 0 0 0 3em;
+  padding: 0 0 0 1em;
+  line-height: 1.5em;
+  font-style: italic;
+  color: #999;
+}
+.single_job_listing .company .website:before {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+  content: '\e809';
+}
+.single_job_listing .company .company_twitter:before {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+  content: '\e80a';
+}
+.single_job_listing .company .company_video {
+  border-top: 1px solid #eee;
+  padding: 1em 0 0;
+  margin: 1em 0 0 0;
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+}
+.single_job_listing .company .company_video iframe,
+.single_job_listing .company .company_video object,
+.single_job_listing .company .company_video embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  display: block;
+}
+.single_job_listing .meta {
+  list-style: none outside;
+  padding: 0;
+  margin: 0 0 1.5em;
+  overflow: hidden;
+  zoom: 1;
+  clear: both;
+}
+.single_job_listing .meta li {
+  margin: 0 1em 0 0;
+  padding: .5em;
+  float: left;
+  line-height: 1em;
+  color: #999;
+}
+.single_job_listing .meta .job-type {
+  color: #fff;
+  background-color: #f08d3c;
+}
+.single_job_listing .meta .full-time {
+  background-color: #90da36;
+}
+.single_job_listing .meta .part-time {
+  background-color: #f08d3c;
+}
+.single_job_listing .meta .temporary {
+  background-color: #d93674;
+}
+.single_job_listing .meta .freelance {
+  background-color: #3399cc;
+}
+.single_job_listing .meta .internship {
+  background-color: #6033cc;
+}
+.single_job_listing .meta .position-filled,
+.single_job_listing .meta .listing-expired {
+  color: #b81c23;
+}
+.single_job_listing .meta .location:before {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+  content: '\e81d';
+}
+.single_job_listing .meta .date-posted:before {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+  content: '\e80f';
+}
+.single_job_listing .meta .position-filled:before,
+.single_job_listing .meta .listing-expired:before {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+  content: '\e80e';
+}
+.single_job_listing .job_description {
+  margin: 0 0 1.5em;
+}
+.job-manager-application-wrapper {
+  clear: both;
+  border: 1px solid #eee;
+  padding: .75em 1em 0;
+  margin: 1em 0;
+  line-height: 1.5em;
+  display: block;
+  position: relative;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+}
+.single_job_listing .application,
+.job-manager-application-wrapper .application {
+  padding: 0;
+  margin: 0 0 1em;
+  overflow: hidden;
+}
+.single_job_listing .application .application_button,
+.job-manager-application-wrapper .application .application_button,
+.single_job_listing .application .application_details,
+.job-manager-application-wrapper .application .application_details {
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+}
+.single_job_listing .application .application_button,
+.job-manager-application-wrapper .application .application_button {
+  text-align: center;
+  font-size: 1.1em;
+  line-height: 1em;
+  display: inline-block;
+  margin: 0 .5em 0 0;
+  padding: 0.90909091em 2em;
+  outline: 0;
+}
+.single_job_listing .application .application_details,
+.job-manager-application-wrapper .application .application_details {
+  clear: both;
+  border: 1px solid #eee;
+  padding: .75em 1em 0;
+  margin: 1em 0;
+  line-height: 1.5em;
+  display: block;
+  position: relative;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+}
+.single_job_listing .application .application_details p,
+.job-manager-application-wrapper .application .application_details p {
+  margin: 0 0 .75em;
+}
+.single_job_listing .application .application_details:before,
+.job-manager-application-wrapper .application .application_details:before {
+  content: "";
+  position: absolute;
+  margin: -10px 0 0 0;
+  top: 0;
+  left: 5em;
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 10px solid #eee;
+}
+.single_job_listing .application .application_details:after,
+.job-manager-application-wrapper .application .application_details:after {
+  content: "";
+  position: absolute;
+  margin: -9px 0 0 1px;
+  left: 5em;
+  top: 0;
+  width: 0;
+  height: 0;
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-bottom: 9px solid #fff;
+}
+.job_filters {
+  background: #eee;
+  zoom: 1;
+  /* For IE 6/7 (trigger hasLayout) */
+}
+.job_filters:before,
+.job_filters:after {
+  content: "";
+  display: table;
+}
+.job_filters:after {
+  clear: both;
+}
+.job_filters .search_jobs {
+  padding: 1em;
+  zoom: 1;
+  /* For IE 6/7 (trigger hasLayout) */
+}
+.job_filters .search_jobs:before,
+.job_filters .search_jobs:after {
+  content: "";
+  display: table;
+}
+.job_filters .search_jobs:after {
+  clear: both;
+}
+.job_filters .search_jobs div {
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+}
+.job_filters .search_jobs div label {
+  display: none;
+}
+.job_filters .search_jobs div.search_keywords,
+.job_filters .search_jobs div.filter_first {
+  float: left;
+  padding-right: .5em;
+  width: 50%;
+}
+.job_filters .search_jobs div.search_location,
+.job_filters .search_jobs div.filter_last {
+  float: right;
+  padding-left: .5em;
+  width: 50%;
+}
+.job_filters .search_jobs div.search_categories,
+.job_filters .search_jobs div.filter_wide {
+  padding-top: .5em;
+  clear: both;
+  width: 100%;
+}
+.job_filters .search_jobs div.search_submit {
+  padding-top: .5em;
+}
+.job_filters .search_jobs div .showing_jobs a {
+  padding: .25em;
+}
+.job_filters .search_jobs div .showing_jobs a.active {
+  background: #ddd;
+  text-decoration: none;
+}
+.job_filters .search_jobs input,
+.job_filters .search_jobs select {
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+  width: 100%;
+}
+.job_filters .job_types {
+  list-style: none outside;
+  margin: 0;
+  padding: 0;
+  font-size: 0.83em;
+  background: #f9f9f9;
+  border-top: 1px solid #e5e5e5;
+  zoom: 1;
+  /* For IE 6/7 (trigger hasLayout) */
+}
+.job_filters .job_types:before,
+.job_filters .job_types:after {
+  content: "";
+  display: table;
+}
+.job_filters .job_types:after {
+  clear: both;
+}
+.job_filters .job_types li {
+  margin: 0;
+  padding: .5em 1em;
+  float: left;
+  border-right: 1px solid #eee;
+}
+.job_filters .job_types li:last-child {
+  border-right: 0;
+}
+.job_filters .showing_jobs {
+  padding: .5em 1em;
+  display: none;
+  font-size: 0.83em;
+  background: #f9f9f9;
+  border-top: 1px solid #e5e5e5;
+}
+.job_filters .showing_jobs a {
+  float: right;
+  padding-left: 10px;
+  border: 0;
+}
+div.job_listings .job-manager-pagination {
+  text-align: center;
+  display: block;
+  padding: 1em 0 1em 0;
+  border-bottom: 1px solid #eee;
+  line-height: 1;
+}
+div.job_listings .load_previous {
+  border-top: 1px solid #eee;
+}
+div.job_listings .load_more_jobs + ul.job_listings {
+  border-top: 0;
+}
+div.job_listings .load_more_jobs {
+  text-align: center;
+  display: block;
+  padding: 1em 1em 1em 2em;
+  border-bottom: 1px solid #eee;
+  font-weight: bold;
+}
+div.job_listings .load_more_jobs.loading {
+  background: url(../images/ajax-loader.gif) no-repeat center;
+}
+div.job_listings .load_more_jobs.loading strong {
+  visibility: hidden;
+}
+div.job_listings .load_more_jobs:hover,
+div.job_listings .load_more_jobs:focus {
+  background-color: #fcfcfc;
+  border-bottom: 1px solid #eee;
+}
+.job_listing_preview {
+  padding: 0 1em 1em;
+  border: 5px solid #eee;
+}
+.single-job_listing .entry-header .attachment-post-thumbnail,
+.single-job_listing .job_listing.has-post-thumbnail .post-thumbnail {
+  display: none;
+}
+.job_listing_preview_title,
+.entry-content .job_listing_preview_title {
+  padding: .5em 1em;
+  vertical-align: middle;
+  position: relative;
+  background: #eee;
+}
+.job_listing_preview_title h2,
+.entry-content .job_listing_preview_title h2 {
+  margin: 0;
+  clear: none;
+}
+.job_listing_preview_title .button,
+.entry-content .job_listing_preview_title .button {
+  float: right;
+  margin-left: .25em;
+}
+.job_summary_shortcode {
+  border: 1px solid #ccc;
+  -moz-border-radius: 4px;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+  text-align: center;
+  position: relative;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  -webkit-box-sizing: border-box;
+  /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;
+  /* Firefox, other Gecko */
+  box-sizing: border-box;
+  /* Opera/IE 8+ */
+}
+.job_summary_shortcode.aligncenter {
+  display: block;
+  margin: 2em auto 2em;
+}
+.job_summary_shortcode.alignleft {
+  float: left;
+  margin: 0 2em 2em 0;
+}
+.job_summary_shortcode.alignright {
+  float: right;
+  margin: 0 0 2em 2em;
+}
+.job_summary_shortcode a {
+  text-decoration: none;
+  color: inherit;
+}
+.job_summary_shortcode img {
+  margin: 0;
+  padding: 0;
+  display: block;
+  width: 100%;
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  -moz-border-top-left-radius: 3px;
+  -moz-border-top-right-radius: 3px;
+  -webkit-border-top-left-radius: 3px;
+  -webkit-border-top-right-radius: 3px;
+  border-radius: 0;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+.job_summary_shortcode .job_summary_content {
+  padding: 0 1em;
+}
+.job_summary_shortcode .meta {
+  font-style: italic;
+  color: #777;
+}
+.job_summary_shortcode .job-type {
+  -moz-border-radius: 1em;
+  -webkit-border-radius: 1em;
+  border-radius: 1em;
+  color: #fff;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: .5em;
+  height: 1em;
+  width: auto;
+  min-width: 1em;
+  font-size: 1em;
+  text-align: center;
+  vertical-align: middle;
+  line-height: 1em;
+  margin: -0.5em -0.5em 0 0;
+}
+.job_summary_shortcode .job-type.full-time {
+  background-color: #90da36;
+}
+.job_summary_shortcode .job-type.part-time {
+  background-color: #f08d3c;
+}
+.job_summary_shortcode .job-type.temporary {
+  background-color: #d93674;
+}
+.job_summary_shortcode .job-type.freelance {
+  background-color: #3399cc;
+}
+.job_summary_shortcode .job-type.internship {
+  background-color: #6033cc;
+}
+#job-manager-job-dashboard .account-sign-in .button {
+  margin-right: .5em;
+}
+#job-manager-job-dashboard .account-sign-in .button:before {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  -webkit-font-smoothing: antialiased;
+  font-family: "job-manager" !important;
+  text-decoration: none;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: top;
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  *overflow: auto;
+  *zoom: 1;
+  *display: inline;
+  content: '\e808';
+}
+#job-manager-job-dashboard table ul.job-dashboard-actions {
+  margin: 0;
+  padding: 0;
+  visibility: hidden;
+  font-size: 0.92em;
+}
+#job-manager-job-dashboard table ul.job-dashboard-actions li {
+  float: none;
+  display: inline;
+  padding: 0;
+  margin: 0 .5em 0 0;
+  font-weight: normal;
+  list-style: none outside;
+}
+#job-manager-job-dashboard table ul.job-dashboard-actions li:after {
+  padding: 0 0 0 .5em;
+  content: "\2023";
+}
+#job-manager-job-dashboard table ul.job-dashboard-actions li:last-child:after {
+  content: '';
+}
+#job-manager-job-dashboard table ul.job-dashboard-actions li .job-dashboard-action-delete {
+  color: red;
+}
+#job-manager-job-dashboard table tr:hover ul.job-dashboard-actions,
+#job-manager-job-dashboard table tr:focus ul.job-dashboard-actions {
+  visibility: visible;
+}
+#job-manager-job-dashboard table td,
+#job-manager-job-dashboard table th {
+  padding: .5em 1em .5em 0;
+}
+#job-manager-job-dashboard table .job_title small {
+  color: #999;
+}
+#job-manager-job-dashboard table .featured-job-icon:before {
+  content: '\e803';
+  font-family: "job-manager" !important;
+  font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  text-align: center;
+  /* For safety - reset parent styles, that can break glyph codes*/
+  font-variant: normal;
+  text-transform: none;
+  /* fix buttons height, for twitter bootstrap */
+  line-height: 1em;
+}
+#job-manager-job-dashboard table .filled,
+#job-manager-job-dashboard table .expires,
+#job-manager-job-dashboard table .applications {
+  text-align: center;
+}
+nav.job-manager-pagination,
+#content nav.job-manager-pagination {
+  text-align: center;
+}
+nav.job-manager-pagination ul,
+#content nav.job-manager-pagination ul {
+  display: inline-block;
+  white-space: nowrap;
+  padding: 0;
+  clear: both;
+  border-left: 1px solid #eee;
+  margin: 1px;
+}
+nav.job-manager-pagination ul li,
+#content nav.job-manager-pagination ul li {
+  border-right: 1px solid #eee;
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+  padding: 0;
+  margin: 0;
+  float: left;
+  display: inline;
+  overflow: hidden;
+}
+nav.job-manager-pagination ul li a,
+#content nav.job-manager-pagination ul li a,
+nav.job-manager-pagination ul li span,
+#content nav.job-manager-pagination ul li span {
+  margin: 0;
+  text-decoration: none;
+  padding: 0;
+  line-height: 1em;
+  font-size: 1em;
+  font-weight: normal;
+  padding: .5em;
+  min-width: 1em;
+  display: block;
+  border: 0;
+}
+nav.job-manager-pagination ul li span.current,
+#content nav.job-manager-pagination ul li span.current,
+nav.job-manager-pagination ul li a:hover,
+#content nav.job-manager-pagination ul li a:hover,
+nav.job-manager-pagination ul li a:focus,
+#content nav.job-manager-pagination ul li a:focus {
+  background: #eee;
+  color: #888888;
+}
+.chosen-container {
+  width: 100% !important;
+}
+.twenty-ten .job_types,
+.twenty-ten .chosen-choices {
+  margin: 0 !important;
+}
+.rtl .job-manager-form label {
+  float: right;
+}
+.rtl .job-manager-form div.field {
+  float: left;
+}
+.rtl .job_listing_preview_title .button,
+.rtl .entry-content .job_listing_preview_title .button {
+  float: left;
+}
+.rtl .single_job_listing .meta li {
+  float: right;
+  margin: 0 0 0 1em;
+}

--- a/assets/css/frontend.less
+++ b/assets/css/frontend.less
@@ -227,6 +227,7 @@ div.job_listings {
 		clear: both;
 		min-height: 3em;
 		box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+		box-sizing: content-box;
 
 		img {
 			width: 3em;


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Fix company logo extending outside parent `div` on single job page.

#### Testing instructions:

* Add a job listing with a company logo.
* Using the Storefront or Twenty Seventeen themes, view the job listing on the front-end.
* Ensure the company logo thumbnail does not extend outside of its parent.
* Repeat the above with other themes.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix company logo extending outside of parent for some themes
