### PR TITLE
Allow multiple file uploads if limit is not set

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -375,7 +375,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						}
 					}
 				}
-				if ( empty( $field['file_limit'] ) && ! empty( $field['multiple'] ) ) {
+				if ( empty( $field['file_limit'] ) && empty( $field['multiple'] ) ) {
 					$field['file_limit'] = 1;
 				}
 				if ( 'file' === $field['type'] && ! empty( $field['file_limit'] ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix the logic that limits to 1 file on non-multiple files.

#### Testing instructions:

* Test with testing instructions in #1783.
* Also test with this snippet and verify there isn't a limit on number of files that can be uploaded
```
add_filter( 'submit_job_form_fields', function( $fields ) {
  $fields['job']['job_files'] = [
	'label'              => __( 'Job Files', 'wp-job-manager' ),
	'type'               => 'file',
	'required'           => false,
	'placeholder'        => '',
	'priority'           => 6,
	'ajax'               => false,
	'multiple'           => true,
  ];
  
  return $fields;
} );
```