### PR TITLE
#1815 selecting all job types filter fix search display

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -142,7 +142,7 @@ class WP_Job_Manager_Ajax {
 		}
 
 		$types              = get_job_listing_types();
-		$job_types_filtered = ! is_null( $filter_job_types ) && count( $types ) !== count( $filter_job_types );
+		$job_types_filtered = ! is_null( $filter_job_types ) && count( $filter_job_types ) <= count( $types );
 
 		$args = array(
 			'search_location'   => $search_location,


### PR DESCRIPTION
Fixes #1815

#### Changes proposed in this Pull Request:

*this fixes the "Search completed. Found %d matching record." display by adjusting the $job_types_filtered parameter to correctly output true value when all job categories are searched

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
fixes the search ajax response when all filtered ategories are being checked
