### PR TITLE
Remove restriction of password setup by email when "Generate usernames from email addresses" is enabled.

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -487,23 +487,6 @@ class WP_Job_Manager_Settings {
 				}
 			}).change();
 
-			// If generate username is enabled on page load, assume use_standard_password_setup_email has been cleared.
-			// Default is true, so let's sneakily set it to that before it gets cleared and disabled.
-			if ( $generate_username_from_email.is(':checked') ) {
-				$use_standard_password_setup_email.prop('checked', true);
-			}
-
-			$generate_username_from_email.change(function() {
-				if ( jQuery( this ).is(':checked') ) {
-					$use_standard_password_setup_email.data('original-state', $use_standard_password_setup_email.is(':checked')).prop('checked', true).prop('disabled', true);
-				} else {
-					$use_standard_password_setup_email.prop('disabled', false);
-					if ( undefined !== $use_standard_password_setup_email.data('original-state') ) {
-						$use_standard_password_setup_email.prop('checked', $use_standard_password_setup_email.data('original-state'));
-					}
-				}
-			}).change();
-
 			jQuery( '.sub-settings-expander' ).on( 'change', function() {
 				var $expandable = jQuery(this).parent().siblings( '.sub-settings-expandable' );
 				var checked = jQuery(this).is( ':checked' );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -862,12 +862,7 @@ function is_wpjm_taxonomy() {
  * @return bool True if they are to use standard email, false to allow user to set password at first job creation.
  */
 function wpjm_use_standard_password_setup_email() {
-	$use_standard_password_setup_email = true;
-
-	// If username is being automatically generated, force them to send password setup email.
-	if ( ! job_manager_generate_username_from_email() ) {
-		$use_standard_password_setup_email = 1 === intval( get_option( 'job_manager_use_standard_password_setup_email' ) );
-	}
+	$use_standard_password_setup_email = 1 === intval( get_option( 'job_manager_use_standard_password_setup_email' ) );
 
 	/**
 	 * Allows an override of the setting for if a password should be auto-generated for new users.

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -687,6 +687,14 @@ function wpjm_get_registration_fields() {
 
 	$registration_fields = array();
 	if ( job_manager_enable_registration() ) {
+		$registration_fields['create_account_email'] = array(
+			'type'        => 'text',
+			'label'       => esc_html__( 'Your email', 'wp-job-manager' ),
+			'placeholder' => __( 'you@yourdomain.com', 'wp-job-manager' ),
+			'required'    => $account_required,
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Just used to populate value when validation failed.
+			'value'       => isset( $_POST['create_account_email'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_email'] ) ) : '',
+		);
 		if ( ! $generate_username_from_email ) {
 			$registration_fields['create_account_username'] = array(
 				'type'     => 'text',
@@ -714,14 +722,6 @@ function wpjm_get_registration_fields() {
 				'required'     => $account_required,
 			);
 		}
-		$registration_fields['create_account_email'] = array(
-			'type'        => 'text',
-			'label'       => esc_html__( 'Your email', 'wp-job-manager' ),
-			'placeholder' => __( 'you@yourdomain.com', 'wp-job-manager' ),
-			'required'    => $account_required,
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Just used to populate value when validation failed.
-			'value'       => isset( $_POST['create_account_email'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_email'] ) ) : '',
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1725 

#### Changes proposed in this Pull Request:

* Removes the JavaScript code which disables **Email new users a link to set a password** option when **Generate usernames from email addresses** is enabled.
* Updates `wpjm_use_standard_password_setup_email()` to remove the restriction to force send password setup email.
* Moves email field to the top to keep it before username/password if both or one of them is enabled.
