### PR TITLE
Remove unused parameter sent in templates/job-submitted.php

### DIFF
--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -31,8 +31,7 @@ switch ( $job->post_status ) :
 		echo wp_kses_post(
 			sprintf(
 				esc_html__( '%s submitted successfully. Your listing will be visible once approved.', 'wp-job-manager' ),
-				esc_html( $wp_post_types['job_listing']->labels->singular_name ),
-				get_permalink( $job->ID )
+				esc_html( $wp_post_types['job_listing']->labels->singular_name )
 			)
 		);
 	break;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This is a minor change. My guess is that the "get_permalink( $job->ID )" was copied from the 'publish' case, in line 26. But this one is not being used.