### PR TITLE
Added page path into the result.

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -164,14 +164,9 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		// Cache results.
 		if ( apply_filters( 'get_job_listings_cache_results', true ) ) {
-			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-				$page_path = substr( parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 1, -1 );
-			} else {
-				$page_path = '';
-			}
-
+			global $wp;
 			$to_hash              = wp_json_encode( $query_args );
-			$query_args_hash      = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION . $page_path ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
+			$query_args_hash      = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION . home_url( $wp->request ) ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
 			$result               = false;
 			$cached_query_results = true;
 			$cached_query_posts   = get_transient( $query_args_hash );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -164,8 +164,9 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		// Cache results.
 		if ( apply_filters( 'get_job_listings_cache_results', true ) ) {
+			$pagePath = substr(parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 1, -1);
 			$to_hash              = wp_json_encode( $query_args );
-			$query_args_hash      = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
+			$query_args_hash      = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION . $pagePath ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
 			$result               = false;
 			$cached_query_results = true;
 			$cached_query_posts   = get_transient( $query_args_hash );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -164,9 +164,14 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		// Cache results.
 		if ( apply_filters( 'get_job_listings_cache_results', true ) ) {
-			$pagePath = substr(parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 1, -1);
+			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+				$page_path = substr( parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 1, -1 );
+			} else {
+				$page_path = '';
+			}
+
 			$to_hash              = wp_json_encode( $query_args );
-			$query_args_hash      = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION . $pagePath ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
+			$query_args_hash      = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION . $page_path ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
 			$result               = false;
 			$cached_query_results = true;
 			$cached_query_posts   = get_transient( $query_args_hash );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:
Added page path to the get_job_listings cache key.
*

#### Testing instructions:
- Install qtranslate-xt (https://github.com/qTranslate/qtranslate-xt)
- Add 2 Languages.
- Run setup for wp-job-manager.
- Provide translations for all the wp-job-manager pages.
- Create jobs and provide translations.
- Go to the job listing page and switch the language.
*
