### PR TITLE
Add `job_manager_before_search` Hook

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -156,6 +156,21 @@ class WP_Job_Manager_Ajax {
 			'posts_per_page'    => max( 1, $per_page ),
 		);
 
+		// Array of keys whose value is passed to `job_manager_before_search` action.
+		$allowed_arg_keys = [ 'search_keywords' ];
+
+		// Build an array with values of whitelisted keys.
+		$search_args = array_intersect_key( $args, array_flip( $allowed_arg_keys ) );
+
+		/**
+		 * This action is intended to be used by site owners to log search arguments.
+		 *
+		 * @since 1.34.0
+		 *
+		 * @param array $search_args Arguments to help owner identify type of job searches.
+		 */
+		do_action( 'job_manager_before_search', $search_args );
+
 		if ( 'true' === $filled || 'false' === $filled ) {
 			$args['filled'] = 'true' === $filled;
 		}


### PR DESCRIPTION
Fixes #1513

#### Changes proposed in this Pull Request:

* Adds `job_manager_before_search` action, which has value of searched keyword, other information can be added as well.

#### Testing instructions:

* User's can make use of the data based on their logging implementation, for simple testing, follow below steps.

- Enable [debug log](https://wordpress.org/support/article/debugging-in-wordpress/#wp_debug_log) and add following snippet to the end of your active theme's **functions.php** file.

```
add_action( 'job_manager_before_search', 'do_the_search' );
function do_the_search( $search_args ) {
	$search_keyword = $search_args['search_keywords'];
	error_log( 'Job Search for Keyword: ' . $search_keyword );
}
```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Dev: Add `job_manager_before_search` action to help site owners identify type of job searches.