### PR TITLE
Add sanitization support for `wp_editor` fields

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1377,7 +1377,7 @@ class WP_Job_Manager_Post_Types {
 			$type = $fields[ $meta_key ]['type'];
 		}
 
-		if ( 'textarea' === $type ) {
+		if ( 'textarea' === $type || 'wp_editor' === $type ) {
 			return wp_kses_post( stripslashes( $meta_value ) );
 		}
 


### PR DESCRIPTION
Fixes #1775

#### Changes proposed in this Pull Request:

* Job Manager does not fully support WP Editor custom fields (not in admin). However, we do on the frontend and this will fix an issue with formatting getting cleared when custom fields are submitted on the frontend. Now that we're registering job manager fields in `WP_Job_Manager_Post_Types` we provide a sanitization handler for our meta fields. This sanitizes `wp_editor` fields the same as `textarea` fields.
* Field Editor (cc @tripflex) is the most common way people add these rich fields in the backend and frontend. Eventually it could pass its own sanitization method when registering these fields. 

#### Testing instructions:

* Right now it is difficult to reproduce and test without using the Field Editor plugin. Using that plugin, add a `WP Editor` field. 
* Save a draft (or edit an existing job listing from the Job Dashboard). Add styles and new paragraphs to your custom field.
* Verify those styles/paragraphs are preserved on save/save draft.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Fix - Preserve formatting on custom rich text fields.