### PR TITLE
Fix #1487: Always show Featured Jobs in Listings 

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -137,6 +137,46 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			);
 		}
 
+		if ( 'title_featured' === $args['orderby'] ) {
+			$query_args['orderby'] = array(
+				'menu_order' => 'ASC',
+				'title'      => $args['order'],
+				'ID'		 =>	$args['order'],
+
+			);
+		}
+
+		if ( 'ID_featured' === $args['orderby'] ) {
+			$query_args['orderby'] = array(
+				'menu_order' => 'ASC',
+				'ID'		 =>	$args['order'],
+			);
+		}
+
+		if ( 'name_featured' === $args['orderby'] ) {
+			$query_args['orderby'] = array(
+				'menu_order' => 'ASC',
+				'name'       => $args['order'],
+				'ID'		 => $args['order'],
+			);
+		}
+
+		if ( 'date_featured' === $args['orderby'] ) {
+			$query_args['orderby'] = array(
+				'menu_order' => 'ASC',
+				'date'       => $args['order'],
+				'ID'		 =>	$args['order'],
+			);
+		}
+
+		if ( 'modified_featured' === $args['orderby'] ) {
+			$query_args['orderby'] = array(
+				'menu_order' => 'ASC',
+				'modified'   => $args['order'],
+				'ID'		 =>	$args['order'],
+			);
+		}
+		
 		$job_manager_keyword = sanitize_text_field( $args['search_keywords'] );
 
 		if ( ! empty( $job_manager_keyword ) && strlen( $job_manager_keyword ) >= apply_filters( 'job_manager_get_listings_keyword_length_threshold', 2 ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -141,7 +141,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$query_args['orderby'] = array(
 				'menu_order' => 'ASC',
 				'title'      => $args['order'],
-				'ID'		 =>	$args['order'],
+				'ID'         => $args['order'],
 
 			);
 		}
@@ -149,7 +149,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		if ( 'ID_featured' === $args['orderby'] ) {
 			$query_args['orderby'] = array(
 				'menu_order' => 'ASC',
-				'ID'		 =>	$args['order'],
+				'ID'         => $args['order'],
 			);
 		}
 
@@ -157,7 +157,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$query_args['orderby'] = array(
 				'menu_order' => 'ASC',
 				'name'       => $args['order'],
-				'ID'		 => $args['order'],
+				'ID'         => $args['order'],
 			);
 		}
 
@@ -165,7 +165,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$query_args['orderby'] = array(
 				'menu_order' => 'ASC',
 				'date'       => $args['order'],
-				'ID'		 =>	$args['order'],
+				'ID'         => $args['order'],
 			);
 		}
 
@@ -173,7 +173,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$query_args['orderby'] = array(
 				'menu_order' => 'ASC',
 				'modified'   => $args['order'],
-				'ID'		 =>	$args['order'],
+				'ID'         => $args['order'],
 			);
 		}
 		

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -176,7 +176,6 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 				'ID'         => $args['order'],
 			);
 		}
-		
 		$job_manager_keyword = sanitize_text_field( $args['search_keywords'] );
 
 		if ( ! empty( $job_manager_keyword ) && strlen( $job_manager_keyword ) >= apply_filters( 'job_manager_get_listings_keyword_length_threshold', 2 ) ) {


### PR DESCRIPTION
Fixes #1487

#### Changes proposed in this Pull Request:

* According to #1487, certain sorting criteria for jobs on the job listing page would not position featured listings at the top.
    * Job listings are outputted by the shortcode `[jobs]`.  The shortcode produces a list of jobs for visitors to search. The shortcode accepts arguments for `orderby` and `order` to order listings.
    * The available arguments for `orderby` are `title`, `ID`, `name`, `date`, `modified`, `rand`, `featured` (default, and allows all listings ordered by descending date with featured on top), and `rand_featured` (random but keeps featured at top). The arguments for `order` are `DESC` and `ASC`, with `DESC` as default.
    * If you use `orderby` with any argument other than `rand_featured` or `featured`, featured listings won't necessarily be grouped at the top before non-featured listings.
    * For example, the following shortcode will display all listings by descending date.  Featured jobs will appear underneath non-featured jobs if the featured jobs have an earlier creation date:
        `[jobs orderby="date"] `
* Some want to make sure that featured listings always appear at the top regardless of the sorting criteria.  
* Now with this fix, you can add the appropriate argument to the `[jobs]` shortcode for the type of sorting that you need while keeping featured listings grouped together at the top.
* The fix introduces five (5) new arguments for the `[jobs]` shortcode that build upon existing arguments for the `orderby` parameter.  The new arguments are:
    1. `title_featured`
    2. `ID_featured`
    3. `name_featured`
    4. `date_featured`
    5. `modified_featured`

#### Testing instructions:

* Create some jobs
* Create a new page
* Enter the `[jobs]` shortcode on the page, update the page, and view on another tab or window. Note what you see as default.  Keep separate window open.
* Enter a test shortcode on page. Update the page and view the page in a separate tab or window for results
* Repeat for each test shortcode. 
    > As a reminder,  the default `order` is `DESC`. 

_**Test shortcodes:**_
* `[jobs orderby="title_featured" order="DESC"]`
* `[jobs orderby="title_featured" order="ASC"]`
* `[jobs orderby="title_featured"]`
* `[jobs orderby="ID_featured" order="DESC"]`
* `[jobs orderby="ID_featured" order="ASC"]`
* `[jobs orderby="ID_featured"]`
* `[jobs orderby="name_featured" order="DESC"]`
* `[jobs orderby="name_featured" order="ASC"]`
* `[jobs orderby="name_featured"]`
* `[jobs orderby="date_featured" order="DESC"]` (note that this is effectively the same as `featured` argument)
* `[jobs orderby="date_featured" order="ASC"]`
* `[jobs orderby="date_featured"]` (note that this is effectively the same as `featured` argument)
* `[jobs orderby="modified_featured" order="DESC"]`
* `[jobs orderby="modified_featured" order="ASC"]`
* `[jobs orderby="modified_featured"]`


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

When retrieving listings in `[jobs]` shortcode, setting `orderby` to `title_featured`, `ID_featured`, `name_featured`, `date_featured`, or `modified_featured` will still place featured listings at the top.