### PR TITLE
Remove unused `_job_manager_activation_redirect` transient

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -115,7 +115,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 * @var $transients
 	 */
 	private static $transients = array(
-		'_job_manager_activation_redirect',
+		'_job_manager_activation_redirect', // Legacy transient that should still be removed.
 		'get_job_listings-transient-version',
 		'jm_.*',
 	);

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -32,7 +32,6 @@ class WP_Job_Manager_Install {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-admin-notices.php';
 			WP_Job_Manager_Admin_Notices::add_notice( WP_Job_Manager_Admin_Notices::NOTICE_CORE_SETUP );
 			$is_new_install = true;
-			set_transient( '_job_manager_activation_redirect', 1, HOUR_IN_SECONDS );
 		}
 
 		// Update featured posts ordering.


### PR DESCRIPTION
Furthers #1636 

#### Changes proposed in this Pull Request:

* The usage of the transient `_job_manager_activation_redirect` was [removed](https://github.com/Automattic/WP-Job-Manager/pull/1636/files#diff-2b07ae82c2fec3ee2228e54b3d0d2d55L62) in 1.32.0 (#1636). This just removes the setting of the transient.
* I'm keeping it in the data cleaner and tests for the data cleaner as it still should be removed.
