### PR TITLE
Add event tracking for extensions and license activation

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -359,6 +359,15 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	}
 
 	/**
+	 * Checks if we have paid extensions installed and activated. Right now, all of our official extensions are paid.
+	 *
+	 * @return bool
+	 */
+	private static function has_paid_extensions() {
+		return self::get_official_extensions_count() > 0;
+	}
+
+	/**
 	 * Get the base fields to be sent for event logging.
 	 *
 	 * @since 1.33.0
@@ -368,6 +377,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	public static function get_event_logging_base_fields() {
 		$base_fields = array(
 			'job_listings' => wp_count_posts( 'job_listing' )->publish,
+			'paid'         => self::has_paid_extensions() ? 1 : 0,
 		);
 
 		/**

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -60,6 +60,8 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_part_time'              => self::get_jobs_by_type_count( 'part-time' ),
 			'jobs_temp'                   => self::get_jobs_by_type_count( 'temporary' ),
 			'jobs_by_guests'              => self::get_jobs_by_guests(),
+			'official_extensions'         => self::get_official_extensions_count(),
+			'licensed_extensions'         => self::get_licensed_extensions_count(),
 		);
 	}
 
@@ -310,6 +312,50 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		);
 
 		return $query->found_posts;
+	}
+
+	/**
+	 * Get the official extensions that are installed.
+	 *
+	 * @param bool $licensed_only Return only official extensions with an active license.
+	 *
+	 * @return array
+	 */
+	private static function get_official_extensions( $licensed_only ) {
+		if ( ! class_exists( 'WP_Job_Manager_Helper' ) ) {
+			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-helper.php';
+		}
+
+		$helper         = WP_Job_Manager_Helper::instance();
+		$active_plugins = $helper->get_installed_plugins( true );
+
+		if ( $licensed_only ) {
+			foreach ( $active_plugins as $plugin_slug => $data ) {
+				if ( ! $helper->has_plugin_licence( $plugin_slug ) ) {
+					unset( $active_plugins[ $plugin_slug ] );
+				}
+			}
+		}
+
+		return $active_plugins;
+	}
+
+	/**
+	 * Gets the count of all official extensions that are installed and activated.
+	 */
+	private static function get_official_extensions_count() {
+		$extensions = self::get_official_extensions( false );
+
+		return count( $extensions );
+	}
+
+	/**
+	 * Gets the count of all official extensions that are installed, activated, and have active license.
+	 */
+	private static function get_licensed_extensions_count() {
+		$extensions = self::get_official_extensions( true );
+
+		return count( $extensions );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -344,18 +344,14 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 * Gets the count of all official extensions that are installed and activated.
 	 */
 	private static function get_official_extensions_count() {
-		$extensions = self::get_official_extensions( false );
-
-		return count( $extensions );
+		return count( self::get_official_extensions( false ) );
 	}
 
 	/**
 	 * Gets the count of all official extensions that are installed, activated, and have active license.
 	 */
 	private static function get_licensed_extensions_count() {
-		$extensions = self::get_official_extensions( true );
-
-		return count( $extensions );
+		return count( self::get_official_extensions( true ) );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -36,6 +36,18 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	/**
+	 * Gets the base data returned with system information.
+	 *
+	 * @return array
+	 */
+	protected function get_base_system_data() {
+		$base_data = array();
+		$base_data['version'] = JOB_MANAGER_VERSION;
+
+		return $base_data;
+	}
+
+	/**
 	 * Track a WP Job Manager event.
 	 *
 	 * @since 1.33.0

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -242,6 +242,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {
 			return true;
 		}
+
 		return false;
 	}
 

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -41,7 +41,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @return array
 	 */
 	protected function get_base_system_data() {
-		$base_data = array();
+		$base_data            = array();
 		$base_data['version'] = JOB_MANAGER_VERSION;
 
 		return $base_data;

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -198,7 +198,10 @@ class WP_Job_Manager {
 		WP_Job_Manager_Usage_Tracking::get_instance()->set_callback(
 			array( 'WP_Job_Manager_Usage_Tracking_Data', 'get_usage_data' )
 		);
-		WP_Job_Manager_Usage_Tracking::get_instance()->schedule_tracking_task();
+
+		if ( is_admin() ) {
+			WP_Job_Manager_Usage_Tracking::get_instance()->schedule_tracking_task();
+		}
 	}
 
 	/**

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -363,6 +363,19 @@ class WP_Job_Manager_Helper {
 	}
 
 	/**
+	 * Check if an official extension has an active license.
+	 *
+	 * @param string $product_slug
+	 *
+	 * @return bool
+	 */
+	public function has_plugin_licence( $product_slug ) {
+		$licence = $this->get_plugin_licence( $product_slug );
+
+		return ! empty( $licence['licence_key'] ) && ! empty( $licence['email'] );
+	}
+
+	/**
 	 * Adds newly recognized data header in WordPress plugin files.
 	 *
 	 * @param array $headers
@@ -379,7 +392,7 @@ class WP_Job_Manager_Helper {
 	 * @param bool $active_only Only return active plugins.
 	 * @return array
 	 */
-	protected function get_installed_plugins( $active_only = true ) {
+	public function get_installed_plugins( $active_only = true ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -151,6 +151,7 @@ class WP_Job_Manager_Helper {
 				$check_for_updates_data->response[ $plugin_data['_filename'] ] = (object) $response;
 			}
 		}
+
 		return $check_for_updates_data;
 	}
 
@@ -277,6 +278,7 @@ class WP_Job_Manager_Helper {
 			$css_class            = 'wpjm-activate-licence-link';
 		}
 		$actions[] = '<a class="' . esc_attr( $css_class ) . '" href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper' ) ) . '">' . esc_html( $manage_licence_label ) . '</a>';
+
 		return $actions;
 	}
 
