### PR TITLE
Fix #1465 Menu Position of the Job Listings Custom Post Type

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -373,7 +373,7 @@ class WP_Job_Manager_Post_Types {
 					'rest_controller_class' => 'WP_REST_Posts_Controller',
 					'template'              => array( array( 'core/freeform' ) ),
 					'template_lock'         => 'all',
-					'menu_position'			=> 30,
+					'menu_position'         => 30,
 				)
 			)
 		);

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -373,6 +373,7 @@ class WP_Job_Manager_Post_Types {
 					'rest_controller_class' => 'WP_REST_Posts_Controller',
 					'template'              => array( array( 'core/freeform' ) ),
 					'template_lock'         => 'all',
+					'menu_position'			=> 30,
 				)
 			)
 		);


### PR DESCRIPTION
Fixes #1465

#### Changes proposed in this Pull Request:

* Set Job Listings menu_position to 30. 
* If Job Applications add-on menu_position is 31, and Resumes add-on is 32, each will appear one after another in WP Admin dashboard 

#### Testing instructions:

* View Job Listings in WP Admin dashboard. It should be below Comments.
* Add Job Applications add-on.
* Job Listings should appear before Job Applications in WP Admin dashboard, regardless of whether the Job Applications menu_position is already set to 31 or not set at all.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Set Job Listings menu_position
