### PR TITLE
Conditionally use https on Google Maps link.

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -789,7 +789,7 @@ function the_job_location( $map_link = true, $post = null ) {
 			echo wp_kses_post(
 				apply_filters(
 					'the_job_location_map_link',
-					'<a class="google_map_link" href="' . esc_url( 'http://maps.google.com/maps?q=' . rawurlencode( wp_strip_all_tags( $location ) ) . '&zoom=14&size=512x512&maptype=roadmap&sensor=false' ) . '">' . esc_html( wp_strip_all_tags( $location ) ) . '</a>',
+					'<a class="google_map_link" href="' . esc_url( 'http' . ( is_ssl() ? 's' : '' ) . '://maps.google.com/maps?q=' . rawurlencode( wp_strip_all_tags( $location ) ) . '&zoom=14&size=512x512&maptype=roadmap&sensor=false' ) . '">' . esc_html( wp_strip_all_tags( $location ) ) . '</a>',
 					$location,
 					$post
 				)

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -789,7 +789,7 @@ function the_job_location( $map_link = true, $post = null ) {
 			echo wp_kses_post(
 				apply_filters(
 					'the_job_location_map_link',
-					'<a class="google_map_link" href="' . esc_url( 'http' . ( is_ssl() ? 's' : '' ) . '://maps.google.com/maps?q=' . rawurlencode( wp_strip_all_tags( $location ) ) . '&zoom=14&size=512x512&maptype=roadmap&sensor=false' ) . '">' . esc_html( wp_strip_all_tags( $location ) ) . '</a>',
+					'<a class="google_map_link" href="' . esc_url( 'https://maps.google.com/maps?q=' . rawurlencode( wp_strip_all_tags( $location ) ) . '&zoom=14&size=512x512&maptype=roadmap&sensor=false' ) . '">' . esc_html( wp_strip_all_tags( $location ) ) . '</a>',
 					$location,
 					$post
 				)


### PR DESCRIPTION
fixes #1866

#### Changes proposed in this Pull Request:

* Unconditionally use https on Google Maps link.

#### Testing instructions:

- Create a Job listing with a location.
- View the listing location link. the link should always be https

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Conditionally use https on Google Maps link.