### PR TITLE
#1832 jquery-ui minified source change

### DIFF
--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -250,7 +250,7 @@ class WP_Job_Manager {
 		global $wp_scripts;
 
 		$jquery_version = isset( $wp_scripts->registered['jquery-ui-core']->ver ) ? $wp_scripts->registered['jquery-ui-core']->ver : '1.9.2';
-		wp_register_style( 'jquery-ui', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.css', array(), $jquery_version );
+		wp_register_style( 'jquery-ui', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.min.css', array(), $jquery_version );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1832

#### Changes proposed in this Pull Request:

Changes the jquery-ui source url to the minified version.

#### Testing instructions:

1. Make theme stylesheet dependent on jquery-ui style
Before source url change: <img width="1255" alt="before-style-url-change-job-manager" src="https://user-images.githubusercontent.com/537751/62269173-dd92d080-b43a-11e9-8278-e079867da569.png">

After Source Url Change: <img width="1316" alt="after-style-url-change-job-manager" src="https://user-images.githubusercontent.com/537751/62269172-dcfa3a00-b43a-11e9-87ce-526335032057.png">

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Changes the jquery-ui style source url to the minifies version.