### PR TITLE
Add author to the job listing post type "supports".

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -364,7 +364,7 @@ class WP_Job_Manager_Post_Types {
 					'hierarchical'          => false,
 					'rewrite'               => $rewrite,
 					'query_var'             => true,
-					'supports'              => array( 'title', 'editor', 'custom-fields', 'publicize', 'thumbnail' ),
+					'supports'              => array( 'title', 'editor', 'custom-fields', 'publicize', 'thumbnail', 'author' ),
 					'has_archive'           => $has_archive,
 					'show_in_nav_menus'     => false,
 					'delete_with_user'      => true,


### PR DESCRIPTION
Fixes #1809

#### Changes proposed in this Pull Request:

* Add "author" field to the "supports" of the job listing post type.

#### Testing instructions:

* see #1809

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Add "author" field to the "supports" of the job listing post type.
