### PR TITLE
Revert removal of direct database access in two places

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -981,7 +981,6 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
-		remove_action( 'update_post_meta', array( $this, 'update_post_meta' ) );
 		switch ( $meta_key ) {
 			case '_job_location':
 				$this->maybe_update_geolocation_data( $meta_id, $object_id, $meta_key, $meta_value );
@@ -990,7 +989,6 @@ class WP_Job_Manager_Post_Types {
 				$this->maybe_update_menu_order( $meta_id, $object_id, $meta_key, $meta_value );
 				break;
 		}
-		add_action( 'update_post_meta', array( $this, 'update_post_meta' ), 10, 4 );
 	}
 
 	/**
@@ -1014,25 +1012,28 @@ class WP_Job_Manager_Post_Types {
 	 * @param mixed  $meta_value
 	 */
 	public function maybe_update_menu_order( $meta_id, $object_id, $meta_key, $meta_value ) {
+		global $wpdb;
+
 		if ( 1 === intval( $meta_value ) ) {
-			wp_update_post(
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update post menu order without firing actions.
+			$wpdb->update(
+				$wpdb->posts,
+				array( 'menu_order' => -1 ),
+				array( 'ID' => $object_id )
+			);
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update post menu order without firing actions.
+			$wpdb->update(
+				$wpdb->posts,
+				array( 'menu_order' => 0 ),
 				array(
 					'ID'         => $object_id,
 					'menu_order' => -1,
 				)
 			);
-		} else {
-			$post = get_post( $object_id );
-
-			if ( -1 === intval( $post->menu_order ) ) {
-				wp_update_post(
-					array(
-						'ID'         => $object_id,
-						'menu_order' => 0,
-					)
-				);
-			}
 		}
+
+		clean_post_cache( $object_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1843
Fixes #1877

#### Changes proposed in this Pull Request:

* Revert change made in #1798 that avoided direct database access to update the post author. 
* Revert an additional change made in same PR around updating the menu order for the featured flag. This was causing issues around alternative versions in Polylang (#1877).
* This seems to fix #1843 and potentially saves us from other third-party plugin conflicts as well as a bug that would probably be introduced when/if we enable revisions.

#### Testing instructions:

* Update post author using WPJM meta box in WP Admin when editing job listing. Verify it updates on save.
* Follow steps in #1843 to make sure bug is fixed.
* Follow steps in https://github.com/Automattic/WP-Job-Manager/issues/1877#issuecomment-528397340 to make sure that bug is also fixed.