### PR TITLE
Fix #1782: Added link to Jobs Dashboard after submitting job.

### DIFF
--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -30,8 +30,10 @@ switch ( $job->post_status ) :
 	case 'pending' :
 		echo wp_kses_post(
 			sprintf(
-				esc_html__( '%s submitted successfully. Your listing will be visible once approved.', 'wp-job-manager' ),
+				__( '%s submitted successfully. Your listing will be visible once approved.<br>
+					<a href="%s">Click here</a> to go to the Jobs Dashboard.', 'wp-job-manager' ),
 				esc_html( $wp_post_types['job_listing']->labels->singular_name ),
+				get_permalink( get_option( 'job_manager_job_dashboard_page_id' ) ),
 				get_permalink( $job->ID )
 			)
 		);


### PR DESCRIPTION
Fixes #1782 

#### Changes proposed in this Pull Request:

* Added a link to the Jobs Dashboard below the message "Jobs submitted successfully. Your listing will be visible once approved." 

#### Testing instructions:

* Activate the setting "Require admin approval of all new listing submissions"
* Submit a new job listing
* You should see the link to the Jobs Dashboard underneath the success message.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Added link to Jobs Dashboard after submitting job.