@@ -312,6 +314,7 @@ class WP_Job_Manager_Helper {
 	 */
 	public function is_product_installed( $product_slug ) {
 		$product_plugins = $this->get_installed_plugins();
+
 		return isset( $product_plugins[ $product_slug ] );
 	}
 
@@ -322,6 +325,7 @@ class WP_Job_Manager_Helper {
 	 */
 	public function has_licenced_products() {
 		$product_plugins = $this->get_installed_plugins();
+
 		return ! empty( $product_plugins );
 	}
 
@@ -458,6 +462,7 @@ class WP_Job_Manager_Helper {
 		) {
 			return false;
 		}
+
 		$product_slug = sanitize_text_field( $_POST['product_slug'] );
 		switch ( $_POST['action'] ) {
 			case 'activate':
@@ -607,6 +612,7 @@ class WP_Job_Manager_Helper {
 		if ( ! isset( $this->licence_messages[ $product_slug ] ) ) {
 			$this->licence_messages[ $product_slug ] = array();
 		}
+
 		return $this->licence_messages[ $product_slug ];
 	}
 }

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -132,6 +132,14 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 */
 	abstract protected function do_track_plugin( $plugin_slug );
 
+	/**
+	 * Gets the base data returned with system information.
+	 *
+	 * @return array
+	 */
+	protected function get_base_system_data() {
+		return array();
+	}
 
 	/*
 	 * Initialization.
@@ -354,7 +362,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		 */
 		$theme = wp_get_theme();
 
-		$system_data                         = array();
+		$system_data                         = $this->get_base_system_data();
 		$system_data['wp_version']           = $wp_version;
 		$system_data['php_version']          = PHP_VERSION;
 		$system_data['locale']               = get_locale();


### PR DESCRIPTION
_Built off of #1739. Will be rebased and moved to non-draft once that is merged, but can be reviewed before that._

#### Changes proposed in this Pull Request:

* Adds basic information about number of official extensions activated (`official_extensions` and with an active license (`licensed_extensions`) under the standard usage data event. 
* Adds new usage events for license activations (`license_activated`), activation errors (`license_activation_error`), and deactivations (`license_deactivated`). Each of these events provides the `slug` for the plugin and in the event of an error, the error code.
* Follows Sensei's convention of passing `paid` flag for events. This will be `0` if no official extensions are activated and `1` if they are. We don't care about license activations here.
* Sneaky addition: passes the `version` with the system data. This is technically already passed,  but it is difficult to query because install directories vary and can pass different slugs.

Note: `license` is used for usage tracking but `licence` is used in legacy code. It was unrelated to this PR, but I'll eventually make things consistent with the US spelling of license.

#### Testing instructions:

* See p6rkRX-10C-p2 for setting up events listener. 
* Submit a new job with at least one official extension activated. Verify the `paid` attribute is `1`.
* Submit a new job with no official extensions activated. Verify the `paid` attribute is `0`.
* Activate at least 2 official extensions. Activate the license for at least one of them.
* Trigger usage data tracking event. I used `WP Crontrol` to manually fire `job_manager_usage_tracking_send_usage_data`.
* For `wpjm_system_log`, verify `version` is passed with the correct version.
* For `wpjm_stats_log`, verify `official_extensions` is number of official extensions activated and `licensed_extensions` is number of official extensions activated and licensed.

From the Add-ons > Licenses page...
* Activate a license. Verify `wpjm_license_activated` fires with the product/plugin `slug` property.
* Submit a bad license and verify `wpjm_license_activation_error` fires with the product/plugin `slug` property.
* Deactivate a license. Verify `wpjm_license_deactivated` fires with the product/plugin `slug` property.

