### PR TITLE
Fix PHPCS errors around lack of nonce checking

### DIFF
--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -27,8 +27,11 @@ add_action( 'pll_init', 'polylang_wpjm_init' );
  * @return array
  */
 function polylang_wpjm_query_language( $query_args ) {
-	if ( isset( $_POST['lang'] ) ) {
-		$query_args['lang'] = sanitize_text_field( wp_unslash( $_POST['lang'] ) );
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
+	$input_lang = isset( $_POST['lang'] ) ? sanitize_text_field( wp_unslash( $_POST['lang'] ) ) : false;
+
+	if ( $input_lang ) {
+		$query_args['lang'] = $input_lang;
 	}
 	return $query_args;
 }

--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -44,7 +44,7 @@ function wpml_wpjm_set_language() {
 		isset( $_SERVER['REQUEST_URI'] )
 		&& (
 			strstr( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/jm-ajax/' )
-			|| ! empty( $_GET['jm-ajax'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
+			|| ! empty( $_GET['jm-ajax'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		)
 		&& $input_lang
 	) {

--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -37,15 +37,18 @@ add_action( 'wpml_loaded', 'wpml_wpjm_set_language' );
  * @since 1.26.0
  */
 function wpml_wpjm_set_language() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
+	$input_lang = isset( $_POST['lang'] ) ? sanitize_text_field( wp_unslash( $_POST['lang'] ) ) : false;
+
 	if (
 		isset( $_SERVER['REQUEST_URI'] )
 		&& (
 			strstr( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/jm-ajax/' )
-			|| ! empty( $_GET['jm-ajax'] )
+			|| ! empty( $_GET['jm-ajax'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
 		)
-		&& isset( $_POST['lang'] )
+		&& $input_lang
 	) {
-		do_action( 'wpml_switch_language', sanitize_text_field( wp_unslash( $_POST['lang'] ) ) );
+		do_action( 'wpml_switch_language', $input_lang );
 	}
 }
 

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -94,7 +94,7 @@ abstract class WP_Job_Manager_Form {
 
 		// reset cookie.
 		if (
-			isset( $_GET['new'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action taken based on input.
+			isset( $_GET['new'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 			isset( $_COOKIE['wp-job-manager-submitting-job-id'] ) &&
 			isset( $_COOKIE['wp-job-manager-submitting-job-key'] ) &&
 			get_post_meta( sanitize_text_field( wp_unslash( $_COOKIE['wp-job-manager-submitting-job-id'] ) ), '_submitting_key', true ) === $_COOKIE['wp-job-manager-submitting-job-key']

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -94,7 +94,7 @@ abstract class WP_Job_Manager_Form {
 
 		// reset cookie.
 		if (
-			isset( $_GET['new'] ) &&
+			isset( $_GET['new'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action taken based on input.
 			isset( $_COOKIE['wp-job-manager-submitting-job-id'] ) &&
 			isset( $_COOKIE['wp-job-manager-submitting-job-key'] ) &&
 			get_post_meta( sanitize_text_field( wp_unslash( $_COOKIE['wp-job-manager-submitting-job-id'] ) ), '_submitting_key', true ) === $_COOKIE['wp-job-manager-submitting-job-key']
@@ -362,8 +362,11 @@ abstract class WP_Job_Manager_Form {
 	 * @return bool|WP_Error
 	 */
 	public function validate_recaptcha_field( $success ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier (when possible).
+		$input_recaptcha_response = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ) ) : '';
+
 		$recaptcha_field_label = get_option( 'job_manager_recaptcha_label' );
-		if ( empty( $_POST['g-recaptcha-response'] ) ) {
+		if ( empty( $input_recaptcha_response ) ) {
 			// translators: Placeholder is for the label of the reCAPTCHA field.
 			return new WP_Error( 'validation-error', sprintf( esc_html__( '"%s" check failed. Please try again.', 'wp-job-manager' ), $recaptcha_field_label ) );
 		}
@@ -373,7 +376,7 @@ abstract class WP_Job_Manager_Form {
 			add_query_arg(
 				array(
 					'secret'   => get_option( 'job_manager_recaptcha_secret_key' ),
-					'response' => isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ) ) : '',
+					'response' => $input_recaptcha_response,
 					'remoteip' => isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) : $default_remote_addr,
 				),
 				'https://www.google.com/recaptcha/api/siteverify'
@@ -493,7 +496,7 @@ abstract class WP_Job_Manager_Form {
 			$field['sanitizer'] = null;
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- WP_Job_Manager_Form::sanitize_posted_field handles the sanitization based on the type of data passed
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification -- WP_Job_Manager_Form::sanitize_posted_field handles the sanitization based on the type of data passed; nonce check happens elsewhere.
 		return isset( $_POST[ $key ] ) ? $this->sanitize_posted_field( wp_unslash( $_POST[ $key ] ), $field['sanitizer'] ) : '';
 	}
 
@@ -505,6 +508,7 @@ abstract class WP_Job_Manager_Form {
 	 * @return array
 	 */
 	protected function get_posted_multiselect_field( $key, $field ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 		return isset( $_POST[ $key ] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST[ $key ] ) ) : array();
 	}
 
@@ -537,6 +541,7 @@ abstract class WP_Job_Manager_Form {
 	 * @return string
 	 */
 	protected function get_posted_textarea_field( $key, $field ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 		return isset( $_POST[ $key ] ) ? trim( wp_kses_post( wp_unslash( $_POST[ $key ] ) ) ) : '';
 	}
 
@@ -559,7 +564,9 @@ abstract class WP_Job_Manager_Form {
 	 * @return array
 	 */
 	protected function get_posted_term_checklist_field( $key, $field ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 		if ( isset( $_POST['tax_input'] ) && isset( $_POST['tax_input'][ $field['taxonomy'] ] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 			return array_map( 'absint', $_POST['tax_input'][ $field['taxonomy'] ] );
 		} else {
 			return array();
@@ -574,6 +581,7 @@ abstract class WP_Job_Manager_Form {
 	 * @return array
 	 */
 	protected function get_posted_term_multiselect_field( $key, $field ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 		return isset( $_POST[ $key ] ) ? array_map( 'absint', $_POST[ $key ] ) : array();
 	}
 
@@ -585,6 +593,7 @@ abstract class WP_Job_Manager_Form {
 	 * @return int
 	 */
 	protected function get_posted_term_select_field( $key, $field ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 		return ! empty( $_POST[ $key ] ) && $_POST[ $key ] > 0 ? absint( $_POST[ $key ] ) : '';
 	}
 

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -117,6 +117,7 @@ class WP_Job_Manager_Addons {
 			<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons' ) ); ?>" class="nav-tab
 									<?php
+									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
 									if ( ! isset( $_GET['section'] ) || 'helper' !== $_GET['section'] ) {
 										echo ' nav-tab-active';
 									}
@@ -125,6 +126,7 @@ class WP_Job_Manager_Addons {
 				<?php if ( current_user_can( 'update_plugins' ) ) : ?>
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper' ) ); ?>" class="nav-tab
 									<?php
+									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
 									if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 										echo ' nav-tab-active'; }
 									?>
@@ -132,9 +134,11 @@ class WP_Job_Manager_Addons {
 				<?php endif; ?>
 			</nav>
 			<?php
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
 			if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 				do_action( 'job_manager_helper_output' );
 			} else {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
 				$category   = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : null;
 				$messages   = $this->get_messages();
 				$categories = $this->get_categories();

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -117,7 +117,7 @@ class WP_Job_Manager_Addons {
 			<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons' ) ); ?>" class="nav-tab
 									<?php
-									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
+									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 									if ( ! isset( $_GET['section'] ) || 'helper' !== $_GET['section'] ) {
 										echo ' nav-tab-active';
 									}
@@ -126,7 +126,7 @@ class WP_Job_Manager_Addons {
 				<?php if ( current_user_can( 'update_plugins' ) ) : ?>
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper' ) ); ?>" class="nav-tab
 									<?php
-									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
+									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 									if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 										echo ' nav-tab-active'; }
 									?>
@@ -134,11 +134,11 @@ class WP_Job_Manager_Addons {
 				<?php endif; ?>
 			</nav>
 			<?php
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 			if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 				do_action( 'job_manager_helper_output' );
 			} else {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes on based on input.
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 				$category   = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : null;
 				$messages   = $this->get_messages();
 				$categories = $this->get_categories();

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -270,9 +270,11 @@ class WP_Job_Manager_CPT {
 	public function action_notices() {
 		global $post_type, $pagenow;
 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No changes made from input.
 		$handled_jobs    = isset( $_REQUEST['handled_jobs'] ) && is_array( $_REQUEST['handled_jobs'] ) ? array_map( 'absint', $_REQUEST['handled_jobs'] ) : false;
 		$action          = isset( $_REQUEST['action_performed'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['action_performed'] ) ) : false;
 		$actions_handled = $this->get_bulk_actions();
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if (
 			'edit.php' === $pagenow
@@ -329,6 +331,7 @@ class WP_Job_Manager_CPT {
 			),
 		);
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes or data exposed based on input.
 		$selected_category = isset( $_GET['job_listing_category'] ) ? sanitize_text_field( wp_unslash( $_GET['job_listing_category'] ) ) : '';
 		echo "<select name='job_listing_category' id='dropdown_job_listing_category'>";
 		echo '<option value="" ' . selected( $selected_category, '', false ) . '>' . esc_html__( 'Select category', 'wp-job-manager' ) . '</option>';
@@ -406,6 +409,7 @@ class WP_Job_Manager_CPT {
 	 * @param array  $options      The options for the dropdown. See the description above.
 	 */
 	private function jobs_filter_dropdown( $param, $options ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes or data exposed based on input.
 		$selected = isset( $_GET[ $param ] ) ? sanitize_text_field( wp_unslash( $_GET[ $param ] ) ) : '';
 
 		echo '<select name="' . esc_attr( $param ) . '" id="dropdown_' . esc_attr( $param ) . '">';
@@ -442,6 +446,9 @@ class WP_Job_Manager_CPT {
 	public function post_updated_messages( $messages ) {
 		global $post, $post_ID, $wp_post_types;
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes based on input.
+		$revision_title = isset( $_GET['revision'] ) ? wp_post_revision_title( (int) $_GET['revision'], false ) : false;
+
 		$messages['job_listing'] = array(
 			0  => '',
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
@@ -451,7 +458,7 @@ class WP_Job_Manager_CPT {
 			// translators: %s is the singular name of the job listing post type.
 			4  => sprintf( esc_html__( '%s updated.', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name ),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the revision number.
-			5  => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			5  => $revision_title ? sprintf( __( '%1$s restored to revision from %2$s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, $revision_title ) : false,
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 			6  => sprintf( __( '%1$s published. <a href="%2$s">View</a>', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, esc_url( get_permalink( $post_ID ) ) ),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
@@ -766,24 +773,29 @@ class WP_Job_Manager_CPT {
 			return;
 		}
 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No changes made from input.
+		$input_job_listing_filled   = isset( $_GET['job_listing_filled'] ) && '' !== $_GET['job_listing_filled'] ? absint( $_GET['job_listing_filled'] ) : false;
+		$input_job_listing_featured = isset( $_GET['job_listing_featured'] ) && '' !== $_GET['job_listing_featured'] ? absint( $_GET['job_listing_featured'] ) : false;
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
 		$meta_query = $wp->get( 'meta_query' );
 		if ( ! is_array( $meta_query ) ) {
 			$meta_query = array();
 		}
 
 		// Filter on _filled meta.
-		if ( isset( $_GET['job_listing_filled'] ) && '' !== $_GET['job_listing_filled'] ) {
+		if ( $input_job_listing_filled ) {
 			$meta_query[] = array(
 				'key'   => '_filled',
-				'value' => absint( $_GET['job_listing_filled'] ),
+				'value' => $input_job_listing_filled,
 			);
 		}
 
 		// Filter on _featured meta.
-		if ( isset( $_GET['job_listing_featured'] ) && '' !== $_GET['job_listing_featured'] ) {
+		if ( $input_job_listing_featured ) {
 			$meta_query[] = array(
 				'key'   => '_featured',
-				'value' => absint( $_GET['job_listing_featured'] ),
+				'value' => $input_job_listing_featured,
 			);
 		}
 
@@ -802,10 +814,12 @@ class WP_Job_Manager_CPT {
 	public function search_meta_label( $query ) {
 		global $pagenow, $typenow;
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes made from input.
 		if ( 'edit.php' !== $pagenow || 'job_listing' !== $typenow || ! get_query_var( 'job_listing_search' ) || ! isset( $_GET['s'] ) ) {
 			return $query;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes made from input.
 		return sanitize_text_field( wp_unslash( $_GET['s'] ) );
 	}
 

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -784,7 +784,7 @@ class WP_Job_Manager_CPT {
 		}
 
 		// Filter on _filled meta.
-		if ( $input_job_listing_filled ) {
+		if ( false !== $input_job_listing_filled ) {
 			$meta_query[] = array(
 				'key'   => '_filled',
 				'value' => $input_job_listing_filled,
@@ -792,7 +792,7 @@ class WP_Job_Manager_CPT {
 		}
 
 		// Filter on _featured meta.
-		if ( $input_job_listing_featured ) {
+		if ( false !== $input_job_listing_featured ) {
 			$meta_query[] = array(
 				'key'   => '_featured',
 				'value' => $input_job_listing_featured,

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -270,7 +270,7 @@ class WP_Job_Manager_CPT {
 	public function action_notices() {
 		global $post_type, $pagenow;
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No changes made from input.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		$handled_jobs    = isset( $_REQUEST['handled_jobs'] ) && is_array( $_REQUEST['handled_jobs'] ) ? array_map( 'absint', $_REQUEST['handled_jobs'] ) : false;
 		$action          = isset( $_REQUEST['action_performed'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['action_performed'] ) ) : false;
 		$actions_handled = $this->get_bulk_actions();
@@ -773,7 +773,7 @@ class WP_Job_Manager_CPT {
 			return;
 		}
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No changes made from input.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		$input_job_listing_filled   = isset( $_GET['job_listing_filled'] ) && '' !== $_GET['job_listing_filled'] ? absint( $_GET['job_listing_filled'] ) : false;
 		$input_job_listing_featured = isset( $_GET['job_listing_featured'] ) && '' !== $_GET['job_listing_featured'] ? absint( $_GET['job_listing_featured'] ) : false;
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -814,12 +814,12 @@ class WP_Job_Manager_CPT {
 	public function search_meta_label( $query ) {
 		global $pagenow, $typenow;
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes made from input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( 'edit.php' !== $pagenow || 'job_listing' !== $typenow || ! get_query_var( 'job_listing_search' ) || ! isset( $_GET['s'] ) ) {
 			return $query;
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes made from input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		return sanitize_text_field( wp_unslash( $_GET['s'] ) );
 	}
 

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -135,26 +135,32 @@ class WP_Job_Manager_Permalink_Settings {
 			return;
 		}
 
-		if ( isset( $_POST['permalink_structure'] ) ) {
-			if ( function_exists( 'switch_to_locale' ) ) {
-				switch_to_locale( get_locale() );
-			}
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- WP core handles nonce check for settings save.
+		if ( ! isset( $_POST['permalink_structure'] ) ) {
+			// We must not be saving permalinks.
+			return;
+		}
 
-			$permalink_settings = WP_Job_Manager_Post_Types::get_raw_permalink_settings();
+		if ( function_exists( 'switch_to_locale' ) ) {
+			switch_to_locale( get_locale() );
+		}
 
-			$permalink_settings['job_base']      = isset( $_POST['wpjm_job_base_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_base_slug'] ) ) : '';
-			$permalink_settings['category_base'] = isset( $_POST['wpjm_job_category_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_category_slug'] ) ) : '';
-			$permalink_settings['type_base']     = isset( $_POST['wpjm_job_type_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_type_slug'] ) ) : '';
+		$permalink_settings = WP_Job_Manager_Post_Types::get_raw_permalink_settings();
 
-			if ( isset( $_POST['wpjm_job_listings_archive_slug'] ) ) {
-				$permalink_settings['jobs_archive'] = sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_listings_archive_slug'] ) );
-			}
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- WP core handles nonce check for settings save.
+		$permalink_settings['job_base']      = isset( $_POST['wpjm_job_base_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_base_slug'] ) ) : '';
+		$permalink_settings['category_base'] = isset( $_POST['wpjm_job_category_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_category_slug'] ) ) : '';
+		$permalink_settings['type_base']     = isset( $_POST['wpjm_job_type_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_type_slug'] ) ) : '';
 
-			update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
+		if ( isset( $_POST['wpjm_job_listings_archive_slug'] ) ) {
+			$permalink_settings['jobs_archive'] = sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_listings_archive_slug'] ) );
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-			if ( function_exists( 'restore_current_locale' ) ) {
-				restore_current_locale();
-			}
+		update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
+
+		if ( function_exists( 'restore_current_locale' ) ) {
+			restore_current_locale();
 		}
 	}
 }

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -411,6 +411,7 @@ class WP_Job_Manager_Settings {
 				</h2>
 
 				<?php
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Used for basic flow.
 				if ( ! empty( $_GET['settings-updated'] ) ) {
 					flush_rewrite_rules();
 					echo '<div class="updated fade job-manager-updated"><p>' . esc_html__( 'Settings successfully saved', 'wp-job-manager' ) . '</p></div>';
@@ -651,7 +652,8 @@ class WP_Job_Manager_Settings {
 			'selected'         => absint( $value ),
 		);
 
-		echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'wp-job-manager' ) . "' id=", wp_dropdown_pages( $args ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe output.
+		echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'wp-job-manager' ) . "' id=", wp_dropdown_pages( $args ) );
 
 		if ( ! empty( $option['desc'] ) ) {
 			echo ' <p class="description">' . wp_kses_post( $option['desc'] ) . '</p>';

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -45,7 +45,7 @@ class WP_Job_Manager_Setup {
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
 		add_action( 'admin_head', array( $this, 'admin_head' ) );
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 12 );
 		}
@@ -176,7 +176,7 @@ class WP_Job_Manager_Setup {
 	 * Displays setup page.
 	 */
 	public function output() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		$step = ! empty( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 
 		include dirname( __FILE__ ) . '/views/html-admin-setup-header.php';

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -44,6 +44,8 @@ class WP_Job_Manager_Setup {
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
 		add_action( 'admin_head', array( $this, 'admin_head' ) );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
 		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 12 );
 		}
@@ -174,6 +176,7 @@ class WP_Job_Manager_Setup {
 	 * Displays setup page.
 	 */
 	public function output() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
 		$step = ! empty( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 
 		include dirname( __FILE__ ) . '/views/html-admin-setup-header.php';

--- a/includes/admin/class-wp-job-manager-taxonomy-meta.php
+++ b/includes/admin/class-wp-job-manager-taxonomy-meta.php
@@ -60,9 +60,13 @@ class WP_Job_Manager_Taxonomy_Meta {
 	 */
 	public function set_schema_org_employment_type_field( $term_id, $tt_id ) {
 		$employment_types = wpjm_job_listing_employment_type_options();
-		if ( isset( $_POST['employment_type'] ) && isset( $employment_types[ $_POST['employment_type'] ] ) ) {
-			update_term_meta( $term_id, 'employment_type', sanitize_text_field( wp_unslash( $_POST['employment_type'] ) ) );
-		} elseif ( isset( $_POST['employment_type'] ) ) {
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
+		$input_employment_type = isset( $_POST['employment_type'] ) ? sanitize_text_field( wp_unslash( $_POST['employment_type'] ) ) : null;
+
+		if ( $input_employment_type && isset( $employment_types[ $input_employment_type ] ) ) {
+			update_term_meta( $term_id, 'employment_type', sanitize_text_field( wp_unslash( $input_employment_type ) ) );
+		} elseif ( null !== $input_employment_type ) {
 			delete_term_meta( $term_id, 'employment_type' );
 		}
 	}

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -618,6 +618,7 @@ class WP_Job_Manager_Writepanels {
 
 			// Checkboxes that aren't sent are unchecked.
 			if ( 'checkbox' === $field['type'] ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 				if ( ! empty( $_POST[ $key ] ) ) {
 					$_POST[ $key ] = 1;
 				} else {
@@ -627,6 +628,7 @@ class WP_Job_Manager_Writepanels {
 
 			// Expirey date.
 			if ( '_job_expires' === $key ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 				if ( empty( $_POST[ $key ] ) ) {
 					if ( get_option( 'job_manager_submission_duration' ) ) {
 						update_post_meta( $post_id, $key, calculate_job_expiry( $post_id ) );
@@ -634,15 +636,19 @@ class WP_Job_Manager_Writepanels {
 						delete_post_meta( $post_id, $key );
 					}
 				} else {
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 					update_post_meta( $post_id, $key, date( 'Y-m-d', strtotime( sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) ) ) );
 				}
 			} elseif ( '_job_author' === $key ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 				if ( empty( $_POST[ $key ] ) ) {
 					$_POST[ $key ] = 0;
 				}
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 				$wpdb->update( $wpdb->posts, array( 'post_author' => $_POST[ $key ] > 0 ? absint( $_POST[ $key ] ) : 0 ), array( 'ID' => $post_id ) );
-			} elseif ( isset( $_POST[ $key ] ) ) {
-				update_post_meta( $post_id, $key, wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Input sanitized in registered post meta config; see WP_Job_Manager_Post_Types::register_meta_fields() and WP_Job_Manager_Post_Types::get_job_listing_fields() methods.
+			} elseif ( isset( $_POST[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing -- Input sanitized in registered post meta config; see WP_Job_Manager_Post_Types::register_meta_fields() and WP_Job_Manager_Post_Types::get_job_listing_fields() methods. Nonce check handled by WP core..
+				update_post_meta( $post_id, $key, wp_unslash( $_POST[ $key ] ) );
 			}
 		}
 
@@ -674,6 +680,7 @@ class WP_Job_Manager_Writepanels {
 	 * @return bool True if status is changing from $from_status to $to_status.
 	 */
 	private function is_job_listing_status_changing( $from_status, $to_status ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 		return isset( $_POST['post_status'] )
 				&& isset( $_POST['original_post_status'] )
 				&& $_POST['original_post_status'] !== $_POST['post_status']
@@ -682,6 +689,7 @@ class WP_Job_Manager_Writepanels {
 					|| $from_status === $_POST['original_post_status']
 				)
 				&& $to_status === $_POST['post_status'];
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 }
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -32,6 +32,7 @@ if ( ! empty( $messages ) ) {
 	}
 }
 if ( ! empty( $categories ) ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 	$current_category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '_all';
 	echo '<ul class="subsubsub">';
 	foreach ( $categories as $category ) {

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -89,7 +89,9 @@ class WP_Job_Manager_Ajax {
 	public static function do_jm_ajax() {
 		global $wp_query;
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( ! empty( $_GET['jm-ajax'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 			$wp_query->set( 'jm-ajax', sanitize_text_field( wp_unslash( $_GET['jm-ajax'] ) ) );
 		}
 
@@ -118,15 +120,20 @@ class WP_Job_Manager_Ajax {
 	 */
 	public function get_listings() {
 		// Get input variables.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Fetching data only; often for logged out visitors.
 		$search_location    = isset( $_REQUEST['search_location'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['search_location'] ) ) : '';
 		$search_keywords    = isset( $_REQUEST['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['search_keywords'] ) ) : '';
-		$search_categories  = isset( $_REQUEST['search_categories'] ) ? wp_unslash( $_REQUEST['search_categories'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- done below
+		$search_categories  = isset( $_REQUEST['search_categories'] ) ? wp_unslash( $_REQUEST['search_categories'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Input is sanitized below.
 		$filter_job_types   = isset( $_REQUEST['filter_job_type'] ) ? array_filter( array_map( 'sanitize_title', wp_unslash( (array) $_REQUEST['filter_job_type'] ) ) ) : null;
 		$filter_post_status = isset( $_REQUEST['filter_post_status'] ) ? array_filter( array_map( 'sanitize_title', wp_unslash( (array) $_REQUEST['filter_post_status'] ) ) ) : null;
 		$order              = isset( $_REQUEST['order'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['order'] ) ) : 'DESC';
 		$orderby            = isset( $_REQUEST['orderby'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['orderby'] ) ) : 'featured';
 		$page               = isset( $_REQUEST['page'] ) ? absint( $_REQUEST['page'] ) : 1;
 		$per_page           = isset( $_REQUEST['per_page'] ) ? absint( $_REQUEST['per_page'] ) : absint( get_option( 'job_manager_per_page' ) );
+		$filled             = isset( $_REQUEST['filled'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['filled'] ) ) : null;
+		$featured           = isset( $_REQUEST['featured'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured'] ) ) : null;
+		$show_pagination    = isset( $_REQUEST['show_pagination'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['show_pagination'] ) ) : null;
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( is_array( $search_categories ) ) {
 			$search_categories = array_filter( array_map( 'sanitize_text_field', array_map( 'stripslashes', $search_categories ) ) );
@@ -149,12 +156,12 @@ class WP_Job_Manager_Ajax {
 			'posts_per_page'    => max( 1, $per_page ),
 		);
 
-		if ( isset( $_REQUEST['filled'] ) && ( 'true' === $_REQUEST['filled'] || 'false' === $_REQUEST['filled'] ) ) {
-			$args['filled'] = 'true' === $_REQUEST['filled'];
+		if ( 'true' === $filled || 'false' === $filled ) {
+			$args['filled'] = 'true' === $filled;
 		}
 
-		if ( isset( $_REQUEST['featured'] ) && ( 'true' === $_REQUEST['featured'] || 'false' === $_REQUEST['featured'] ) ) {
-			$args['featured'] = 'true' === $_REQUEST['featured'];
+		if ( 'true' === $featured || 'false' === $featured ) {
+			$args['featured'] = 'true' === $featured;
 			$args['orderby']  = 'featured' === $orderby ? 'date' : $orderby;
 		}
 
@@ -258,8 +265,8 @@ class WP_Job_Manager_Ajax {
 		$result['html'] = ob_get_clean();
 
 		// Generate pagination.
-		if ( isset( $_REQUEST['show_pagination'] ) && 'true' === $_REQUEST['show_pagination'] ) {
-			$result['pagination'] = get_job_listing_pagination( $jobs->max_num_pages, absint( $_REQUEST['page'] ) );
+		if ( 'true' === $show_pagination ) {
+			$result['pagination'] = get_job_listing_pagination( $jobs->max_num_pages, $page );
 		}
 
 		/** This filter is documented in includes/class-wp-job-manager-ajax.php (above) */

--- a/includes/class-wp-job-manager-api.php
+++ b/includes/class-wp-job-manager-api.php
@@ -71,7 +71,9 @@ class WP_Job_Manager_API {
 	public function api_requests() {
 		global $wp;
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- If necessary/possible, nonce should be checked by API handler.
 		if ( ! empty( $_GET['job-manager-api'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- If necessary/possible, nonce should be checked by API handler.
 			$wp->query_vars['job-manager-api'] = sanitize_text_field( wp_unslash( $_GET['job-manager-api'] ) );
 		}
 

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -358,7 +358,7 @@ class WP_Job_Manager_Data_Cleaner {
 		global $wpdb;
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
-			// phpcs:ignore
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$wpdb->delete( $wpdb->usermeta, array( 'meta_key' => $meta_key ) );
 		}
 	}

--- a/includes/class-wp-job-manager-forms.php
+++ b/includes/class-wp-job-manager-forms.php
@@ -49,7 +49,7 @@ class WP_Job_Manager_Forms {
 	 * If a form was posted, load its class so that it can be processed before display.
 	 */
 	public function load_posted_form() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Data not modified or exposed from input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
 		$job_manager_form = ! empty( $_POST['job_manager_form'] ) ? sanitize_title( wp_unslash( $_POST['job_manager_form'] ) ) : false;
 
 		if ( ! empty( $job_manager_form ) ) {

--- a/includes/class-wp-job-manager-forms.php
+++ b/includes/class-wp-job-manager-forms.php
@@ -49,8 +49,11 @@ class WP_Job_Manager_Forms {
 	 * If a form was posted, load its class so that it can be processed before display.
 	 */
 	public function load_posted_form() {
-		if ( ! empty( $_POST['job_manager_form'] ) ) {
-			$this->load_form_class( sanitize_title( wp_unslash( $_POST['job_manager_form'] ) ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Data not modified or exposed from input.
+		$job_manager_form = ! empty( $_POST['job_manager_form'] ) ? sanitize_title( wp_unslash( $_POST['job_manager_form'] ) ) : false;
+
+		if ( ! empty( $job_manager_form ) ) {
+			$this->load_form_class( $job_manager_form );
 		}
 	}
 
@@ -58,7 +61,7 @@ class WP_Job_Manager_Forms {
 	 * Load a form's class
 	 *
 	 * @param  string $form_name
-	 * @return string class name on success, false on failure.
+	 * @return bool|WP_Job_Manager_Form Class instance on success, false on failure.
 	 */
 	private function load_form_class( $form_name ) {
 		if ( ! class_exists( 'WP_Job_Manager_Form' ) ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -545,39 +545,47 @@ class WP_Job_Manager_Post_Types {
 	public function job_feed() {
 		global $job_manager_keyword;
 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input used to filter public data in feed.
+		$input_posts_per_page  = isset( $_GET['posts_per_page'] ) ? absint( $_GET['posts_per_page'] ) : 10;
+		$input_search_location = isset( $_GET['search_location'] ) ? sanitize_text_field( wp_unslash( $_GET['search_location'] ) ) : false;
+		$input_job_types       = isset( $_GET['job_types'] ) ? explode( ',', sanitize_text_field( wp_unslash( $_GET['job_types'] ) ) ) : false;
+		$input_job_categories  = isset( $_GET['job_categories'] ) ? explode( ',', sanitize_text_field( wp_unslash( $_GET['job_categories'] ) ) ) : false;
+		$job_manager_keyword   = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
 		$query_args = array(
 			'post_type'           => 'job_listing',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
-			'posts_per_page'      => isset( $_GET['posts_per_page'] ) ? absint( $_GET['posts_per_page'] ) : 10,
+			'posts_per_page'      => $input_posts_per_page,
 			'paged'               => absint( get_query_var( 'paged', 1 ) ),
 			'tax_query'           => array(),
 			'meta_query'          => array(),
 		);
 
-		if ( ! empty( $_GET['search_location'] ) ) {
+		if ( ! empty( $input_search_location ) ) {
 			$location_meta_keys = array( 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' );
 			$location_search    = array( 'relation' => 'OR' );
 			foreach ( $location_meta_keys as $meta_key ) {
 				$location_search[] = array(
 					'key'     => $meta_key,
-					'value'   => sanitize_text_field( wp_unslash( $_GET['search_location'] ) ),
+					'value'   => $input_search_location,
 					'compare' => 'like',
 				);
 			}
 			$query_args['meta_query'][] = $location_search;
 		}
 
-		if ( ! empty( $_GET['job_types'] ) ) {
+		if ( ! empty( $input_job_types ) ) {
 			$query_args['tax_query'][] = array(
 				'taxonomy' => 'job_listing_type',
 				'field'    => 'slug',
-				'terms'    => explode( ',', sanitize_text_field( wp_unslash( $_GET['job_types'] ) ) ) + array( 0 ),
+				'terms'    => $input_job_types + array( 0 ),
 			);
 		}
 
-		if ( ! empty( $_GET['job_categories'] ) ) {
-			$cats                      = explode( ',', sanitize_text_field( wp_unslash( $_GET['job_categories'] ) ) ) + array( 0 );
+		if ( ! empty( $input_job_categories ) ) {
+			$cats                      = $input_job_categories + array( 0 );
 			$field                     = is_numeric( $cats ) ? 'term_id' : 'slug';
 			$operator                  = 'all' === get_option( 'job_manager_category_filter_type', 'all' ) && count( $cats ) > 1 ? 'AND' : 'IN';
 			$query_args['tax_query'][] = array(
@@ -589,7 +597,6 @@ class WP_Job_Manager_Post_Types {
 			);
 		}
 
-		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
 		if ( ! empty( $job_manager_keyword ) ) {
 			$query_args['s'] = $job_manager_keyword;
 			add_filter( 'posts_search', 'get_job_listings_keyword_search' );
@@ -603,7 +610,8 @@ class WP_Job_Manager_Post_Types {
 			unset( $query_args['tax_query'] );
 		}
 
-		query_posts( apply_filters( 'job_feed_args', $query_args ) ); // phpcs:ignore WordPress.WP.DiscouragedFunctions
+		// phpcs:ignore WordPress.WP.DiscouragedFunctions
+		query_posts( apply_filters( 'job_feed_args', $query_args ) );
 		add_action( 'rss2_ns', array( $this, 'job_feed_namespace' ) );
 		add_action( 'rss2_item', array( $this, 'job_feed_item' ) );
 		do_feed_rss2( false );
@@ -773,16 +781,19 @@ class WP_Job_Manager_Post_Types {
 			}
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
+		$input_job_expires = isset( $_POST['_job_expires'] ) ? sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) : null;
+
 		// See if the user has set the expiry manually.
-		if ( ! empty( $_POST['_job_expires'] ) ) {
-			update_post_meta( $post->ID, '_job_expires', date( 'Y-m-d', strtotime( sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) ) ) );
+		if ( ! empty( $input_job_expires ) ) {
+			update_post_meta( $post->ID, '_job_expires', date( 'Y-m-d', strtotime( $input_job_expires ) ) );
 		} elseif ( ! isset( $expires ) ) {
 			// No manual setting? Lets generate a date if there isn't already one.
 			$expires = calculate_job_expiry( $post->ID );
 			update_post_meta( $post->ID, '_job_expires', $expires );
 
 			// In case we are saving a post, ensure post data is updated so the field is not overridden.
-			if ( isset( $_POST['_job_expires'] ) ) {
+			if ( null !== $input_job_expires ) {
 				$_POST['_job_expires'] = $expires;
 			}
 		}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -220,7 +220,7 @@ class WP_Job_Manager_Shortcodes {
 		ob_start();
 
 		// If doing an action, show conditional content if needed....
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		$action = isset( $_REQUEST['action'] ) ? sanitize_title( wp_unslash( $_REQUEST['action'] ) ) : false;
 		if ( ! empty( $action ) ) {
 			// Show alternative content if a plugin wants to.
@@ -343,7 +343,7 @@ class WP_Job_Manager_Shortcodes {
 		}
 
 		// Get keywords, location, category and type from querystring if set.
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input used safely.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( ! empty( $_GET['search_keywords'] ) ) {
 			$atts['keywords'] = sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) );
 		}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -220,9 +220,9 @@ class WP_Job_Manager_Shortcodes {
 		ob_start();
 
 		// If doing an action, show conditional content if needed....
-		if ( ! empty( $_REQUEST['action'] ) ) {
-			$action = sanitize_title( wp_unslash( $_REQUEST['action'] ) );
-
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of input.
+		$action = isset( $_REQUEST['action'] ) ? sanitize_title( wp_unslash( $_REQUEST['action'] ) ) : false;
+		if ( ! empty( $action ) ) {
 			// Show alternative content if a plugin wants to.
 			if ( has_action( 'job_manager_job_dashboard_content_' . $action ) ) {
 				do_action( 'job_manager_job_dashboard_content_' . $action, $atts );
@@ -278,7 +278,8 @@ class WP_Job_Manager_Shortcodes {
 	public function edit_job() {
 		global $job_manager;
 
-		echo $job_manager->forms->get_form( 'edit-job' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output should be appropriately escaped in the form generator.
+		echo $job_manager->forms->get_form( 'edit-job' );
 	}
 
 	/**
@@ -342,6 +343,7 @@ class WP_Job_Manager_Shortcodes {
 		}
 
 		// Get keywords, location, category and type from querystring if set.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input used safely.
 		if ( ! empty( $_GET['search_keywords'] ) ) {
 			$atts['keywords'] = sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) );
 		}
@@ -354,6 +356,7 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $_GET['search_job_type'] ) ) {
 			$atts['selected_job_types'] = sanitize_text_field( wp_unslash( $_GET['search_job_type'] ) );
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Array handling.
 		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
@@ -371,8 +374,8 @@ class WP_Job_Manager_Shortcodes {
 			'order'           => $atts['order'],
 			'categories'      => implode( ',', $atts['categories'] ),
 		);
-		if ( $atts['show_filters'] ) {
 
+		if ( $atts['show_filters'] ) {
 			get_job_manager_template(
 				'job-filters.php',
 				array(
@@ -430,7 +433,8 @@ class WP_Job_Manager_Shortcodes {
 				if ( $jobs->found_posts > $atts['per_page'] && $atts['show_more'] ) {
 					wp_enqueue_script( 'wp-job-manager-ajax-filters' );
 					if ( $atts['show_pagination'] ) {
-						echo get_job_listing_pagination( $jobs->max_num_pages ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Template output.
+						echo get_job_listing_pagination( $jobs->max_num_pages );
 					} else {
 						echo '<a class="load_more_jobs" href="#"><strong>' . esc_html__( 'Load more listings', 'wp-job-manager' ) . '</strong></a>';
 					}
@@ -521,7 +525,7 @@ class WP_Job_Manager_Shortcodes {
 		);
 
 		if ( ! $atts['id'] ) {
-			return;
+			return null;
 		}
 
 		ob_start();

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -30,7 +30,8 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		add_filter( 'job_manager_settings', array( $this, 'add_setting_field' ) );
 
 		// In the setup wizard, do not display the normal opt-in dialog.
-		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action taken based on input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action taken based on input.
+		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
 			remove_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
 		}
 	}

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -30,7 +30,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		add_filter( 'job_manager_settings', array( $this, 'add_setting_field' ) );
 
 		// In the setup wizard, do not display the normal opt-in dialog.
-		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
+		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action taken based on input.
 			remove_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
 		}
 	}

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -30,7 +30,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		add_filter( 'job_manager_settings', array( $this, 'add_setting_field' ) );
 
 		// In the setup wizard, do not display the normal opt-in dialog.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action taken based on input.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
 			remove_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
 		}

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -65,6 +65,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 		add_action( 'wp', array( $this, 'submit_handler' ) );
 		add_action( 'submit_job_form_start', array( $this, 'output_submit_form_nonce_field' ) );
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Check happens later when possible.
 		$this->job_id = ! empty( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : 0;
 
 		if ( ! job_manager_user_can_edit_job( $this->job_id ) ) {
@@ -166,6 +167,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 	 * @throws Exception When invalid fields are submitted.
 	 */
 	public function submit_handler() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Check happens later when possible.
 		if ( empty( $_POST['submit_job'] ) ) {
 			return;
 		}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -101,7 +101,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		uasort( $this->steps, array( $this, 'sort_by_priority' ) );
 
-		// phpcs:disable WordPress.Security.NonceVerification.Missing,  WordPress.Security.NonceVerification.Recommended -- Check happens later when possible. Input used safely.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,  WordPress.Security.NonceVerification.Recommended -- Check happens later when possible. Input is used safely.
 		// Get step/job.
 		if ( isset( $_POST['step'] ) ) {
 			$this->step = is_numeric( $_POST['step'] ) ? max( absint( $_POST['step'] ), 0 ) : array_search( intval( $_POST['step'] ), array_keys( $this->steps ), true );
@@ -119,7 +119,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		// Allow resuming from cookie.
 		$this->resume_edit = false;
 		if (
-			! isset( $_GET['new'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input used safely.
+			! isset( $_GET['new'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 			&& (
 				'before' === get_option( 'job_manager_paid_listings_flow' )
 				|| ! $this->job_id
@@ -593,7 +593,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			// Get posted values.
 			$values = $this->get_posted_fields();
 
-			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Input used safely. Nonce checked below when possible.
+			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Input is used safely. Nonce checked below when possible.
 			$input_create_account_username        = isset( $_POST['create_account_username'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_username'] ) ) : false;
 			$input_create_account_password        = isset( $_POST['create_account_password'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_password'] ) ) : false;
 			$input_create_account_password_verify = isset( $_POST['create_account_password_verify'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_password_verify'] ) ) : false;
@@ -947,7 +947,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * Handles the preview step form response.
 	 */
 	public function preview_handler() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input used safely.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
 		if ( empty( $_POST ) ) {
 			return;
 		}
@@ -955,12 +955,12 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$this->check_preview_form_nonce_field();
 
 		// Edit = show submit form again.
-		if ( ! empty( $_POST['edit_job'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input used safely.
+		if ( ! empty( $_POST['edit_job'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
 			$this->step --;
 		}
 
 		// Continue = change job status then show next screen.
-		if ( ! empty( $_POST['continue'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input used safely.
+		if ( ! empty( $_POST['continue'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
 			$job = get_post( $this->job_id );
 
 			if ( in_array( $job->post_status, array( 'preview', 'expired' ), true ) ) {

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -94,9 +94,14 @@ class WP_Job_Manager_Helper {
 	 * Handles special tasks on admin requests.
 	 */
 	private function handle_admin_request() {
-		if ( ! empty( $_GET['dismiss-wpjm-licence-notice'] ) ) {
+		if ( ! isset( $_GET['_wpjm_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['_wpjm_nonce'] ), 'dismiss-wpjm-licence-notice' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+			return;
+		}
+
+		$product_slug = isset( $_GET['dismiss-wpjm-licence-notice'] ) ? sanitize_text_field( wp_unslash( $_GET['dismiss-wpjm-licence-notice'] ) ) : false;
+
+		if ( ! empty( $product_slug ) ) {
 			$product_plugins = $this->get_installed_plugins();
-			$product_slug    = sanitize_text_field( wp_unslash( $_GET['dismiss-wpjm-licence-notice'] ) );
 			if ( isset( $product_plugins[ $product_slug ] ) ) {
 				WP_Job_Manager_Helper_Options::update( $product_slug, 'hide_key_notice', true );
 			}
@@ -436,6 +441,8 @@ class WP_Job_Manager_Helper {
 		if ( ! current_user_can( 'update_plugins' ) ) {
 			return;
 		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Flow use only. Method does nonce check.
 		if ( ! empty( $_POST ) ) {
 			$this->handle_request();
 		}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -94,7 +94,8 @@ class WP_Job_Manager_Helper {
 	 * Handles special tasks on admin requests.
 	 */
 	private function handle_admin_request() {
-		if ( ! isset( $_GET['_wpjm_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['_wpjm_nonce'] ), 'dismiss-wpjm-licence-notice' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+		if ( ! isset( $_GET['_wpjm_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['_wpjm_nonce'] ), 'dismiss-wpjm-licence-notice' ) ) {
 			return;
 		}
 

--- a/includes/helper/views/html-licence-key-error.php
+++ b/includes/helper/views/html-licence-key-error.php
@@ -10,6 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div class="error">
-	<p class="wpjm-updater-dismiss" style="float:right;"><a href="<?php echo esc_url( add_query_arg( 'dismiss-wpjm-licence-notice', $product_slug ) ); ?>"><?php esc_html_e( 'Hide notice', 'wp-job-manager' ); ?></a></p>
+	<p class="wpjm-updater-dismiss" style="float:right;"><a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'dismiss-wpjm-licence-notice', $product_slug ), 'dismiss-wpjm-licence-notice', '_wpjm_nonce' ) ); ?>"><?php esc_html_e( 'Hide notice', 'wp-job-manager' ); ?></a></p>
 	<p><?php printf( 'There is a problem with the license for "%s". Please <a href="%s">manage the license</a> to check for a solution and continue receiving updates.', esc_html( $plugin_data['Name'] ), esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) ) ); ?></p>
 </div>

--- a/includes/helper/views/html-licence-key-notice.php
+++ b/includes/helper/views/html-licence-key-notice.php
@@ -10,6 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div class="updated">
-	<p class="wpjm-updater-dismiss" style="float:right;"><a href="<?php echo esc_url( add_query_arg( 'dismiss-wpjm-licence-notice', $product_slug ) ); ?>"><?php esc_html_e( 'Hide notice', 'wp-job-manager' ); ?></a></p>
+	<p class="wpjm-updater-dismiss" style="float:right;"><a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'dismiss-wpjm-licence-notice', $product_slug ), 'dismiss-wpjm-licence-notice', '_wpjm_nonce' ) ); ?>"><?php esc_html_e( 'Hide notice', 'wp-job-manager' ); ?></a></p>
 	<p><?php printf( '<a href="%s">Please enter your license key</a> to get updates for "%s".', esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) ), esc_html( $plugin_data['Name'] ) ); ?></p>
 </div>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,9 +30,6 @@
 	<rule ref="WordPress.Security.ValidatedSanitizedInput" />
 
 	<!-- Temporary Rule Exclusions -->
-	<rule ref="WordPress.Security.NonceVerification">
-		<severity>4</severity>
-	</rule>
 	<rule ref="WordPress.DB.DirectDatabaseQuery">
 		<severity>4</severity>
 	</rule>

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
@@ -29,6 +29,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 		$product_slug = 'test';
 		$default      = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
 		$this->assertNull( $default );
+		$_GET['_wpjm_nonce'] = wp_create_nonce( 'dismiss-wpjm-licence-notice' );
 		unset( $_GET['dismiss-wpjm-licence-notice'] );
 		$instance->admin_init();
 		$key_notice_status = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
@@ -45,10 +46,45 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 		$product_slug = 'test';
 		$default      = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
 		$this->assertNull( $default );
+		$_GET['_wpjm_nonce']                 = wp_create_nonce( 'dismiss-wpjm-licence-notice' );
 		$_GET['dismiss-wpjm-licence-notice'] = $product_slug;
 		$instance->admin_init();
 		$key_notice_status = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
 		$this->assertTrue( $key_notice_status );
+	}
+
+	/**
+	 * @since 1.34.0
+	 * @covers WP_Job_Manager_Helper::admin_init
+	 * @requires PHP 5.3.0
+	 */
+	public function test_admin_init_with_bad_nonce() {
+		$instance     = $this->getMockHelper();
+		$product_slug = 'test';
+		$default      = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertNull( $default );
+		$_GET['_wpjm_nonce']                 = wp_create_nonce( 'a-bad-nonce' );
+		$_GET['dismiss-wpjm-licence-notice'] = $product_slug;
+		$instance->admin_init();
+		$key_notice_status = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertNull( $key_notice_status );
+	}
+
+	/**
+	 * @since 1.34.0
+	 * @covers WP_Job_Manager_Helper::admin_init
+	 * @requires PHP 5.3.0
+	 */
+	public function test_admin_init_with_no_nonce() {
+		$instance     = $this->getMockHelper();
+		$product_slug = 'test';
+		$default      = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertNull( $default );
+		unset( $_GET['_wpjm_nonce'] );
+		$_GET['dismiss-wpjm-licence-notice'] = $product_slug;
+		$instance->admin_init();
+		$key_notice_status = WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice', null );
+		$this->assertNull( $key_notice_status );
 	}
 
 	/**

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -518,7 +518,8 @@ if ( ! function_exists( 'wp_job_manager_notify_new_user' ) ) :
 		global $wp_version;
 
 		if ( version_compare( $wp_version, '4.3.1', '<' ) ) {
-			wp_new_user_notification( $user_id, $password ); // phpcs:ignore WordPress.WP.DeprecatedParameters.Wp_new_user_notificationParam2Found
+			// phpcs:ignore WordPress.WP.DeprecatedParameters.Wp_new_user_notificationParam2Found
+			wp_new_user_notification( $user_id, $password );
 		} else {
 			$notify = 'admin';
 			if ( empty( $password ) ) {
@@ -1140,7 +1141,8 @@ function job_manager_dropdown_categories( $args = '' ) {
 	$output .= "</select>\n";
 
 	if ( $r['echo'] ) {
-		echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $output;
 	}
 
 	return $output;

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -21,8 +21,8 @@
  */
 function get_job_manager_template( $template_name, $args = array(), $template_path = 'job_manager', $default_path = '' ) {
 	if ( $args && is_array( $args ) ) {
-		// Please, forgive us.
-		extract( $args ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
+		// phpcs:ignore WordPress.PHP.DontExtract.extract_extract -- Please, forgive us.
+		extract( $args );
 	}
 	include locate_job_manager_template( $template_name, $template_path, $default_path );
 }
@@ -692,6 +692,7 @@ function wpjm_get_registration_fields() {
 				'type'     => 'text',
 				'label'    => esc_html__( 'Username', 'wp-job-manager' ),
 				'required' => $account_required,
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Just used to populate value when validation failed.
 				'value'    => isset( $_POST['create_account_username'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_username'] ) ) : '',
 			);
 		}
@@ -718,6 +719,7 @@ function wpjm_get_registration_fields() {
 			'label'       => esc_html__( 'Your email', 'wp-job-manager' ),
 			'placeholder' => __( 'you@yourdomain.com', 'wp-job-manager' ),
 			'required'    => $account_required,
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Just used to populate value when validation failed.
 			'value'       => isset( $_POST['create_account_email'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_email'] ) ) : '',
 		);
 	}
@@ -955,7 +957,8 @@ function the_company_video( $post = null ) {
 	$video_embed = apply_filters( 'the_company_video_embed', $video_embed, $post );
 
 	if ( $video_embed ) {
-		echo '<div class="company_video">' . $video_embed . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<div class="company_video">' . $video_embed . '</div>';
 	}
 }
 


### PR DESCRIPTION
Fixes #1768

#### Changes proposed in this Pull Request:

* Adds nonce checking when hiding license notifications in WP admin. It isn't serious, but does technically change data. 
* Everything else either has a nonce check when possible or the data is use for flow/filtering and can be considered safe.
* Note: Some methods required a slight refactor in order to prevent unreadable code covered in comments. When necessary, I chunked together some reading of `$_GET` and `$_POST` variables and wrapped in `phpcs:disable` and `phpcs:enable`. I used this sparingly and tried to keep it in tight blocks of code.

Style notes: I'm trying to put ignore statements above the line they are ignoring. Some exceptions (put at the end of the line):
- When it is embedded in a [multiline] `if()` statement.
- When it hinders readability (sometimes within blocks of variable sets).