### PR TITLE
Fix PHPCS errors related to overriding globals

### DIFF
--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -15,10 +15,10 @@ if ( ! empty( $messages ) ) {
 		if ( empty( $message->message ) ) {
 			continue;
 		}
-		$type = 'info';
+		$message_type = 'info';
 		if ( isset( $message->type )
 		&& in_array( $message->type, array( 'info', 'success', 'warning', 'error' ), true ) ) {
-			$type = $message->type;
+			$message_type = $message->type;
 		}
 		$action_label  = isset( $message->action_label ) ? esc_attr( $message->action_label ) : __( 'More Information &rarr;', 'wp-job-manager' );
 		$action_url    = isset( $message->action_url ) ? esc_url( $message->action_url, array( 'http', 'https' ) ) : false;
@@ -28,7 +28,7 @@ if ( ! empty( $messages ) ) {
 			$action_str = ' <a href="' . esc_url( $action_url ) . '" target="' . esc_attr( $action_target ) . '" class="button">' . esc_html( $action_label ) . '</a>';
 		}
 
-		echo '<div class="notice notice-' . esc_attr( $type ) . ' below-h2"><p><strong>' . esc_html( $message->message ) . '</strong>' . wp_kses_post( $action_str ) . '</p></div>';
+		echo '<div class="notice notice-' . esc_attr( $message_type ) . ' below-h2"><p><strong>' . esc_html( $message->message ) . '</strong>' . wp_kses_post( $action_str ) . '</p></div>';
 	}
 }
 if ( ! empty( $categories ) ) {

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -69,13 +69,9 @@ class WP_Job_Manager_Install {
 	 * Initializes user roles.
 	 */
 	private static function init_user_roles() {
-		global $wp_roles;
+		$roles = wp_roles();
 
-		if ( class_exists( 'WP_Roles' ) && ! isset( $wp_roles ) ) {
-			$wp_roles = new WP_Roles();
-		}
-
-		if ( is_object( $wp_roles ) ) {
+		if ( is_object( $roles ) ) {
 			add_role(
 				'employer',
 				__( 'Employer', 'wp-job-manager' ),
@@ -90,7 +86,7 @@ class WP_Job_Manager_Install {
 
 			foreach ( $capabilities as $cap_group ) {
 				foreach ( $cap_group as $cap ) {
-					$wp_roles->add_cap( 'administrator', $cap );
+					$roles->add_cap( 'administrator', $cap );
 				}
 			}
 		}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -431,6 +431,7 @@ class WP_Job_Manager_Post_Types {
 
 		foreach ( $menu as $key => $menu_item ) {
 			if ( strpos( $menu_item[0], $plural ) === 0 ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Only way to add pending listing count.
 				$menu[ $key ][0] .= " <span class='awaiting-mod update-plugins count-" . esc_attr( $pending_jobs ) . "'><span class='pending-count'>" . absint( number_format_i18n( $pending_jobs ) ) . '</span></span>';
 				break;
 			}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -904,7 +904,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		if ( $this->job_id ) {
 			$job_preview       = true;
-			$post              = get_post( $this->job_id );
+			$post              = get_post( $this->job_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Job preview depends on temporary override. Reset below.
 			$post->post_status = 'preview';
 
 			setup_postdata( $post );

--- a/includes/helper/views/html-licences.php
+++ b/includes/helper/views/html-licences.php
@@ -34,10 +34,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 				$notices = WP_Job_Manager_Helper::get_messages( $product_slug );
 				if ( empty( $notices ) && ! empty( $licence['errors'] ) ) {
 					$notices = array();
-					foreach ( $licence['errors'] as $key => $error ) {
+					foreach ( $licence['errors'] as $key => $error_message ) {
 						$notices[] = array(
 							'type'    => 'error',
-							'message' => $error,
+							'message' => $error_message,
 						);
 					}
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5079,10 +5079,9 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-			"integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
-			"dev": true
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
 		},
 		"diff-sequences": {
 			"version": "24.3.0",
@@ -7639,6 +7638,14 @@
 				"chalk": "^1.0.0",
 				"diff": "^2.0.2",
 				"postcss": "^5.0.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+					"integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+					"dev": true
+				}
 			}
 		},
 		"grunt-retro": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 	},
 	"dependencies": {
 		"babel-preset-stage-3": "^6.24.1",
+		"diff": "^4.0.1",
 		"lodash": "^4.17.11",
 		"react": "^16.8.6",
 		"select2": "^4.0.7"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,9 +30,6 @@
 	<rule ref="WordPress.Security.ValidatedSanitizedInput" />
 
 	<!-- Temporary Rule Exclusions -->
-	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
-		<severity>4</severity>
-	</rule>
 	<rule ref="WordPress.Security.NonceVerification">
 		<severity>4</severity>
 	</rule>

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,8 +25,8 @@ if ( ! is_multisite() ) {
 	$blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
 	$original_blog_id = get_current_blog_id();
 
-	foreach ( $blog_ids as $blog_id ) {
-		switch_to_blog( $blog_id );
+	foreach ( $blog_ids as $current_blog_id ) {
+		switch_to_blog( $current_blog_id );
 
 		// Only do deletion if the setting is true.
 		$do_deletion = get_option( 'job_manager_delete_data_on_uninstall' );


### PR DESCRIPTION
Fixes #1766

#### Changes proposed in this Pull Request:

* Renames incidental usage of global names in views and `uninstall.php` (wasn't actually changing variables).
* Removes override of `$wp_roles = new WP_Roles()` by using `wp_roles()` function which is already loaded when called.
