### PR TITLE
fix data-longitude and data-latitude wrong values

### DIFF
--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 ?>
-<li <?php job_listing_class(); ?> data-longitude="<?php echo esc_attr( $post->geolocation_lat ); ?>" data-latitude="<?php echo esc_attr( $post->geolocation_long ); ?>">
+<li <?php job_listing_class(); ?> data-longitude="<?php echo esc_attr( $post->geolocation_long ); ?>" data-latitude="<?php echo esc_attr( $post->geolocation_lat ); ?>">
 	<a href="<?php the_job_permalink(); ?>">
 		<?php the_company_logo(); ?>
 		<div class="position">


### PR DESCRIPTION
In templates/content-job_listing.php, data-longitude and data-latitude has wrong values : they are inverted.

Fixes #

#### Changes proposed in this Pull Request:

Inverse geolocation_lat and geolocation_long in the right attributes

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
