### PR TITLE
Replaced sanitize_title function with sanitize_text_field in page titles

### DIFF
--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -126,7 +126,7 @@ class WP_Job_Manager_Setup {
 					wp_die( 'Error in nonce. Try again.', 'wp-job-manager' );
 				}
 				$create_pages    = isset( $_POST['wp-job-manager-create-page'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-create-page'] ) ) : array();
-				$page_titles     = isset( $_POST['wp-job-manager-page-title'] ) ? array_map( 'sanitize_title', wp_unslash( $_POST['wp-job-manager-page-title'] ) ) : array();
+				$page_titles     = isset( $_POST['wp-job-manager-page-title'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-page-title'] ) ) : array();
 				$pages_to_create = array(
 					'submit_job_form' => '[submit_job_form]',
 					'job_dashboard'   => '[job_dashboard]',


### PR DESCRIPTION
Fixes #1880 

#### Changes proposed in this Pull Request:

* In the setup process, the page titles are sanitized using the "sanitize_title" function, which returns the string in a "this-is-your-title" format (without spaces, uncapitalized, etc). By replacing this function with the "sanitize_text_field" function, we would still be sanitizing the field (to avoid security issues), but we would get the title as written by the user in the setup textfields".

#### Testing instructions:

* Install the plugin (with this PR code)
* Run the setup wizard
* Page titles should be the ones entered by the user (literally, without dashes or un-capitalization) 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Replaced sanitize_title function with sanitize_text_field in page titles
