### PR TITLE
Preselect job types by slug in query string on `[jobs]` page

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -335,13 +335,7 @@ class WP_Job_Manager_Shortcodes {
 			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], array( 1, '1', 'true', 'yes' ), true );
 		}
 
-		// Array handling.
-		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
-		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
-		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
-		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
-
-		// Get keywords and location from querystring if set.
+		// Get keywords, location, category and type from querystring if set.
 		if ( ! empty( $_GET['search_keywords'] ) ) {
 			$atts['keywords'] = sanitize_text_field( $_GET['search_keywords'] );
 		}
@@ -351,6 +345,15 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $_GET['search_category'] ) ) {
 			$atts['selected_category'] = sanitize_text_field( $_GET['search_category'] );
 		}
+		if ( ! empty( $_GET['search_job_type'] ) ) {
+			$atts['selected_job_types'] = sanitize_text_field( $_GET['search_job_type'] );
+		}
+
+		// Array handling.
+		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
+		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
+		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
+		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
 
 		$data_attributes = array(
 			'location'        => $atts['location'],


### PR DESCRIPTION
Fixes #1474

Reintroduces @felipeelia's PR #1569 

Commit was lost when #1570 was reverted.

See original PR for testing instructions.
 
For example: `http://wpjm.docker/jobs/?search_job_type=full-time,internship`, on my test instance, preselects the full-time and internship job types on the filter form.