### PR TITLE
descriptionFieldIsInvalid when fieldset hidden causes form to not submit

### DIFF
--- a/assets/js/job-submission.js
+++ b/assets/js/job-submission.js
@@ -135,7 +135,8 @@ jQuery(document).ready(function($) {
 		var editorTextArea = $( '#job_description' );
 
 		return jobDescription.length === 0 &&
-				editorTextArea.parents( '.required-field' ).length;
+				editorTextArea.parents( '.required-field' ).length &&
+				editorTextArea.parents( '.required-field' ).is(':visible');
 	}
 
 	function descriptionFieldIsPresent() {


### PR DESCRIPTION
`descriptionFieldIsInvalid` is causing form to not submit, and no errors to show, when the `fieldset` wrapper is hidden (which is done manually or by my conditional logic in field editor).  This adds a check to make sure the `fieldset` is actually visible when returning that it is invalid

#### Changes proposed in this Pull Request:

* Add check that `fieldset` is visible before returning that description field is invalid