### PR TITLE
Fix the password form and iframes being filtered out on listing page.

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -443,9 +443,15 @@ class WP_Job_Manager_Post_Types {
 	 *
 	 * @since 1.33.0
 	 * @param string $post_content Post content to filter.
+	 * @param bool   $echo         Whether to echo the content.
 	 */
-	public static function output_kses_post( $post_content ) {
-		echo wp_kses( $post_content, self::kses_allowed_html() );
+	public static function output_kses_post( $post_content, $echo = true ) {
+		$output = wp_kses( $post_content, self::kses_allowed_html() );
+		if ( $echo ) {
+			echo $output;
+		} else {
+			return $output;
+		}
 	}
 
 	/**
@@ -478,6 +484,25 @@ class WP_Job_Manager_Post_Types {
 						'title'           => true,
 						'allow'           => true,
 						'allowfullscreen' => true,
+					),
+					'form'   => array(
+						'action'         => true,
+						'accept'         => true,
+						'accept-charset' => true,
+						'enctype'        => true,
+						'method'         => true,
+						'name'           => true,
+						'class'          => true,
+						'target'         => true,
+					),
+					'input'  => array(
+						'name'  => true,
+						'id'    => true,
+						'type'  => true,
+						'value' => true,
+						'size'  => true,
+						'class' => true,
+						'style' => true,
 					),
 				)
 			)

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -448,7 +448,7 @@ class WP_Job_Manager_Post_Types {
 	public static function output_kses_post( $post_content, $echo = true ) {
 		$output = wp_kses( $post_content, self::kses_allowed_html() );
 		if ( $echo ) {
-			echo $output;
+			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput
 		} else {
 			return $output;
 		}

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -529,10 +529,7 @@ function wpjm_get_the_job_title( $post = null ) {
  * @param int|WP_Post $post
  */
 function wpjm_the_job_description( $post = null ) {
-	$job_description = wpjm_get_the_job_description( $post );
-	if ( $job_description ) {
-		WP_Job_Manager_Post_Types::output_kses_post( $job_description );
-	}
+	echo wpjm_get_the_job_description( $post );
 }
 
 /**
@@ -548,7 +545,8 @@ function wpjm_get_the_job_description( $post = null ) {
 		return null;
 	}
 
-	$description = apply_filters( 'the_job_description', wp_kses_post( $post->post_content ) );
+	$description = apply_filters( 'the_job_description', get_the_content( null, false, $post ) );
+	$description = WP_Job_Manager_Post_Types::output_kses_post( $description, false );
 
 	/**
 	 * Filter for the job description.


### PR DESCRIPTION
Fixes #1672 and #1584 which was not fixed in earlier PR.

This PR given full control to the users to modify the listing page content via `wpjm_the_job_description` filter.

#### Changes proposed in this Pull Request:

* Makes `wpjm_get_the_job_description` to do all the pre-output processing.
* Allows the form to be rendered for password protected listings
* Moved `kses` before `wpjm_the_job_description` filter to avoid removing the changes made by the filter callback.
* The above change also allows iframes to be allowed.