### PR TITLE
Fix #1782 Add link to Jobs Dashboard after submitting job

### DIFF
--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -36,19 +36,8 @@ switch ( $job->post_status ) :
 			)
 		);
 
-		global $wpdb;
-
-		$id = $wpdb->get_var(
-			' SELECT ID
-				FROM ' . $wpdb->posts . '
-				WHERE
-					post_type = "page"
-					AND post_status = "publish"
-					AND post_content LIKE "%[job_dashboard]%"'
-		);
-
-		$permalink = get_permalink($id);
-		$title = get_the_title($id);
+		$permalink = job_manager_get_permalink('job_dashboard');
+		$title = get_the_title((job_manager_get_page_id('job_dashboard')));
 
 		// If job_dashboard page exists but there is no title
 		if ( $permalink && empty($title) ) {
@@ -61,8 +50,7 @@ switch ( $job->post_status ) :
 					esc_html( $wp_post_types['job_listing' ]->labels->name )
 				)
 			);
-		// If there is both a job_dashboard page and a title on the page
-		} elseif ( $permalink && $title ) { 
+		} elseif ( $permalink && $title ) { // If there is both a job_dashboard page and a title on the page
 			echo wp_kses_post(
 				sprintf(
 					__( '  <a href="%s"> %s</a>', 'wp-job-manager' ),

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -36,8 +36,19 @@ switch ( $job->post_status ) :
 			)
 		);
 
-		$permalink = job_manager_get_permalink('job_dashboard');
-		$title = get_the_title((job_manager_get_page_id('job_dashboard')));
+		global $wpdb;
+
+		$id = $wpdb->get_var(
+			' SELECT ID
+				FROM ' . $wpdb->posts . '
+				WHERE
+					post_type = "page"
+					AND post_status = "publish"
+					AND post_content LIKE "%[job_dashboard]%"'
+		);
+
+		$permalink = get_permalink($id);
+		$title = get_the_title($id);
 
 		// If job_dashboard page exists but there is no title
 		if ( $permalink && empty($title) ) {
@@ -50,7 +61,8 @@ switch ( $job->post_status ) :
 					esc_html( $wp_post_types['job_listing' ]->labels->name )
 				)
 			);
-		} elseif ( $permalink && $title ) { // If there is both a job_dashboard page and a title on the page
+		// If there is both a job_dashboard page and a title on the page
+		} elseif ( $permalink && $title ) { 
 			echo wp_kses_post(
 				sprintf(
 					__( '  <a href="%s"> %s</a>', 'wp-job-manager' ),

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -40,7 +40,7 @@ switch ( $job->post_status ) :
 		$title = get_the_title((job_manager_get_page_id('job_dashboard')));
 
 		// If job_dashboard page exists but there is no title
-		if ( $permalink && empty($title)) {
+		if ( $permalink && empty($title) ) {
 			echo wp_kses_post(
 				sprintf(
 					// translators: %1$s is the URL to view the listing; %2$s is
@@ -50,7 +50,7 @@ switch ( $job->post_status ) :
 					esc_html( $wp_post_types['job_listing' ]->labels->name )
 				)
 			);
-		} elseif ($permalink && $title) { // If there is both a job_dashboard page and a title on the page
+		} elseif ( $permalink && $title ) { // If there is both a job_dashboard page and a title on the page
 			echo wp_kses_post(
 				sprintf(
 					__( '  <a href="%s"> %s</a>', 'wp-job-manager' ),

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -35,6 +35,31 @@ switch ( $job->post_status ) :
 				get_permalink( $job->ID )
 			)
 		);
+
+		$permalink = job_manager_get_permalink('job_dashboard');
+		$title = get_the_title((job_manager_get_page_id('job_dashboard')));
+
+		// If job_dashboard page exists but there is no title
+		if ( $permalink && empty($title)) {
+			echo wp_kses_post(
+				sprintf(
+					// translators: %1$s is the URL to view the listing; %2$s is
+					// the plural name of the job listing post type
+					__( '  <a href="%1$s"> View your %2$s</a>', 'wp-job-manager' ),
+					$permalink,
+					esc_html( $wp_post_types['job_listing' ]->labels->name )
+				)
+			);
+
+		} elseif ($permalink && $title) { // If there is both a job_dashboard page and a title on the page
+			echo wp_kses_post(
+				sprintf(
+					__( '  <a href="%s"> %s</a>', 'wp-job-manager' ),
+					$permalink,
+					$title
+				)
+			);
+		}
 	break;
 	default :
 		do_action( 'job_manager_job_submitted_content_' . str_replace( '-', '_', sanitize_title( $job->post_status ) ), $job );

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -40,7 +40,7 @@ switch ( $job->post_status ) :
 		$title     = get_the_title( job_manager_get_page_id( 'job_dashboard' ) );
 
 		// If job_dashboard page exists but there is no title
-		if ( $permalink && empty($title) ) {
+		if ( $permalink && empty( $title ) ) {
 			echo wp_kses_post(
 				sprintf(
 					// translators: %1$s is the URL to view the listing; %2$s is

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -37,7 +37,7 @@ switch ( $job->post_status ) :
 		);
 
 		$permalink = job_manager_get_permalink('job_dashboard');
-		$title = get_the_title((job_manager_get_page_id('job_dashboard')));
+		$title     = get_the_title( job_manager_get_page_id( 'job_dashboard' ) );
 
 		// If job_dashboard page exists but there is no title
 		if ( $permalink && empty($title) ) {

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -50,7 +50,6 @@ switch ( $job->post_status ) :
 					esc_html( $wp_post_types['job_listing' ]->labels->name )
 				)
 			);
-
 		} elseif ($permalink && $title) { // If there is both a job_dashboard page and a title on the page
 			echo wp_kses_post(
 				sprintf(


### PR DESCRIPTION
Fixes #1782

#### Changes proposed in this Pull Request:

* Add a link to the job dashboard after submitting a job. Link appears next to the message "Jobs submitted successfully. Your listing will be visible once approved." 
    * If the job dashboard page doesn't have a title, the link text states "View your Jobs" or whatever name the user gave to "Jobs".
    * If the job dashboard page has a title, the link text is the page title.


#### Testing instructions:

**_Page with title_**
* Make sure you have a page with shortcode `[job_dashboard]`. Make sure page has a title. Make sure page is designated as Job Dashboard Page in WP Admin dashboard -> Job Listings -> Settings -> Pages. Keep page open in separate tab or window.
* Make sure you have a page with shortcode `[submit_job_form]`. Make sure page is designated as Submit Job Form Page in WP Admin dashboard -> Job Listings -> Settings -> Pages.
* Make sure the following settings are activated in WP Admin dashboard -> Job Listings -> Settings -> Job Submission:
    * "Require an account to submit listings"
    * "Enable account creation during submission"
    * "Require admin approval of all new listing submissions"
* View page with shortcode `[submit_job_form]`. Create and submit listing as a non-admin user.
* Note confirmation message.

**_Page without title_**
* Edit page with shortcode `[job_dashboard]`as follows: Delete page title and update page. View page.
* Create and submit listing as a non-admin user.
* Note different confirmation message.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Add link to job dashboard after submitting job

