### PR TITLE
Fix the fields returned for cached results

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -184,6 +184,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 					} else {
 						$posts = array_map( 'get_post', $cached_query_posts->posts );
 					}
+
 					$result = new WP_Query();
 					$result->parse_query( $query_args );
 					$result->posts         = $posts;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -179,7 +179,11 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 					&& isset( $cached_query_posts->posts )
 					&& is_array( $cached_query_posts->posts )
 				) {
-					$posts  = array_map( 'get_post', $cached_query_posts->posts );
+					if ( 'ids' === $query_args['fields'] ) {
+						$posts = $cached_query_posts->posts;
+					} else {
+						$posts = array_map( 'get_post', $cached_query_posts->posts );
+					}
 					$result = new WP_Query();
 					$result->parse_query( $query_args );
 					$result->posts         = $posts;


### PR DESCRIPTION
Fixes #1784 

Before the change it would ignore the value passed in `fields` for cached results.
 
#### Changes proposed in this Pull Request:

* This would change how the fields are returned for cached results. 