### PR TITLE
Just return cached results when the fields arg is `id=>parent`

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -179,7 +179,8 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 					&& isset( $cached_query_posts->posts )
 					&& is_array( $cached_query_posts->posts )
 				) {
-					if ( 'ids' === $query_args['fields'] ) {
+					if ( in_array( $query_args['fields'], array( 'ids', 'id=>parent' ), true ) ) {
+						// For these special requests, just return the array of results as set.
 						$posts = $cached_query_posts->posts;
 					} else {
 						$posts = array_map( 'get_post', $cached_query_posts->posts );


### PR DESCRIPTION
Builds off of #1835 to fix #1784

#### Changes proposed in this Pull Request:

* When getting listings via `get_job_listings()` and setting `fields` to either `ids` or `id=>parent`, just return the results as cached.

#### Testing instructions:

* I used this super exciting snippet to test:
```php
add_action( 'wp', function() {
  if ( ! isset( $_GET['debug'] ) ) {
	return;
  }
  
  echo '<pre>';
  var_dump( get_job_listings( [ 'fields' => $_GET['debug'] ] ) );
  exit;
} );
```

I then visited `?debug=ids` and `?debug=id%3D>parent` and verified the `posts` var was set to either an array of ids or an array of `stdClass` with `ID` and `post_parent` vars set. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
