### PR TITLE
Fix PHPCS errors around direct database access and lack of caching

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -725,6 +725,7 @@ class WP_Job_Manager_CPT {
 
 		$post_ids = array_unique(
 			array_merge(
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- WP_Query doesn't allow for meta query to be an optional match.
 				$wpdb->get_col(
 					$wpdb->prepare(
 						"SELECT posts.ID

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -649,8 +649,8 @@ class WP_Job_Manager_Writepanels {
 				remove_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20 );
 				wp_update_post( $job_data );
 				add_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20, 2 );
-			} elseif ( isset( $_POST[ $key ] ) ) {
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Input sanitized in registered post meta config; see WP_Job_Manager_Post_Types::register_meta_fields() and WP_Job_Manager_Post_Types::get_job_listing_fields() methods.
+			} elseif ( isset( $_POST[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing -- Input sanitized in registered post meta config; see WP_Job_Manager_Post_Types::register_meta_fields() and WP_Job_Manager_Post_Types::get_job_listing_fields() methods.
 				update_post_meta( $post_id, $key, wp_unslash( $_POST[ $key ] ) );
 			}
 		}

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -604,8 +604,6 @@ class WP_Job_Manager_Writepanels {
 	 * @param WP_Post $post (Unused).
 	 */
 	public function save_job_listing_data( $post_id, $post ) {
-		global $wpdb;
-
 		// These need to exist.
 		add_post_meta( $post_id, '_filled', 0, true );
 		add_post_meta( $post_id, '_featured', 0, true );
@@ -640,7 +638,13 @@ class WP_Job_Manager_Writepanels {
 				if ( empty( $_POST[ $key ] ) ) {
 					$_POST[ $key ] = 0;
 				}
-				$wpdb->update( $wpdb->posts, array( 'post_author' => $_POST[ $key ] > 0 ? absint( $_POST[ $key ] ) : 0 ), array( 'ID' => $post_id ) );
+				$job_data                = array();
+				$job_data['ID']          = $post_id;
+				$job_data['post_author'] = $_POST[ $key ] > 0 ? intval( $_POST[ $key ] ) : 0;
+
+				remove_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20 );
+				wp_update_post( $job_data );
+				add_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20, 2 );
 			} elseif ( isset( $_POST[ $key ] ) ) {
 				update_post_meta( $post_id, $key, wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Input sanitized in registered post meta config; see WP_Job_Manager_Post_Types::register_meta_fields() and WP_Job_Manager_Post_Types::get_job_listing_fields() methods.
 			}
@@ -651,7 +655,7 @@ class WP_Job_Manager_Writepanels {
 		$today_date             = date( 'Y-m-d', current_time( 'timestamp' ) );
 		$is_job_listing_expired = $expiry_date && $today_date > $expiry_date;
 		if ( $is_job_listing_expired && ! $this->is_job_listing_status_changing( null, 'draft' ) ) {
-			remove_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20, 2 );
+			remove_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20 );
 			if ( $this->is_job_listing_status_changing( 'expired', 'publish' ) ) {
 				update_post_meta( $post_id, '_job_expires', calculate_job_expiry( $post_id ) );
 			} else {

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -188,6 +188,7 @@ class WP_Job_Manager_Cache_Helper {
 			return;
 		}
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetches dynamic list of cached counts.
 		$transients = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT option_name FROM $wpdb->options WHERE option_name RLIKE %s",

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -29,7 +29,6 @@ class WP_Job_Manager_Cache_Helper {
 		add_action( 'edited_term', array( __CLASS__, 'edited_term' ), 10, 3 );
 		add_action( 'create_term', array( __CLASS__, 'edited_term' ), 10, 3 );
 		add_action( 'delete_term', array( __CLASS__, 'edited_term' ), 10, 3 );
-		add_action( 'job_manager_clear_expired_transients', array( __CLASS__, 'clear_expired_transients' ), 10 );
 		add_action( 'transition_post_status', array( __CLASS__, 'maybe_clear_count_transients' ), 10, 3 );
 	}
 
@@ -124,24 +123,11 @@ class WP_Job_Manager_Cache_Helper {
 
 	/**
 	 * Clear expired transients.
+	 *
+	 * @deprecated 1.34.0 Handled by WordPress since 4.9.
 	 */
 	public static function clear_expired_transients() {
-		global $wpdb;
-
-		if ( ! wp_using_ext_object_cache() && ! defined( 'WP_SETUP_CONFIG' ) && ! defined( 'WP_INSTALLING' ) ) {
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE a, b FROM $wpdb->options a, $wpdb->options b
-						WHERE a.option_name LIKE %s
-						AND a.option_name NOT LIKE %s
-						AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-						AND b.option_value < %s;",
-					$wpdb->esc_like( '_transient_jm_' ) . '%',
-					$wpdb->esc_like( '_transient_timeout_jm_' ) . '%',
-					time()
-				)
-			);
-		}
+		_deprecated_function( __METHOD__, '1.34.0', 'handled by WordPress core since 4.9' );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -109,13 +109,15 @@ class WP_Job_Manager_Cache_Helper {
 	/**
 	 * When the transient version increases, this is used to remove all past transients to avoid filling the DB.
 	 *
-	 * Note; this only works on transients appended with the transient version, and when object caching is not being used.
+	 * Note: this only works on transients appended with the transient version, and when object caching is not being used.
 	 *
 	 * @param string $version
 	 */
 	private static function delete_version_transients( $version ) {
+		global $wpdb;
+
 		if ( ! wp_using_ext_object_cache() && ! empty( $version ) ) {
-			global $wpdb;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Only used when object caching is disabled.
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s;", '\_transient\_%' . $version ) );
 		}
 	}

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -43,9 +43,11 @@ class WP_Job_Manager_Data_Cleaner {
 	private static $cron_jobs = array(
 		'job_manager_check_for_expired_jobs',
 		'job_manager_delete_old_previews',
-		'job_manager_clear_expired_transients',
 		'job_manager_email_daily_notices',
 		'job_manager_usage_tracking_send_usage_data',
+
+		// Old cron jobs.
+		'job_manager_clear_expired_transients',
 	);
 
 	/**

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -360,8 +360,9 @@ class WP_Job_Manager_Data_Cleaner {
 		global $wpdb;
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery -- Delete data across all users.
 			$wpdb->delete( $wpdb->usermeta, array( 'meta_key' => $meta_key ) );
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 		}
 	}
 

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -548,20 +548,19 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @param int    $days_notice
 	 */
 	private static function send_expiring_notice( $email_notification_key, $days_notice ) {
-		global $wpdb;
-
 		$notice_before_ts = current_time( 'timestamp' ) + ( DAY_IN_SECONDS * $days_notice );
-		$job_ids          = $wpdb->get_col(
-			$wpdb->prepare(
-				"
-			SELECT postmeta.post_id FROM {$wpdb->postmeta} as postmeta
-			LEFT JOIN {$wpdb->posts} as posts ON postmeta.post_id = posts.ID
-			WHERE postmeta.meta_key = '_job_expires'
-			AND postmeta.meta_value = %s
-			AND posts.post_status = 'publish'
-			AND posts.post_type = 'job_listing'
-		",
-				date( 'Y-m-d', $notice_before_ts )
+		$job_ids          = get_posts(
+			array(
+				'post_type'      => 'job_listing',
+				'post_status'    => 'publish',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'meta_query'     => array(
+					array(
+						'key'     => '_job_expires',
+						'value'   => date( 'Y-m-d', $notice_before_ts ),
+					),
+				),
 			)
 		);
 
@@ -659,6 +658,24 @@ final class WP_Job_Manager_Email_Notifications {
 	 */
 	public static function get_deferred_notification_count() {
 		return count( self::$deferred_notifications );
+	}
+
+	/**
+	 * Returns the hash representation of the notifications to be sent.
+	 *
+	 * Do not use. Used just in unit tests.
+	 *
+	 * @access private
+	 *
+	 * @return string[]
+	 */
+	public static function get_deferred_notification_hashes() {
+		return array_map(
+			function( $value ) {
+				return sha1( json_encode( $value ) );
+			},
+			self::$deferred_notifications
+		);
 	}
 
 	/**

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -557,8 +557,8 @@ final class WP_Job_Manager_Email_Notifications {
 				'posts_per_page' => -1,
 				'meta_query'     => array(
 					array(
-						'key'     => '_job_expires',
-						'value'   => date( 'Y-m-d', $notice_before_ts ),
+						'key'   => '_job_expires',
+						'value' => date( 'Y-m-d', $notice_before_ts ),
 					),
 				),
 			)
@@ -672,7 +672,7 @@ final class WP_Job_Manager_Email_Notifications {
 	public static function get_deferred_notification_hashes() {
 		return array_map(
 			function( $value ) {
-				return sha1( json_encode( $value ) );
+				return sha1( wp_json_encode( $value ) );
 			},
 			self::$deferred_notifications
 		);

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -55,6 +55,11 @@ class WP_Job_Manager_Install {
 			update_option( 'job_manager_job_dashboard_page_id', $page_id );
 		}
 
+		// Scheduled hook was removed in 1.34.0.
+		if ( wp_next_scheduled( 'job_manager_clear_expired_transients' ) ) {
+			wp_clear_scheduled_hook( 'job_manager_clear_expired_transients' );
+		}
+
 		if ( $is_new_install ) {
 			$permalink_options                 = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
 			$permalink_options['jobs_archive'] = '';

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -36,7 +36,9 @@ class WP_Job_Manager_Install {
 
 		// Update featured posts ordering.
 		if ( version_compare( get_option( 'wp_job_manager_version', JOB_MANAGER_VERSION ), '1.22.0', '<' ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One time data update.
 			$wpdb->query( "UPDATE {$wpdb->posts} p SET p.menu_order = 0 WHERE p.post_type='job_listing';" );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One time data update.
 			$wpdb->query( "UPDATE {$wpdb->posts} p LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id SET p.menu_order = -1 WHERE pm.meta_key = '_featured' AND pm.meta_value='1' AND p.post_type='job_listing';" );
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -735,16 +735,19 @@ class WP_Job_Manager_Post_Types {
 	 * Deletes old previewed jobs after 30 days to keep the DB clean.
 	 */
 	public function delete_old_previews() {
-		global $wpdb;
-
 		// Delete old expired jobs.
-		$job_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT posts.ID FROM {$wpdb->posts} as posts
-					WHERE posts.post_type = 'job_listing'
-					AND posts.post_modified < %s
-					AND posts.post_status = 'preview'",
-				date( 'Y-m-d', strtotime( '-30 days', current_time( 'timestamp' ) ) )
+		$job_ids = get_posts(
+			array(
+				'post_type'      => 'job_listing',
+				'post_status'    => 'preview',
+				'fields'         => 'ids',
+				'date_query'     => array(
+					array(
+						'column' => 'post_modified',
+						'before' => date( 'Y-m-d', strtotime( '-30 days', current_time( 'timestamp' ) ) ),
+					),
+				),
+				'posts_per_page' => -1,
 			)
 		);
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -752,7 +752,7 @@ class WP_Job_Manager_Post_Types {
 	 * Deletes old previewed jobs after 30 days to keep the DB clean.
 	 */
 	public function delete_old_previews() {
-		// Delete old expired jobs.
+		// Delete old jobs stuck in preview.
 		$job_ids = get_posts(
 			array(
 				'post_type'      => 'job_listing',

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1004,18 +1004,22 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function maybe_update_menu_order( $meta_id, $object_id, $meta_key, $meta_value ) {
 		if ( 1 === intval( $meta_value ) ) {
-			wp_update_post( array(
-				'ID'         => $object_id,
-				'menu_order' => -1,
-			) );
+			wp_update_post(
+				array(
+					'ID'         => $object_id,
+					'menu_order' => -1,
+				)
+			);
 		} else {
 			$post = get_post( $object_id );
 
 			if ( -1 === intval( $post->menu_order ) ) {
-				wp_update_post( array(
-					'ID'         => $object_id,
-					'menu_order' => 0,
-				) );
+				wp_update_post(
+					array(
+						'ID'         => $object_id,
+						'menu_order' => 0,
+					)
+				);
 			}
 		}
 	}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -985,12 +985,14 @@ class WP_Job_Manager_Post_Types {
 		global $wpdb;
 
 		if ( 1 === intval( $meta_value ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update post menu order without firing actions.
 			$wpdb->update(
 				$wpdb->posts,
 				array( 'menu_order' => -1 ),
 				array( 'ID' => $object_id )
 			);
 		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update post menu order without firing actions.
 			$wpdb->update(
 				$wpdb->posts,
 				array( 'menu_order' => 0 ),

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -707,7 +707,24 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		// Delete old expired jobs.
+
+		/**
+		 * Set whether or not we should delete expired jobs after a certain amount of time.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool $delete_expired_jobs Whether we should delete expired jobs after a certain amount of time. Defaults to false.
+		 */
 		if ( apply_filters( 'job_manager_delete_expired_jobs', false ) ) {
+			/**
+			 * Days to preserve expired job listings before deleting them.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param int $delete_expired_jobs_days Number of days to preserve expired job listings before deleting them.
+			 */
+			$delete_expired_jobs_days = apply_filters( 'job_manager_delete_expired_jobs_days', 30 );
+
 			$job_ids = get_posts(
 				array(
 					'post_type'      => 'job_listing',
@@ -716,7 +733,7 @@ class WP_Job_Manager_Post_Types {
 					'date_query'     => array(
 						array(
 							'column' => 'post_modified',
-							'before' => date( 'Y-m-d', strtotime( '-' . apply_filters( 'job_manager_delete_expired_jobs_days', 30 ) . ' days', current_time( 'timestamp' ) ) ),
+							'before' => date( 'Y-m-d', strtotime( '-' . $delete_expired_jobs_days . ' days', current_time( 'timestamp' ) ) ),
 						),
 					),
 					'posts_per_page' => -1,

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -127,6 +127,7 @@ class WP_Job_Manager {
 	public function updater() {
 		if ( version_compare( JOB_MANAGER_VERSION, get_option( 'wp_job_manager_version' ), '>' ) ) {
 			WP_Job_Manager_Install::install();
+
 			flush_rewrite_rules();
 		}
 	}
@@ -223,9 +224,6 @@ class WP_Job_Manager {
 		if ( ! wp_next_scheduled( 'job_manager_delete_old_previews' ) ) {
 			wp_schedule_event( time(), 'daily', 'job_manager_delete_old_previews' );
 		}
-		if ( ! wp_next_scheduled( 'job_manager_clear_expired_transients' ) ) {
-			wp_schedule_event( time(), 'twicedaily', 'job_manager_clear_expired_transients' );
-		}
 		if ( ! wp_next_scheduled( 'job_manager_email_daily_notices' ) ) {
 			wp_schedule_event( time(), 'daily', 'job_manager_email_daily_notices' );
 		}
@@ -237,7 +235,6 @@ class WP_Job_Manager {
 	public static function unschedule_cron_jobs() {
 		wp_clear_scheduled_hook( 'job_manager_check_for_expired_jobs' );
 		wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
-		wp_clear_scheduled_hook( 'job_manager_clear_expired_transients' );
 		wp_clear_scheduled_hook( 'job_manager_email_daily_notices' );
 	}
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,12 +28,10 @@
 	<rule ref="WordPress-Extra" />
 
 	<rule ref="WordPress.Security.ValidatedSanitizedInput" />
+	<rule ref="WordPress.DB.DirectDatabaseQuery" />
 
 	<!-- Temporary Rule Exclusions -->
 	<rule ref="WordPress.Security.NonceVerification">
-		<severity>4</severity>
-	</rule>
-	<rule ref="WordPress.DB.DirectDatabaseQuery">
 		<severity>4</severity>
 	</rule>
 	<rule ref="VariableAnalysis">

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -386,7 +386,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @param array  $args         Notification arguments sent.
 	 */
 	public function assertNotificationNotSent( $notification, $args ) {
-		$hash = sha1( json_encode( array( $notification, $args ) ) );
+		$hash = sha1( wp_json_encode( array( $notification, $args ) ) );
 
 		$this->assertNotContains( $hash, WP_Job_Manager_Email_Notifications::get_deferred_notification_hashes(), "Email '{$notification}' was NOT meant to be sent with arguments '" . json_encode( $args ) . "'" );
 	}

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -405,7 +405,6 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$instance->check_for_expired_jobs();
 		$this->assertNotTrashed( $new_jobs['ancient'] );
 
-		$this->commit_transaction();
 		add_filter( 'job_manager_delete_expired_jobs', '__return_true' );
 		$instance->check_for_expired_jobs();
 		remove_filter( 'job_manager_delete_expired_jobs', '__return_true' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -19,10 +19,14 @@ if ( ! is_multisite() ) {
 	if ( $do_deletion ) {
 		WP_Job_Manager_Data_Cleaner::cleanup_all();
 	}
-} else {
-	global $wpdb;
+} elseif ( function_exists( 'get_sites' ) ) {
+	$blog_ids = get_sites(
+		array(
+			'fields'            => 'ids',
+			'update_site_cache' => false,
+		)
+	);
 
-	$blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
 	$original_blog_id = get_current_blog_id();
 
 	foreach ( $blog_ids as $current_blog_id ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1441,6 +1441,8 @@ function job_manager_duplicate_listing( $post_id ) {
 	/*
 	 * Duplicate post meta, aside from some reserved fields.
 	 */
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Easiest way to retrieve raw meta values without filters.
 	$post_meta = $wpdb->get_results( $wpdb->prepare( "SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id=%d", $post_id ) );
 
 	if ( ! empty( $post_meta ) ) {


### PR DESCRIPTION
Fixes #1770

## Changes proposed in this Pull Request:

This PR makes a few more potentially breaking changes than previous PHPCS PRs.

### Ignored Warnings

I didn't see any elegant alternatives for any of these.

- Cache version deletion: The prefix is dynamic and should work with WPJM plugins. I didn't see a workaround for this. https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/58e34723976d9cadc580481d1fc8099d316aa242
- Cache manager count handling: Similar to above the prefix is dynamic. https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/6dc0367a0e517b0df0e39853171307b9c4175b73
- Post search in WP admin: Previous behavior searches all meta fields here. `WP_Query` connects the meta query with `AND` so it would have to match one of the core post fields (title, content, etc) _and_ a meta field. https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/4db57fd557d8eec6b70f4d830fa269244216f015
- Installer data update for menu order: This seems the easiest way to update all job listings without loading them all. We could use `wpdb::update()`, but this seems fine for legacy data-update code. https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/12703dcdd67c756f6a643d640f2b367eb508effd
- Retrieving raw meta values when duplicating post: Easiest way to receive raw values of meta data when duplicating a job listing. https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/2def4869f067b0557b1069c4508690b8d1125612

### Fixed

These had better alternatives that we could use. I either made existing tests more robust or created new tests to check for breaks in behavior.

- `uninstall.php`: Switched to using `get_sites()` to retrieve all sites we should remove data on MS. https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/39473df4c4569b3950efecc4d885aa378788ae1e
- Update author field: Switched to using `wp_update_post()` and removing actions to prevent calling self. https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/ac6c9f42d46982d6205880dbd1f8932ff143fb4f
- Use `WP_Query`/`get_posts` to retrieve expired job listings https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/69c51d4df4fd36b54fea35eed4706dc86153fcf6 
- Use `WP_Query`/`get_posts` to retrieve stale preview job listings https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/81da6bc345c1bf736bccc48db20c8eb5f81035ee
- Use `WP_Query`/`get_posts` to retrieve expiring jobs for notifications https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/bfc8cf09728001a3401c986a4b9435d12fa6a44a

### Deprecated/Removed
- I removed WPJM's expired transient handling functionality. This was added to WordPress core in 4.9. See [delete_expired_transients()](https://developer.wordpress.org/reference/functions/delete_expired_transients/). https://github.com/Automattic/WP-Job-Manager/pull/1798/commits/507c3188a1089f621cc438f08b333a8307284e9e

## Testing Instructions
- Change the author field for job listings in WP admin. Make sure the `post_author` post field is updated.
- Enable future expiring email notification for 1 day notice. Set job listings to expire tomorrow. Run notifications manually using Crontrol to run the `job_manager_email_daily_notices` event manually. Verify notifications are sent.
- Set a job listing to expire today and check back tomorrow to make sure it expired. You might need to run `job_manager_check_for_expired_jobs` event with Crontrol beforehand. You could also manually change the `_job_expires` post meta (in the database) to be yesterday and then run this.