### PR TITLE
Require PHP 5.6.20 or greater

### DIFF
--- a/includes/class-wp-job-manager-dependency-checker.php
+++ b/includes/class-wp-job-manager-dependency-checker.php
@@ -27,6 +27,9 @@ class WP_Job_Manager_Dependency_Checker {
 	public static function check_dependencies() {
 		if ( ! self::check_php() ) {
 			add_action( 'admin_notices', array( 'WP_Job_Manager_Dependency_Checker', 'add_php_notice' ) );
+			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
+
+			return false;
 		}
 
 		if ( ! self::check_wp() ) {
@@ -60,7 +63,7 @@ class WP_Job_Manager_Dependency_Checker {
 		}
 
 		// translators: %1$s is version of PHP that WP Job Manager requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( 'The next release of <strong>WP Job Manager</strong> will require a minimum PHP version of %1$s, but you are running %2$s. Please update PHP to continue using this plugin.', 'wp-job-manager' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		$message = sprintf( __( '<strong>WP Job Manager</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'wp-job-manager' ), self::MINIMUM_PHP_VERSION, phpversion() );
 
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
@@ -76,6 +79,13 @@ class WP_Job_Manager_Dependency_Checker {
 			esc_html__( '(opens in a new tab)', 'wp-job-manager' )
 		);
 		echo '</p></div>';
+	}
+
+	/**
+	 * Deactivate self.
+	 */
+	public static function deactivate_self() {
+		deactivate_plugins( JOB_MANAGER_PLUGIN_BASENAME );
 	}
 
 	/**

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 **Tags:** job manager, job listing, job board, job management, job lists, job list, job, jobs, company, hiring, employment, employer, employees, candidate, freelance, internship, job listings, positions, board, application, hiring, listing, manager, recruiting, recruitment, talent  
 **Requires at least:** 4.9  
 **Tested up to:** 5.2  
+**Requires PHP:** 5.6  
 **Stable tag:** 1.33.2  
 **License:** GPLv3  
 **License URI:** http://www.gnu.org/licenses/gpl-3.0.html  

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: mikejolley, automattic, adamkheckler, alexsanford1, annezazu, cena
 Tags: job manager, job listing, job board, job management, job lists, job list, job, jobs, company, hiring, employment, employer, employees, candidate, freelance, internship, job listings, positions, board, application, hiring, listing, manager, recruiting, recruitment, talent
 Requires at least: 4.9
 Tested up to: 5.2
+Requires PHP: 5.6
 Stable tag: 1.33.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -8,6 +8,7 @@
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 4.9
  * Tested up to: 5.2
+ * Requires PHP: 5.6
  * Text Domain: wp-job-manager
  * Domain Path: /languages/
  * License: GPL2+


### PR DESCRIPTION
Fixes #1729

#### Changes proposed in this Pull Request:

* Requires PHP 5.6.20 (matching WordPress 5.2). 
* Deactivates itself if attempt is made to activate with older version (so activation hooks run properly when they update PHP).
* Note: Travis and PHPCS were already changed here: https://github.com/Automattic/WP-Job-Manager/commit/db2f9bb50043a2ce02a09a5d901798d5f1f15447

#### Testing instructions:

* Install on version of PHP older than 5.6.20. Verify it deactivates right away when you try to activate and also shows notice on plugins page.

Here is a build for easy testing:
[wp-job-manager.zip](https://github.com/Automattic/WP-Job-Manager/files/3301313/wp-job-manager.zip)
