### PR TITLE
Properly format file extensions that were separated by pipes in upload error message

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1293,13 +1293,14 @@ function job_manager_upload_file( $file, $args = array() ) {
 		return $file;
 	}
 
+	$allowed_file_extensions = implode( ', ', str_replace( '|', ', ', array_keys( $allowed_mime_types ) ) );
 	if ( ! in_array( $file['type'], $allowed_mime_types, true ) ) {
 		if ( $args['file_label'] ) {
 			// translators: %1$s is the file field label; %2$s is the file type; %3$s is the list of allowed file types.
 			return new WP_Error( 'upload', sprintf( __( '"%1$s" (filetype %2$s) needs to be one of the following file types: %3$s', 'wp-job-manager' ), $args['file_label'], $file['type'], implode( ', ', array_keys( $allowed_mime_types ) ) ) );
 		} else {
 			// translators: %s is the list of allowed file types.
-			return new WP_Error( 'upload', sprintf( __( 'Uploaded files need to be one of the following file types: %s', 'wp-job-manager' ), implode( ', ', array_keys( $allowed_mime_types ) ) ) );
+			return new WP_Error( 'upload', sprintf( __( 'Uploaded files need to be one of the following file types: %s', 'wp-job-manager' ), $allowed_file_extensions ) );
 		}
 	} else {
 		$upload = wp_handle_upload( $file, apply_filters( 'submit_job_wp_handle_upload_overrides', array( 'test_form' => false ) ) );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1293,11 +1293,13 @@ function job_manager_upload_file( $file, $args = array() ) {
 		return $file;
 	}
 
-	$allowed_file_extensions = implode( ', ', str_replace( '|', ', ', array_keys( $allowed_mime_types ) ) );
 	if ( ! in_array( $file['type'], $allowed_mime_types, true ) ) {
+		// Replace pipe separating similar extensions (e.g. jpeg|jpg) to comma to match the list separator.
+		$allowed_file_extensions = implode( ', ', str_replace( '|', ', ', array_keys( $allowed_mime_types ) ) );
+
 		if ( $args['file_label'] ) {
 			// translators: %1$s is the file field label; %2$s is the file type; %3$s is the list of allowed file types.
-			return new WP_Error( 'upload', sprintf( __( '"%1$s" (filetype %2$s) needs to be one of the following file types: %3$s', 'wp-job-manager' ), $args['file_label'], $file['type'], implode( ', ', array_keys( $allowed_mime_types ) ) ) );
+			return new WP_Error( 'upload', sprintf( __( '"%1$s" (filetype %2$s) needs to be one of the following file types: %3$s', 'wp-job-manager' ), $args['file_label'], $file['type'], $allowed_file_extensions ) );
 		} else {
 			// translators: %s is the list of allowed file types.
 			return new WP_Error( 'upload', sprintf( __( 'Uploaded files need to be one of the following file types: %s', 'wp-job-manager' ), $allowed_file_extensions ) );


### PR DESCRIPTION
Fixes #1479 

#### Changes proposed in this Pull Request:

* Replaces pipes with commas on file extension list when user attempts to upload an unsupported file type.
* Kudos to @tripflex for the patch (in the original issue)

#### Testing instructions:

* Attempt to upload an unsupported file (such as txt) to a file field on the frontend job submission form.
* Error should have file extensions separated by comma.