### PR TITLE
checking typeof undefined should be in quotes (in job_submission.js)

### DIFF
--- a/assets/js/job-submission.js
+++ b/assets/js/job-submission.js
@@ -139,7 +139,7 @@ jQuery(document).ready(function($) {
 	}
 
 	function descriptionFieldIsPresent() {
-		return typeof tinymce !== undefined ||
+		return typeof tinymce !== "undefined" ||
 				tinymce.get( 'job_description' ) != null;
 	}
 
@@ -152,7 +152,7 @@ jQuery(document).ready(function($) {
 
 	// Listen for changes to the description field to clear validity
 	setTimeout( function() {
-		if ( typeof tinymce === undefined || tinymce.get( 'job_description' ) == null ) {
+		if ( typeof tinymce === "undefined" || tinymce.get( 'job_description' ) == null ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1808

#### Changes proposed in this Pull Request:
* When checking for `undefined` it should be in quotes
