### PR TITLE
Allow using term slugs for preselecting category filter

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -360,9 +360,23 @@ class WP_Job_Manager_Shortcodes {
 
 		// Array handling.
 		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
+		$atts['selected_category']  = is_array( $atts['selected_category'] ) ? $atts['selected_category'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_category'] ) ) );
 		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
 		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
 		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
+
+		// Normalize field for categories.
+		if ( ! empty( $atts['selected_category'] ) ) {
+			foreach ( $atts['selected_category'] as $cat_index => $category ) {
+				if ( ! is_numeric( $category ) ) {
+					$term = get_term_by( 'slug', $category, 'job_listing_category' );
+
+					if ( $term ) {
+						$atts['selected_category'][ $cat_index ] = $term->term_id;
+					}
+				}
+			}
+		}
 
 		$data_attributes = array(
 			'location'        => $atts['location'],


### PR DESCRIPTION
Fixes #1300

#### Changes proposed in this Pull Request:

* This allows for pre-selecting categories in `[jobs]` filter by term slug instead of just term ID.
* Note: Existing functionality was to use `/jobs/?search_category=7` to pre-select category by term ID. I used the same field (instead of the one in the issue) and allowed it to be a comma separated list of IDs and/or slugs. For example: `/jobs/?search_category=7,nice-category,okay` should select the category with term ID 7 and slugs `nice-category` and `okay` (if they have jobs in them).

#### Testing instructions:

* Enable categories with multiple select in WPJM settings (should work without multiple select, but will just take the first one listed probably).
* Add categories and published/accepted jobs in those categories.
* Using the `search_category` query variable, use a combination of the term ID or slug to pre-select the categories on the filter form.
* Verify the terms are selected.