### PR TITLE
#1806 filled relist fix

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -160,7 +160,7 @@ class WP_Job_Manager_Shortcodes {
 					case 'relist':
 					case 'continue':
 
-					    if( $action == 'relist' ) {
+					    if ( $action == 'relist' ) {
                             update_post_meta( $job_id, '_filled', 0 );
                         }
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -160,10 +160,10 @@ class WP_Job_Manager_Shortcodes {
 					case 'relist':
 					case 'continue':
 
-					    if($action == 'relist') {
+					    if( $action == 'relist' ) {
                             update_post_meta( $job_id, '_filled', 0 );
                         }
-					    
+
 						if ( ! job_manager_get_permalink( 'submit_job_form' ) ) {
 							throw new Exception( __( 'Missing submission page.', 'wp-job-manager' ) );
 						}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -159,6 +159,11 @@ class WP_Job_Manager_Shortcodes {
 						break;
 					case 'relist':
 					case 'continue':
+
+					    if($action == 'relist') {
+                            update_post_meta( $job_id, '_filled', 0 );
+                        }
+					    
 						if ( ! job_manager_get_permalink( 'submit_job_form' ) ) {
 							throw new Exception( __( 'Missing submission page.', 'wp-job-manager' ) );
 						}


### PR DESCRIPTION
Fixes #1806

#### Changes proposed in this Pull Request:

*when the Dashboard action is set to relist, before redirecting to the edit job post form, we can trigger a _filled parameter reset

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* _fillted option reset fix when relist dashboard action takes place