### PR TITLE
Fix escaping issue with expiring jobs email notice

### DIFF
--- a/templates/emails/admin-expiring-job.php
+++ b/templates/emails/admin-expiring-job.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.31.1
+ * @version     1.34.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,15 +24,21 @@ $job = $args['job'];
  * @var bool
  */
 $expiring_today = $args['expiring_today'];
+$edit_post_link = admin_url( sprintf( 'post.php?post=%d&amp;action=edit', $job->ID ) );
 
 echo '<p>';
 if ( $expiring_today ) {
-	printf( esc_html__( 'The following job listing is expiring today from <a href="%s">%s</a>.', 'wp-job-manager' ), esc_url( home_url() ), esc_html( get_bloginfo( 'name' ) ) );
+	// translators: %1$s placeholder is URL to the blog. %2$s placeholder is the name of the site.
+	echo wp_kses_post( sprintf( __( 'The following job listing is expiring today from <a href="%1$s">%2$s</a>.', 'wp-job-manager' ), esc_url( home_url() ), esc_html( get_bloginfo( 'name' ) ) ) );
 } else {
-	printf( esc_html__( 'The following job listing is expiring soon from <a href="%s">%s</a>.', 'wp-job-manager' ), esc_url( home_url() ), esc_html( get_bloginfo( 'name' ) ) );
+	// translators: %1$s placeholder is URL to the blog. %2$s placeholder is the name of the site.
+	echo wp_kses_post( sprintf( __( 'The following job listing is expiring soon from <a href="%1$s">%2$s</a>.', 'wp-job-manager' ), esc_url( home_url() ), esc_html( get_bloginfo( 'name' ) ) ) );
 }
-$edit_post_link = admin_url( sprintf( 'post.php?post=%d&amp;action=edit', $job->ID ) );
-printf( ' ' . esc_html__( 'Visit <a href="%s">WordPress admin</a> to manage the listing.', 'wp-job-manager' ), esc_url( $edit_post_link ) );
+
+echo ' ';
+
+// translators: Placeholder is URL to site's WP admin.
+echo wp_kses_post( sprintf( __( 'Visit <a href="%s">WordPress admin</a> to manage the listing.', 'wp-job-manager' ), esc_url( $edit_post_link ) ) );
 echo '</p>';
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fixes issue where HTML was being escaped in email notice for expiring job listings.

#### Testing instructions:

* Enable future expiring email notification for 1 day notice. Set job listings to expire tomorrow. Run notifications manually using Crontrol to run the job_manager_email_daily_notices event manually. Verify notifications are sent.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Fix: Issue with escaped HTML being used in expiring job listing notification emails.