### PR TITLE
Fix: Two options aren't deleted when plugin is uninstalled.

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -99,6 +99,8 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_email_admin_expiring_job',
 		'job_manager_email_employer_expiring_job',
 		'job_manager_admin_notices',
+		'widget_widget_featured_jobs',
+		'widget_widget_recent_jobs',
 	);
 
 	/**
@@ -170,16 +172,6 @@ class WP_Job_Manager_Data_Cleaner {
 	);
 
 	/**
-	 * Widget options to be deleted.
-	 *
-	 * @var $widget_options
-	 */
-	private static $widget_options = array(
-		'widget_widget_featured_jobs',
-		'widget_widget_recent_jobs',
-	);
-
-	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -194,7 +186,6 @@ class WP_Job_Manager_Data_Cleaner {
 		self::cleanup_user_meta();
 		self::cleanup_options();
 		self::cleanup_site_options();
-		self::cleanup_widget_options();
 	}
 
 	/**
@@ -386,17 +377,6 @@ class WP_Job_Manager_Data_Cleaner {
 	private static function cleanup_cron_jobs() {
 		foreach ( self::$cron_jobs as $job ) {
 			wp_clear_scheduled_hook( $job );
-		}
-	}
-
-	/**
-	 * Cleanup widget options.
-	 *
-	 * @access private
-	 */
-	private static function cleanup_widget_options() {
-		foreach ( self::$widget_options as $widget_option ) {
-			delete_option( $widget_option );
 		}
 	}
 }

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -170,6 +170,16 @@ class WP_Job_Manager_Data_Cleaner {
 	);
 
 	/**
+	 * Widget options to be deleted.
+	 *
+	 * @var $widget_options
+	 */
+	private static $widget_options = array(
+		'widget_widget_featured_jobs',
+		'widget_widget_recent_jobs',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -184,6 +194,7 @@ class WP_Job_Manager_Data_Cleaner {
 		self::cleanup_user_meta();
 		self::cleanup_options();
 		self::cleanup_site_options();
+		self::cleanup_widget_options();
 	}
 
 	/**
@@ -375,6 +386,17 @@ class WP_Job_Manager_Data_Cleaner {
 	private static function cleanup_cron_jobs() {
 		foreach ( self::$cron_jobs as $job ) {
 			wp_clear_scheduled_hook( $job );
+		}
+	}
+
+	/**
+	 * Cleanup widget options.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_widget_options() {
+		foreach ( self::$widget_options as $widget_option ) {
+			delete_option( $widget_option );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

After the plugin is uninstalled (with the "Delete data on uninstall" option selected), there are two options (in the wp_options table) that are not deleted by the cleanup process:
1. 'widget_widget_featured_jobs'
2. 'widget_widget_recent_jobs'

Now, from what I understand, the best thing to do when uninstalling a plugin is to delete the options you created in the wp_options table (and any other tables you created or modified) to basically leave no trace of your plugin; except in a very specific situation where this is intended because you want to keep data for future use in case of the plugin being reinstalled (with your user consent, and letting them choose this option).
I tried to find a reason for letting those two options alive after deletion, but couldn't find one (of course, I might be wrong!). And I also tried to find if they were automatically deleted with a transient but also couldn't find it...

Again, I might be wrong here, and if it's the case, I apologize for wrongly creating this PR, and I would really appreciate an explanation for the sake of learning and understanding!

But in case I'm not wrong, this PR fixes the issue. Feedback, comments, and suggestions are gladly welcome and also, if there's anything else I could do to contribute please let me know and I'll do my best!

#### Testing instructions:

* Install and activate WPJM
* Go to settings and activate the 'Delete on Uninstall' option
* Delete the plugin
* Go to the $wpdb->prefix . 'options' table
* If you installed the plugin without this PR code, there should be two options there: 
1. 'widget_widget_featured_jobs'
2. 'widget_widget_recent_jobs'
* If the plugin is installed with this PR code, those options should have been deleted

#### Proposed changelog entry for your changes:
Fix: Two options aren't deleted when plugin is uninstalled.
