### PR TITLE
Fix WP All Import import fatal error

### DIFF
--- a/includes/3rd-party/wp-all-import.php
+++ b/includes/3rd-party/wp-all-import.php
@@ -14,7 +14,7 @@ add_action( 'pmxi_saved_post', 'wpjm_pmxi_saved_post', 10, 1 );
  */
 function wpjm_pmxi_saved_post( $post_id ) {
 	if ( 'job_listing' === get_post_type( $post_id ) ) {
-		WP_Job_Manager_Post_Types::instance()->maybe_add_default_meta_data( $post_id );
+		WP_Job_Manager_Post_Types::instance()->maybe_add_default_meta_data( $post_id, get_post( $post_id ) );
 		if ( ! WP_Job_Manager_Geocode::has_location_data( $post_id ) ) {
 			$location = get_post_meta( $post_id, '_job_location', true );
 			if ( $location ) {


### PR DESCRIPTION
Fixes #1773

Added in 1.33.0 when I made an optional param required. Issue reported in 2087074-zen. I based this on `version/1.33` in case we release a 1.33.1.

#### Changes proposed in this Pull Request:

* Fix fatal error when importing from WP All Import.

#### Testing instructions:

* Import jobs using All-in-One Import and verify it doesn't cause error.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Fix: Issue causing errors with WP All Import.

#### Temporary Work Around

Until this is shipped (either in 1.33.1 or 1.34.0), this snippet should fix the issue:
```php
remove_action( 'pmxi_saved_post', 'wpjm_pmxi_saved_post' );
add_action( 'pmxi_saved_post', function( $post_id ) {
	if ( 'job_listing' === get_post_type( $post_id ) ) {
		WP_Job_Manager_Post_Types::instance()->maybe_add_default_meta_data( $post_id, get_post( $post_id ) );
		if ( ! WP_Job_Manager_Geocode::has_location_data( $post_id ) ) {
			$location = get_post_meta( $post_id, '_job_location', true );
			if ( $location ) {
				WP_Job_Manager_Geocode::generate_location_data( $post_id, $location );
			}
		}
	}
} );
```
