### PR TITLE
Use the correct sanitizer for page titles on setup wizard

### DIFF
--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -126,7 +126,7 @@ class WP_Job_Manager_Setup {
 					wp_die( 'Error in nonce. Try again.', 'wp-job-manager' );
 				}
 				$create_pages    = isset( $_POST['wp-job-manager-create-page'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-create-page'] ) ) : array();
-				$page_titles     = isset( $_POST['wp-job-manager-page-title'] ) ? array_map( 'sanitize_title', wp_unslash( $_POST['wp-job-manager-page-title'] ) ) : array();
+				$page_titles     = isset( $_POST['wp-job-manager-page-title'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-page-title'] ) ) : array();
 				$pages_to_create = array(
 					'submit_job_form' => '[submit_job_form]',
 					'job_dashboard'   => '[job_dashboard]',


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Straightforward change to use the sanitizer that doesn't slugify the page title input.

#### Testing instructions:

* Go through setup wizard (`/wp-admin/index.php?page=job-manager-setup`) and verify the pages that are created get set up with the correct title.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fix: Properly sanitize the page titles during the initial setup wizard.