### PR TITLE
Upgrade PHPCS standards to WPCS 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license"    : "GPL-3.0+",
   "require-dev"    : {
     "phpunit/phpunit": "^5.7",
-    "wp-coding-standards/wpcs": "^0.14.0",
+    "wp-coding-standards/wpcs": "^2.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "phpcompatibility/php-compatibility": "^9.1",
     "bjornjohansen/wp-pre-commit-hook": "^0.2.2",

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "phpcompatibility/phpcompatibility-wp": "^2.0",
     "bjornjohansen/wp-pre-commit-hook": "^0.2.2",
     "squizlabs/php_codesniffer": "^3.3",
-    "wp-coding-standards/wpcs": "^2.1"
+    "wp-coding-standards/wpcs": "^2.1",
+    "sirbrillig/phpcs-variable-analysis": "^2.6"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
   "license"    : "GPL-3.0+",
   "require-dev"    : {
     "phpunit/phpunit": "^5.7",
-    "wp-coding-standards/wpcs": "^2.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-    "phpcompatibility/php-compatibility": "^9.1",
+    "phpcompatibility/phpcompatibility-wp": "^2.0",
     "bjornjohansen/wp-pre-commit-hook": "^0.2.2",
-    "squizlabs/php_codesniffer": "^3.3"
+    "squizlabs/php_codesniffer": "^3.3",
+    "wp-coding-standards/wpcs": "^2.1"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e0570b4f6a31854cbae4f95f95a5a50",
+    "content-hash": "e068c3229ab973630723c961f8576fde",
     "packages": [],
     "packages-dev": [
         {
@@ -277,6 +277,106 @@
                 "standards"
             ],
             "time": "2018-12-30T23:16:27+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/9160de79fcd683b5c99e9c4133728d91529753ea",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2018-12-16T19:10:44+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2018-10-07T18:31:37+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e068c3229ab973630723c961f8576fde",
+    "content-hash": "6e300e07b0d8e2a415ca45c47c4747ae",
     "packages": [],
     "packages-dev": [
         {
@@ -1496,6 +1496,53 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "fd217f2077fbcc287aded2b52147e68d208ace4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/fd217f2077fbcc287aded2b52147e68d208ace4b",
+                "reference": "fd217f2077fbcc287aded2b52147e68d208ace4b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "limedeck/phpunit-detailed-printer": "^3.1",
+                "phpunit/phpunit": "^6.5",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                },
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "time": "2019-05-10T21:08:30+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf2d04fab599a29ea5d235846b1daa1a",
+    "content-hash": "8e0570b4f6a31854cbae4f95f95a5a50",
     "packages": [],
     "packages-dev": [
         {
@@ -118,27 +118,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -163,25 +165,25 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.8.1",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
@@ -216,7 +218,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-06-11T23:09:50+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -332,16 +334,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -379,7 +381,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -879,6 +881,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {
@@ -1396,16 +1399,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
@@ -1438,25 +1441,25 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-19T23:57:18+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -1468,7 +1471,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -1490,7 +1493,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1501,20 +1504,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.2.2",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "d0aa6c0ea484087927b49fd513383a7d36190ca6"
+                "reference": "c60ecf5ba842324433b46f58dc7afc4487dbab99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d0aa6c0ea484087927b49fd513383a7d36190ca6",
-                "reference": "d0aa6c0ea484087927b49fd513383a7d36190ca6",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c60ecf5ba842324433b46f58dc7afc4487dbab99",
+                "reference": "c60ecf5ba842324433b46f58dc7afc4487dbab99",
                 "shasum": ""
             },
             "require": {
@@ -1533,7 +1536,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1560,7 +1563,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03T09:07:35+00:00"
+            "time": "2019-04-06T14:04:46+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1615,24 +1618,29 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
+                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1651,7 +1659,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2019-05-21T02:50:00+00:00"
         }
     ],
     "aliases": [],

--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -42,9 +42,11 @@ function polylang_wpjm_query_language( $query_args ) {
  * @return string
  */
 function polylang_wpjm_get_job_listings_lang( $lang ) {
-	if ( function_exists( 'pll_current_language' )
-		 && function_exists( 'pll_is_translated_post_type' )
-		 && pll_is_translated_post_type( 'job_listing' ) ) {
+	if (
+		function_exists( 'pll_current_language' )
+		&& function_exists( 'pll_is_translated_post_type' )
+		&& pll_is_translated_post_type( 'job_listing' )
+	) {
 		return pll_current_language();
 	}
 	return $lang;
@@ -75,6 +77,6 @@ function polylang_wpjm_page_id( $page_id ) {
  * @return bool
  */
 function polylang_wpjm_doing_ajax( $is_ajax ) {
-	return false === strpos( $_SERVER['REQUEST_URI'], '/jm-ajax/' ) ? $is_ajax : true;
+	return isset( $_SERVER['REQUEST_URI'] ) && false === strpos( $_SERVER['REQUEST_URI'], '/jm-ajax/' ) ? $is_ajax : true;
 }
 add_filter( 'pll_is_ajax_on_front', 'polylang_wpjm_doing_ajax' );

--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -37,7 +37,14 @@ add_action( 'wpml_loaded', 'wpml_wpjm_set_language' );
  * @since 1.26.0
  */
 function wpml_wpjm_set_language() {
-	if ( ( strstr( $_SERVER['REQUEST_URI'], '/jm-ajax/' ) || ! empty( $_GET['jm-ajax'] ) ) && isset( $_POST['lang'] ) ) {
+	if (
+		isset( $_SERVER['REQUEST_URI'] )
+		&& (
+			strstr( $_SERVER['REQUEST_URI'], '/jm-ajax/' )
+			|| ! empty( $_GET['jm-ajax'] )
+		)
+		&& isset( $_POST['lang'] )
+	) {
 		do_action( 'wpml_switch_language', sanitize_text_field( $_POST['lang'] ) );
 	}
 }

--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -188,7 +188,7 @@ abstract class WP_Job_Manager_Email {
 	 * @return string
 	 */
 	public function get_plain_content() {
-		return strip_tags( $this->get_rich_content() );
+		return wp_strip_all_tags( $this->get_rich_content() );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -115,10 +115,11 @@ abstract class WP_Job_Manager_Form {
 		$next_step_key = $this->get_step_key( $this->step );
 
 		// If the next step has a handler to call before going to the view, run it now.
-		if ( $next_step_key
-			 && $step_key !== $next_step_key
-			 && isset( $this->steps[ $next_step_key ]['before'] )
-			 && is_callable( $this->steps[ $next_step_key ]['before'] )
+		if (
+			$next_step_key
+			&& $step_key !== $next_step_key
+			&& isset( $this->steps[ $next_step_key ]['before'] )
+			&& is_callable( $this->steps[ $next_step_key ]['before'] )
 		) {
 			call_user_func( $this->steps[ $next_step_key ]['before'] );
 		}
@@ -188,7 +189,9 @@ abstract class WP_Job_Manager_Form {
 	 * @return string
 	 */
 	public function get_action() {
-		return esc_url_raw( $this->action ? $this->action : wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$default_action = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+
+		return esc_url_raw( $this->action ? $this->action : $default_action );
 	}
 
 	/**
@@ -300,6 +303,7 @@ abstract class WP_Job_Manager_Form {
 	 */
 	public function enqueue_scripts() {
 		if ( $this->use_recaptcha_field() ) {
+			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_enqueue_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js' );
 		}
 	}
@@ -364,12 +368,13 @@ abstract class WP_Job_Manager_Form {
 			return new WP_Error( 'validation-error', sprintf( esc_html__( '"%s" check failed. Please try again.', 'wp-job-manager' ), $recaptcha_field_label ) );
 		}
 
-		$response = wp_remote_get(
+		$default_remote_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
+		$response            = wp_remote_get(
 			add_query_arg(
 				array(
 					'secret'   => get_option( 'job_manager_recaptcha_secret_key' ),
 					'response' => isset( $_POST['g-recaptcha-response'] ) ? $_POST['g-recaptcha-response'] : '',
-					'remoteip' => isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'],
+					'remoteip' => isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $default_remote_addr,
 				),
 				'https://www.google.com/recaptcha/api/siteverify'
 			)

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -102,7 +102,8 @@ abstract class WP_Job_Manager_Form {
 			delete_post_meta( $_COOKIE['wp-job-manager-submitting-job-id'], '_submitting_key' );
 			setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
 			setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-			wp_redirect( remove_query_arg( array( 'new', 'key' ), $_SERVER['REQUEST_URI'] ) );
+			wp_safe_redirect( remove_query_arg( array( 'new', 'key' ) ) );
+			exit;
 		}
 
 		$step_key = $this->get_step_key( $this->step );

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -303,8 +303,8 @@ abstract class WP_Job_Manager_Form {
 	 */
 	public function enqueue_scripts() {
 		if ( $this->use_recaptcha_field() ) {
-			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-			wp_enqueue_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js' );
+			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
+			wp_enqueue_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js', array(), false, false );
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -23,7 +23,7 @@ class WP_Job_Manager_Addons {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -33,10 +33,10 @@ class WP_Job_Manager_Addons {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -94,7 +94,8 @@ class WP_Job_Manager_Addons {
 					array(
 						'version' => JOB_MANAGER_VERSION,
 						'lang'    => get_locale(),
-					), self::WPJM_COM_PRODUCTS_API_BASE_URL . '/messages'
+					),
+					self::WPJM_COM_PRODUCTS_API_BASE_URL . '/messages'
 				)
 			);
 			if ( ! is_wp_error( $raw_messages ) ) {

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -116,7 +116,9 @@ class WP_Job_Manager_Admin_Notices {
 			$hide_notice = sanitize_key( wp_unslash( $_GET['wpjm_hide_notice'] ) );
 
 			self::remove_notice( $hide_notice );
-			wp_redirect( remove_query_arg( array( 'wpjm_hide_notice', '_wpjm_notice_nonce' ), $_SERVER['REQUEST_URI'] ) );
+
+			wp_safe_redirect( remove_query_arg( array( 'wpjm_hide_notice', '_wpjm_notice_nonce' ) ) );
+			exit;
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -104,8 +104,8 @@ class WP_Job_Manager_Admin_Notices {
 	 * Dismiss notices as requested by user. Inspired by WooCommerce's approach.
 	 */
 	public static function dismiss_notices() {
-		if ( isset( $_GET['wpjm_hide_notice'] ) && isset( $_GET['_wpjm_notice_nonce'] ) ) { // WPCS: input var ok, CSRF ok.
-			if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpjm_notice_nonce'] ) ), 'job_manager_hide_notices_nonce' ) ) { // WPCS: input var ok, CSRF ok.
+		if ( isset( $_GET['wpjm_hide_notice'] ) && isset( $_GET['_wpjm_notice_nonce'] ) ) {
+			if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpjm_notice_nonce'] ) ), 'job_manager_hide_notices_nonce' ) ) {
 				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'wp-job-manager' ) );
 			}
 
@@ -113,7 +113,7 @@ class WP_Job_Manager_Admin_Notices {
 				wp_die( esc_html__( 'You don&#8217;t have permission to do this.', 'wp-job-manager' ) );
 			}
 
-			$hide_notice = sanitize_key( wp_unslash( $_GET['wpjm_hide_notice'] ) ); // WPCS: input var ok, CSRF ok.
+			$hide_notice = sanitize_key( wp_unslash( $_GET['wpjm_hide_notice'] ) );
 
 			self::remove_notice( $hide_notice );
 			wp_redirect( remove_query_arg( array( 'wpjm_hide_notice', '_wpjm_notice_nonce' ), $_SERVER['REQUEST_URI'] ) );

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Admin {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -32,10 +32,10 @@ class WP_Job_Manager_Admin {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -155,8 +155,10 @@ class WP_Job_Manager_CPT {
 			$handled_jobs = array();
 			if ( ! empty( $post_ids ) ) {
 				foreach ( $post_ids as $post_id ) {
-					if ( 'job_listing' === get_post_type( $post_id )
-						 && call_user_func( $actions_handled[ $action ]['handler'], $post_id ) ) {
+					if (
+						'job_listing' === get_post_type( $post_id )
+						&& call_user_func( $actions_handled[ $action ]['handler'], $post_id )
+					) {
 						$handled_jobs[] = $post_id;
 					}
 				}
@@ -178,9 +180,10 @@ class WP_Job_Manager_CPT {
 			'ID'          => $post_id,
 			'post_status' => 'publish',
 		);
-		if ( in_array( get_post_status( $post_id ), array( 'pending', 'pending_payment' ), true )
-			 && current_user_can( 'publish_post', $post_id )
-			 && wp_update_post( $job_data )
+		if (
+			in_array( get_post_status( $post_id ), array( 'pending', 'pending_payment' ), true )
+			&& current_user_can( 'publish_post', $post_id )
+			&& wp_update_post( $job_data )
 		) {
 			return true;
 		}
@@ -198,8 +201,9 @@ class WP_Job_Manager_CPT {
 			'ID'          => $post_id,
 			'post_status' => 'expired',
 		);
-		if ( current_user_can( 'manage_job_listings', $post_id )
-			 && wp_update_post( $job_data )
+		if (
+			current_user_can( 'manage_job_listings', $post_id )
+			&& wp_update_post( $job_data )
 		) {
 			return true;
 		}
@@ -214,8 +218,9 @@ class WP_Job_Manager_CPT {
 	 * @return bool
 	 */
 	public function bulk_action_handle_mark_job_filled( $post_id ) {
-		if ( current_user_can( 'manage_job_listings', $post_id )
-			 && update_post_meta( $post_id, '_filled', 1 )
+		if (
+			current_user_can( 'manage_job_listings', $post_id )
+			&& update_post_meta( $post_id, '_filled', 1 )
 		) {
 			return true;
 		}
@@ -229,8 +234,9 @@ class WP_Job_Manager_CPT {
 	 * @return bool
 	 */
 	public function bulk_action_handle_mark_job_not_filled( $post_id ) {
-		if ( current_user_can( 'manage_job_listings', $post_id )
-			 && update_post_meta( $post_id, '_filled', 0 )
+		if (
+			current_user_can( 'manage_job_listings', $post_id )
+			&& update_post_meta( $post_id, '_filled', 0 )
 		) {
 			return true;
 		}
@@ -241,7 +247,12 @@ class WP_Job_Manager_CPT {
 	 * Approves a single job.
 	 */
 	public function approve_job() {
-		if ( ! empty( $_GET['approve_job'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'approve_job' ) && current_user_can( 'publish_post', $_GET['approve_job'] ) ) {
+		if (
+			! empty( $_GET['approve_job'] )
+			&& ! empty( $_REQUEST['_wpnonce'] )
+			&& wp_verify_nonce( $_REQUEST['_wpnonce'], 'approve_job' )
+			&& current_user_can( 'publish_post', $_GET['approve_job'] )
+		) {
 			$post_id  = absint( $_GET['approve_job'] );
 			$job_data = array(
 				'ID'          => $post_id,
@@ -263,12 +274,13 @@ class WP_Job_Manager_CPT {
 		$action          = isset( $_REQUEST['action_performed'] ) ? $_REQUEST['action_performed'] : false;
 		$actions_handled = $this->get_bulk_actions();
 
-		if ( 'edit.php' === $pagenow
-			 && 'job_listing' === $post_type
-			 && $action
-			 && ! empty( $handled_jobs )
-			 && isset( $actions_handled[ $action ] )
-			 && isset( $actions_handled[ $action ]['notice'] )
+		if (
+			'edit.php' === $pagenow
+			&& 'job_listing' === $post_type
+			&& $action
+			&& ! empty( $handled_jobs )
+			&& isset( $actions_handled[ $action ] )
+			&& isset( $actions_handled[ $action ]['notice'] )
 		) {
 			if ( is_array( $handled_jobs ) ) {
 				$handled_jobs = array_map( 'absint', $handled_jobs );
@@ -790,7 +802,7 @@ class WP_Job_Manager_CPT {
 	public function search_meta_label( $query ) {
 		global $pagenow, $typenow;
 
-		if ( 'edit.php' !== $pagenow || 'job_listing' !== $typenow || ! get_query_var( 'job_listing_search' ) ) {
+		if ( 'edit.php' !== $pagenow || 'job_listing' !== $typenow || ! get_query_var( 'job_listing_search' ) || ! isset( $_GET['s'] ) ) {
 			return $query;
 		}
 

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -160,7 +160,7 @@ class WP_Job_Manager_CPT {
 						$handled_jobs[] = $post_id;
 					}
 				}
-				wp_redirect( add_query_arg( 'handled_jobs', $handled_jobs, add_query_arg( 'action_performed', $action, $redirect_url ) ) );
+				wp_safe_redirect( add_query_arg( 'handled_jobs', $handled_jobs, add_query_arg( 'action_performed', $action, $redirect_url ) ) );
 				exit;
 			}
 		}
@@ -248,7 +248,7 @@ class WP_Job_Manager_CPT {
 				'post_status' => 'publish',
 			);
 			wp_update_post( $job_data );
-			wp_redirect( remove_query_arg( 'approve_job', add_query_arg( 'handled_jobs', $post_id, add_query_arg( 'action_performed', 'approve_jobs', admin_url( 'edit.php?post_type=job_listing' ) ) ) ) );
+			wp_safe_redirect( remove_query_arg( 'approve_job', add_query_arg( 'handled_jobs', $post_id, add_query_arg( 'action_performed', 'approve_jobs', admin_url( 'edit.php?post_type=job_listing' ) ) ) ) );
 			exit;
 		}
 	}

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_CPT {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -32,10 +32,10 @@ class WP_Job_Manager_CPT {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Permalink_Settings {
 	 * @var self
 	 * @since  1.27.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Permalink settings.
@@ -40,10 +40,10 @@ class WP_Job_Manager_Permalink_Settings {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -142,9 +142,9 @@ class WP_Job_Manager_Permalink_Settings {
 
 			$permalink_settings = WP_Job_Manager_Post_Types::get_raw_permalink_settings();
 
-			$permalink_settings['job_base']      = sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] );
-			$permalink_settings['category_base'] = sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] );
-			$permalink_settings['type_base']     = sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] );
+			$permalink_settings['job_base']      = isset( $_POST['wpjm_job_base_slug'] ) ? sanitize_title_with_dashes( $_POST['wpjm_job_base_slug'] ) : '';
+			$permalink_settings['category_base'] = isset( $_POST['wpjm_job_category_slug'] ) ? sanitize_title_with_dashes( $_POST['wpjm_job_category_slug'] ) : '';
+			$permalink_settings['type_base']     = isset( $_POST['wpjm_job_type_slug'] ) ? sanitize_title_with_dashes( $_POST['wpjm_job_type_slug'] ) : '';
 
 			if ( isset( $_POST['wpjm_job_listings_archive_slug'] ) ) {
 				$permalink_settings['jobs_archive'] = sanitize_title_with_dashes( $_POST['wpjm_job_listings_archive_slug'] );

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -534,7 +534,7 @@ class WP_Job_Manager_Settings {
 			type="checkbox"
 			value="1"
 			<?php
-			echo implode( ' ', $attributes ) . ' '; // WPCS: XSS ok.
+			echo implode( ' ', $attributes ) . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			checked( '1', $value );
 			?>
 		/> <?php echo wp_kses_post( $option['cb_label'] ); ?></label>
@@ -561,8 +561,8 @@ class WP_Job_Manager_Settings {
 			rows="3"
 			name="<?php echo esc_attr( $option['name'] ); ?>"
 			<?php
-			echo implode( ' ', $attributes ) . ' '; // WPCS: XSS ok.
-			echo $placeholder; // WPCS: XSS ok.
+			echo implode( ' ', $attributes ) . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $placeholder; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		>
 			<?php echo esc_textarea( $value ); ?>
@@ -589,7 +589,7 @@ class WP_Job_Manager_Settings {
 			class="regular-text"
 			name="<?php echo esc_attr( $option['name'] ); ?>"
 			<?php
-			echo implode( ' ', $attributes ); // WPCS: XSS ok.
+			echo implode( ' ', $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		>
 		<?php
@@ -651,7 +651,7 @@ class WP_Job_Manager_Settings {
 			'selected'         => absint( $value ),
 		);
 
-		echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'wp-job-manager' ) . "' id=", wp_dropdown_pages( $args ) ); // WPCS: XSS ok.
+		echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'wp-job-manager' ) . "' id=", wp_dropdown_pages( $args ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( ! empty( $option['desc'] ) ) {
 			echo ' <p class="description">' . wp_kses_post( $option['desc'] ) . '</p>';
@@ -678,7 +678,7 @@ class WP_Job_Manager_Settings {
 			name="<?php echo esc_attr( $option['name'] ); ?>"
 			value="<?php echo esc_attr( $value ); ?>"
 			<?php
-			echo implode( ' ', $attributes ); // WPCS: XSS ok.
+			echo implode( ' ', $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		/><strong><?php echo esc_html( $human_value ); ?></strong>
 		<?php
@@ -705,8 +705,8 @@ class WP_Job_Manager_Settings {
 			name="<?php echo esc_attr( $option['name'] ); ?>"
 			value="<?php echo esc_attr( $value ); ?>"
 			<?php
-			echo implode( ' ', $attributes ) . ' '; // WPCS: XSS ok.
-			echo $placeholder; // WPCS: XSS ok.
+			echo implode( ' ', $attributes ) . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $placeholder; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		/>
 		<?php
@@ -734,8 +734,8 @@ class WP_Job_Manager_Settings {
 			name="<?php echo esc_attr( $option['name'] ); ?>"
 			value="<?php echo esc_attr( $value ); ?>"
 			<?php
-			echo implode( ' ', $attributes ) . ' '; // WPCS: XSS ok.
-			echo $placeholder; // WPCS: XSS ok.
+			echo implode( ' ', $attributes ) . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $placeholder; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		/>
 		<?php
@@ -762,8 +762,8 @@ class WP_Job_Manager_Settings {
 			name="<?php echo esc_attr( $option['name'] ); ?>"
 			value="<?php echo esc_attr( $value ); ?>"
 			<?php
-			echo implode( ' ', $attributes ) . ' '; // WPCS: XSS ok.
-			echo $placeholder; // WPCS: XSS ok.
+			echo implode( ' ', $attributes ) . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $placeholder; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		/>
 		<?php

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Settings {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Our Settings.
@@ -39,10 +39,10 @@ class WP_Job_Manager_Settings {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Setup {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -32,10 +32,10 @@ class WP_Job_Manager_Setup {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -102,7 +102,7 @@ class WP_Job_Manager_Setup {
 		$usage_tracking = WP_Job_Manager_Usage_Tracking::get_instance();
 		$step           = ! empty( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 
-		if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
 			// Handle step 1 (usage tracking).
 			$enable = isset( $_POST['job_manager_usage_tracking_enabled'] )
 				&& '1' === $_POST['job_manager_usage_tracking_enabled'];
@@ -117,11 +117,11 @@ class WP_Job_Manager_Setup {
 
 			// Handle step 2 -> step 3 (setting up pages).
 			if ( 3 === $step && ! empty( $_POST ) ) {
-				if ( false === wp_verify_nonce( $_REQUEST['setup_wizard'], 'step_3' ) ) {
+				if ( ! isset( $_REQUEST['setup_wizard'] ) || false === wp_verify_nonce( $_REQUEST['setup_wizard'], 'step_3' ) ) {
 					wp_die( 'Error in nonce. Try again.', 'wp-job-manager' );
 				}
 				$create_pages    = isset( $_POST['wp-job-manager-create-page'] ) ? $_POST['wp-job-manager-create-page'] : array();
-				$page_titles     = $_POST['wp-job-manager-page-title'];
+				$page_titles     = isset( $_POST['wp-job-manager-page-title'] ) ? $_POST['wp-job-manager-page-title'] : array();
 				$pages_to_create = array(
 					'submit_job_form' => '[submit_job_form]',
 					'job_dashboard'   => '[job_dashboard]',

--- a/includes/admin/class-wp-job-manager-taxonomy-meta.php
+++ b/includes/admin/class-wp-job-manager-taxonomy-meta.php
@@ -21,7 +21,7 @@ class WP_Job_Manager_Taxonomy_Meta {
 	 * @var self
 	 * @since  1.28.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -31,10 +31,10 @@ class WP_Job_Manager_Taxonomy_Meta {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -458,8 +458,8 @@ class WP_Job_Manager_Writepanels {
 			$author_id = $post->post_author;
 		}
 
-		$posted_by      = get_user_by( 'id', $author_id );
-		$name           = ! empty( $field['name'] ) ? $field['name'] : $key;
+		$posted_by = get_user_by( 'id', $author_id );
+		$name      = ! empty( $field['name'] ) ? $field['name'] : $key;
 		?>
 		<p class="form-field form-field-author">
 			<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( wp_strip_all_tags( $field['label'] ) ); ?>:</label>

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Writepanels {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -32,10 +32,10 @@ class WP_Job_Manager_Writepanels {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -479,7 +479,7 @@ class WP_Job_Manager_Writepanels {
 					echo esc_html( $user_string );
 				}
 				?>
-				 <a href="#" class="change-author button button-small"><?php esc_html_e( 'Change', 'wp-job-manager' ); ?></a>
+				<a href="#" class="change-author button button-small"><?php esc_html_e( 'Change', 'wp-job-manager' ); ?></a>
 			</span>
 			<span class="hidden change-author">
 				<select class="wpjm-user-search" id="job_manager_user_search" name="<?php echo esc_attr( $name ); ?>" data-placeholder="<?php esc_attr_e( 'Guest', 'wp-job-manager' ); ?>" data-allow_clear="true">
@@ -672,13 +672,13 @@ class WP_Job_Manager_Writepanels {
 	 */
 	private function is_job_listing_status_changing( $from_status, $to_status ) {
 		return isset( $_POST['post_status'] )
-			   && isset( $_POST['original_post_status'] )
-			   && $_POST['original_post_status'] !== $_POST['post_status']
-			   && (
+				&& isset( $_POST['original_post_status'] )
+				&& $_POST['original_post_status'] !== $_POST['post_status']
+				&& (
 					null === $from_status
 					|| $from_status === $_POST['original_post_status']
-			   )
-			   && $to_status === $_POST['post_status'];
+				)
+				&& $to_status === $_POST['post_status'];
 	}
 }
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -38,7 +38,7 @@ if ( ! empty( $categories ) ) {
 		?>
 		<li>
 			<a class="<?php echo $current_category === $category->slug ? 'current' : ''; ?>"
-			   href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&category=' . esc_attr( $category->slug ) ) ); ?>">
+				href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&category=' . esc_attr( $category->slug ) ) ); ?>">
 				<?php echo esc_html( $category->label ); ?>
 			</a>
 		</li>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -60,7 +60,8 @@ if ( empty( $add_ons ) ) {
 				'utm_medium'   => 'addonpage',
 				'utm_campaign' => 'wpjmplugin',
 				'utm_content'  => 'listing',
-			), $add_on->link
+			),
+			$add_on->link
 		);
 		?>
 		<li class="product">

--- a/includes/admin/views/html-admin-setup-step-2.php
+++ b/includes/admin/views/html-admin-setup-step-2.php
@@ -20,7 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			__(
 				'(These pages are created using <a href="%1$s" title="What is a shortcode?" class="help-page-link">shortcodes</a>,
 								which we take care of in this step. If you\'d like to build these pages yourself or want to add one of these options to an existing
-								page on your site, you can skip this step and take a look at <a href="%2$s" class="help-page-link">shortcode documentation</a> for detailed instructions.)', 'wp-job-manager'
+								page on your site, you can skip this step and take a look at <a href="%2$s" class="help-page-link">shortcode documentation</a> for detailed instructions.)',
+				'wp-job-manager'
 			),
 			'http://codex.wordpress.org/Shortcode',
 			'https://wpjobmanager.com/document/shortcode-reference/'

--- a/includes/admin/views/html-admin-setup-step-3.php
+++ b/includes/admin/views/html-admin-setup-step-3.php
@@ -52,7 +52,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			__(
 				'If you need help, you can find more detail in our
 							<a href="%1$s">support documentation</a> or post your question on the
-							<a href="%2$s">WP Job Manager support forums</a>. Happy hiring!', 'wp-job-manager'
+							<a href="%2$s">WP Job Manager support forums</a>. Happy hiring!',
+				'wp-job-manager'
 			),
 			'https://wpjobmanager.com/documentation/',
 			'https://wordpress.org/support/plugin/wp-job-manager'

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -91,7 +91,7 @@ class WP_Job_Manager_Ajax {
 		global $wp_query;
 
 		if ( ! empty( $_GET['jm-ajax'] ) ) {
-			 $wp_query->set( 'jm-ajax', sanitize_text_field( $_GET['jm-ajax'] ) );
+			$wp_query->set( 'jm-ajax', sanitize_text_field( $_GET['jm-ajax'] ) );
 		}
 
 		$action = $wp_query->get( 'jm-ajax' );
@@ -121,14 +121,17 @@ class WP_Job_Manager_Ajax {
 		global $wp_post_types;
 
 		$result             = array();
-		$search_location    = sanitize_text_field( stripslashes( $_REQUEST['search_location'] ) );
-		$search_keywords    = sanitize_text_field( stripslashes( $_REQUEST['search_keywords'] ) );
+		$search_location    = isset( $_REQUEST['search_location'] ) ? sanitize_text_field( stripslashes( $_REQUEST['search_location'] ) ) : '';
+		$search_keywords    = isset( $_REQUEST['search_keywords'] ) ? sanitize_text_field( stripslashes( $_REQUEST['search_keywords'] ) ) : '';
 		$search_categories  = isset( $_REQUEST['search_categories'] ) ? $_REQUEST['search_categories'] : '';
 		$filter_job_types   = isset( $_REQUEST['filter_job_type'] ) ? array_filter( array_map( 'sanitize_title', (array) $_REQUEST['filter_job_type'] ) ) : null;
 		$filter_post_status = isset( $_REQUEST['filter_post_status'] ) ? array_filter( array_map( 'sanitize_title', (array) $_REQUEST['filter_post_status'] ) ) : null;
 		$types              = get_job_listing_types();
 		$post_type_label    = $wp_post_types['job_listing']->labels->name;
-		$orderby            = sanitize_text_field( $_REQUEST['orderby'] );
+		$order              = isset( $_REQUEST['order'] ) ? sanitize_text_field( $_REQUEST['order'] ) : 'DESC';
+		$orderby            = isset( $_REQUEST['orderby'] ) ? sanitize_text_field( $_REQUEST['orderby'] ) : 'featured';
+		$page               = isset( $_REQUEST['page'] ) ? absint( $_REQUEST['page'] ) : 1;
+		$per_page           = isset( $_REQUEST['per_page'] ) ? absint( $_REQUEST['per_page'] ) : absint( get_option( 'job_manager_per_page' ) );
 
 		if ( is_array( $search_categories ) ) {
 			$search_categories = array_filter( array_map( 'sanitize_text_field', array_map( 'stripslashes', $search_categories ) ) );
@@ -145,9 +148,9 @@ class WP_Job_Manager_Ajax {
 			'job_types'         => is_null( $filter_job_types ) || count( $types ) === count( $filter_job_types ) ? '' : $filter_job_types + array( 0 ),
 			'post_status'       => $filter_post_status,
 			'orderby'           => $orderby,
-			'order'             => sanitize_text_field( $_REQUEST['order'] ),
-			'offset'            => ( absint( $_REQUEST['page'] ) - 1 ) * absint( $_REQUEST['per_page'] ),
-			'posts_per_page'    => max( 1, absint( $_REQUEST['per_page'] ) ),
+			'order'             => $order,
+			'offset'            => ( $page - 1 ) * $per_page,
+			'posts_per_page'    => max( 1, $per_page ),
 		);
 
 		if ( isset( $_REQUEST['filled'] ) && ( 'true' === $_REQUEST['filled'] || 'false' === $_REQUEST['filled'] ) ) {
@@ -347,7 +350,7 @@ class WP_Job_Manager_Ajax {
 			wp_die( -1 );
 		}
 
-		$term     = sanitize_text_field( wp_unslash( $_GET['term'] ) );
+		$term     = isset( $_GET['term'] ) ? sanitize_text_field( wp_unslash( $_GET['term'] ) ) : '';
 		$page     = isset( $_GET['page'] ) ? intval( $_GET['page'] ) : 1;
 		$per_page = 20;
 

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Ajax {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -32,10 +32,10 @@ class WP_Job_Manager_Ajax {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-api.php
+++ b/includes/class-wp-job-manager-api.php
@@ -23,7 +23,7 @@ class WP_Job_Manager_API {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -33,10 +33,10 @@ class WP_Job_Manager_API {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-blocks.php
+++ b/includes/class-wp-job-manager-blocks.php
@@ -19,7 +19,7 @@ class WP_Job_Manager_Blocks {
 	 *
 	 * @var self
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Singleton instance getter
@@ -27,11 +27,11 @@ class WP_Job_Manager_Blocks {
 	 * @return self
 	 */
 	public static function get_instance() {
-		if ( ! self::$_instance ) {
-			self::$_instance = new WP_Job_Manager_Blocks();
+		if ( ! self::$instance ) {
+			self::$instance = new WP_Job_Manager_Blocks();
 		}
 
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-category-walker.php
+++ b/includes/class-wp-job-manager-category-walker.php
@@ -62,10 +62,11 @@ class WP_Job_Manager_Category_Walker extends Walker {
 
 		$output .= "\t<option class=\"level-" . intval( $depth ) . '" value="' . esc_attr( $value ) . '"';
 
-		if ( isset( $args['selected'] ) && (
+		if (
+			isset( $args['selected'] ) && (
 				$value == $args['selected'] // phpcs:ignore WordPress.PHP.StrictComparisons
 				|| ( is_array( $args['selected'] ) && in_array( $value, $args['selected'] ) ) // phpcs:ignore WordPress.PHP.StrictInArray
-			 )
+			)
 		) {
 			$output .= ' selected="selected"';
 		}

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -214,6 +214,8 @@ class WP_Job_Manager_Data_Cleaner {
 	private static function cleanup_taxonomies() {
 		global $wpdb;
 
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		foreach ( self::$taxonomies as $taxonomy ) {
 			$terms = $wpdb->get_results(
 				$wpdb->prepare(
@@ -234,6 +236,9 @@ class WP_Job_Manager_Data_Cleaner {
 				clean_taxonomy_cache( $taxonomy );
 			}
 		}
+
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 
 	/**
@@ -291,6 +296,8 @@ class WP_Job_Manager_Data_Cleaner {
 	private static function cleanup_transients() {
 		global $wpdb;
 
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		foreach ( array( '_transient_', '_transient_timeout_' ) as $prefix ) {
 			foreach ( self::$transients as $transient ) {
 				$wpdb->query(
@@ -301,6 +308,8 @@ class WP_Job_Manager_Data_Cleaner {
 				);
 			}
 		}
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 
 	/**
@@ -349,6 +358,7 @@ class WP_Job_Manager_Data_Cleaner {
 		global $wpdb;
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
+			// phpcs:ignore
 			$wpdb->delete( $wpdb->usermeta, array( 'meta_key' => $meta_key ) );
 		}
 	}

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -560,7 +560,8 @@ final class WP_Job_Manager_Email_Notifications {
 			AND postmeta.meta_value = %s
 			AND posts.post_status = 'publish'
 			AND posts.post_type = 'job_listing'
-		", date( 'Y-m-d', $notice_before_ts )
+		",
+				date( 'Y-m-d', $notice_before_ts )
 			)
 		);
 

--- a/includes/class-wp-job-manager-forms.php
+++ b/includes/class-wp-job-manager-forms.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Forms {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -32,10 +32,10 @@ class WP_Job_Manager_Forms {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-geocode.php
+++ b/includes/class-wp-job-manager-geocode.php
@@ -24,7 +24,7 @@ class WP_Job_Manager_Geocode {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -34,10 +34,10 @@ class WP_Job_Manager_Geocode {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -73,7 +73,7 @@ class WP_Job_Manager_Install {
 		global $wp_roles;
 
 		if ( class_exists( 'WP_Roles' ) && ! isset( $wp_roles ) ) {
-			$wp_roles = new WP_Roles(); // WPCS: override ok.
+			$wp_roles = new WP_Roles();
 		}
 
 		if ( is_object( $wp_roles ) ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -145,7 +145,7 @@ class WP_Job_Manager_Post_Types {
 
 		$admin_capability = 'manage_job_listings';
 
-		$permalink_structure = WP_Job_Manager_Post_Types::get_permalink_structure();
+		$permalink_structure = self::get_permalink_structure();
 
 		/**
 		 * Taxonomies
@@ -1116,7 +1116,7 @@ class WP_Job_Manager_Post_Types {
 	 * Registers job listing meta fields.
 	 */
 	public function register_meta_fields() {
-		$fields       = WP_Job_Manager_Post_Types::get_job_listing_fields();
+		$fields = self::get_job_listing_fields();
 
 		foreach ( $fields as $meta_key => $field ) {
 			register_meta(

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -128,7 +128,7 @@ class WP_Job_Manager_Post_Types {
 	public function hide_job_type_block_editor_selector( $response, $taxonomy, $request ) {
 		if (
 			'job_listing_type' === $taxonomy->name
-			 && 'edit' === $request->get_param( 'context' )
+			&& 'edit' === $request->get_param( 'context' )
 		) {
 			$response->data['visibility']['show_ui'] = false;
 		}
@@ -431,7 +431,7 @@ class WP_Job_Manager_Post_Types {
 
 		foreach ( $menu as $key => $menu_item ) {
 			if ( strpos( $menu_item[0], $plural ) === 0 ) {
-				$menu[ $key ][0] .= " <span class='awaiting-mod update-plugins count-" . esc_attr( $pending_jobs ) . "'><span class='pending-count'>" . absint( number_format_i18n( $pending_jobs ) ) . '</span></span>'; // WPCS: override ok.
+				$menu[ $key ][0] .= " <span class='awaiting-mod update-plugins count-" . esc_attr( $pending_jobs ) . "'><span class='pending-count'>" . absint( number_format_i18n( $pending_jobs ) ) . '</span></span>';
 				break;
 			}
 		}
@@ -666,7 +666,7 @@ class WP_Job_Manager_Post_Types {
 		 *
 		 * @param int $post_id The post ID of the job.
 		 */
-		 do_action( 'job_feed_item', $post_id );
+		do_action( 'job_feed_item', $post_id );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -24,7 +24,7 @@ class WP_Job_Manager_Post_Types {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -34,10 +34,10 @@ class WP_Job_Manager_Post_Types {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -206,7 +206,8 @@ class WP_Job_Manager_Shortcodes {
 		$new_atts       = shortcode_atts(
 			array(
 				'posts_per_page' => '25',
-			), $atts
+			),
+			$atts
 		);
 		$posts_per_page = $new_atts['posts_per_page'];
 
@@ -313,7 +314,8 @@ class WP_Job_Manager_Shortcodes {
 					'selected_category'         => '',
 					'selected_job_types'        => implode( ',', array_values( get_job_listing_types( 'id=>slug' ) ) ),
 				)
-			), $atts
+			),
+			$atts
 		);
 
 		if ( ! get_option( 'job_manager_enable_categories' ) ) {
@@ -507,7 +509,8 @@ class WP_Job_Manager_Shortcodes {
 		$atts = shortcode_atts(
 			array(
 				'id' => '',
-			), $atts
+			),
+			$atts
 		);
 
 		if ( ! $atts['id'] ) {
@@ -551,7 +554,8 @@ class WP_Job_Manager_Shortcodes {
 				'align'    => 'left',
 				'featured' => null, // True to show only featured, false to hide featured, leave null to show both (when leaving out id).
 				'limit'    => 1,
-			), $atts
+			),
+			$atts
 		);
 
 		ob_start();
@@ -604,7 +608,8 @@ class WP_Job_Manager_Shortcodes {
 		$new_atts = shortcode_atts(
 			array(
 				'id' => '',
-			), $atts
+			),
+			$atts
 		);
 		$id       = $new_atts['id'];
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -273,7 +273,7 @@ class WP_Job_Manager_Shortcodes {
 	public function edit_job() {
 		global $job_manager;
 
-		echo $job_manager->forms->get_form( 'edit-job' ); // WPCS: XSS ok.
+		echo $job_manager->forms->get_form( 'edit-job' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -424,7 +424,7 @@ class WP_Job_Manager_Shortcodes {
 				if ( $jobs->found_posts > $atts['per_page'] && $atts['show_more'] ) {
 					wp_enqueue_script( 'wp-job-manager-ajax-filters' );
 					if ( $atts['show_pagination'] ) {
-						echo get_job_listing_pagination( $jobs->max_num_pages ); // WPCS: XSS ok.
+						echo get_job_listing_pagination( $jobs->max_num_pages ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					} else {
 						echo '<a class="load_more_jobs" href="#"><strong>' . esc_html__( 'Load more listings', 'wp-job-manager' ) . '</strong></a>';
 					}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -30,7 +30,7 @@ class WP_Job_Manager_Shortcodes {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -40,10 +40,10 @@ class WP_Job_Manager_Shortcodes {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -148,7 +148,7 @@ class WP_Job_Manager_Shortcodes {
 						$new_job_id = job_manager_duplicate_listing( $job_id );
 
 						if ( $new_job_id ) {
-							wp_redirect( add_query_arg( array( 'job_id' => absint( $new_job_id ) ), job_manager_get_permalink( 'submit_job_form' ) ) );
+							wp_safe_redirect( add_query_arg( array( 'job_id' => absint( $new_job_id ) ), job_manager_get_permalink( 'submit_job_form' ) ) );
 							exit;
 						}
 
@@ -160,7 +160,7 @@ class WP_Job_Manager_Shortcodes {
 						}
 
 						// redirect to post page.
-						wp_redirect( add_query_arg( array( 'job_id' => absint( $job_id ) ), job_manager_get_permalink( 'submit_job_form' ) ) );
+						wp_safe_redirect( add_query_arg( array( 'job_id' => absint( $job_id ) ), job_manager_get_permalink( 'submit_job_form' ) ) );
 						exit;
 					default:
 						do_action( 'job_manager_job_dashboard_do_action_' . $action, $job_id );

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -93,7 +93,7 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $_REQUEST['action'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'job_manager_my_job_actions' ) ) {
 
 			$action = sanitize_title( $_REQUEST['action'] );
-			$job_id = absint( $_REQUEST['job_id'] );
+			$job_id = isset( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : 0;
 
 			try {
 				// Get Job.

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -115,12 +115,12 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		$properties['job_id']      = intval( $post_id );
 		$properties['post_status'] = get_post_status( $post_id );
 
-		$user_role  = self::get_current_role();
+		$user_role = self::get_current_role();
 		if ( $user_role ) {
 			$properties['user_role'] = $user_role;
 		}
 
-		WP_Job_Manager_Usage_Tracking::log_event( 'job_listing_submitted', $properties );
+		self::log_event( 'job_listing_submitted', $properties );
 	}
 
 	/**
@@ -141,12 +141,12 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		$properties['job_id'] = intval( $post_id );
 		$properties['age']    = time() - strtotime( $post->post_date_gmt );
 
-		$user_role  = self::get_current_role();
+		$user_role = self::get_current_role();
 		if ( $user_role ) {
 			$properties['user_role'] = $user_role;
 		}
 
-		WP_Job_Manager_Usage_Tracking::log_event( 'job_listing_approved', $properties );
+		self::log_event( 'job_listing_approved', $properties );
 	}
 
 	/**
@@ -229,7 +229,8 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 				<a href="%s">usage tracking data</a>. No sensitive information is
 				collected, and you can opt out at any time.',
 				'wp-job-manager'
-			), self::WPJM_TRACKING_INFO_URL
+			),
+			self::WPJM_TRACKING_INFO_URL
 		);
 	}
 
@@ -295,8 +296,10 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			__(
 				'Help us make WP Job Manager better by allowing us to collect
 				<a href="%s">usage tracking data</a>.
-				No sensitive information is collected.', 'wp-job-manager'
-			), self::WPJM_TRACKING_INFO_URL
+				No sensitive information is collected.',
+				'wp-job-manager'
+			),
+			self::WPJM_TRACKING_INFO_URL
 		);
 	}
 

--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -88,7 +88,7 @@ class WP_Job_Manager_Widget extends WP_Widget {
 		}
 
 		if ( isset( $cache[ $args['widget_id'] ] ) ) {
-			echo $cache[ $args['widget_id'] ]; // WPCS: XSS ok.
+			echo $cache[ $args['widget_id'] ]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return true;
 		}
 

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -22,7 +22,7 @@ class WP_Job_Manager {
 	 * @var self
 	 * @since  1.26.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Main WP Job Manager Instance.
@@ -35,10 +35,10 @@ class WP_Job_Manager {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -267,7 +267,7 @@ class WP_Job_Manager {
 	 * Registers select2 assets when needed.
 	 */
 	public static function register_select2_assets() {
-		wp_register_script( 'select2', JOB_MANAGER_PLUGIN_URL . '/assets/js/select2/select2.full.min.js', array( 'jquery' ), '4.0.5' );
+		wp_register_script( 'select2', JOB_MANAGER_PLUGIN_URL . '/assets/js/select2/select2.full.min.js', array( 'jquery' ), '4.0.5', false );
 		wp_register_style( 'select2', JOB_MANAGER_PLUGIN_URL . '/assets/js/select2/select2.min.css', array(), '4.0.5' );
 	}
 

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -143,9 +143,11 @@ class WP_Job_Manager {
 			// translators: Placeholders %1$s and %2$s are the names of the two cookies used in WP Job Manager.
 			__(
 				'This site adds the following cookies to help users resume job submissions that they 
-				have started but have not completed: %1$s and %2$s', 'wp-job-manager'
+				have started but have not completed: %1$s and %2$s',
+				'wp-job-manager'
 			),
-			'<code>wp-job-manager-submitting-job-id</code>', '<code>wp-job-manager-submitting-job-key</code>'
+			'<code>wp-job-manager-submitting-job-id</code>',
+			'<code>wp-job-manager-submitting-job-key</code>'
 		);
 
 		wp_add_privacy_policy_content(
@@ -313,9 +315,11 @@ class WP_Job_Manager {
 
 			// Backwards compatibility for third-party themes/plugins while they transition to Select2.
 			wp_localize_script(
-				'chosen', 'job_manager_chosen_multiselect_args',
+				'chosen',
+				'job_manager_chosen_multiselect_args',
 				apply_filters(
-					'job_manager_chosen_multiselect_args', array(
+					'job_manager_chosen_multiselect_args',
+					array(
 						'search_contains' => true,
 					)
 				)
@@ -366,7 +370,8 @@ class WP_Job_Manager {
 			$select2_args['width'] = '100%';
 
 			wp_localize_script(
-				'select2', 'job_manager_select2_args',
+				'select2',
+				'job_manager_select2_args',
 				apply_filters( 'job_manager_select2_args', $select2_args )
 			);
 		}

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -137,8 +137,10 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 		$this->enqueue_job_form_assets();
 
 		$save_button_text = __( 'Save changes', 'wp-job-manager' );
-		if ( 'publish' === get_post_status( $this->job_id )
-			 && wpjm_published_submission_edits_require_moderation() ) {
+		if (
+			'publish' === get_post_status( $this->job_id )
+			&& wpjm_published_submission_edits_require_moderation()
+		) {
 			$save_button_text = __( 'Submit changes for approval', 'wp-job-manager' );
 		}
 

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -46,16 +46,16 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 	 * @access protected
 	 * @var WP_Job_Manager_Form_Edit_Job The single instance of the class
 	 */
-	protected static $_instance = null;
+	protected static $instance = null;
 
 	/**
 	 * Main Instance
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -548,7 +548,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				'job_fields'         => $this->get_fields( 'job' ),
 				'company_fields'     => $this->get_fields( 'company' ),
 				'step'               => $this->get_step(),
-				'can_continue_later'   => $this->can_continue_later(),
+				'can_continue_later' => $this->can_continue_later(),
 				'submit_button_text' => apply_filters( 'submit_job_form_submit_button_text', __( 'Preview', 'wp-job-manager' ) ),
 			)
 		);
@@ -1002,7 +1002,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @return bool
 	 */
 	protected function can_continue_later() {
-		$can_continue_later = false;
+		$can_continue_later    = false;
 		$job_dashboard_page_id = get_option( 'job_manager_job_dashboard_page_id', false );
 
 		if ( ! $job_dashboard_page_id ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -46,7 +46,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @access protected
 	 * @var WP_Job_Manager_Form_Submit_Job The single instance of the class
 	 */
-	protected static $_instance = null;
+	protected static $instance = null;
 
 	/**
 	 * Returns static instance of class.
@@ -54,10 +54,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @return self
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -882,7 +882,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		if ( $this->job_id ) {
 			$job_preview       = true;
-			$post              = get_post( $this->job_id ); // WPCS: override ok.
+			$post              = get_post( $this->job_id );
 			$post->post_status = 'preview';
 
 			setup_postdata( $post );

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Helper_API {
 	 * @var self
 	 * @since  1.29.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -32,10 +32,10 @@ class WP_Job_Manager_Helper_API {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -170,9 +170,10 @@ class WP_Job_Manager_Helper_API {
 	 * @return string
 	 */
 	private function get_api_base_url() {
-		if ( defined( 'JOB_MANAGER_VERSION' )
-			 && defined( 'JOB_MANAGER_DEV_API_BASE_URL' )
-			 && '-dev' === substr( JOB_MANAGER_VERSION, -4 )
+		if (
+			defined( 'JOB_MANAGER_VERSION' )
+			&& defined( 'JOB_MANAGER_DEV_API_BASE_URL' )
+			&& '-dev' === substr( JOB_MANAGER_VERSION, -4 )
 		) {
 			return JOB_MANAGER_DEV_API_BASE_URL;
 		}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -36,7 +36,7 @@ class WP_Job_Manager_Helper {
 	 * @var self
 	 * @since  1.29.0
 	 */
-	private static $_instance = null;
+	private static $instance = null;
 
 	/**
 	 * True if the plugin cache has already been cleared.
@@ -54,10 +54,10 @@ class WP_Job_Manager_Helper {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -144,9 +144,10 @@ class WP_Job_Manager_Helper {
 		foreach ( $this->get_installed_plugins() as $product_slug => $plugin_data ) {
 			$response = $this->get_plugin_version( $plugin_data['_filename'] );
 			// If there is a new version, modify the transient to reflect an update is available.
-			if ( $response
-				 && isset( $response['new_version'] )
-				 && version_compare( $response['new_version'], $plugin_data['Version'], '>' )
+			if (
+				$response
+				&& isset( $response['new_version'] )
+				&& version_compare( $response['new_version'], $plugin_data['Version'], '>' )
 			) {
 				$check_for_updates_data->response[ $plugin_data['_filename'] ] = (object) $response;
 			}
@@ -467,12 +468,13 @@ class WP_Job_Manager_Helper {
 	 */
 	private function handle_request() {
 		$licenced_plugins = $this->get_installed_plugins();
-		if ( empty( $_POST )
-			 || empty( $_POST['_wpnonce'] )
-			 || empty( $_POST['action'] )
-			 || empty( $_POST['product_slug'] )
-			 || ! isset( $licenced_plugins[ $_POST['product_slug'] ] )
-			 || ! wp_verify_nonce( $_POST['_wpnonce'], 'wpjm-manage-licence' )
+		if (
+			empty( $_POST )
+			|| empty( $_POST['_wpnonce'] )
+			|| empty( $_POST['action'] )
+			|| empty( $_POST['product_slug'] )
+			|| ! isset( $licenced_plugins[ $_POST['product_slug'] ] )
+			|| ! wp_verify_nonce( $_POST['_wpnonce'], 'wpjm-manage-licence' )
 		) {
 			return false;
 		}

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -107,11 +107,11 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 		if ( $jobs->have_posts() ) : ?>
 
-			<?php echo $args['before_widget']; // WPCS: XSS ok. ?>
+			<?php echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 			<?php
 			if ( $title ) {
-				echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // WPCS: XSS ok.
+				echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 			?>
 
@@ -128,7 +128,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 			</ul>
 
-			<?php echo $args['after_widget']; // WPCS: XSS ok. ?>
+			<?php echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 		<?php else : ?>
 
@@ -141,7 +141,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 		$content = ob_get_clean();
 
-		echo $content; // WPCS: XSS ok.
+		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		$this->cache_widget( $args, $content );
 	}

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -107,11 +107,11 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		if ( $jobs->have_posts() ) : ?>
 
-			<?php echo $args['before_widget']; // WPCS: XSS ok. ?>
+			<?php echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 			<?php
 			if ( $title ) {
-				echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // WPCS: XSS ok.
+				echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 			?>
 
@@ -128,7 +128,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 			</ul>
 
-			<?php echo $args['after_widget']; // WPCS: XSS ok. ?>
+			<?php echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 		<?php else : ?>
 
@@ -152,7 +152,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		$content = ob_get_clean();
 
-		echo $content; // WPCS: XSS ok.
+		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		$this->cache_widget( $args, $content );
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,6 +3,7 @@
 	<description>A custom set of code standard rules to check for WordPress themes and plugins.</description>
 
 	<arg value="s"/>
+	<arg value="p"/>
 	<arg name="colors"/>
 
 	<arg name="extensions" value="php"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,49 +1,60 @@
 <?xml version="1.0"?>
 <ruleset name="WP Job Manager">
-	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
-
-	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress themes and plugins.</description>
 
-	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/phpcompatibility/php-compatibility" />
+	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/phpcompatibility/phpcompatibility-paragonie,vendor/phpcompatibility/php-compatibility,vendor/phpcompatibility/phpcompatibility-wp" />
 
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*/lib/*</exclude-pattern>
-	<exclude-pattern>*/tests/bin/*</exclude-pattern>
-	<!-- Exclude templates for now -->
-	<exclude-pattern>*/templates/*</exclude-pattern>
+	<arg value="s"/>
+	<arg name="colors"/>
+
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<exclude-pattern>node_modules/</exclude-pattern>
+	<exclude-pattern>vendor/</exclude-pattern>
+	<exclude-pattern>tests/</exclude-pattern>
+	<exclude-pattern>tmp/</exclude-pattern>
+
+	<!-- Temporarily exclude templates and lib for now -->
+	<exclude-pattern>templates/</exclude-pattern>
+	<exclude-pattern>lib/</exclude-pattern>
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
 	<config name="testVersion" value="5.2-"/>
 
 	<!-- Rules -->
-	<rule ref="WordPress-Extra">
-		<exclude name="WordPress.Security.NonceVerification.Missing"/>
+	<rule ref="PHPCompatibilityWP"/>
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-Extra" />
+
+	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
+		<severity>4</severity>
 	</rule>
-	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput.MissingUnslash">
+		<severity>4</severity>
+	</rule>
+	<rule ref="WordPress.Security.NonceVerification">
+		<severity>4</severity>
+	</rule>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
+		<severity>4</severity>
+	</rule>
+	<rule ref="WordPress.DB.DirectDatabaseQuery">
+		<severity>4</severity>
+	</rule>
+
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
-		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
-	<rule ref="PHPCompatibility">
-		<exclude-pattern>tests/</exclude-pattern>
-	</rule>
-	<rule ref="WordPress">
-		<exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
+
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="wp-job-manager" />
 		</properties>
 	</rule>
-	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
+
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
 			<property name="customEscapingFunctions" type="array">
@@ -51,9 +62,7 @@
 			</property>
 		</properties>
 	</rule>
-	<rule ref="WordPress.DB.DirectDatabaseQuery.NoCaching">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
+
 	<rule ref="Squiz.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 		<exclude name="Squiz.Commenting.LongConditionClosingComment" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,7 +24,6 @@
 
 	<!-- Rules -->
 	<rule ref="PHPCompatibilityWP"/>
-	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,6 @@
 <ruleset name="WP Job Manager">
 	<description>A custom set of code standard rules to check for WordPress themes and plugins.</description>
 
-	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/phpcompatibility/phpcompatibility-paragonie,vendor/phpcompatibility/php-compatibility,vendor/phpcompatibility/phpcompatibility-wp,vendor/sirbrillig/phpcs-variable-analysis" />
-
 	<arg value="s"/>
 	<arg name="colors"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,19 +20,18 @@
 	<config name="testVersion" value="5.2-"/>
 
 	<!-- Rules -->
+	<rule ref="WordPress-Extra">
+		<exclude name="WordPress.Security.NonceVerification.Missing"/>
+	</rule>
+	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility">
-		<exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound" />
-		<exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound" />
-		<exclude name="PHPCompatibility.PHP.NewKeywords.t_namespaceFound" />
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 	<rule ref="WordPress">
-		<exclude name="WordPress.VIP" />
-		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
 		<exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
@@ -41,6 +40,20 @@
 			<property name="text_domain" type="array" value="wp-job-manager" />
 		</properties>
 	</rule>
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.EscapeOutput">
+		<properties>
+			<property name="customEscapingFunctions" type="array">
+				<element value="wpjm_esc_json"/>
+			</property>
+		</properties>
+	</rule>
+	<rule ref="WordPress.DB.DirectDatabaseQuery.NoCaching">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
 	<rule ref="Squiz.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 		<exclude name="Squiz.Commenting.LongConditionClosingComment" />
@@ -48,15 +61,4 @@
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
-	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="WordPress.XSS.EscapeOutput">
-    	<properties>
-    		<property name="customEscapingFunctions" type="array">
-    			<element value="wpjm_esc_json"/>
-    		</property>
-    	</properties>
-    </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="WP Job Manager">
 	<description>A custom set of code standard rules to check for WordPress themes and plugins.</description>
 
-	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/phpcompatibility/phpcompatibility-paragonie,vendor/phpcompatibility/php-compatibility,vendor/phpcompatibility/phpcompatibility-wp" />
+	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/phpcompatibility/phpcompatibility-paragonie,vendor/phpcompatibility/php-compatibility,vendor/phpcompatibility/phpcompatibility-wp,vendor/sirbrillig/phpcs-variable-analysis" />
 
 	<arg value="s"/>
 	<arg name="colors"/>
@@ -29,6 +29,7 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 
+	<!-- Temporary Rule Exclusions -->
 	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
 		<severity>4</severity>
 	</rule>
@@ -44,6 +45,13 @@
 	<rule ref="WordPress.DB.DirectDatabaseQuery">
 		<severity>4</severity>
 	</rule>
+	<rule ref="VariableAnalysis">
+		<exclude-pattern>includes/admin/views/</exclude-pattern>
+		<exclude-pattern>templates/</exclude-pattern>
+
+		<severity>4</severity>
+	</rule>
+	<!-- End of Temporary Rule Exclusions -->
 
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -182,7 +182,7 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 				'wpjm_' . $slug . '_user',
 				'wpjm_' . $slug . '_user@example.com'
 			);
-			$user = get_user_by( 'ID', $user_id );
+			$user    = get_user_by( 'ID', $user_id );
 			$user->set_role( $role );
 		}
 		return $user->ID;

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -52,10 +52,12 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 		global $wpdb;
 		$mod_date = date( 'Y-m-d', strtotime( $age ) );
 		$wpdb->update(
-			$wpdb->posts, array(
+			$wpdb->posts,
+			array(
 				'post_modified'     => $mod_date,
 				'post_modified_gmt' => $mod_date,
-			), array( 'ID' => $post_id )
+			),
+			array( 'ID' => $post_id )
 		);
 	}
 }

--- a/tests/php/includes/stubs/class-wp-job-manager-form-test.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-form-test.php
@@ -1,20 +1,20 @@
 <?php
 class WP_Job_Manager_Form_Test extends WP_Job_Manager_Form {
-	protected static $_instance = null;
+	protected static $instance = null;
 
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	public static function reset() {
-		self::$_instance = null;
+		self::$instance = null;
 	}
 
 	public static function has_instance() {
-		return null !== self::$_instance;
+		return null !== self::$instance;
 	}
 
 	public function output( $atts = array() ) {

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -44,7 +44,8 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 					array(
 						'wc-api'  => 'wp_plugin_licencing_update_api',
 						'request' => 'pluginupdatecheck',
-					), $base_args
+					),
+					$base_args
 				),
 			)
 		);
@@ -79,7 +80,8 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 					array(
 						'wc-api'  => 'wp_plugin_licencing_update_api',
 						'request' => 'plugininformation',
-					), $base_args
+					),
+					$base_args
 				),
 			)
 		);
@@ -114,7 +116,8 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 					array(
 						'wc-api'  => 'wp_plugin_licencing_activation_api',
 						'request' => 'activate',
-					), $base_args
+					),
+					$base_args
 				),
 			)
 		);
@@ -150,7 +153,8 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 					array(
 						'wc-api'  => 'wp_plugin_licencing_activation_api',
 						'request' => 'deactivate',
-					), $base_args
+					),
+					$base_args
 				),
 			)
 		);

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
@@ -40,7 +40,8 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_guest_post_job_categories_fail() {
 		$this->logout();
 		$response = $this->post(
-			'/wp/v2/job-categories', array(
+			'/wp/v2/job-categories',
+			array(
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
 			)
@@ -50,10 +51,11 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_guest_put_job_categories_fail() {
-		$term_id  = $this->get_job_category();
+		$term_id = $this->get_job_category();
 		$this->logout();
 		$response = $this->put(
-			sprintf( '/wp/v2/job-categories/%d', $term_id ), array(
+			sprintf( '/wp/v2/job-categories/%d', $term_id ),
+			array(
 				'name'   => 'Software Engineer 2',
 			)
 		);
@@ -84,7 +86,8 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_employer_post_job_categories_fail() {
 		$this->login_as_employer();
 		$response = $this->post(
-			'/wp/v2/job-categories', array(
+			'/wp/v2/job-categories',
+			array(
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
 			)
@@ -94,10 +97,11 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_employer_put_job_categories_fail() {
-		$term_id  = $this->get_job_category();
+		$term_id = $this->get_job_category();
 		$this->login_as_employer();
 		$response = $this->put(
-			sprintf( '/wp/v2/job-categories/%d', $term_id ), array(
+			sprintf( '/wp/v2/job-categories/%d', $term_id ),
+			array(
 				'name'   => 'Software Engineer 2',
 			)
 		);
@@ -114,7 +118,8 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_post_fail_when_guest() {
 		$this->logout();
 		$response = $this->post(
-			'/wp/v2/job-categories', array(
+			'/wp/v2/job-categories',
+			array(
 				'name' => 'REST Test' . microtime( true ),
 			)
 		);
@@ -124,7 +129,8 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_post_success_when_admin() {
 		$this->login_as_admin();
 		$response = $this->post(
-			'/wp/v2/job-categories', array(
+			'/wp/v2/job-categories',
+			array(
 				'name' => 'REST Test' . microtime( true ),
 			)
 		);
@@ -134,7 +140,8 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_post_fail_when_default_user() {
 		$this->login_as_default_user();
 		$response = $this->post(
-			'/wp/v2/job-categories', array(
+			'/wp/v2/job-categories',
+			array(
 				'name' => 'REST Test' . microtime( true ),
 			)
 		);

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -38,7 +38,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	public function test_guest_get_unpublished_job_listing_fail() {
 		$this->logout();
-		$post_id = $this->get_job_listing( array( 'post_status' => 'draft' ) );
+		$post_id  = $this->get_job_listing( array( 'post_status' => 'draft' ) );
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		$this->assertResponseStatus( $response, 401 );
 	}
@@ -53,7 +53,8 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	public function test_guest_post_job_listings_fail() {
 		$this->logout();
 		$response = $this->post(
-			'/wp/v2/job-listings', array(
+			'/wp/v2/job-listings',
+			array(
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 			)
@@ -63,10 +64,11 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_guest_put_job_listings_fail() {
-		$post_id  = $this->get_job_listing();
+		$post_id = $this->get_job_listing();
 		$this->logout();
 		$response = $this->put(
-			sprintf( '/wp/v2/job-listings/%d', $post_id ), array(
+			sprintf( '/wp/v2/job-listings/%d', $post_id ),
+			array(
 				'post_title' => 'Software Engineer 2',
 			)
 		);
@@ -96,19 +98,20 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	public function test_employer_get_their_own_unpublished_job_listing_success() {
 		$this->login_as_employer();
-		$post_id = $this->get_job_listing( array( 'post_status' => 'draft' ) );
+		$post_id  = $this->get_job_listing( array( 'post_status' => 'draft' ) );
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		$this->assertResponseStatus( $response, 200 );
 	}
 
 	public function test_employer_publish_their_own_unpublished_job_listing_success() {
 		$this->login_as_employer();
-		$post_id = $this->get_job_listing( array( 'post_status' => 'draft' ) );
+		$post_id      = $this->get_job_listing( array( 'post_status' => 'draft' ) );
 		$response_get = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		$this->assertResponseStatus( $response_get, 200 );
 
 		$response_post = $this->put(
-			sprintf( '/wp/v2/job-listings/%d', $post_id ), array(
+			sprintf( '/wp/v2/job-listings/%d', $post_id ),
+			array(
 				'post_status' => 'publish',
 			)
 		);
@@ -126,7 +129,8 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	public function test_employer_post_job_listings_fail() {
 		$this->login_as_employer();
 		$response = $this->post(
-			'/wp/v2/job-listings', array(
+			'/wp/v2/job-listings',
+			array(
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 			)
@@ -136,10 +140,11 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_employer_put_job_listings_fail() {
-		$post_id  = $this->get_job_listing();
+		$post_id = $this->get_job_listing();
 		$this->login_as_employer();
 		$response = $this->put(
-			sprintf( '/wp/v2/job-listings/%d', $post_id ), array(
+			sprintf( '/wp/v2/job-listings/%d', $post_id ),
+			array(
 				'post_title' => 'Software Engineer 2',
 			)
 		);
@@ -169,7 +174,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$public_fields  = array( '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' );
 		$private_fields = array( '_job_expires' );
 		$this->logout();
-		$post_id  = $this->get_job_listing();
+		$post_id = $this->get_job_listing();
 
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 
@@ -187,9 +192,9 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_same_employer_read_access_to_private_meta_fields() {
-		$available_fields  = array( '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires' );
+		$available_fields = array( '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires' );
 		$this->login_as_employer();
-		$post_id  = $this->get_job_listing();
+		$post_id = $this->get_job_listing();
 
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 
@@ -205,7 +210,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$public_fields  = array( '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' );
 		$private_fields = array( '_job_expires' );
 		$this->login_as_employer();
-		$post_id  = $this->get_job_listing();
+		$post_id = $this->get_job_listing();
 		$this->login_as_employer_b();
 
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
@@ -226,7 +231,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		add_filter( 'job_manager_job_listing_data_fields', array( $this, 'add_legacy_field' ) );
 		$this->reset_meta_keys();
 		$this->login_as_admin();
-		$post_id = $this->get_job_listing();
+		$post_id  = $this->get_job_listing();
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		remove_filter( 'job_manager_job_listing_data_fields', array( $this, 'add_legacy_field' ) );
 
@@ -251,7 +256,8 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		);
 
 		$response = $this->post(
-			'/wp/v2/job-listings', array(
+			'/wp/v2/job-listings',
+			array(
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 				'meta'       => $test_meta,
@@ -276,16 +282,19 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	public function test_admin_can_delete_meta_fields() {
 		$this->login_as_admin();
-		$post_id = $this->get_job_listing( array(
+		$post_id = $this->get_job_listing(
+			array(
 			'meta_input' => array(
 				'_company_name' => 'Test Company',
+			 )
 			)
-		) );
+		);
 
 		$this->assertEquals( 'Test Company', get_post_meta( $post_id, '_company_name', true ) );
 
 		$response = $this->put(
-			'/wp/v2/job-listings/' . $post_id, array(
+			'/wp/v2/job-listings/' . $post_id,
+			array(
 				'meta'       => array(
 					'_company_name' => null,
 				),
@@ -320,7 +329,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 				'expected' => 'Best Example Money Can Buy',
 			),
 			'_company_twitter' => array(
-				'sent'     => "    @exampledotcom ",
+				'sent'     => '    @exampledotcom ',
 				'expected' => '@exampledotcom',
 			),
 			'_company_video'   => array(
@@ -347,7 +356,8 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		}
 
 		$response = $this->post(
-			'/wp/v2/job-listings', array(
+			'/wp/v2/job-listings',
+			array(
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 				'meta'       => $test_meta_values,
@@ -366,6 +376,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	/**
 	 * Data provider for the `\WP_Test_WP_Job_Manager_Job_Listings_Test::test_meta_input_bad_data_type` test.
+	 *
 	 * @return array
 	 */
 	public function data_provider_test_meta_input_bad_data_type() {
@@ -395,7 +406,8 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$this->login_as_admin();
 
 		$response = $this->post(
-			'/wp/v2/job-listings', array(
+			'/wp/v2/job-listings',
+			array(
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 				'meta'       => $test_meta,

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
@@ -50,7 +50,8 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	public function test_guest_post_job_types_fail() {
 		$this->logout();
 		$response = $this->post(
-			'/wp/v2/job-types', array(
+			'/wp/v2/job-types',
+			array(
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
 			)
@@ -60,10 +61,11 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_guest_put_job_types_fail() {
-		$term_id  = $this->get_job_type();
+		$term_id = $this->get_job_type();
 		$this->logout();
 		$response = $this->put(
-			sprintf( '/wp/v2/job-types/%d', $term_id ), array(
+			sprintf( '/wp/v2/job-types/%d', $term_id ),
+			array(
 				'name'   => 'Software Engineer 2',
 			)
 		);
@@ -94,7 +96,8 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	public function test_employer_post_job_types_fail() {
 		$this->login_as_employer();
 		$response = $this->post(
-			'/wp/v2/job-types', array(
+			'/wp/v2/job-types',
+			array(
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
 			)
@@ -104,10 +107,11 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_employer_put_job_types_fail() {
-		$term_id  = $this->get_job_type();
+		$term_id = $this->get_job_type();
 		$this->login_as_employer();
 		$response = $this->put(
-			sprintf( '/wp/v2/job-types/%d', $term_id ), array(
+			sprintf( '/wp/v2/job-types/%d', $term_id ),
+			array(
 				'name'   => 'Software Engineer 2',
 			)
 		);
@@ -146,7 +150,8 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 
 		$this->login_as_admin();
 		$response = $this->post(
-			'/wp/v2/job-types', array(
+			'/wp/v2/job-types',
+			array(
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
 				'meta' => array(
@@ -168,7 +173,8 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		}
 		$this->login_as_admin();
 		$response = $this->post(
-			'/wp/v2/job-types', array(
+			'/wp/v2/job-types',
+			array(
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
 				'meta' => array(

--- a/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
@@ -65,7 +65,8 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		$this->set_up_job_listing_search_request();
 		$published = $this->factory->job_listing->create_many( 2 );
 		$draft     = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'post_status' => 'expired',
 				'meta_input'  => array(),
 			)
@@ -107,7 +108,8 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		$this->set_up_job_listing_search_request();
 		$published = $this->factory->job_listing->create_many( 2 );
 		$draft     = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'post_status' => 'expired',
 				'meta_input'  => array(),
 			)

--- a/tests/php/tests/includes/test_class.wp-job-manager-category-walker.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-category-walker.php
@@ -25,7 +25,10 @@ class WP_Test_WP_Job_Manager_Category_Walker extends WPJM_BaseTest {
 		// With empty county.
 		$test_output_b = '';
 		$walker->start_el(
-			$test_output_b, $terms[0], 11, array(
+			$test_output_b,
+			$terms[0],
+			11,
+			array(
 				'show_count'   => true,
 				'hierarchical' => true,
 			)

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -30,7 +30,8 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 	private function setupPosts() {
 		// Create some regular posts.
 		$this->post_ids = $this->factory->post->create_many(
-			2, array(
+			2,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'post',
 			)
@@ -38,14 +39,16 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		// Create an unrelated CPT to ensure its posts do not get deleted.
 		register_post_type(
-			'biography', array(
+			'biography',
+			array(
 				'label'       => 'Biographies',
 				'description' => 'A biography of a famous person (for testing)',
 				'public'      => true,
 			)
 		);
 		$this->biography_ids = $this->factory->post->create_many(
-			4, array(
+			4,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'biography',
 			)
@@ -53,7 +56,8 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		// Create some Job Listings.
 		$this->job_listing_ids = $this->factory->post->create_many(
-			8, array(
+			8,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'job_listing',
 			)
@@ -158,7 +162,8 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 	private function setupPages() {
 		// Create some regular pages.
 		$this->regular_page_ids = $this->factory->post->create_many(
-			2, array(
+			2,
+			array(
 				'post_type'  => 'page',
 				'post_title' => 'Normal page',
 			)
@@ -278,39 +283,47 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 			// Ensure the data is deleted from all the relevant DB tables.
 			$this->assertEquals(
-				array(), $wpdb->get_results(
+				array(),
+				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->termmeta WHERE term_id = %s",
 						$term_id
 					)
-				), 'WPJM term meta should be deleted'
+				),
+				'WPJM term meta should be deleted'
 			);
 
 			$this->assertEquals(
-				array(), $wpdb->get_results(
+				array(),
+				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->terms WHERE term_id = %s",
 						$term_id
 					)
-				), 'WPJM term should be deleted'
+				),
+				'WPJM term should be deleted'
 			);
 
 			$this->assertEquals(
-				array(), $wpdb->get_results(
+				array(),
+				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->term_taxonomy WHERE term_taxonomy_id = %s",
 						$term_taxonomy_id
 					)
-				), 'WPJM term taxonomy should be deleted'
+				),
+				'WPJM term taxonomy should be deleted'
 			);
 
 			$this->assertEquals(
-				array(), $wpdb->get_results(
+				array(),
+				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->term_relationships WHERE term_taxonomy_id = %s",
 						$term_taxonomy_id
 					)
-				), 'WPJM term relationships should be deleted'
+				),
+				'WPJM term relationships should be deleted'
 			);
 		}
 	}

--- a/tests/php/tests/includes/test_class.wp-job-manager-geocode.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-geocode.php
@@ -265,6 +265,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 
 	/**
 	 * Used in `test_add_geolocation_endpoint_query_args()`
+	 *
 	 * @param string $region
 	 *
 	 * @return string
@@ -275,6 +276,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 
 	/**
 	 * Used in `test_add_geolocation_endpoint_query_args()`
+	 *
 	 * @param string $key
 	 *
 	 * @return string

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -20,9 +20,11 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::output_kses_post
 	 */
 	public function test_output_kses_post_simple() {
-		$job_id = $this->factory->job_listing->create( array(
+		$job_id = $this->factory->job_listing->create(
+			array(
 			'post_content' => '<p>This is a simple job listing</p>',
-		) );
+			)
+		);
 
 		$test_content = wpjm_get_the_job_description( $job_id );
 
@@ -38,9 +40,11 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::output_kses_post
 	 */
 	public function test_output_kses_post_allow_embeds() {
-		$job_id = $this->factory->job_listing->create( array(
+		$job_id = $this->factory->job_listing->create(
+			array(
 			'post_content' => '<p>This is a simple job listing</p><p>https://www.youtube.com/watch?v=S_GVbuddri8</p>',
-		) );
+			)
+		);
 
 		$test_content = wpjm_get_the_job_description( $job_id );
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -58,22 +58,28 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 */
 	private function create_default_job_listings() {
 		$this->draft           = $this->factory->job_listing->create_many(
-			2, array( 'post_status' => 'draft' )
+			2,
+			array( 'post_status' => 'draft' )
 		);
 		$this->expired         = $this->factory->job_listing->create_many(
-			10, array( 'post_status' => 'expired' )
+			10,
+			array( 'post_status' => 'expired' )
 		);
 		$this->preview         = $this->factory->job_listing->create_many(
-			1, array( 'post_status' => 'preview' )
+			1,
+			array( 'post_status' => 'preview' )
 		);
 		$this->pending         = $this->factory->job_listing->create_many(
-			8, array( 'post_status' => 'pending' )
+			8,
+			array( 'post_status' => 'pending' )
 		);
 		$this->pending_payment = $this->factory->job_listing->create_many(
-			3, array( 'post_status' => 'pending_payment' )
+			3,
+			array( 'post_status' => 'pending_payment' )
 		);
 		$this->publish         = $this->factory->job_listing->create_many(
-			15, array( 'post_status' => 'publish' )
+			15,
+			array( 'post_status' => 'publish' )
 		);
 	}
 
@@ -89,10 +95,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$subscriber_count = 2;
 
 		$this->factory->user->create_many(
-			$employer_count, array( 'role' => 'employer' )
+			$employer_count,
+			array( 'role' => 'employer' )
 		);
 		$this->factory->user->create_many(
-			$subscriber_count, array( 'role' => 'subscriber' )
+			$subscriber_count,
+			array( 'role' => 'subscriber' )
 		);
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
@@ -644,14 +652,16 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		// Create published listings.
 		$this->factory->job_listing->create_many(
-			$published_by_guest, array(
+			$published_by_guest,
+			array(
 				'post_author' => '0',
 			)
 		);
 
 		// Create expired listings.
 		$this->factory->job_listing->create_many(
-			$expired_by_guest, array(
+			$expired_by_guest,
+			array(
 				'post_author' => '0',
 				'post_status' => 'expired',
 			)
@@ -873,7 +883,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		// Create expired listings.
 		$this->factory->job_listing->create_many(
-			$expired, array(
+			$expired,
+			array(
 				'post_status' => 'expired',
 				'meta_input'  => array(
 					$meta_name => $meta_value,

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -260,21 +260,24 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		);
 
 		$post_categories['main']  = $this->factory->job_listing->create_many(
-			3, array(
+			3,
+			array(
 				'tax_input' => array(
 					'job_listing_category' => $categories['main'],
 				),
 			)
 		);
 		$post_categories['weird'] = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'tax_input' => array(
 					'job_listing_category' => $categories['weird'],
 				),
 			)
 		);
 		$post_categories['happy'] = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'tax_input' => array(
 					'job_listing_category' => $categories['happy'],
 				),
@@ -376,21 +379,24 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		);
 
 		$post_job_types['main']   = $this->factory->job_listing->create_many(
-			3, array(
+			3,
+			array(
 				'tax_input' => array(
 					'job_listing_type' => $tags['main'],
 				),
 			)
 		);
 		$post_job_types['weird']  = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'tax_input' => array(
 					'job_listing_type' => $tags['weird'],
 				),
 			)
 		);
 		$post_job_types['happy']  = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'tax_input' => array(
 					'job_listing_type' => $tags['happy'],
 				),
@@ -451,14 +457,16 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		);
 
 		$featured_flag['featured']     = $this->factory->job_listing->create_many(
-			3, array(
+			3,
+			array(
 				'meta_input' => array(
 					'_featured' => 1,
 				),
 			)
 		);
 		$featured_flag['not-featured'] = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'meta_input' => array(
 					'_featured' => 0,
 				),
@@ -501,7 +509,8 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		);
 
 		$featured_flag['featured']     = $this->factory->job_listing->create_many(
-			5, array(
+			5,
+			array(
 				'post_title' => 'Featured Post',
 				'meta_input' => array(
 					'_featured' => 1,
@@ -509,7 +518,8 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			)
 		);
 		$featured_flag['not-featured'] = $this->factory->job_listing->create_many(
-			5, array(
+			5,
+			array(
 				'post_title' => 'Not Featured Post',
 				'meta_input' => array(
 					'_featured' => 0,
@@ -551,7 +561,8 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		);
 
 		$featured_flag['featured']     = $this->factory->job_listing->create_many(
-			5, array(
+			5,
+			array(
 				'post_title' => 'Featured Post',
 				'meta_input' => array(
 					'_featured' => 1,
@@ -559,7 +570,8 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			)
 		);
 		$featured_flag['not-featured'] = $this->factory->job_listing->create_many(
-			5, array(
+			5,
+			array(
 				'post_title' => 'Not Featured Post',
 				'meta_input' => array(
 					'_featured' => 0,
@@ -600,14 +612,16 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		);
 
 		$featured_flag['filled']     = $this->factory->job_listing->create_many(
-			3, array(
+			3,
+			array(
 				'meta_input' => array(
 					'_filled' => 1,
 				),
 			)
 		);
 		$featured_flag['not-filled'] = $this->factory->job_listing->create_many(
-			2, array(
+			2,
+			array(
 				'meta_input' => array(
 					'_filled' => 0,
 				),

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Uninstall file for the plugin. Runs when plugin is deleted in WordPress Admin.
+ *
+ * @package wp-job-manager
+ */
+
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit();
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -459,7 +459,8 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 						)
 					),
 				),
-			), $args
+			),
+			$args
 		);
 
 		if ( count( (array) $args['filter_job_types'] ) === count( $types )

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Global WP Job Manager functions.
+ *
+ * New global functions are discouraged whenever possible.
+ *
+ * @package wp-job-manager
+ */
+
 if ( ! function_exists( 'get_job_listings' ) ) :
 	/**
 	 * Queries job listings with certain criteria and returns them.
@@ -163,12 +171,13 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$cached_query_posts   = get_transient( $query_args_hash );
 			if ( is_string( $cached_query_posts ) ) {
 				$cached_query_posts = json_decode( $cached_query_posts, false );
-				if ( $cached_query_posts
-				 && is_object( $cached_query_posts )
-				 && isset( $cached_query_posts->max_num_pages )
-				 && isset( $cached_query_posts->found_posts )
-				 && isset( $cached_query_posts->posts )
-				 && is_array( $cached_query_posts->posts )
+				if (
+					$cached_query_posts
+					&& is_object( $cached_query_posts )
+					&& isset( $cached_query_posts->max_num_pages )
+					&& isset( $cached_query_posts->found_posts )
+					&& isset( $cached_query_posts->posts )
+					&& is_array( $cached_query_posts->posts )
 				) {
 					$posts  = array_map( 'get_post', $cached_query_posts->posts );
 					$result = new WP_Query();
@@ -231,7 +240,7 @@ if ( ! function_exists( '_wpjm_shuffle_featured_post_results_helper' ) ) :
 				return 1;
 			}
 		}
-		return rand( -1, 1 );
+		return wp_rand( -1, 1 );
 	}
 endif;
 
@@ -463,11 +472,12 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 			$args
 		);
 
-		if ( count( (array) $args['filter_job_types'] ) === count( $types )
-			 && empty( $args['search_keywords'] )
-			 && empty( $args['search_location'] )
-			 && empty( $args['search_categories'] )
-			 && ! apply_filters( 'job_manager_get_listings_custom_filter', false )
+		if (
+			count( (array) $args['filter_job_types'] ) === count( $types )
+			&& empty( $args['search_keywords'] )
+			&& empty( $args['search_location'] )
+			&& empty( $args['search_categories'] )
+			&& ! apply_filters( 'job_manager_get_listings_custom_filter', false )
 		) {
 			unset( $links['reset'] );
 		}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1129,7 +1129,7 @@ function job_manager_dropdown_categories( $args = '' ) {
 	$output .= "</select>\n";
 
 	if ( $r['echo'] ) {
-		echo $output; // WPCS: XSS ok.
+		echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	return $output;

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -22,7 +22,7 @@
 function get_job_manager_template( $template_name, $args = array(), $template_path = 'job_manager', $default_path = '' ) {
 	if ( $args && is_array( $args ) ) {
 		// Please, forgive us.
-		extract( $args ); // phpcs:ignore WordPress.Functions.DontExtract.extract_extract
+		extract( $args ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 	}
 	include locate_job_manager_template( $template_name, $template_path, $default_path );
 }
@@ -876,9 +876,10 @@ function get_the_company_logo( $post = null, $size = 'thumbnail' ) {
 function job_manager_get_resized_image( $logo, $size ) {
 	global $_wp_additional_image_sizes;
 
-	if ( 'full' !== $size
-		 && strstr( $logo, WP_CONTENT_URL )
-		 && ( isset( $_wp_additional_image_sizes[ $size ] ) || in_array( $size, array( 'thumbnail', 'medium', 'large' ), true ) )
+	if (
+		'full' !== $size
+		&& strstr( $logo, WP_CONTENT_URL )
+		&& ( isset( $_wp_additional_image_sizes[ $size ] ) || in_array( $size, array( 'thumbnail', 'medium', 'large' ), true ) )
 	) {
 
 		if ( in_array( $size, array( 'thumbnail', 'medium', 'large' ), true ) ) {

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -953,7 +953,7 @@ function the_company_video( $post = null ) {
 	$video_embed = apply_filters( 'the_company_video_embed', $video_embed, $post );
 
 	if ( $video_embed ) {
-		echo '<div class="company_video">' . $video_embed . '</div>'; // WPCS: XSS ok.
+		echo '<div class="company_video">' . $video_embed . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -788,7 +788,8 @@ function the_job_location( $map_link = true, $post = null ) {
 				apply_filters(
 					'the_job_location_map_link',
 					'<a class="google_map_link" href="' . esc_url( 'http://maps.google.com/maps?q=' . rawurlencode( wp_strip_all_tags( $location ) ) . '&zoom=14&size=512x512&maptype=roadmap&sensor=false' ) . '">' . esc_html( wp_strip_all_tags( $location ) ) . '</a>',
-					$location, $post
+					$location,
+					$post
 				)
 			);
 		} else {


### PR DESCRIPTION
This upgrades the PHPCS standards to WPCS 2.1 and includes some less controversial fixes (a lot of whitespace changes and `isset()` checks). 
 
This involves a number of composer updates, so make sure you run `composer install` on this PR.

To keep this PR from getting massive, I've hidden some of the rules under `severity=4`. You can see these errors and warnings if you run:
` phpcs -p --severity=4 -s phpcs.xml.dist .`

After this PR is merged (post-1.33.0 release), I'll create issues to remove the remaining rules.

### Post Merge

Create issues to fix rule breaks and remove exclusions for:
- [ ] `WordPress.WP.GlobalVariablesOverride.Prohibited`: Most of these seem to be naming conflicts for variables. Some are indeed global overrides.
- [ ] `WordPress.Security.ValidatedSanitizedInput.MissingUnslash`: Lots of changes, but pretty uncontroversial. 
- [ ] `WordPress.Security.NonceVerification`: I foresee a lot of `phpcs:ignore` comments :)
- [ ] `WordPress.Security.ValidatedSanitizedInput.InputNotSanitized`: I foresee a lot of `phpcs:ignore` comments :)
- [ ] `WordPress.DB.DirectDatabaseQuery`: Probably a lot of `phpcs:ignore`.
- [ ] `VariableAnalysis`: Some valid fixes required here. Some of these variables go into templates.