### PR TITLE
#1814 submitting existing jobs prefill fix

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -514,7 +514,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$this->init_fields();
 
 		// Load data if necessary.
-		if ( $this->job_id && !$this->errors ) {
+		if ( $this->job_id && ! $this->errors ) {
 			$job = get_post( $this->job_id );
 			foreach ( $this->fields as $group_key => $group_fields ) {
 				foreach ( $group_fields as $key => $field ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -514,7 +514,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$this->init_fields();
 
 		// Load data if necessary.
-		if ( $this->job_id ) {
+		if ( $this->job_id && !$this->errors) {
 			$job = get_post( $this->job_id );
 			foreach ( $this->fields as $group_key => $group_fields ) {
 				foreach ( $group_fields as $key => $field ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -514,7 +514,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$this->init_fields();
 
 		// Load data if necessary.
-		if ( $this->job_id && !$this->errors) {
+		if ( $this->job_id && !$this->errors ) {
 			$job = get_post( $this->job_id );
 			foreach ( $this->fields as $group_key => $group_fields ) {
 				foreach ( $group_fields as $key => $field ) {


### PR DESCRIPTION
Fixes #1814 

#### Changes proposed in this Pull Request:

*when submitting the form data of an existing job post, upon submit, the form tries to always fetch the saved job data and not the pending object, so we can test that if a form error occured, we keep the proposed object for further editing in frontend.
