### PR TITLE
Fix plugin activation issue

### DIFF
--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -96,10 +96,6 @@ class WP_Job_Manager {
 		add_filter( 'wp_privacy_personal_data_exporters', array( 'WP_Job_Manager_Data_Exporter', 'register_wpjm_user_data_exporter' ) );
 
 		add_action( 'init', array( $this, 'usage_tracking_init' ) );
-		register_deactivation_hook( __FILE__, array( $this, 'usage_tracking_cleanup' ) );
-
-		// Other cleanup.
-		register_deactivation_hook( __FILE__, array( $this, 'unschedule_cron_jobs' ) );
 
 		// Defaults for WPJM core actions.
 		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -75,9 +75,6 @@ class WP_Job_Manager {
 		// Schedule cron jobs.
 		self::maybe_schedule_cron_jobs();
 
-		// Activation - works with symlinks.
-		register_activation_hook( basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ ), array( $this, 'activate' ) );
-
 		// Switch theme.
 		add_action( 'after_switch_theme', array( 'WP_Job_Manager_Ajax', 'add_endpoint' ), 10 );
 		add_action( 'after_switch_theme', array( $this->post_types, 'register_post_types' ), 11 );

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -155,7 +155,7 @@ class WP_Job_Manager {
 	 */
 	public function load_plugin_textdomain() {
 		load_textdomain( 'wp-job-manager', WP_LANG_DIR . '/wp-job-manager/wp-job-manager-' . apply_filters( 'plugin_locale', get_locale(), 'wp-job-manager' ) . '.mo' );
-		load_plugin_textdomain( 'wp-job-manager', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+		load_plugin_textdomain( 'wp-job-manager', false, JOB_MANAGER_PLUGIN_DIR . '/languages/' );
 	}
 
 	/**

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -46,3 +46,6 @@ function WPJM() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 }
 
 $GLOBALS['job_manager'] = WPJM();
+
+// Activation - works with symlinks.
+register_activation_hook( basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ ), array( WPJM(), 'activate' ) );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -49,3 +49,7 @@ $GLOBALS['job_manager'] = WPJM();
 
 // Activation - works with symlinks.
 register_activation_hook( basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ ), array( WPJM(), 'activate' ) );
+
+// Cleanup on deactivation.
+register_deactivation_hook( __FILE__, array( WPJM(), 'unschedule_cron_jobs' ) );
+register_deactivation_hook( __FILE__, array( WPJM(), 'usage_tracking_cleanup' ) );


### PR DESCRIPTION
The plugin activation hook for WPJM was not running properly. This PR ensures that the hook is run, and fixes some related issues with deactivation and i18n loading.

#### Changes proposed in this Pull Request:

* Move activation and deactivation hook setup back to the root WPJM file.
* Access language files using the `JOB_MANAGER_PLUGIN_DIR` constant, rather than `__FILE__` (which is no longer correct).

#### Package

[wp-job-manager-255537b.zip](https://github.com/Automattic/WP-Job-Manager/files/3418673/wp-job-manager-255537b.zip)

#### Testing instructions:

To test one of the symptomatic issues ([#](https://wordpress.org/support/topic/something-critically-wrong-with-the-latest-update/)):

* Create a clean WordPress instance.
* Install and activate WP Job Manager on this branch (or using the package linked above).
* **Immediately after activation, before refreshing or going to another page,** hover over the Job Listings sidebar menu item.
* Ensure that the links are all there (i.e. "All Jobs", "Add New", etc).