### PR TITLE
Switch to short-array syntax in PHP files

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-email-template.php
+++ b/includes/abstracts/abstract-wp-job-manager-email-template.php
@@ -92,8 +92,8 @@ abstract class WP_Job_Manager_Email_Template extends WP_Job_Manager_Email {
 	 */
 	protected function locate_template( $plain_text ) {
 		$class_name            = get_class( $this );
-		$template_path         = call_user_func( array( $class_name, 'get_template_path' ) );
-		$template_default_path = call_user_func( array( $class_name, 'get_template_default_path' ) );
+		$template_path         = call_user_func( [ $class_name, 'get_template_path' ] );
+		$template_default_path = call_user_func( [ $class_name, 'get_template_default_path' ] );
 		return locate_job_manager_template( $this->get_template_file_name( $plain_text ), $template_path, $template_default_path );
 	}
 
@@ -106,7 +106,7 @@ abstract class WP_Job_Manager_Email_Template extends WP_Job_Manager_Email {
 	protected function get_template_file_name( $plain_text = false ) {
 		$class_name = get_class( $this );
 		// PHP 5.2: Using `call_user_func()` but `$class_name::get_key()` preferred.
-		$email_notification_key = call_user_func( array( $class_name, 'get_key' ) );
+		$email_notification_key = call_user_func( [ $class_name, 'get_key' ] );
 		$template_name          = str_replace( '_', '-', $email_notification_key );
 		return self::generate_template_file_name( $template_name, $plain_text );
 	}
@@ -119,7 +119,7 @@ abstract class WP_Job_Manager_Email_Template extends WP_Job_Manager_Email {
 	 * @return string
 	 */
 	public static function generate_template_file_name( $template_name, $plain_text = false ) {
-		$file_name_parts = array( 'emails' );
+		$file_name_parts = [ 'emails' ];
 		if ( $plain_text ) {
 			$file_name_parts[] = 'plain';
 		}

--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -36,14 +36,14 @@ abstract class WP_Job_Manager_Email {
 	 *
 	 * @var array
 	 */
-	private $args = array();
+	private $args = [];
 
 	/**
 	 * Settings for this email notification.
 	 *
 	 * @var array
 	 */
-	private $settings = array();
+	private $settings = [];
 
 	/**
 	 * WP_Job_Manager_Email constructor.
@@ -161,7 +161,7 @@ abstract class WP_Job_Manager_Email {
 	 * @return array
 	 */
 	public function get_attachments() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -179,7 +179,7 @@ abstract class WP_Job_Manager_Email {
 	 * @return array
 	 */
 	public function get_headers() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -197,7 +197,7 @@ abstract class WP_Job_Manager_Email {
 	 * @return array
 	 */
 	public static function get_setting_fields() {
-		return array();
+		return [];
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -23,7 +23,7 @@ abstract class WP_Job_Manager_Form {
 	 * @access protected
 	 * @var array
 	 */
-	protected $fields = array();
+	protected $fields = [];
 
 	/**
 	 * Form action.
@@ -39,7 +39,7 @@ abstract class WP_Job_Manager_Form {
 	 * @access protected
 	 * @var array
 	 */
-	protected $errors = array();
+	protected $errors = [];
 
 	/**
 	 * Form notices.
@@ -47,7 +47,7 @@ abstract class WP_Job_Manager_Form {
 	 * @access protected
 	 * @var array
 	 */
-	protected $messages = array();
+	protected $messages = [];
 
 	/**
 	 * Form steps.
@@ -55,7 +55,7 @@ abstract class WP_Job_Manager_Form {
 	 * @access protected
 	 * @var array
 	 */
-	protected $steps = array();
+	protected $steps = [];
 
 	/**
 	 * Current form step.
@@ -102,7 +102,7 @@ abstract class WP_Job_Manager_Form {
 			delete_post_meta( sanitize_text_field( wp_unslash( $_COOKIE['wp-job-manager-submitting-job-id'] ) ), '_submitting_key' );
 			setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
 			setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-			wp_safe_redirect( remove_query_arg( array( 'new', 'key' ) ) );
+			wp_safe_redirect( remove_query_arg( [ 'new', 'key' ] ) );
 			exit;
 		}
 
@@ -135,7 +135,7 @@ abstract class WP_Job_Manager_Form {
 	 *
 	 * @param array $atts Attributes to use in the view handler.
 	 */
-	public function output( $atts = array() ) {
+	public function output( $atts = [] ) {
 		$this->enqueue_scripts();
 		$step_key = $this->get_step_key( $this->step );
 		$this->show_errors();
@@ -267,12 +267,12 @@ abstract class WP_Job_Manager_Form {
 	 */
 	public function get_fields( $key ) {
 		if ( empty( $this->fields[ $key ] ) ) {
-			return array();
+			return [];
 		}
 
 		$fields = $this->fields[ $key ];
 
-		uasort( $fields, array( $this, 'sort_by_priority' ) );
+		uasort( $fields, [ $this, 'sort_by_priority' ] );
 
 		return $fields;
 	}
@@ -295,7 +295,7 @@ abstract class WP_Job_Manager_Form {
 	 * Initializes form fields.
 	 */
 	protected function init_fields() {
-		$this->fields = array();
+		$this->fields = [];
 	}
 
 	/**
@@ -304,7 +304,7 @@ abstract class WP_Job_Manager_Form {
 	public function enqueue_scripts() {
 		if ( $this->use_recaptcha_field() ) {
 			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
-			wp_enqueue_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js', array(), false, false );
+			wp_enqueue_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js', [], false, false );
 		}
 	}
 
@@ -341,16 +341,16 @@ abstract class WP_Job_Manager_Form {
 	 * Output the reCAPTCHA field.
 	 */
 	public function display_recaptcha_field() {
-		$field             = array();
+		$field             = [];
 		$field['label']    = get_option( 'job_manager_recaptcha_label' );
 		$field['required'] = true;
 		$field['site_key'] = get_option( 'job_manager_recaptcha_site_key' );
 		get_job_manager_template(
 			'form-fields/recaptcha-field.php',
-			array(
+			[
 				'key'   => 'recaptcha',
 				'field' => $field,
-			)
+			]
 		);
 	}
 
@@ -374,11 +374,11 @@ abstract class WP_Job_Manager_Form {
 		$default_remote_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 		$response            = wp_remote_get(
 			add_query_arg(
-				array(
+				[
 					'secret'   => get_option( 'job_manager_recaptcha_secret_key' ),
 					'response' => $input_recaptcha_response,
 					'remoteip' => isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) : $default_remote_addr,
-				),
+				],
 				'https://www.google.com/recaptcha/api/siteverify'
 			)
 		);
@@ -406,7 +406,7 @@ abstract class WP_Job_Manager_Form {
 	protected function get_posted_fields() {
 		$this->init_fields();
 
-		$values = array();
+		$values = [];
 
 		foreach ( $this->fields as $group_key => $group_fields ) {
 			foreach ( $group_fields as $key => $field ) {
@@ -417,7 +417,7 @@ abstract class WP_Job_Manager_Form {
 				if ( $handler ) {
 					$values[ $group_key ][ $key ] = call_user_func( $handler, $key, $field );
 				} elseif ( method_exists( $this, "get_posted_{$field_type}_field" ) ) {
-					$values[ $group_key ][ $key ] = call_user_func( array( $this, "get_posted_{$field_type}_field" ), $key, $field );
+					$values[ $group_key ][ $key ] = call_user_func( [ $this, "get_posted_{$field_type}_field" ], $key, $field );
 				} else {
 					$values[ $group_key ][ $key ] = $this->get_posted_field( $key, $field );
 				}
@@ -509,7 +509,7 @@ abstract class WP_Job_Manager_Form {
 	 */
 	protected function get_posted_multiselect_field( $key, $field ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
-		return isset( $_POST[ $key ] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST[ $key ] ) ) : array();
+		return isset( $_POST[ $key ] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST[ $key ] ) ) : [];
 	}
 
 	/**
@@ -569,7 +569,7 @@ abstract class WP_Job_Manager_Form {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 			return array_map( 'absint', $_POST['tax_input'][ $field['taxonomy'] ] );
 		} else {
-			return array();
+			return [];
 		}
 	}
 
@@ -582,7 +582,7 @@ abstract class WP_Job_Manager_Form {
 	 */
 	protected function get_posted_term_multiselect_field( $key, $field ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
-		return isset( $_POST[ $key ] ) ? array_map( 'absint', $_POST[ $key ] ) : array();
+		return isset( $_POST[ $key ] ) ? array_map( 'absint', $_POST[ $key ] ) : [];
 	}
 
 	/**
@@ -613,16 +613,16 @@ abstract class WP_Job_Manager_Form {
 				$allowed_mime_types = job_manager_get_allowed_mime_types();
 			}
 
-			$file_urls       = array();
+			$file_urls       = [];
 			$files_to_upload = job_manager_prepare_uploaded_files( $_FILES[ $field_key ] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- see https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1720.
 
 			foreach ( $files_to_upload as $file_to_upload ) {
 				$uploaded_file = job_manager_upload_file(
 					$file_to_upload,
-					array(
+					[
 						'file_key'           => $field_key,
 						'allowed_mime_types' => $allowed_mime_types,
-					)
+					]
 				);
 
 				if ( is_wp_error( $uploaded_file ) ) {

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -50,7 +50,7 @@ class WP_Job_Manager_Addons {
 	 */
 	private function get_add_ons( $category = null ) {
 		$raw_add_ons = wp_remote_get(
-			add_query_arg( array( array( 'category' => $category ) ), self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' )
+			add_query_arg( [ [ 'category' => $category ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' )
 		);
 		if ( ! is_wp_error( $raw_add_ons ) ) {
 			$add_ons = json_decode( wp_remote_retrieve_body( $raw_add_ons ) )->products;
@@ -91,10 +91,10 @@ class WP_Job_Manager_Addons {
 		if ( false === ( $add_on_messages ) ) {
 			$raw_messages = wp_safe_remote_get(
 				add_query_arg(
-					array(
+					[
 						'version' => JOB_MANAGER_VERSION,
 						'lang'    => get_locale(),
-					),
+					],
 					self::WPJM_COM_PRODUCTS_API_BASE_URL . '/messages'
 				)
 			);

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -29,9 +29,9 @@ class WP_Job_Manager_Admin_Notices {
 	 * Initialize admin notice handling.
 	 */
 	public static function init() {
-		add_action( 'job_manager_init_admin_notices', array( __CLASS__, 'init_core_notices' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'display_notices' ) );
-		add_action( 'wp_loaded', array( __CLASS__, 'dismiss_notices' ) );
+		add_action( 'job_manager_init_admin_notices', [ __CLASS__, 'init_core_notices' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'display_notices' ] );
+		add_action( 'wp_loaded', [ __CLASS__, 'dismiss_notices' ] );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class WP_Job_Manager_Admin_Notices {
 	 * Clears all enqueued notices.
 	 */
 	public static function reset_notices() {
-		self::$notice_state = array();
+		self::$notice_state = [];
 		self::save_notice_state();
 	}
 
@@ -97,7 +97,7 @@ class WP_Job_Manager_Admin_Notices {
 	 */
 	public static function init_core_notices() {
 		// core_setup: Notice is used when first activating WP Job Manager.
-		add_action( 'job_manager_admin_notice_' . self::NOTICE_CORE_SETUP, array( __CLASS__, 'display_core_setup' ) );
+		add_action( 'job_manager_admin_notice_' . self::NOTICE_CORE_SETUP, [ __CLASS__, 'display_core_setup' ] );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class WP_Job_Manager_Admin_Notices {
 
 			self::remove_notice( $hide_notice );
 
-			wp_safe_redirect( remove_query_arg( array( 'wpjm_hide_notice', '_wpjm_notice_nonce' ) ) );
+			wp_safe_redirect( remove_query_arg( [ 'wpjm_hide_notice', '_wpjm_notice_nonce' ] ) );
 			exit;
 		}
 	}
@@ -165,17 +165,17 @@ class WP_Job_Manager_Admin_Notices {
 	 * @param array $additional_screens Screen IDs to also show a notice on.
 	 * @return bool
 	 */
-	public static function is_admin_on_standard_job_manager_screen( $additional_screens = array() ) {
+	public static function is_admin_on_standard_job_manager_screen( $additional_screens = [] ) {
 		$screen          = get_current_screen();
 		$screen_id       = $screen ? $screen->id : '';
 		$show_on_screens = array_merge(
-			array(
+			[
 				'edit-job_listing',
 				'edit-job_listing_category',
 				'edit-job_listing_type',
 				'job_listing_page_job-manager-addons',
 				'job_listing_page_job-manager-settings',
-			),
+			],
 			$additional_screens
 		);
 
@@ -196,7 +196,7 @@ class WP_Job_Manager_Admin_Notices {
 	 * Note: For internal use only. Do not call manually.
 	 */
 	public static function display_core_setup() {
-		if ( ! self::is_admin_on_standard_job_manager_screen( array( 'plugins', 'dashboard' ) ) ) {
+		if ( ! self::is_admin_on_standard_job_manager_screen( [ 'plugins', 'dashboard' ] ) ) {
 			return;
 		}
 		include dirname( __FILE__ ) . '/views/html-admin-notice-core-setup.php';
@@ -211,7 +211,7 @@ class WP_Job_Manager_Admin_Notices {
 		if ( null === self::$notice_state ) {
 			self::$notice_state = json_decode( get_option( self::STATE_OPTION, '[]' ), true );
 			if ( ! is_array( self::$notice_state ) ) {
-				self::$notice_state = array();
+				self::$notice_state = [];
 			}
 		}
 		return self::$notice_state;

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -54,10 +54,10 @@ class WP_Job_Manager_Admin {
 
 		$this->settings_page = WP_Job_Manager_Settings::instance();
 
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
-		add_action( 'current_screen', array( $this, 'conditional_includes' ) );
-		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+		add_action( 'admin_init', [ $this, 'admin_init' ] );
+		add_action( 'current_screen', [ $this, 'conditional_includes' ] );
+		add_action( 'admin_menu', [ $this, 'admin_menu' ], 12 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 	}
 
 	/**
@@ -89,54 +89,54 @@ class WP_Job_Manager_Admin {
 		WP_Job_Manager::register_select2_assets();
 
 		$screen = get_current_screen();
-		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', array( 'edit-job_listing', 'plugins', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-addons' ) ), true ) ) {
+		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', [ 'edit-job_listing', 'plugins', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-addons' ] ), true ) ) {
 			wp_enqueue_style( 'jquery-ui' );
 			wp_enqueue_style( 'select2' );
-			wp_enqueue_style( 'job_manager_admin_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/admin.css', array(), JOB_MANAGER_VERSION );
-			wp_register_script( 'jquery-tiptip', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-tiptip/jquery.tipTip.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
-			wp_enqueue_script( 'job_manager_datepicker_js', JOB_MANAGER_PLUGIN_URL . '/assets/js/datepicker.min.js', array( 'jquery', 'jquery-ui-datepicker' ), JOB_MANAGER_VERSION, true );
-			wp_enqueue_script( 'job_manager_admin_js', JOB_MANAGER_PLUGIN_URL . '/assets/js/admin.min.js', array( 'jquery', 'jquery-tiptip', 'select2' ), JOB_MANAGER_VERSION, true );
+			wp_enqueue_style( 'job_manager_admin_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/admin.css', [], JOB_MANAGER_VERSION );
+			wp_register_script( 'jquery-tiptip', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-tiptip/jquery.tipTip.min.js', [ 'jquery' ], JOB_MANAGER_VERSION, true );
+			wp_enqueue_script( 'job_manager_datepicker_js', JOB_MANAGER_PLUGIN_URL . '/assets/js/datepicker.min.js', [ 'jquery', 'jquery-ui-datepicker' ], JOB_MANAGER_VERSION, true );
+			wp_enqueue_script( 'job_manager_admin_js', JOB_MANAGER_PLUGIN_URL . '/assets/js/admin.min.js', [ 'jquery', 'jquery-tiptip', 'select2' ], JOB_MANAGER_VERSION, true );
 
 			wp_localize_script(
 				'job_manager_admin_js',
 				'job_manager_admin_params',
-				array(
-					'user_selection_strings' => array(
+				[
+					'user_selection_strings' => [
 						'no_matches'        => _x( 'No matches found', 'user selection', 'wp-job-manager' ),
 						'ajax_error'        => _x( 'Loading failed', 'user selection', 'wp-job-manager' ),
 						'input_too_short_1' => _x( 'Please enter 1 or more characters', 'user selection', 'wp-job-manager' ),
 						'input_too_short_n' => _x( 'Please enter %qty% or more characters', 'user selection', 'wp-job-manager' ),
 						'load_more'         => _x( 'Loading more results&hellip;', 'user selection', 'wp-job-manager' ),
 						'searching'         => _x( 'Searching&hellip;', 'user selection', 'wp-job-manager' ),
-					),
+					],
 					'ajax_url'               => admin_url( 'admin-ajax.php' ),
 					'search_users_nonce'     => wp_create_nonce( 'search-users' ),
-				)
+				]
 			);
 
 			if ( ! function_exists( 'wp_localize_jquery_ui_datepicker' ) || ! has_action( 'admin_enqueue_scripts', 'wp_localize_jquery_ui_datepicker' ) ) {
 				wp_localize_script(
 					'job_manager_datepicker_js',
 					'job_manager_datepicker',
-					array(
+					[
 						/* translators: jQuery date format, see http://api.jqueryui.com/datepicker/#utility-formatDate */
 						'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker.', 'wp-job-manager' ),
-					)
+					]
 				);
 			}
 		}
 
-		wp_enqueue_style( 'job_manager_admin_menu_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/menu.css', array(), JOB_MANAGER_VERSION );
+		wp_enqueue_style( 'job_manager_admin_menu_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/menu.css', [], JOB_MANAGER_VERSION );
 	}
 
 	/**
 	 * Adds pages to admin menu.
 	 */
 	public function admin_menu() {
-		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), __( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', array( $this->settings_page, 'output' ) );
+		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), __( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', [ $this->settings_page, 'output' ] );
 
 		if ( WP_Job_Manager_Helper::instance()->has_licenced_products() || apply_filters( 'job_manager_show_addons_page', true ) ) {
-			add_submenu_page( 'edit.php?post_type=job_listing', __( 'WP Job Manager Add-ons', 'wp-job-manager' ), __( 'Add-ons', 'wp-job-manager' ), 'manage_options', 'job-manager-addons', array( $this, 'addons_page' ) );
+			add_submenu_page( 'edit.php?post_type=job_listing', __( 'WP Job Manager Add-ons', 'wp-job-manager' ), __( 'Add-ons', 'wp-job-manager' ), 'manage_options', 'job-manager-addons', [ $this, 'addons_page' ] );
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -42,30 +42,30 @@ class WP_Job_Manager_CPT {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'enter_title_here', array( $this, 'enter_title_here' ), 1, 2 );
-		add_filter( 'manage_edit-job_listing_columns', array( $this, 'columns' ) );
-		add_filter( 'list_table_primary_column', array( $this, 'primary_column' ), 10, 2 );
-		add_filter( 'post_row_actions', array( $this, 'row_actions' ) );
-		add_action( 'manage_job_listing_posts_custom_column', array( $this, 'custom_columns' ), 2 );
-		add_filter( 'manage_edit-job_listing_sortable_columns', array( $this, 'sortable_columns' ) );
-		add_filter( 'request', array( $this, 'sort_columns' ) );
-		add_action( 'parse_query', array( $this, 'search_meta' ) );
-		add_action( 'parse_query', array( $this, 'filter_meta' ) );
-		add_filter( 'get_search_query', array( $this, 'search_meta_label' ) );
-		add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
-		add_action( 'bulk_actions-edit-job_listing', array( $this, 'add_bulk_actions' ) );
-		add_action( 'handle_bulk_actions-edit-job_listing', array( $this, 'do_bulk_actions' ), 10, 3 );
-		add_action( 'admin_init', array( $this, 'approve_job' ) );
-		add_action( 'admin_notices', array( $this, 'action_notices' ) );
-		add_action( 'view_mode_post_types', array( $this, 'disable_view_mode' ) );
+		add_filter( 'enter_title_here', [ $this, 'enter_title_here' ], 1, 2 );
+		add_filter( 'manage_edit-job_listing_columns', [ $this, 'columns' ] );
+		add_filter( 'list_table_primary_column', [ $this, 'primary_column' ], 10, 2 );
+		add_filter( 'post_row_actions', [ $this, 'row_actions' ] );
+		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'custom_columns' ], 2 );
+		add_filter( 'manage_edit-job_listing_sortable_columns', [ $this, 'sortable_columns' ] );
+		add_filter( 'request', [ $this, 'sort_columns' ] );
+		add_action( 'parse_query', [ $this, 'search_meta' ] );
+		add_action( 'parse_query', [ $this, 'filter_meta' ] );
+		add_filter( 'get_search_query', [ $this, 'search_meta_label' ] );
+		add_filter( 'post_updated_messages', [ $this, 'post_updated_messages' ] );
+		add_action( 'bulk_actions-edit-job_listing', [ $this, 'add_bulk_actions' ] );
+		add_action( 'handle_bulk_actions-edit-job_listing', [ $this, 'do_bulk_actions' ], 10, 3 );
+		add_action( 'admin_init', [ $this, 'approve_job' ] );
+		add_action( 'admin_notices', [ $this, 'action_notices' ] );
+		add_action( 'view_mode_post_types', [ $this, 'disable_view_mode' ] );
 
 		if ( get_option( 'job_manager_enable_categories' ) ) {
-			add_action( 'restrict_manage_posts', array( $this, 'jobs_by_category' ) );
+			add_action( 'restrict_manage_posts', [ $this, 'jobs_by_category' ] );
 		}
-		add_action( 'restrict_manage_posts', array( $this, 'jobs_meta_filters' ) );
+		add_action( 'restrict_manage_posts', [ $this, 'jobs_meta_filters' ] );
 
-		foreach ( array( 'post', 'post-new' ) as $hook ) {
-			add_action( "admin_footer-{$hook}.php", array( $this, 'extend_submitdiv_post_status' ) );
+		foreach ( [ 'post', 'post-new' ] as $hook ) {
+			add_action( "admin_footer-{$hook}.php", [ $this, 'extend_submitdiv_post_status' ] );
 		}
 	}
 
@@ -75,35 +75,35 @@ class WP_Job_Manager_CPT {
 	 * @return array
 	 */
 	public function get_bulk_actions() {
-		$actions_handled                         = array();
-		$actions_handled['approve_jobs']         = array(
+		$actions_handled                         = [];
+		$actions_handled['approve_jobs']         = [
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'label'   => __( 'Approve %s', 'wp-job-manager' ),
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'notice'  => __( '%s approved', 'wp-job-manager' ),
-			'handler' => array( $this, 'bulk_action_handle_approve_job' ),
-		);
-		$actions_handled['expire_jobs']          = array(
+			'handler' => [ $this, 'bulk_action_handle_approve_job' ],
+		];
+		$actions_handled['expire_jobs']          = [
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'label'   => __( 'Expire %s', 'wp-job-manager' ),
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'notice'  => __( '%s expired', 'wp-job-manager' ),
-			'handler' => array( $this, 'bulk_action_handle_expire_job' ),
-		);
-		$actions_handled['mark_jobs_filled']     = array(
+			'handler' => [ $this, 'bulk_action_handle_expire_job' ],
+		];
+		$actions_handled['mark_jobs_filled']     = [
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'label'   => __( 'Mark %s Filled', 'wp-job-manager' ),
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'notice'  => __( '%s marked as filled', 'wp-job-manager' ),
-			'handler' => array( $this, 'bulk_action_handle_mark_job_filled' ),
-		);
-		$actions_handled['mark_jobs_not_filled'] = array(
+			'handler' => [ $this, 'bulk_action_handle_mark_job_filled' ],
+		];
+		$actions_handled['mark_jobs_not_filled'] = [
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'label'   => __( 'Mark %s Not Filled', 'wp-job-manager' ),
 			// translators: Placeholder (%s) is the plural name of the job listings post type.
 			'notice'  => __( '%s marked as not filled', 'wp-job-manager' ),
-			'handler' => array( $this, 'bulk_action_handle_mark_job_not_filled' ),
-		);
+			'handler' => [ $this, 'bulk_action_handle_mark_job_not_filled' ],
+		];
 
 		/**
 		 * Filters the bulk actions that can be applied to job listings.
@@ -152,7 +152,7 @@ class WP_Job_Manager_CPT {
 	public function do_bulk_actions( $redirect_url, $action, $post_ids ) {
 		$actions_handled = $this->get_bulk_actions();
 		if ( isset( $actions_handled[ $action ] ) && isset( $actions_handled[ $action ]['handler'] ) ) {
-			$handled_jobs = array();
+			$handled_jobs = [];
 			if ( ! empty( $post_ids ) ) {
 				foreach ( $post_ids as $post_id ) {
 					if (
@@ -176,12 +176,12 @@ class WP_Job_Manager_CPT {
 	 * @return bool
 	 */
 	public function bulk_action_handle_approve_job( $post_id ) {
-		$job_data = array(
+		$job_data = [
 			'ID'          => $post_id,
 			'post_status' => 'publish',
-		);
+		];
 		if (
-			in_array( get_post_status( $post_id ), array( 'pending', 'pending_payment' ), true )
+			in_array( get_post_status( $post_id ), [ 'pending', 'pending_payment' ], true )
 			&& current_user_can( 'publish_post', $post_id )
 			&& wp_update_post( $job_data )
 		) {
@@ -197,10 +197,10 @@ class WP_Job_Manager_CPT {
 	 * @return bool
 	 */
 	public function bulk_action_handle_expire_job( $post_id ) {
-		$job_data = array(
+		$job_data = [
 			'ID'          => $post_id,
 			'post_status' => 'expired',
-		);
+		];
 		if (
 			current_user_can( 'manage_job_listings', $post_id )
 			&& wp_update_post( $job_data )
@@ -254,10 +254,10 @@ class WP_Job_Manager_CPT {
 			&& current_user_can( 'publish_post', absint( $_GET['approve_job'] ) )
 		) {
 			$post_id  = absint( $_GET['approve_job'] );
-			$job_data = array(
+			$job_data = [
 				'ID'          => $post_id,
 				'post_status' => 'publish',
-			);
+			];
 			wp_update_post( $job_data );
 			wp_safe_redirect( remove_query_arg( 'approve_job', add_query_arg( 'handled_jobs', $post_id, add_query_arg( 'action_performed', 'approve_jobs', admin_url( 'edit.php?post_type=job_listing' ) ) ) ) );
 			exit;
@@ -285,7 +285,7 @@ class WP_Job_Manager_CPT {
 			&& isset( $actions_handled[ $action ]['notice'] )
 		) {
 			if ( is_array( $handled_jobs ) ) {
-				$titles = array();
+				$titles = [];
 				foreach ( $handled_jobs as $job_id ) {
 					$titles[] = wpjm_get_the_job_title( $job_id );
 				}
@@ -308,7 +308,7 @@ class WP_Job_Manager_CPT {
 
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-category-walker.php';
 
-		$r                 = array();
+		$r                 = [];
 		$r['taxonomy']     = 'job_listing_category';
 		$r['pad_counts']   = 1;
 		$r['hierarchical'] = 1;
@@ -323,13 +323,13 @@ class WP_Job_Manager_CPT {
 			return;
 		}
 
-		$allowed_html = array(
-			'option' => array(
-				'value'    => array(),
-				'selected' => array(),
-				'class'    => array(),
-			),
-		);
+		$allowed_html = [
+			'option' => [
+				'value'    => [],
+				'selected' => [],
+				'class'    => [],
+			],
+		];
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes or data exposed based on input.
 		$selected_category = isset( $_GET['job_listing_category'] ) ? sanitize_text_field( wp_unslash( $_GET['job_listing_category'] ) ) : '';
@@ -356,39 +356,39 @@ class WP_Job_Manager_CPT {
 		// Filter by Filled.
 		$this->jobs_filter_dropdown(
 			'job_listing_filled',
-			array(
-				array(
+			[
+				[
 					'value' => '',
 					'text'  => __( 'Select Filled', 'wp-job-manager' ),
-				),
-				array(
+				],
+				[
 					'value' => '1',
 					'text'  => __( 'Filled', 'wp-job-manager' ),
-				),
-				array(
+				],
+				[
 					'value' => '0',
 					'text'  => __( 'Not Filled', 'wp-job-manager' ),
-				),
-			)
+				],
+			]
 		);
 
 		// Filter by Featured.
 		$this->jobs_filter_dropdown(
 			'job_listing_featured',
-			array(
-				array(
+			[
+				[
 					'value' => '',
 					'text'  => __( 'Select Featured', 'wp-job-manager' ),
-				),
-				array(
+				],
+				[
 					'value' => '1',
 					'text'  => __( 'Featured', 'wp-job-manager' ),
-				),
-				array(
+				],
+				[
 					'value' => '0',
 					'text'  => __( 'Not Featured', 'wp-job-manager' ),
-				),
-			)
+				],
+			]
 		);
 	}
 
@@ -449,7 +449,7 @@ class WP_Job_Manager_CPT {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes based on input.
 		$revision_title = isset( $_GET['revision'] ) ? wp_post_revision_title( (int) $_GET['revision'], false ) : false;
 
-		$messages['job_listing'] = array(
+		$messages['job_listing'] = [
 			0  => '',
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 			1  => sprintf( __( '%1$s updated. <a href="%2$s">View</a>', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, esc_url( get_permalink( $post_ID ) ) ),
@@ -474,7 +474,7 @@ class WP_Job_Manager_CPT {
 			),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 			10 => sprintf( __( '%1$s draft updated. <a target="_blank" href="%2$s">Preview</a>', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
-		);
+		];
 
 		return $messages;
 	}
@@ -487,7 +487,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function columns( $columns ) {
 		if ( ! is_array( $columns ) ) {
-			$columns = array();
+			$columns = [];
 		}
 
 		unset( $columns['title'], $columns['date'], $columns['author'] );
@@ -540,7 +540,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function row_actions( $actions ) {
 		if ( 'job_listing' === get_post_type() ) {
-			return array();
+			return [];
 		}
 		return $actions;
 	}
@@ -624,36 +624,36 @@ class WP_Job_Manager_CPT {
 				break;
 			case 'job_actions':
 				echo '<div class="actions">';
-				$admin_actions = apply_filters( 'post_row_actions', array(), $post );
+				$admin_actions = apply_filters( 'post_row_actions', [], $post );
 
-				if ( in_array( $post->post_status, array( 'pending', 'pending_payment' ), true ) && current_user_can( 'publish_post', $post->ID ) ) {
-					$admin_actions['approve'] = array(
+				if ( in_array( $post->post_status, [ 'pending', 'pending_payment' ], true ) && current_user_can( 'publish_post', $post->ID ) ) {
+					$admin_actions['approve'] = [
 						'action' => 'approve',
 						'name'   => __( 'Approve', 'wp-job-manager' ),
 						'url'    => wp_nonce_url( add_query_arg( 'approve_job', $post->ID ), 'approve_job' ),
-					);
+					];
 				}
 				if ( 'trash' !== $post->post_status ) {
 					if ( current_user_can( 'read_post', $post->ID ) ) {
-						$admin_actions['view'] = array(
+						$admin_actions['view'] = [
 							'action' => 'view',
 							'name'   => __( 'View', 'wp-job-manager' ),
 							'url'    => get_permalink( $post->ID ),
-						);
+						];
 					}
 					if ( current_user_can( 'edit_post', $post->ID ) ) {
-						$admin_actions['edit'] = array(
+						$admin_actions['edit'] = [
 							'action' => 'edit',
 							'name'   => __( 'Edit', 'wp-job-manager' ),
 							'url'    => get_edit_post_link( $post->ID ),
-						);
+						];
 					}
 					if ( current_user_can( 'delete_post', $post->ID ) ) {
-						$admin_actions['delete'] = array(
+						$admin_actions['delete'] = [
 							'action' => 'delete',
 							'name'   => __( 'Delete', 'wp-job-manager' ),
 							'url'    => get_delete_post_link( $post->ID ),
-						);
+						];
 					}
 				}
 
@@ -680,12 +680,12 @@ class WP_Job_Manager_CPT {
 	 * @return array
 	 */
 	public function sortable_columns( $columns ) {
-		$custom = array(
+		$custom = [
 			'job_posted'   => 'date',
 			'job_position' => 'title',
 			'job_location' => 'job_location',
 			'job_expires'  => 'job_expires',
-		);
+		];
 		return wp_parse_args( $custom, $columns );
 	}
 
@@ -700,18 +700,18 @@ class WP_Job_Manager_CPT {
 			if ( 'job_expires' === $vars['orderby'] ) {
 				$vars = array_merge(
 					$vars,
-					array(
+					[
 						'meta_key' => '_job_expires',
 						'orderby'  => 'meta_value',
-					)
+					]
 				);
 			} elseif ( 'job_location' === $vars['orderby'] ) {
 				$vars = array_merge(
 					$vars,
-					array(
+					[
 						'meta_key' => '_job_location',
 						'orderby'  => 'meta_value',
-					)
+					]
 				);
 			}
 		}
@@ -752,7 +752,7 @@ class WP_Job_Manager_CPT {
 						'%' . $wpdb->esc_like( $wp->query_vars['s'] ) . '%'
 					)
 				),
-				array( 0 )
+				[ 0 ]
 			)
 		);
 
@@ -781,23 +781,23 @@ class WP_Job_Manager_CPT {
 
 		$meta_query = $wp->get( 'meta_query' );
 		if ( ! is_array( $meta_query ) ) {
-			$meta_query = array();
+			$meta_query = [];
 		}
 
 		// Filter on _filled meta.
 		if ( false !== $input_job_listing_filled ) {
-			$meta_query[] = array(
+			$meta_query[] = [
 				'key'   => '_filled',
 				'value' => $input_job_listing_filled,
-			);
+			];
 		}
 
 		// Filter on _featured meta.
 		if ( false !== $input_job_listing_featured ) {
-			$meta_query[] = array(
+			$meta_query[] = [
 				'key'   => '_featured',
 				'value' => $input_job_listing_featured,
-			);
+			];
 		}
 
 		// Set new meta query.

--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -30,7 +30,7 @@ class WP_Job_Manager_Permalink_Settings {
 	 * @var array
 	 * @since 1.27.0
 	 */
-	private $permalinks = array();
+	private $permalinks = [];
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -62,21 +62,21 @@ class WP_Job_Manager_Permalink_Settings {
 		add_settings_field(
 			'wpjm_job_base_slug',
 			__( 'Job base', 'wp-job-manager' ),
-			array( $this, 'job_base_slug_input' ),
+			[ $this, 'job_base_slug_input' ],
 			'permalink',
 			'optional'
 		);
 		add_settings_field(
 			'wpjm_job_category_slug',
 			__( 'Job category base', 'wp-job-manager' ),
-			array( $this, 'job_category_slug_input' ),
+			[ $this, 'job_category_slug_input' ],
 			'permalink',
 			'optional'
 		);
 		add_settings_field(
 			'wpjm_job_type_slug',
 			__( 'Job type base', 'wp-job-manager' ),
-			array( $this, 'job_type_slug_input' ),
+			[ $this, 'job_type_slug_input' ],
 			'permalink',
 			'optional'
 		);
@@ -84,7 +84,7 @@ class WP_Job_Manager_Permalink_Settings {
 			add_settings_field(
 				'wpjm_job_listings_archive_slug',
 				__( 'Job listing archive page', 'wp-job-manager' ),
-				array( $this, 'job_listings_archive_slug_input' ),
+				[ $this, 'job_listings_archive_slug_input' ],
 				'permalink',
 				'optional'
 			);

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -29,7 +29,7 @@ class WP_Job_Manager_Settings {
 	 *
 	 * @var array Settings.
 	 */
-	protected $settings = array();
+	protected $settings = [];
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
@@ -50,7 +50,7 @@ class WP_Job_Manager_Settings {
 	 */
 	public function __construct() {
 		$this->settings_group = 'job_manager';
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class WP_Job_Manager_Settings {
 	protected function init_settings() {
 		// Prepare roles option.
 		$roles         = get_editable_roles();
-		$account_roles = array();
+		$account_roles = [];
 
 		foreach ( $roles as $key => $role ) {
 			if ( 'administrator' === $key ) {
@@ -84,294 +84,294 @@ class WP_Job_Manager_Settings {
 
 		$this->settings = apply_filters(
 			'job_manager_settings',
-			array(
-				'general'        => array(
+			[
+				'general'        => [
 					__( 'General', 'wp-job-manager' ),
-					array(
-						array(
+					[
+						[
 							'name'    => 'job_manager_date_format',
 							'std'     => 'relative',
 							'label'   => __( 'Date Format', 'wp-job-manager' ),
 							'desc'    => __( 'Choose how you want the published date for jobs to be displayed on the front-end.', 'wp-job-manager' ),
 							'type'    => 'radio',
-							'options' => array(
+							'options' => [
 								'relative' => __( 'Relative to the current date (e.g., 1 day, 1 week, 1 month ago)', 'wp-job-manager' ),
 								'default'  => __( 'Default date format as defined in Settings', 'wp-job-manager' ),
-							),
-						),
-						array(
+							],
+						],
+						[
 							'name'       => 'job_manager_google_maps_api_key',
 							'std'        => '',
 							'label'      => __( 'Google Maps API Key', 'wp-job-manager' ),
 							// translators: Placeholder %s is URL to set up a Google Maps API key.
 							'desc'       => sprintf( __( 'Google requires an API key to retrieve location information for job listings. Acquire an API key from the <a href="%s">Google Maps API developer site</a>.', 'wp-job-manager' ), 'https://developers.google.com/maps/documentation/geocoding/get-api-key' ),
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_delete_data_on_uninstall',
 							'std'        => '0',
 							'label'      => __( 'Delete Data On Uninstall', 'wp-job-manager' ),
 							'cb_label'   => __( 'Delete WP Job Manager data when the plugin is deleted. Once removed, this data cannot be restored.', 'wp-job-manager' ),
 							'desc'       => '',
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-					),
-				),
-				'job_listings'   => array(
+							'attributes' => [],
+						],
+					],
+				],
+				'job_listings'   => [
 					__( 'Job Listings', 'wp-job-manager' ),
-					array(
-						array(
+					[
+						[
 							'name'        => 'job_manager_per_page',
 							'std'         => '10',
 							'placeholder' => '',
 							'label'       => __( 'Listings Per Page', 'wp-job-manager' ),
 							'desc'        => __( 'Number of job listings to display per page.', 'wp-job-manager' ),
-							'attributes'  => array(),
-						),
-						array(
+							'attributes'  => [],
+						],
+						[
 							'name'       => 'job_manager_hide_filled_positions',
 							'std'        => '0',
 							'label'      => __( 'Filled Positions', 'wp-job-manager' ),
 							'cb_label'   => __( 'Hide filled positions', 'wp-job-manager' ),
 							'desc'       => __( 'Filled positions will not display in your archives.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_hide_expired',
 							'std'        => get_option( 'job_manager_hide_expired_content' ) ? '1' : '0', // back compat.
 							'label'      => __( 'Hide Expired Listings', 'wp-job-manager' ),
 							'cb_label'   => __( 'Hide expired listings in job archives/search', 'wp-job-manager' ),
 							'desc'       => __( 'Expired job listings will not be searchable.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_hide_expired_content',
 							'std'        => '1',
 							'label'      => __( 'Hide Expired Listings Content', 'wp-job-manager' ),
 							'cb_label'   => __( 'Hide content in expired single job listings', 'wp-job-manager' ),
 							'desc'       => __( 'Your site will display the titles of expired listings, but not the content of the listings. Otherwise, expired listings display their full content minus the application area.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_enable_categories',
 							'std'        => '0',
 							'label'      => __( 'Categories', 'wp-job-manager' ),
 							'cb_label'   => __( 'Enable listing categories', 'wp-job-manager' ),
 							'desc'       => __( 'This lets users select from a list of categories when submitting a job. Note: an admin has to create categories before site users can select them.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_enable_default_category_multiselect',
 							'std'        => '0',
 							'label'      => __( 'Multi-select Categories', 'wp-job-manager' ),
 							'cb_label'   => __( 'Default to category multiselect', 'wp-job-manager' ),
 							'desc'       => __( 'The category selection box will default to allowing multiple selections on the [jobs] shortcode. Without this, visitors will only be able to select a single category when filtering jobs.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'    => 'job_manager_category_filter_type',
 							'std'     => 'any',
 							'label'   => __( 'Category Filter Type', 'wp-job-manager' ),
 							'desc'    => __( 'Determines the logic used to display jobs when selecting multiple categories.', 'wp-job-manager' ),
 							'type'    => 'radio',
-							'options' => array(
+							'options' => [
 								'any' => __( 'Jobs will be shown if within ANY selected category', 'wp-job-manager' ),
 								'all' => __( 'Jobs will be shown if within ALL selected categories', 'wp-job-manager' ),
-							),
-						),
-						array(
+							],
+						],
+						[
 							'name'       => 'job_manager_enable_types',
 							'std'        => '1',
 							'label'      => __( 'Types', 'wp-job-manager' ),
 							'cb_label'   => __( 'Enable listing types', 'wp-job-manager' ),
 							'desc'       => __( 'This lets users select from a list of types when submitting a job. Note: an admin has to create types before site users can select them.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_multi_job_type',
 							'std'        => '0',
 							'label'      => __( 'Multi-select Listing Types', 'wp-job-manager' ),
 							'cb_label'   => __( 'Allow multiple types for listings', 'wp-job-manager' ),
 							'desc'       => __( 'This allows users to select more than one type when submitting a job. The metabox on the post editor and the selection box on the front-end job submission form will both reflect this.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-					),
-				),
-				'job_submission' => array(
+							'attributes' => [],
+						],
+					],
+				],
+				'job_submission' => [
 					__( 'Job Submission', 'wp-job-manager' ),
-					array(
-						array(
+					[
+						[
 							'name'       => 'job_manager_user_requires_account',
 							'std'        => '1',
 							'label'      => __( 'Account Required', 'wp-job-manager' ),
 							'cb_label'   => __( 'Require an account to submit listings', 'wp-job-manager' ),
 							'desc'       => __( 'Limits job listing submissions to registered, logged-in users.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_enable_registration',
 							'std'        => '1',
 							'label'      => __( 'Account Creation', 'wp-job-manager' ),
 							'cb_label'   => __( 'Enable account creation during submission', 'wp-job-manager' ),
 							'desc'       => __( 'Includes account creation on the listing submission form, to allow non-registered users to create an account and submit a job listing simultaneously.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_generate_username_from_email',
 							'std'        => '1',
 							'label'      => __( 'Account Username', 'wp-job-manager' ),
 							'cb_label'   => __( 'Generate usernames from email addresses', 'wp-job-manager' ),
 							'desc'       => __( 'Automatically generates usernames for new accounts from the registrant\'s email address. If this is not enabled, a "username" field will display instead.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_use_standard_password_setup_email',
 							'std'        => '1',
 							'label'      => __( 'Account Password', 'wp-job-manager' ),
 							'cb_label'   => __( 'Email new users a link to set a password', 'wp-job-manager' ),
 							'desc'       => __( 'Sends an email to the user with their username and a link to set their password. If this is not enabled, a "password" field will display instead, and their email address won\'t be verified.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'    => 'job_manager_registration_role',
 							'std'     => 'employer',
 							'label'   => __( 'Account Role', 'wp-job-manager' ),
 							'desc'    => __( 'Any new accounts created during submission will have this role. If you haven\'t enabled account creation during submission in the options above, your own method of assigning roles will apply.', 'wp-job-manager' ),
 							'type'    => 'select',
 							'options' => $account_roles,
-						),
-						array(
+						],
+						[
 							'name'       => 'job_manager_submission_requires_approval',
 							'std'        => '1',
 							'label'      => __( 'Moderate New Listings', 'wp-job-manager' ),
 							'cb_label'   => __( 'Require admin approval of all new listing submissions', 'wp-job-manager' ),
 							'desc'       => __( 'Sets all new submissions to "pending." They will not appear on your site until an admin approves them.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_user_can_edit_pending_submissions',
 							'std'        => '0',
 							'label'      => __( 'Allow Pending Edits', 'wp-job-manager' ),
 							'cb_label'   => __( 'Allow editing of pending listings', 'wp-job-manager' ),
 							'desc'       => __( 'Users can continue to edit pending listings until they are approved by an admin.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_user_edit_published_submissions',
 							'std'        => 'yes',
 							'label'      => __( 'Allow Published Edits', 'wp-job-manager' ),
 							'cb_label'   => __( 'Allow editing of published listings', 'wp-job-manager' ),
 							'desc'       => __( 'Choose whether published job listings can be edited and if edits require admin approval. When moderation is required, the original job listings will be unpublished while edits await admin approval.', 'wp-job-manager' ),
 							'type'       => 'radio',
-							'options'    => array(
+							'options'    => [
 								'no'            => __( 'Users cannot edit', 'wp-job-manager' ),
 								'yes'           => __( 'Users can edit without admin approval', 'wp-job-manager' ),
 								'yes_moderated' => __( 'Users can edit, but edits require admin approval', 'wp-job-manager' ),
-							),
-							'attributes' => array(),
-						),
-						array(
+							],
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_submission_duration',
 							'std'        => '30',
 							'label'      => __( 'Listing Duration', 'wp-job-manager' ),
 							'desc'       => __( 'Listings will display for the set number of days, then expire. Leave this field blank if you don\'t want listings to have an expiration date.', 'wp-job-manager' ),
-							'attributes' => array(),
-						),
-						array(
+							'attributes' => [],
+						],
+						[
 							'name'    => 'job_manager_allowed_application_method',
 							'std'     => '',
 							'label'   => __( 'Application Method', 'wp-job-manager' ),
 							'desc'    => __( 'Choose the application method job listers will need to provide. Specify URL or email address only, or allow listers to choose which they prefer.', 'wp-job-manager' ),
 							'type'    => 'radio',
-							'options' => array(
+							'options' => [
 								''      => __( 'Email address or website URL', 'wp-job-manager' ),
 								'email' => __( 'Email addresses only', 'wp-job-manager' ),
 								'url'   => __( 'Website URLs only', 'wp-job-manager' ),
-							),
-						),
-					),
-				),
-				'recaptcha'      => array(
+							],
+						],
+					],
+				],
+				'recaptcha'      => [
 					__( 'reCAPTCHA', 'wp-job-manager' ),
-					array(
-						array(
+					[
+						[
 							'name'        => 'job_manager_recaptcha_label',
 							'std'         => __( 'Are you human?', 'wp-job-manager' ),
 							'placeholder' => '',
 							'label'       => __( 'Field Label', 'wp-job-manager' ),
 							'desc'        => __( 'The label used for the reCAPTCHA field on forms.', 'wp-job-manager' ),
-							'attributes'  => array(),
-						),
-						array(
+							'attributes'  => [],
+						],
+						[
 							'name'        => 'job_manager_recaptcha_site_key',
 							'std'         => '',
 							'placeholder' => '',
 							'label'       => __( 'Site Key', 'wp-job-manager' ),
 							// translators: Placeholder %s is URL to set up Google reCAPTCHA API key.
 							'desc'        => sprintf( __( 'You can retrieve your site key from <a href="%s">Google\'s reCAPTCHA admin dashboard</a>.', 'wp-job-manager' ), 'https://www.google.com/recaptcha/admin#list' ),
-							'attributes'  => array(),
-						),
-						array(
+							'attributes'  => [],
+						],
+						[
 							'name'        => 'job_manager_recaptcha_secret_key',
 							'std'         => '',
 							'placeholder' => '',
 							'label'       => __( 'Secret Key', 'wp-job-manager' ),
 							// translators: Placeholder %s is URL to set up Google reCAPTCHA API key.
 							'desc'        => sprintf( __( 'You can retrieve your secret key from <a href="%s">Google\'s reCAPTCHA admin dashboard</a>.', 'wp-job-manager' ), 'https://www.google.com/recaptcha/admin#list' ),
-							'attributes'  => array(),
-						),
-						array(
+							'attributes'  => [],
+						],
+						[
 							'name'       => 'job_manager_enable_recaptcha_job_submission',
 							'std'        => '0',
 							'label'      => __( 'Job Submission Form', 'wp-job-manager' ),
 							'cb_label'   => __( 'Display a reCAPTCHA field on job submission form.', 'wp-job-manager' ),
 							'desc'       => sprintf( __( 'This will help prevent bots from submitting job listings. You must have entered a valid site key and secret key above.', 'wp-job-manager' ), 'https://www.google.com/recaptcha/admin#list' ),
 							'type'       => 'checkbox',
-							'attributes' => array(),
-						),
-					),
-				),
-				'job_pages'      => array(
+							'attributes' => [],
+						],
+					],
+				],
+				'job_pages'      => [
 					__( 'Pages', 'wp-job-manager' ),
-					array(
-						array(
+					[
+						[
 							'name'  => 'job_manager_submit_job_form_page_id',
 							'std'   => '',
 							'label' => __( 'Submit Job Form Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page where you\'ve used the [submit_job_form] shortcode. This lets the plugin know the location of the form.', 'wp-job-manager' ),
 							'type'  => 'page',
-						),
-						array(
+						],
+						[
 							'name'  => 'job_manager_job_dashboard_page_id',
 							'std'   => '',
 							'label' => __( 'Job Dashboard Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page where you\'ve used the [job_dashboard] shortcode. This lets the plugin know the location of the dashboard.', 'wp-job-manager' ),
 							'type'  => 'page',
-						),
-						array(
+						],
+						[
 							'name'  => 'job_manager_jobs_page_id',
 							'std'   => '',
 							'label' => __( 'Job Listings Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page where you\'ve used the [jobs] shortcode. This lets the plugin know the location of the job listings page.', 'wp-job-manager' ),
 							'type'  => 'page',
-						),
-					),
-				),
-			)
+						],
+					],
+				],
+			]
 		);
 	}
 
@@ -418,7 +418,7 @@ class WP_Job_Manager_Settings {
 				}
 
 				foreach ( $this->settings as $key => $section ) {
-					$section_args = isset( $section[2] ) ? (array) $section[2] : array();
+					$section_args = isset( $section[2] ) ? (array) $section[2] : [];
 					echo '<div id="settings-' . esc_attr( sanitize_title( $key ) ) . '" class="settings_panel">';
 					if ( ! empty( $section_args['before'] ) ) {
 						echo '<p class="before-settings">' . wp_kses_post( $section_args['before'] ) . '</p>';
@@ -625,7 +625,7 @@ class WP_Job_Manager_Settings {
 	 * @param string $ignored_placeholder
 	 */
 	protected function input_page( $option, $ignored_attributes, $value, $ignored_placeholder ) {
-		$args = array(
+		$args = [
 			'name'             => $option['name'],
 			'id'               => $option['name'],
 			'sort_column'      => 'menu_order',
@@ -633,7 +633,7 @@ class WP_Job_Manager_Settings {
 			'show_option_none' => __( '--no page--', 'wp-job-manager' ),
 			'echo'             => false,
 			'selected'         => absint( $value ),
-		);
+		];
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe output.
 		echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'wp-job-manager' ) . "' id=", wp_dropdown_pages( $args ) );
@@ -768,7 +768,7 @@ class WP_Job_Manager_Settings {
 		$placeholder    = ( ! empty( $option['placeholder'] ) ) ? 'placeholder="' . esc_attr( $option['placeholder'] ) . '"' : '';
 		$class          = ! empty( $option['class'] ) ? $option['class'] : '';
 		$option['type'] = ! empty( $option['type'] ) ? $option['type'] : 'text';
-		$attributes     = array();
+		$attributes     = [];
 		if ( ! empty( $option['attributes'] ) && is_array( $option['attributes'] ) ) {
 			foreach ( $option['attributes'] as $attribute_name => $attribute_value ) {
 				$attributes[] = esc_attr( $attribute_name ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -815,7 +815,7 @@ class WP_Job_Manager_Settings {
 		$enable_option               = $option['enable_field'];
 		$enable_option['name']       = $option['name'] . '[' . $enable_option['name'] . ']';
 		$enable_option['type']       = 'checkbox';
-		$enable_option['attributes'] = array( 'class="sub-settings-expander"' );
+		$enable_option['attributes'] = [ 'class="sub-settings-expander"' ];
 		$this->input_checkbox( $enable_option, $enable_option['attributes'], $values[ $option['enable_field']['name'] ], null );
 
 		echo '<div class="sub-settings-expandable">';

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -42,12 +42,12 @@ class WP_Job_Manager_Setup {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'admin_menu' ), 12 );
-		add_action( 'admin_head', array( $this, 'admin_head' ) );
+		add_action( 'admin_menu', [ $this, 'admin_menu' ], 12 );
+		add_action( 'admin_head', [ $this, 'admin_head' ] );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 12 );
+			add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ], 12 );
 		}
 	}
 
@@ -55,7 +55,7 @@ class WP_Job_Manager_Setup {
 	 * Adds setup link to admin dashboard menu briefly so the page callback is registered.
 	 */
 	public function admin_menu() {
-		add_dashboard_page( __( 'Setup', 'wp-job-manager' ), __( 'Setup', 'wp-job-manager' ), 'manage_options', 'job-manager-setup', array( $this, 'setup_page' ) );
+		add_dashboard_page( __( 'Setup', 'wp-job-manager' ), __( 'Setup', 'wp-job-manager' ), 'manage_options', 'job-manager-setup', [ $this, 'setup_page' ] );
 	}
 
 	/**
@@ -69,7 +69,7 @@ class WP_Job_Manager_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'job_manager_setup_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/setup.css', array( 'dashicons' ), JOB_MANAGER_VERSION );
+		wp_enqueue_style( 'job_manager_setup_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/setup.css', [ 'dashicons' ], JOB_MANAGER_VERSION );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class WP_Job_Manager_Setup {
 	 * @param  string $option
 	 */
 	public function create_page( $title, $content, $option ) {
-		$page_data = array(
+		$page_data = [
 			'post_status'    => 'publish',
 			'post_type'      => 'page',
 			'post_author'    => 1,
@@ -89,7 +89,7 @@ class WP_Job_Manager_Setup {
 			'post_content'   => $content,
 			'post_parent'    => 0,
 			'comment_status' => 'closed',
-		);
+		];
 		$page_id   = wp_insert_post( $page_data );
 
 		if ( $option ) {
@@ -125,13 +125,13 @@ class WP_Job_Manager_Setup {
 				) {
 					wp_die( 'Error in nonce. Try again.', 'wp-job-manager' );
 				}
-				$create_pages    = isset( $_POST['wp-job-manager-create-page'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-create-page'] ) ) : array();
-				$page_titles     = isset( $_POST['wp-job-manager-page-title'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-page-title'] ) ) : array();
-				$pages_to_create = array(
+				$create_pages    = isset( $_POST['wp-job-manager-create-page'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-create-page'] ) ) : [];
+				$page_titles     = isset( $_POST['wp-job-manager-page-title'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wp-job-manager-page-title'] ) ) : [];
+				$pages_to_create = [
 					'submit_job_form' => '[submit_job_form]',
 					'job_dashboard'   => '[job_dashboard]',
 					'jobs'            => '[jobs]',
-				);
+				];
 
 				foreach ( $pages_to_create as $page => $content ) {
 					if ( ! isset( $create_pages[ $page ] ) || empty( $page_titles[ $page ] ) ) {

--- a/includes/admin/class-wp-job-manager-taxonomy-meta.php
+++ b/includes/admin/class-wp-job-manager-taxonomy-meta.php
@@ -42,13 +42,13 @@ class WP_Job_Manager_Taxonomy_Meta {
 	 */
 	public function __construct() {
 		if ( wpjm_job_listing_employment_type_enabled() ) {
-			add_action( 'job_listing_type_edit_form_fields', array( $this, 'display_schema_org_employment_type_field' ), 10, 2 );
-			add_action( 'job_listing_type_add_form_fields', array( $this, 'add_form_display_schema_org_employment_type_field' ), 10 );
-			add_action( 'edited_job_listing_type', array( $this, 'set_schema_org_employment_type_field' ), 10, 2 );
-			add_action( 'created_job_listing_type', array( $this, 'set_schema_org_employment_type_field' ), 10, 2 );
-			add_filter( 'manage_edit-job_listing_type_columns', array( $this, 'add_employment_type_column' ) );
-			add_filter( 'manage_job_listing_type_custom_column', array( $this, 'add_employment_type_column_content' ), 10, 3 );
-			add_filter( 'manage_edit-job_listing_type_sortable_columns', array( $this, 'add_employment_type_column_sortable' ) );
+			add_action( 'job_listing_type_edit_form_fields', [ $this, 'display_schema_org_employment_type_field' ], 10, 2 );
+			add_action( 'job_listing_type_add_form_fields', [ $this, 'add_form_display_schema_org_employment_type_field' ], 10 );
+			add_action( 'edited_job_listing_type', [ $this, 'set_schema_org_employment_type_field' ], 10, 2 );
+			add_action( 'created_job_listing_type', [ $this, 'set_schema_org_employment_type_field' ], 10, 2 );
+			add_filter( 'manage_edit-job_listing_type_columns', [ $this, 'add_employment_type_column' ] );
+			add_filter( 'manage_job_listing_type_custom_column', [ $this, 'add_employment_type_column_content' ], 10, 3 );
+			add_filter( 'manage_edit-job_listing_type_sortable_columns', [ $this, 'add_employment_type_column_sortable' ] );
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -42,9 +42,9 @@ class WP_Job_Manager_Writepanels {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
-		add_action( 'save_post', array( $this, 'save_post' ), 1, 2 );
-		add_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20, 2 );
+		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
+		add_action( 'save_post', [ $this, 'save_post' ], 1, 2 );
+		add_action( 'job_manager_save_job_listing', [ $this, 'save_job_listing_data' ], 20, 2 );
 	}
 
 	/**
@@ -57,14 +57,14 @@ class WP_Job_Manager_Writepanels {
 
 		$current_user = wp_get_current_user();
 		$fields_raw   = WP_Job_Manager_Post_Types::get_job_listing_fields();
-		$fields       = array();
+		$fields       = [];
 
 		if ( $current_user->has_cap( 'edit_others_job_listings' ) ) {
-			$fields['_job_author'] = array(
+			$fields['_job_author'] = [
 				'label'    => __( 'Posted by', 'wp-job-manager' ),
 				'type'     => 'author',
 				'priority' => 0,
-			);
+			];
 		}
 
 		foreach ( $fields_raw as $meta_key => $field ) {
@@ -120,7 +120,7 @@ class WP_Job_Manager_Writepanels {
 		 */
 		$fields = apply_filters( 'job_manager_job_listing_wp_admin_fields', $fields, $post_id );
 
-		uasort( $fields, array( __CLASS__, 'sort_by_priority' ) );
+		uasort( $fields, [ __CLASS__, 'sort_by_priority' ] );
 
 		return $fields;
 	}
@@ -147,13 +147,13 @@ class WP_Job_Manager_Writepanels {
 		global $wp_post_types;
 
 		// translators: Placeholder %s is the singular name for a job listing post type.
-		add_meta_box( 'job_listing_data', sprintf( __( '%s Data', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name ), array( $this, 'job_listing_data' ), 'job_listing', 'normal', 'high' );
+		add_meta_box( 'job_listing_data', sprintf( __( '%s Data', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name ), [ $this, 'job_listing_data' ], 'job_listing', 'normal', 'high' );
 		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( 'job_listing_type' ) ) ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side' );
 		} elseif ( false === job_manager_multi_job_type() ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side' );
 			$job_listing_type = get_taxonomy( 'job_listing_type' );
-			add_meta_box( 'job_listing_type', $job_listing_type->labels->menu_name, array( $this, 'job_type_single_meta_box' ), 'job_listing', 'side', 'core' );
+			add_meta_box( 'job_listing_type', $job_listing_type->labels->menu_name, [ $this, 'job_type_single_meta_box' ], 'job_listing', 'side', 'core' );
 		}
 	}
 
@@ -168,10 +168,10 @@ class WP_Job_Manager_Writepanels {
 
 		// Get all the terms for this taxonomy.
 		$terms     = get_terms(
-			array(
+			[
 				'taxonomy'   => $taxonomy_name,
 				'hide_empty' => 0,
-			)
+			]
 		);
 		$postterms = get_the_terms( $post->ID, $taxonomy_name );
 		$current   = $postterms ? array_pop( $postterms ) : false;
@@ -255,7 +255,7 @@ class WP_Job_Manager_Writepanels {
 			$name = $key;
 		}
 		if ( ! empty( $field['classes'] ) ) {
-			$classes = implode( ' ', is_array( $field['classes'] ) ? $field['classes'] : array( $field['classes'] ) );
+			$classes = implode( ' ', is_array( $field['classes'] ) ? $field['classes'] : [ $field['classes'] ] );
 		} else {
 			$classes = '';
 		}
@@ -298,7 +298,7 @@ class WP_Job_Manager_Writepanels {
 			$name = $key;
 		}
 		if ( ! empty( $field['classes'] ) ) {
-			$classes = implode( ' ', is_array( $field['classes'] ) ? $field['classes'] : array( $field['classes'] ) );
+			$classes = implode( ' ', is_array( $field['classes'] ) ? $field['classes'] : [ $field['classes'] ] );
 		} else {
 			$classes = '';
 		}
@@ -316,7 +316,7 @@ class WP_Job_Manager_Writepanels {
 			<?php endif; ?>
 			</label>
 			<?php if ( ! empty( $field['information'] ) ) : ?>
-				<span class="information"><?php echo wp_kses( $field['information'], array( 'a' => array( 'href' => array() ) ) ); ?></span>
+				<span class="information"><?php echo wp_kses( $field['information'], [ 'a' => [ 'href' => [] ] ] ); ?></span>
 			<?php endif; ?>
 			<?php echo '<input type="hidden" name="' . esc_attr( $name ) . '" class="' . esc_attr( $classes ) . '" id="' . esc_attr( $key ) . '" value="' . esc_attr( $field['value'] ) . '" />'; ?>
 		</p>
@@ -545,7 +545,7 @@ class WP_Job_Manager_Writepanels {
 			if ( has_action( 'job_manager_input_' . $type ) ) {
 				do_action( 'job_manager_input_' . $type, $key, $field );
 			} elseif ( method_exists( $this, 'input_' . $type ) ) {
-				call_user_func( array( $this, 'input_' . $type ), $key, $field );
+				call_user_func( [ $this, 'input_' . $type ], $key, $field );
 			}
 		}
 
@@ -649,7 +649,7 @@ class WP_Job_Manager_Writepanels {
 				$input_post_author = $_POST[ $key ] > 0 ? intval( $_POST[ $key ] ) : 0;
 
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Avoid update post within `save_post` action.
-				$wpdb->update( $wpdb->posts, array( 'post_author' => $input_post_author ), array( 'ID' => $post_id ) );
+				$wpdb->update( $wpdb->posts, [ 'post_author' => $input_post_author ], [ 'ID' => $post_id ] );
 			} elseif ( isset( $_POST[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing -- Input sanitized in registered post meta config; see WP_Job_Manager_Post_Types::register_meta_fields() and WP_Job_Manager_Post_Types::get_job_listing_fields() methods.
 				update_post_meta( $post_id, $key, wp_unslash( $_POST[ $key ] ) );
@@ -661,17 +661,17 @@ class WP_Job_Manager_Writepanels {
 		$today_date             = date( 'Y-m-d', current_time( 'timestamp' ) );
 		$is_job_listing_expired = $expiry_date && $today_date > $expiry_date;
 		if ( $is_job_listing_expired && ! $this->is_job_listing_status_changing( null, 'draft' ) ) {
-			remove_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20 );
+			remove_action( 'job_manager_save_job_listing', [ $this, 'save_job_listing_data' ], 20 );
 			if ( $this->is_job_listing_status_changing( 'expired', 'publish' ) ) {
 				update_post_meta( $post_id, '_job_expires', calculate_job_expiry( $post_id ) );
 			} else {
-				$job_data = array(
+				$job_data = [
 					'ID'          => $post_id,
 					'post_status' => 'expired',
-				);
+				];
 				wp_update_post( $job_data );
 			}
-			add_action( 'job_manager_save_job_listing', array( $this, 'save_job_listing_data' ), 20, 2 );
+			add_action( 'job_manager_save_job_listing', [ $this, 'save_job_listing_data' ], 20, 2 );
 		}
 	}
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -17,11 +17,11 @@ if ( ! empty( $messages ) ) {
 		}
 		$message_type = 'info';
 		if ( isset( $message->type )
-		&& in_array( $message->type, array( 'info', 'success', 'warning', 'error' ), true ) ) {
+		&& in_array( $message->type, [ 'info', 'success', 'warning', 'error' ], true ) ) {
 			$message_type = $message->type;
 		}
 		$action_label  = isset( $message->action_label ) ? esc_attr( $message->action_label ) : __( 'More Information &rarr;', 'wp-job-manager' );
-		$action_url    = isset( $message->action_url ) ? esc_url( $message->action_url, array( 'http', 'https' ) ) : false;
+		$action_url    = isset( $message->action_url ) ? esc_url( $message->action_url, [ 'http', 'https' ] ) : false;
 		$action_target = isset( $message->action_target ) && 'self' === $message->action_target ? '_self' : '_blank';
 		$action_str    = '';
 		if ( $action_url ) {
@@ -56,17 +56,17 @@ if ( empty( $add_ons ) ) {
 	echo '<ul class="products">';
 	foreach ( $add_ons as $add_on ) {
 		$url = add_query_arg(
-			array(
+			[
 				'utm_source'   => 'product',
 				'utm_medium'   => 'addonpage',
 				'utm_campaign' => 'wpjmplugin',
 				'utm_content'  => 'listing',
-			),
+			],
 			$add_on->link
 		);
 		?>
 		<li class="product">
-			<a href="<?php echo esc_url( $url, array( 'http', 'https' ) ); ?>">
+			<a href="<?php echo esc_url( $url, [ 'http', 'https' ] ); ?>">
 				<?php if ( ! empty( $add_on->image ) ) : ?>
 					<img src="<?php echo esc_url( $add_on->image ); ?>" />
 				<?php endif; ?>

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -42,19 +42,19 @@ class WP_Job_Manager_Ajax {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', array( __CLASS__, 'add_endpoint' ) );
-		add_action( 'template_redirect', array( __CLASS__, 'do_jm_ajax' ), 0 );
+		add_action( 'init', [ __CLASS__, 'add_endpoint' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'do_jm_ajax' ], 0 );
 
 		// JM Ajax endpoints.
-		add_action( 'job_manager_ajax_get_listings', array( $this, 'get_listings' ) );
-		add_action( 'job_manager_ajax_upload_file', array( $this, 'upload_file' ) );
+		add_action( 'job_manager_ajax_get_listings', [ $this, 'get_listings' ] );
+		add_action( 'job_manager_ajax_upload_file', [ $this, 'upload_file' ] );
 
 		// BW compatible handlers.
-		add_action( 'wp_ajax_nopriv_job_manager_get_listings', array( $this, 'get_listings' ) );
-		add_action( 'wp_ajax_job_manager_get_listings', array( $this, 'get_listings' ) );
-		add_action( 'wp_ajax_nopriv_job_manager_upload_file', array( $this, 'upload_file' ) );
-		add_action( 'wp_ajax_job_manager_upload_file', array( $this, 'upload_file' ) );
-		add_action( 'wp_ajax_job_manager_search_users', array( $this, 'ajax_search_users' ) );
+		add_action( 'wp_ajax_nopriv_job_manager_get_listings', [ $this, 'get_listings' ] );
+		add_action( 'wp_ajax_job_manager_get_listings', [ $this, 'get_listings' ] );
+		add_action( 'wp_ajax_nopriv_job_manager_upload_file', [ $this, 'upload_file' ] );
+		add_action( 'wp_ajax_job_manager_upload_file', [ $this, 'upload_file' ] );
+		add_action( 'wp_ajax_job_manager_search_users', [ $this, 'ajax_search_users' ] );
 	}
 
 	/**
@@ -138,23 +138,23 @@ class WP_Job_Manager_Ajax {
 		if ( is_array( $search_categories ) ) {
 			$search_categories = array_filter( array_map( 'sanitize_text_field', array_map( 'stripslashes', $search_categories ) ) );
 		} else {
-			$search_categories = array_filter( array( sanitize_text_field( wp_unslash( $search_categories ) ) ) );
+			$search_categories = array_filter( [ sanitize_text_field( wp_unslash( $search_categories ) ) ] );
 		}
 
 		$types              = get_job_listing_types();
 		$job_types_filtered = ! is_null( $filter_job_types ) && count( $types ) !== count( $filter_job_types );
 
-		$args = array(
+		$args = [
 			'search_location'   => $search_location,
 			'search_keywords'   => $search_keywords,
 			'search_categories' => $search_categories,
-			'job_types'         => is_null( $filter_job_types ) || count( $types ) === count( $filter_job_types ) ? '' : $filter_job_types + array( 0 ),
+			'job_types'         => is_null( $filter_job_types ) || count( $types ) === count( $filter_job_types ) ? '' : $filter_job_types + [ 0 ],
 			'post_status'       => $filter_post_status,
 			'orderby'           => $orderby,
 			'order'             => $order,
 			'offset'            => ( $page - 1 ) * $per_page,
 			'posts_per_page'    => max( 1, $per_page ),
-		);
+		];
 
 		if ( 'true' === $filled || 'false' === $filled ) {
 			$args['filled'] = 'true' === $filled;
@@ -174,11 +174,11 @@ class WP_Job_Manager_Ajax {
 		 */
 		$jobs = get_job_listings( apply_filters( 'job_manager_get_listings_args', $args ) );
 
-		$result = array(
+		$result = [
 			'found_jobs'    => $jobs->have_posts(),
 			'showing'       => '',
 			'max_num_pages' => $jobs->max_num_pages,
-		);
+		];
 
 		if ( $jobs->post_count && ( $search_location || $search_keywords || $search_categories || $job_types_filtered ) ) {
 			// translators: Placeholder %d is the number of found search results.
@@ -188,11 +188,11 @@ class WP_Job_Manager_Ajax {
 			$message = '';
 		}
 
-		$search_values = array(
+		$search_values = [
 			'location'   => $search_location,
 			'keywords'   => $search_keywords,
 			'categories' => $search_categories,
-		);
+		];
 
 		/**
 		 * Filter the message that describes the results of the search query.
@@ -212,12 +212,12 @@ class WP_Job_Manager_Ajax {
 
 		// Generate RSS link.
 		$result['showing_links'] = job_manager_get_filtered_links(
-			array(
+			[
 				'filter_job_types'  => $filter_job_types,
 				'search_location'   => $search_location,
 				'search_categories' => $search_categories,
 				'search_keywords'   => $search_keywords,
-			)
+			]
 		);
 
 		/**
@@ -283,9 +283,9 @@ class WP_Job_Manager_Ajax {
 			wp_send_json_error( __( 'You must be logged in to upload files using this method.', 'wp-job-manager' ) );
 			return;
 		}
-		$data = array(
-			'files' => array(),
-		);
+		$data = [
+			'files' => [],
+		];
 
 		if ( ! empty( $_FILES ) ) {
 			foreach ( $_FILES as $file_key => $file ) {
@@ -293,15 +293,15 @@ class WP_Job_Manager_Ajax {
 				foreach ( $files_to_upload as $file_to_upload ) {
 					$uploaded_file = job_manager_upload_file(
 						$file_to_upload,
-						array(
+						[
 							'file_key' => $file_key,
-						)
+						]
 					);
 
 					if ( is_wp_error( $uploaded_file ) ) {
-						$data['files'][] = array(
+						$data['files'][] = [
 							'error' => $uploaded_file->get_error_message(),
-						);
+						];
 					} else {
 						$data['files'][] = $uploaded_file;
 					}
@@ -327,7 +327,7 @@ class WP_Job_Manager_Ajax {
 		 *
 		 * @param array $user_caps Array of capabilities/roles that are allowed to search for users.
 		 */
-		$allowed_capabilities = apply_filters( 'job_manager_caps_can_search_users', array( 'edit_job_listings' ) );
+		$allowed_capabilities = apply_filters( 'job_manager_caps_can_search_users', [ 'edit_job_listings' ] );
 		foreach ( $allowed_capabilities as $cap ) {
 			if ( current_user_can( $cap ) ) {
 				$user_can_search_users = true;
@@ -359,7 +359,7 @@ class WP_Job_Manager_Ajax {
 		$page     = isset( $_GET['page'] ) ? intval( $_GET['page'] ) : 1;
 		$per_page = 20;
 
-		$exclude = array();
+		$exclude = [];
 		if ( ! empty( $_GET['exclude'] ) ) {
 			$exclude = array_map( 'intval', $_GET['exclude'] );
 		}
@@ -369,7 +369,7 @@ class WP_Job_Manager_Ajax {
 		}
 
 		$more_exist = false;
-		$users      = array();
+		$users      = [];
 
 		// Search by ID.
 		if ( is_numeric( $term ) && ! in_array( intval( $term ), $exclude, true ) ) {
@@ -380,15 +380,15 @@ class WP_Job_Manager_Ajax {
 		}
 
 		if ( empty( $users ) ) {
-			$search_args = array(
+			$search_args = [
 				'exclude'        => $exclude,
 				'search'         => '*' . esc_attr( $term ) . '*',
-				'search_columns' => array( 'user_login', 'user_email', 'user_nicename', 'display_name' ),
+				'search_columns' => [ 'user_login', 'user_email', 'user_nicename', 'display_name' ],
 				'number'         => $per_page,
 				'paged'          => $page,
 				'orderby'        => 'display_name',
 				'order'          => 'ASC',
-			);
+			];
 
 			/**
 			 * Modify the arguments used for `WP_User_Query` constructor.
@@ -410,7 +410,7 @@ class WP_Job_Manager_Ajax {
 			$more_exist  = $total_pages > $page;
 		}
 
-		$found_users = array();
+		$found_users = [];
 
 		foreach ( $users as $user ) {
 			$found_users[ $user->ID ] = sprintf(
@@ -422,10 +422,10 @@ class WP_Job_Manager_Ajax {
 			);
 		}
 
-		$response = array(
+		$response = [
 			'results' => $found_users,
 			'more'    => $more_exist,
-		);
+		];
 
 		/**
 		 * Modify the search results response for users in ajax call.

--- a/includes/class-wp-job-manager-api.php
+++ b/includes/class-wp-job-manager-api.php
@@ -43,8 +43,8 @@ class WP_Job_Manager_API {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
-		add_action( 'parse_request', array( $this, 'api_requests' ), 0 );
+		add_filter( 'query_vars', [ $this, 'add_query_vars' ], 0 );
+		add_action( 'parse_request', [ $this, 'api_requests' ], 0 );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-blocks.php
+++ b/includes/class-wp-job-manager-blocks.php
@@ -42,7 +42,7 @@ class WP_Job_Manager_Blocks {
 			return;
 		}
 
-		add_action( 'init', array( $this, 'register_blocks' ) );
+		add_action( 'init', [ $this, 'register_blocks' ] );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -21,15 +21,15 @@ class WP_Job_Manager_Cache_Helper {
 	 * Initializes cache hooks.
 	 */
 	public static function init() {
-		add_action( 'save_post', array( __CLASS__, 'flush_get_job_listings_cache' ) );
-		add_action( 'delete_post', array( __CLASS__, 'flush_get_job_listings_cache' ) );
-		add_action( 'trash_post', array( __CLASS__, 'flush_get_job_listings_cache' ) );
-		add_action( 'job_manager_my_job_do_action', array( __CLASS__, 'job_manager_my_job_do_action' ) );
-		add_action( 'set_object_terms', array( __CLASS__, 'set_term' ), 10, 4 );
-		add_action( 'edited_term', array( __CLASS__, 'edited_term' ), 10, 3 );
-		add_action( 'create_term', array( __CLASS__, 'edited_term' ), 10, 3 );
-		add_action( 'delete_term', array( __CLASS__, 'edited_term' ), 10, 3 );
-		add_action( 'transition_post_status', array( __CLASS__, 'maybe_clear_count_transients' ), 10, 3 );
+		add_action( 'save_post', [ __CLASS__, 'flush_get_job_listings_cache' ] );
+		add_action( 'delete_post', [ __CLASS__, 'flush_get_job_listings_cache' ] );
+		add_action( 'trash_post', [ __CLASS__, 'flush_get_job_listings_cache' ] );
+		add_action( 'job_manager_my_job_do_action', [ __CLASS__, 'job_manager_my_job_do_action' ] );
+		add_action( 'set_object_terms', [ __CLASS__, 'set_term' ], 10, 4 );
+		add_action( 'edited_term', [ __CLASS__, 'edited_term' ], 10, 3 );
+		add_action( 'create_term', [ __CLASS__, 'edited_term' ], 10, 3 );
+		add_action( 'delete_term', [ __CLASS__, 'edited_term' ], 10, 3 );
+		add_action( 'transition_post_status', [ __CLASS__, 'maybe_clear_count_transients' ], 10, 3 );
 	}
 
 	/**
@@ -155,7 +155,7 @@ class WP_Job_Manager_Cache_Helper {
 		 * @param string  $old_status Old post status.
 		 * @param WP_Post $post       Post object.
 		 */
-		$post_types = apply_filters( 'wpjm_count_cache_supported_post_types', array( 'job_listing' ), $new_status, $old_status, $post );
+		$post_types = apply_filters( 'wpjm_count_cache_supported_post_types', [ 'job_listing' ], $new_status, $old_status, $post );
 
 		// Only proceed when statuses do not match, and post type is supported post type.
 		if ( $new_status === $old_status || ! in_array( $post->post_type, $post_types, true ) ) {
@@ -172,9 +172,9 @@ class WP_Job_Manager_Cache_Helper {
 		 * @param string  $old_status    Old post status.
 		 * @param WP_Post $post          Post object.
 		 */
-		$valid_statuses = apply_filters( 'wpjm_count_cache_supported_statuses', array( 'pending' ), $new_status, $old_status, $post );
+		$valid_statuses = apply_filters( 'wpjm_count_cache_supported_statuses', [ 'pending' ], $new_status, $old_status, $post );
 
-		$rlike = array();
+		$rlike = [];
 		// New status transient option name.
 		if ( in_array( $new_status, $valid_statuses, true ) ) {
 			$rlike[] = "^_transient_jm_{$new_status}_{$post->post_type}_count_user_";

--- a/includes/class-wp-job-manager-category-walker.php
+++ b/includes/class-wp-job-manager-category-walker.php
@@ -30,11 +30,11 @@ class WP_Job_Manager_Category_Walker extends Walker {
 	 *
 	 * @var array
 	 */
-	public $db_fields = array(
+	public $db_fields = [
 		'parent' => 'parent',
 		'id'     => 'term_id',
 		'slug'   => 'slug',
-	);
+	];
 
 	/**
 	 * Start the list walker.
@@ -48,7 +48,7 @@ class WP_Job_Manager_Category_Walker extends Walker {
 	 * @param array  $args
 	 * @param int    $current_object_id
 	 */
-	public function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
+	public function start_el( &$output, $object, $depth = 0, $args = [], $current_object_id = 0 ) {
 
 		if ( ! empty( $args['hierarchical'] ) ) {
 			$pad = str_repeat( '&nbsp;', $depth * 3 );

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -22,25 +22,25 @@ class WP_Job_Manager_Data_Cleaner {
 	 *
 	 * @var $custom_post_types
 	 */
-	private static $custom_post_types = array(
+	private static $custom_post_types = [
 		'job_listing',
-	);
+	];
 
 	/**
 	 * Taxonomies to be deleted.
 	 *
 	 * @var $taxonomies
 	 */
-	private static $taxonomies = array(
+	private static $taxonomies = [
 		'job_listing_category',
 		'job_listing_type',
-	);
+	];
 
 	/** Cron jobs to be unscheduled.
 	 *
 	 * @var $cron_jobs
 	 */
-	private static $cron_jobs = array(
+	private static $cron_jobs = [
 		'job_manager_check_for_expired_jobs',
 		'job_manager_delete_old_previews',
 		'job_manager_email_daily_notices',
@@ -48,14 +48,14 @@ class WP_Job_Manager_Data_Cleaner {
 
 		// Old cron jobs.
 		'job_manager_clear_expired_transients',
-	);
+	];
 
 	/**
 	 * Options to be deleted.
 	 *
 	 * @var $options
 	 */
-	private static $options = array(
+	private static $options = [
 		'wp_job_manager_version',
 		'job_manager_installed_terms',
 		'wpjm_permalinks',
@@ -101,16 +101,16 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_admin_notices',
 		'widget_widget_featured_jobs',
 		'widget_widget_recent_jobs',
-	);
+	];
 
 	/**
 	 * Site options to be deleted.
 	 *
 	 * @var $site_options
 	 */
-	private static $site_options = array(
+	private static $site_options = [
 		'job_manager_helper',
-	);
+	];
 
 	/**
 	 * Transient names (as MySQL regexes) to be deleted. The prefixes
@@ -118,11 +118,11 @@ class WP_Job_Manager_Data_Cleaner {
 	 *
 	 * @var $transients
 	 */
-	private static $transients = array(
+	private static $transients = [
 		'_job_manager_activation_redirect', // Legacy transient that should still be removed.
 		'get_job_listings-transient-version',
 		'jm_.*',
-	);
+	];
 
 	/**
 	 * Role to be removed.
@@ -136,7 +136,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 *
 	 * @var $caps
 	 */
-	private static $caps = array(
+	private static $caps = [
 		'manage_job_listings',
 		'edit_job_listing',
 		'read_job_listing',
@@ -155,21 +155,21 @@ class WP_Job_Manager_Data_Cleaner {
 		'edit_job_listing_terms',
 		'delete_job_listing_terms',
 		'assign_job_listing_terms',
-	);
+	];
 
 	/**
 	 * User meta key names to be deleted.
 	 *
 	 * @var array $user_meta_keys
 	 */
-	private static $user_meta_keys = array(
+	private static $user_meta_keys = [
 		'_company_logo',
 		'_company_name',
 		'_company_website',
 		'_company_tagline',
 		'_company_twitter',
 		'_company_video',
-	);
+	];
 
 	/**
 	 * Cleanup all data.
@@ -196,12 +196,12 @@ class WP_Job_Manager_Data_Cleaner {
 	private static function cleanup_custom_post_types() {
 		foreach ( self::$custom_post_types as $post_type ) {
 			$items = get_posts(
-				array(
+				[
 					'post_type'   => $post_type,
 					'post_status' => 'any',
 					'numberposts' => -1,
 					'fields'      => 'ids',
-				)
+				]
 			);
 
 			foreach ( $items as $item ) {
@@ -230,10 +230,10 @@ class WP_Job_Manager_Data_Cleaner {
 
 			// Delete all data for each term.
 			foreach ( $terms as $term ) {
-				$wpdb->delete( $wpdb->term_relationships, array( 'term_taxonomy_id' => $term->term_taxonomy_id ) );
-				$wpdb->delete( $wpdb->term_taxonomy, array( 'term_taxonomy_id' => $term->term_taxonomy_id ) );
-				$wpdb->delete( $wpdb->terms, array( 'term_id' => $term->term_id ) );
-				$wpdb->delete( $wpdb->termmeta, array( 'term_id' => $term->term_id ) );
+				$wpdb->delete( $wpdb->term_relationships, [ 'term_taxonomy_id' => $term->term_taxonomy_id ] );
+				$wpdb->delete( $wpdb->term_taxonomy, [ 'term_taxonomy_id' => $term->term_taxonomy_id ] );
+				$wpdb->delete( $wpdb->terms, [ 'term_id' => $term->term_id ] );
+				$wpdb->delete( $wpdb->termmeta, [ 'term_id' => $term->term_id ] );
 			}
 
 			if ( function_exists( 'clean_taxonomy_cache' ) ) {
@@ -302,7 +302,7 @@ class WP_Job_Manager_Data_Cleaner {
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		foreach ( array( '_transient_', '_transient_timeout_' ) as $prefix ) {
+		foreach ( [ '_transient_', '_transient_timeout_' ] as $prefix ) {
 			foreach ( self::$transients as $transient ) {
 				$wpdb->query(
 					$wpdb->prepare(
@@ -332,7 +332,7 @@ class WP_Job_Manager_Data_Cleaner {
 		}
 
 		// Remove caps and role from users.
-		$users = get_users( array() );
+		$users = get_users( [] );
 		foreach ( $users as $user ) {
 			self::remove_all_job_manager_caps( $user );
 			$user->remove_role( self::$role );
@@ -363,7 +363,7 @@ class WP_Job_Manager_Data_Cleaner {
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery -- Delete data across all users.
-			$wpdb->delete( $wpdb->usermeta, array( 'meta_key' => $meta_key ) );
+			$wpdb->delete( $wpdb->usermeta, [ 'meta_key' => $meta_key ] );
 			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 		}
 	}

--- a/includes/class-wp-job-manager-data-exporter.php
+++ b/includes/class-wp-job-manager-data-exporter.php
@@ -23,10 +23,10 @@ class WP_Job_Manager_Data_Exporter {
 	 * @return array $exporters The exporter array.
 	 */
 	public static function register_wpjm_user_data_exporter( $exporters ) {
-		$exporters['wp-job-manager'] = array(
+		$exporters['wp-job-manager'] = [
 			'exporter_friendly_name' => __( 'WP Job Manager', 'wp-job-manager' ),
-			'callback'               => array( __CLASS__, 'user_data_exporter' ),
-		);
+			'callback'               => [ __CLASS__, 'user_data_exporter' ],
+		];
 		return $exporters;
 	}
 
@@ -37,24 +37,24 @@ class WP_Job_Manager_Data_Exporter {
 	 * @return array
 	 */
 	public static function user_data_exporter( $email_address ) {
-		$export_items = array();
+		$export_items = [];
 		$user         = get_user_by( 'email', $email_address );
 		if ( false === $user ) {
-			return array(
+			return [
 				'data' => $export_items,
 				'done' => true,
-			);
+			];
 		}
 
-		$user_data_to_export = array();
-		$user_meta_keys      = array(
+		$user_data_to_export = [];
+		$user_meta_keys      = [
 			'_company_logo'    => __( 'Company Logo', 'wp-job-manager' ),
 			'_company_name'    => __( 'Company Name', 'wp-job-manager' ),
 			'_company_website' => __( 'Company Website', 'wp-job-manager' ),
 			'_company_tagline' => __( 'Company Tagline', 'wp-job-manager' ),
 			'_company_twitter' => __( 'Company Twitter', 'wp-job-manager' ),
 			'_company_video'   => __( 'Company Video', 'wp-job-manager' ),
-		);
+		];
 
 		foreach ( $user_meta_keys as $user_meta_key => $name ) {
 			$user_meta = get_user_meta( $user->ID, $user_meta_key, true );
@@ -70,22 +70,22 @@ class WP_Job_Manager_Data_Exporter {
 				}
 			}
 
-			$user_data_to_export[] = array(
+			$user_data_to_export[] = [
 				'name'  => $name,
 				'value' => $user_meta,
-			);
+			];
 		}
 
-		$export_items[] = array(
+		$export_items[] = [
 			'group_id'    => 'wpjm-user-data',
 			'group_label' => __( 'WP Job Manager User Data', 'wp-job-manager' ),
 			'item_id'     => "wpjm-user-data-{$user->ID}",
 			'data'        => $user_data_to_export,
-		);
+		];
 
-		return array(
+		return [
 			'data' => $export_items,
 			'done' => true,
-		);
+		];
 	}
 }

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -24,7 +24,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 *
 	 * @var array
 	 */
-	private static $deferred_notifications = array();
+	private static $deferred_notifications = [];
 
 	/**
 	 * Sets up initial hooks.
@@ -32,16 +32,16 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @static
 	 */
 	public static function init() {
-		add_action( 'job_manager_send_notification', array( __CLASS__, 'schedule_notification' ), 10, 2 );
-		add_action( 'job_manager_email_init', array( __CLASS__, 'lazy_init' ) );
-		add_action( 'job_manager_email_job_details', array( __CLASS__, 'output_job_details' ), 10, 4 );
-		add_action( 'job_manager_email_header', array( __CLASS__, 'output_header' ), 10, 3 );
-		add_action( 'job_manager_email_footer', array( __CLASS__, 'output_footer' ), 10, 3 );
-		add_action( 'job_manager_email_daily_notices', array( __CLASS__, 'send_employer_expiring_notice' ) );
-		add_action( 'job_manager_email_daily_notices', array( __CLASS__, 'send_admin_expiring_notice' ) );
-		add_filter( 'job_manager_settings', array( __CLASS__, 'add_job_manager_email_settings' ), 1 );
-		add_action( 'job_manager_job_submitted', array( __CLASS__, 'send_new_job_notification' ) );
-		add_action( 'job_manager_user_edit_job_listing', array( __CLASS__, 'send_updated_job_notification' ) );
+		add_action( 'job_manager_send_notification', [ __CLASS__, 'schedule_notification' ], 10, 2 );
+		add_action( 'job_manager_email_init', [ __CLASS__, 'lazy_init' ] );
+		add_action( 'job_manager_email_job_details', [ __CLASS__, 'output_job_details' ], 10, 4 );
+		add_action( 'job_manager_email_header', [ __CLASS__, 'output_header' ], 10, 3 );
+		add_action( 'job_manager_email_footer', [ __CLASS__, 'output_footer' ], 10, 3 );
+		add_action( 'job_manager_email_daily_notices', [ __CLASS__, 'send_employer_expiring_notice' ] );
+		add_action( 'job_manager_email_daily_notices', [ __CLASS__, 'send_admin_expiring_notice' ] );
+		add_filter( 'job_manager_settings', [ __CLASS__, 'add_job_manager_email_settings' ], 1 );
+		add_action( 'job_manager_job_submitted', [ __CLASS__, 'send_new_job_notification' ] );
+		add_action( 'job_manager_user_edit_job_listing', [ __CLASS__, 'send_updated_job_notification' ] );
 	}
 
 	/**
@@ -50,12 +50,12 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @return array
 	 */
 	public static function core_email_notifications() {
-		return array(
+		return [
 			'WP_Job_Manager_Email_Admin_New_Job',
 			'WP_Job_Manager_Email_Admin_Updated_Job',
 			'WP_Job_Manager_Email_Admin_Expiring_Job',
 			'WP_Job_Manager_Email_Employer_Expiring_Job',
-		);
+		];
 	}
 
 	/**
@@ -68,10 +68,10 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @param string $notification
 	 * @param array  $args
 	 */
-	public static function schedule_notification( $notification, $args = array() ) {
+	public static function schedule_notification( $notification, $args = [] ) {
 		self::maybe_init();
 
-		self::$deferred_notifications[] = array( $notification, $args );
+		self::$deferred_notifications[] = [ $notification, $args ];
 	}
 
 	/**
@@ -93,7 +93,7 @@ final class WP_Job_Manager_Email_Notifications {
 
 			$email_class            = $email_notifications[ $email[0] ];
 			$email_notification_key = $email[0];
-			$email_args             = is_array( $email[1] ) ? $email[1] : array();
+			$email_args             = is_array( $email[1] ) ? $email[1] : [];
 
 			self::send_email( $email[0], new $email_class( $email_args, self::get_email_settings( $email_notification_key ) ) );
 		}
@@ -122,7 +122,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @access private
 	 */
 	public static function lazy_init() {
-		add_action( 'shutdown', array( __CLASS__, 'send_deferred_notifications' ) );
+		add_action( 'shutdown', [ __CLASS__, 'send_deferred_notifications' ] );
 
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-new-job.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-updated-job.php';
@@ -145,7 +145,7 @@ final class WP_Job_Manager_Email_Notifications {
 		if ( ! defined( 'PHPUNIT_WPJM_TESTSUITE' ) || ! PHPUNIT_WPJM_TESTSUITE ) {
 			die( 'This is just for use while testing' );
 		}
-		self::$deferred_notifications = array();
+		self::$deferred_notifications = [];
 	}
 
 	/**
@@ -165,7 +165,7 @@ final class WP_Job_Manager_Email_Notifications {
 		 * @param array $email_notifications All the email notifications to be registered.
 		 */
 		$email_notification_classes = array_unique( apply_filters( 'job_manager_email_notifications', self::core_email_notifications() ) );
-		$email_notifications        = array();
+		$email_notifications        = [];
 
 		/**
 		 * Email class in loop.
@@ -179,7 +179,7 @@ final class WP_Job_Manager_Email_Notifications {
 			}
 
 			// PHP 5.2: Using `call_user_func()` but `$email_class::get_key()` preferred.
-			$email_notification_key = call_user_func( array( $email_class, 'get_key' ) );
+			$email_notification_key = call_user_func( [ $email_class, 'get_key' ] );
 			if (
 				isset( $email_notifications[ $email_notification_key ] )
 				|| ( $enabled_notifications_only && ! self::is_email_notification_enabled( $email_notification_key ) )
@@ -221,12 +221,12 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @return array
 	 */
 	private static function get_job_detail_fields( WP_Post $job, $sent_to_admin, $plain_text = false ) {
-		$fields = array();
+		$fields = [];
 
-		$fields['job_title'] = array(
+		$fields['job_title'] = [
 			'label' => __( 'Job title', 'wp-job-manager' ),
 			'value' => $job->post_title,
-		);
+		];
 
 		if ( $sent_to_admin || 'publish' === $job->post_status ) {
 			$fields['job_title']['url'] = get_permalink( $job );
@@ -234,65 +234,65 @@ final class WP_Job_Manager_Email_Notifications {
 
 		$job_location = get_the_job_location( $job );
 		if ( ! empty( $job_location ) ) {
-			$fields['job_location'] = array(
+			$fields['job_location'] = [
 				'label' => __( 'Location', 'wp-job-manager' ),
 				'value' => $job_location,
-			);
+			];
 		}
 
 		if ( get_option( 'job_manager_enable_types' ) && wp_count_terms( 'job_listing_type' ) > 0 ) {
 			$job_types = wpjm_get_the_job_types( $job );
 			if ( ! empty( $job_types ) ) {
-				$fields['job_type'] = array(
+				$fields['job_type'] = [
 					'label' => __( 'Job type', 'wp-job-manager' ),
 					'value' => implode( ', ', wp_list_pluck( $job_types, 'name' ) ),
-				);
+				];
 			}
 		}
 
 		if ( get_option( 'job_manager_enable_categories' ) && wp_count_terms( 'job_listing_category' ) > 0 ) {
 			$job_categories = wpjm_get_the_job_categories( $job );
 			if ( ! empty( $job_categories ) ) {
-				$fields['job_category'] = array(
+				$fields['job_category'] = [
 					'label' => __( 'Job category', 'wp-job-manager' ),
 					'value' => implode( ', ', wp_list_pluck( $job_categories, 'name' ) ),
-				);
+				];
 			}
 		}
 
 		$company_name = get_the_company_name( $job );
 		if ( ! empty( $company_name ) ) {
-			$fields['company_name'] = array(
+			$fields['company_name'] = [
 				'label' => __( 'Company name', 'wp-job-manager' ),
 				'value' => $company_name,
-			);
+			];
 		}
 
 		$company_website = get_the_company_website( $job );
 		if ( ! empty( $company_website ) ) {
-			$fields['company_website'] = array(
+			$fields['company_website'] = [
 				'label' => __( 'Company website', 'wp-job-manager' ),
-				'value' => $plain_text ? $company_website : sprintf( '<a href="%1$s">%1$s</a>', esc_url( $company_website, array( 'http', 'https' ) ) ),
-			);
+				'value' => $plain_text ? $company_website : sprintf( '<a href="%1$s">%1$s</a>', esc_url( $company_website, [ 'http', 'https' ] ) ),
+			];
 		}
 
 		$job_expires = get_post_meta( $job->ID, '_job_expires', true );
 		if ( ! empty( $job_expires ) ) {
 			$job_expires_str       = date_i18n( get_option( 'date_format' ), strtotime( $job_expires ) );
-			$fields['job_expires'] = array(
+			$fields['job_expires'] = [
 				'label' => __( 'Listing expires', 'wp-job-manager' ),
 				'value' => $job_expires_str,
-			);
+			];
 		}
 
 		if ( $sent_to_admin ) {
 			$author = get_user_by( 'ID', $job->post_author );
 			if ( $author instanceof WP_User ) {
-				$fields['author'] = array(
+				$fields['author'] = [
 					'label' => __( 'Posted by', 'wp-job-manager' ),
 					'value' => $author->user_nicename,
 					'url'   => 'mailto:' . $author->user_email,
-				);
+				];
 			}
 		}
 
@@ -367,12 +367,12 @@ final class WP_Job_Manager_Email_Notifications {
 			return false;
 		}
 
-		$template_default_path = call_user_func( array( $email_class, 'get_template_default_path' ) );
+		$template_default_path = call_user_func( [ $email_class, 'get_template_default_path' ] );
 		if ( '' === $template_default_path ) {
 			return false;
 		}
 
-		$template_path = call_user_func( array( $email_class, 'get_template_path' ) );
+		$template_path = call_user_func( [ $email_class, 'get_template_path' ] );
 		$template      = self::locate_template_file( $template_name, $plain_text, $template_path, $template_default_path );
 		if ( '' === $template ) {
 			return false;
@@ -413,37 +413,37 @@ final class WP_Job_Manager_Email_Notifications {
 	 */
 	public static function add_email_settings( $settings, $context ) {
 		$email_notifications = self::get_email_notifications( false );
-		$email_settings      = array();
+		$email_settings      = [];
 
 		foreach ( $email_notifications as $email_notification_key => $email_class ) {
-			$email_notification_context = call_user_func( array( $email_class, 'get_context' ) );
+			$email_notification_context = call_user_func( [ $email_class, 'get_context' ] );
 			if ( $context !== $email_notification_context ) {
 				continue;
 			}
 
-			$email_settings[] = array(
+			$email_settings[] = [
 				'type'         => 'multi_enable_expand',
 				'class'        => 'email-setting-row no-separator',
-				'name'         => self::EMAIL_SETTING_PREFIX . call_user_func( array( $email_class, 'get_key' ) ),
-				'enable_field' => array(
+				'name'         => self::EMAIL_SETTING_PREFIX . call_user_func( [ $email_class, 'get_key' ] ),
+				'enable_field' => [
 					'name'     => self::EMAIL_SETTING_ENABLED,
-					'cb_label' => call_user_func( array( $email_class, 'get_name' ) ),
-					'desc'     => call_user_func( array( $email_class, 'get_description' ) ),
-				),
+					'cb_label' => call_user_func( [ $email_class, 'get_name' ] ),
+					'desc'     => call_user_func( [ $email_class, 'get_description' ] ),
+				],
 				'label'        => false,
 				'std'          => self::get_email_setting_defaults( $email_notification_key ),
 				'settings'     => self::get_email_setting_fields( $email_notification_key ),
-			);
+			];
 		}
 
 		if ( ! empty( $email_settings ) ) {
-			$settings['email_notifications'] = array(
+			$settings['email_notifications'] = [
 				__( 'Email Notifications', 'wp-job-manager' ),
 				$email_settings,
-				array(
+				[
 					'before' => __( 'Select the email notifications to enable.', 'wp-job-manager' ),
-				),
-			);
+				],
+			];
 		}
 
 		return $settings;
@@ -529,7 +529,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @param int $job_id
 	 */
 	public static function send_new_job_notification( $job_id ) {
-		do_action( 'job_manager_send_notification', 'admin_new_job', array( 'job_id' => $job_id ) );
+		do_action( 'job_manager_send_notification', 'admin_new_job', [ 'job_id' => $job_id ] );
 	}
 
 	/**
@@ -538,7 +538,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @param int $job_id
 	 */
 	public static function send_updated_job_notification( $job_id ) {
-		do_action( 'job_manager_send_notification', 'admin_updated_job', array( 'job_id' => $job_id ) );
+		do_action( 'job_manager_send_notification', 'admin_updated_job', [ 'job_id' => $job_id ] );
 	}
 
 	/**
@@ -550,23 +550,23 @@ final class WP_Job_Manager_Email_Notifications {
 	private static function send_expiring_notice( $email_notification_key, $days_notice ) {
 		$notice_before_ts = current_time( 'timestamp' ) + ( DAY_IN_SECONDS * $days_notice );
 		$job_ids          = get_posts(
-			array(
+			[
 				'post_type'      => 'job_listing',
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => -1,
-				'meta_query'     => array(
-					array(
+				'meta_query'     => [
+					[
 						'key'   => '_job_expires',
 						'value' => date( 'Y-m-d', $notice_before_ts ),
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		if ( $job_ids ) {
 			foreach ( $job_ids as $job_id ) {
-				do_action( 'job_manager_send_notification', $email_notification_key, array( 'job_id' => $job_id ) );
+				do_action( 'job_manager_send_notification', $email_notification_key, [ 'job_id' => $job_id ] );
 			}
 		}
 	}
@@ -579,19 +579,19 @@ final class WP_Job_Manager_Email_Notifications {
 	 */
 	private static function get_email_setting_fields( $email_notification_key ) {
 		$email_class    = self::get_email_class( $email_notification_key );
-		$core_settings  = array(
-			array(
+		$core_settings  = [
+			[
 				'name'    => 'plain_text',
 				'std'     => '0',
 				'label'   => __( 'Format', 'wp-job-manager' ),
 				'type'    => 'radio',
-				'options' => array(
+				'options' => [
 					'1' => __( 'Send plain text email', 'wp-job-manager' ),
 					'0' => __( 'Send rich text email', 'wp-job-manager' ),
-				),
-			),
-		);
-		$email_settings = call_user_func( array( $email_class, 'get_setting_fields' ) );
+				],
+			],
+		];
+		$email_settings = call_user_func( [ $email_class, 'get_setting_fields' ] );
 		return array_merge( $core_settings, $email_settings );
 	}
 
@@ -605,7 +605,7 @@ final class WP_Job_Manager_Email_Notifications {
 		$option_name  = self::EMAIL_SETTING_PREFIX . $email_notification_key;
 		$option_value = get_option( $option_name );
 		if ( empty( $option_value ) || ! is_array( $option_value ) ) {
-			$option_value = array();
+			$option_value = [];
 		}
 		$default_settings = self::get_email_setting_defaults( $email_notification_key );
 
@@ -622,8 +622,8 @@ final class WP_Job_Manager_Email_Notifications {
 		$settings    = self::get_email_setting_fields( $email_notification_key );
 		$email_class = self::get_email_class( $email_notification_key );
 
-		$defaults                                = array();
-		$defaults[ self::EMAIL_SETTING_ENABLED ] = call_user_func( array( $email_class, 'is_default_enabled' ) ) ? '1' : '0';
+		$defaults                                = [];
+		$defaults[ self::EMAIL_SETTING_ENABLED ] = call_user_func( [ $email_class, 'is_default_enabled' ] ) ? '1' : '0';
 
 		foreach ( $settings as $setting ) {
 			$defaults[ $setting['name'] ] = null;
@@ -691,8 +691,8 @@ final class WP_Job_Manager_Email_Notifications {
 		return is_string( $email_class )
 				&& class_exists( $email_class )
 				&& is_subclass_of( $email_class, 'WP_Job_Manager_Email' )
-				&& false !== call_user_func( array( $email_class, 'get_key' ) )
-				&& false !== call_user_func( array( $email_class, 'get_name' ) );
+				&& false !== call_user_func( [ $email_class, 'get_key' ] )
+				&& false !== call_user_func( [ $email_class, 'get_name' ] );
 	}
 
 	/**
@@ -709,8 +709,8 @@ final class WP_Job_Manager_Email_Notifications {
 			return false;
 		}
 
-		$fields = array( 'to', 'from', 'subject', 'rich_content', 'plain_content', 'attachments', 'cc', 'headers' );
-		$args   = array();
+		$fields = [ 'to', 'from', 'subject', 'rich_content', 'plain_content', 'attachments', 'cc', 'headers' ];
+		$args   = [];
 		foreach ( $fields as $field ) {
 			$method = 'get_' . $field;
 
@@ -725,7 +725,7 @@ final class WP_Job_Manager_Email_Notifications {
 			$args[ $field ] = apply_filters( "job_manager_email_{$email_notification_key}_{$field}", $email->$method(), $email );
 		}
 
-		$headers = is_array( $args['headers'] ) ? $args['headers'] : array();
+		$headers = is_array( $args['headers'] ) ? $args['headers'] : [];
 
 		if ( ! empty( $args['from'] ) ) {
 			$headers[] = 'From: ' . $args['from'];

--- a/includes/class-wp-job-manager-forms.php
+++ b/includes/class-wp-job-manager-forms.php
@@ -42,7 +42,7 @@ class WP_Job_Manager_Forms {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', array( $this, 'load_posted_form' ) );
+		add_action( 'init', [ $this, 'load_posted_form' ] );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class WP_Job_Manager_Forms {
 		$form_file  = JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-' . $form_name . '.php';
 
 		if ( class_exists( $form_class ) ) {
-			return call_user_func( array( $form_class, 'instance' ) );
+			return call_user_func( [ $form_class, 'instance' ] );
 		}
 
 		if ( ! file_exists( $form_file ) ) {
@@ -85,7 +85,7 @@ class WP_Job_Manager_Forms {
 		}
 
 		// Init the form.
-		return call_user_func( array( $form_class, 'instance' ) );
+		return call_user_func( [ $form_class, 'instance' ] );
 	}
 
 	/**
@@ -95,7 +95,7 @@ class WP_Job_Manager_Forms {
 	 * @param array  $atts Optional passed attributes.
 	 * @return string|null
 	 */
-	public function get_form( $form_name, $atts = array() ) {
+	public function get_form( $form_name, $atts = [] ) {
 		$form = $this->load_form_class( $form_name );
 		if ( $form ) {
 			ob_start();

--- a/includes/class-wp-job-manager-geocode.php
+++ b/includes/class-wp-job-manager-geocode.php
@@ -44,10 +44,10 @@ class WP_Job_Manager_Geocode {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'job_manager_geolocation_endpoint', array( $this, 'add_geolocation_endpoint_query_args' ), 0, 2 );
-		add_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 0 );
-		add_action( 'job_manager_update_job_data', array( $this, 'update_location_data' ), 20, 2 );
-		add_action( 'job_manager_job_location_edited', array( $this, 'change_location_data' ), 20, 2 );
+		add_filter( 'job_manager_geolocation_endpoint', [ $this, 'add_geolocation_endpoint_query_args' ], 0, 2 );
+		add_filter( 'job_manager_geolocation_api_key', [ $this, 'get_google_maps_api_key' ], 0 );
+		add_action( 'job_manager_update_job_data', [ $this, 'update_location_data' ], 20, 2 );
+		add_action( 'job_manager_job_location_edited', [ $this, 'change_location_data' ], 20, 2 );
 	}
 
 	/**
@@ -186,14 +186,14 @@ class WP_Job_Manager_Geocode {
 	 * @throws Exception After geocoding error.
 	 */
 	public static function get_location_data( $raw_address ) {
-		$invalid_chars = array(
+		$invalid_chars = [
 			' ' => '+',
 			',' => '',
 			'?' => '',
 			'&' => '',
 			'=' => '',
 			'#' => '',
-		);
+		];
 		$raw_address   = trim( strtolower( str_replace( array_keys( $invalid_chars ), array_values( $invalid_chars ), $raw_address ) ) );
 
 		if ( empty( $raw_address ) ) {
@@ -218,13 +218,13 @@ class WP_Job_Manager_Geocode {
 			if ( false === $geocoded_address || empty( $geocoded_address->results[0] ) ) {
 				$result           = wp_remote_get(
 					$geocode_api_url,
-					array(
+					[
 						'timeout'     => 5,
 						'redirection' => 1,
 						'httpversion' => '1.1',
 						'user-agent'  => 'WordPress/WP-Job-Manager-' . JOB_MANAGER_VERSION . '; ' . get_bloginfo( 'url' ),
 						'sslverify'   => false,
-					)
+					]
 				);
 				$result           = wp_remote_retrieve_body( $result );
 				$geocoded_address = json_decode( $result );
@@ -248,7 +248,7 @@ class WP_Job_Manager_Geocode {
 			return new WP_Error( 'error', $e->getMessage() );
 		}
 
-		$address                      = array();
+		$address                      = [];
 		$address['lat']               = sanitize_text_field( $geocoded_address->results[0]->geometry->location->lat );
 		$address['long']              = sanitize_text_field( $geocoded_address->results[0]->geometry->location->lng );
 		$address['formatted_address'] = sanitize_text_field( $geocoded_address->results[0]->formatted_address );

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -82,11 +82,11 @@ class WP_Job_Manager_Install {
 			add_role(
 				'employer',
 				__( 'Employer', 'wp-job-manager' ),
-				array(
+				[
 					'read'         => true,
 					'edit_posts'   => false,
 					'delete_posts' => false,
-				)
+				]
 			);
 
 			$capabilities = self::get_core_capabilities();
@@ -105,11 +105,11 @@ class WP_Job_Manager_Install {
 	 * @return array
 	 */
 	private static function get_core_capabilities() {
-		return array(
-			'core'        => array(
+		return [
+			'core'        => [
 				'manage_job_listings',
-			),
-			'job_listing' => array(
+			],
+			'job_listing' => [
 				'edit_job_listing',
 				'read_job_listing',
 				'delete_job_listing',
@@ -127,8 +127,8 @@ class WP_Job_Manager_Install {
 				'edit_job_listing_terms',
 				'delete_job_listing_terms',
 				'assign_job_listing_terms',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -162,25 +162,25 @@ class WP_Job_Manager_Install {
 	 * @return array Default taxonomy terms.
 	 */
 	private static function get_default_taxonomy_terms() {
-		return array(
-			'job_listing_type' => array(
-				'Full Time'  => array(
+		return [
+			'job_listing_type' => [
+				'Full Time'  => [
 					'employment_type' => 'FULL_TIME',
-				),
-				'Part Time'  => array(
+				],
+				'Part Time'  => [
 					'employment_type' => 'PART_TIME',
-				),
-				'Temporary'  => array(
+				],
+				'Temporary'  => [
 					'employment_type' => 'TEMPORARY',
-				),
-				'Freelance'  => array(
+				],
+				'Freelance'  => [
 					'employment_type' => 'CONTRACTOR',
-				),
-				'Internship' => array(
+				],
+				'Internship' => [
 					'employment_type' => 'INTERN',
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -44,21 +44,21 @@ class WP_Job_Manager_Post_Types {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', array( $this, 'register_post_types' ), 0 );
-		add_action( 'init', array( $this, 'prepare_block_editor' ) );
-		add_action( 'init', array( $this, 'register_meta_fields' ) );
-		add_filter( 'admin_head', array( $this, 'admin_head' ) );
-		add_action( 'job_manager_check_for_expired_jobs', array( $this, 'check_for_expired_jobs' ) );
-		add_action( 'job_manager_delete_old_previews', array( $this, 'delete_old_previews' ) );
+		add_action( 'init', [ $this, 'register_post_types' ], 0 );
+		add_action( 'init', [ $this, 'prepare_block_editor' ] );
+		add_action( 'init', [ $this, 'register_meta_fields' ] );
+		add_filter( 'admin_head', [ $this, 'admin_head' ] );
+		add_action( 'job_manager_check_for_expired_jobs', [ $this, 'check_for_expired_jobs' ] );
+		add_action( 'job_manager_delete_old_previews', [ $this, 'delete_old_previews' ] );
 
-		add_action( 'pending_to_publish', array( $this, 'set_expiry' ) );
-		add_action( 'preview_to_publish', array( $this, 'set_expiry' ) );
-		add_action( 'draft_to_publish', array( $this, 'set_expiry' ) );
-		add_action( 'auto-draft_to_publish', array( $this, 'set_expiry' ) );
-		add_action( 'expired_to_publish', array( $this, 'set_expiry' ) );
+		add_action( 'pending_to_publish', [ $this, 'set_expiry' ] );
+		add_action( 'preview_to_publish', [ $this, 'set_expiry' ] );
+		add_action( 'draft_to_publish', [ $this, 'set_expiry' ] );
+		add_action( 'auto-draft_to_publish', [ $this, 'set_expiry' ] );
+		add_action( 'expired_to_publish', [ $this, 'set_expiry' ] );
 
-		add_action( 'wp_head', array( $this, 'noindex_expired_filled_job_listings' ) );
-		add_action( 'wp_footer', array( $this, 'output_structured_data' ) );
+		add_action( 'wp_head', [ $this, 'noindex_expired_filled_job_listings' ] );
+		add_action( 'wp_footer', [ $this, 'output_structured_data' ] );
 
 		add_filter( 'the_job_description', 'wptexturize' );
 		add_filter( 'the_job_description', 'convert_smilies' );
@@ -67,22 +67,22 @@ class WP_Job_Manager_Post_Types {
 		add_filter( 'the_job_description', 'shortcode_unautop' );
 		add_filter( 'the_job_description', 'prepend_attachment' );
 		if ( ! empty( $GLOBALS['wp_embed'] ) ) {
-			add_filter( 'the_job_description', array( $GLOBALS['wp_embed'], 'run_shortcode' ), 8 );
-			add_filter( 'the_job_description', array( $GLOBALS['wp_embed'], 'autoembed' ), 8 );
+			add_filter( 'the_job_description', [ $GLOBALS['wp_embed'], 'run_shortcode' ], 8 );
+			add_filter( 'the_job_description', [ $GLOBALS['wp_embed'], 'autoembed' ], 8 );
 		}
 
-		add_action( 'job_manager_application_details_email', array( $this, 'application_details_email' ) );
-		add_action( 'job_manager_application_details_url', array( $this, 'application_details_url' ) );
+		add_action( 'job_manager_application_details_email', [ $this, 'application_details_email' ] );
+		add_action( 'job_manager_application_details_url', [ $this, 'application_details_url' ] );
 
-		add_filter( 'wp_insert_post_data', array( $this, 'fix_post_name' ), 10, 2 );
-		add_action( 'add_post_meta', array( $this, 'maybe_add_geolocation_data' ), 10, 3 );
-		add_action( 'update_post_meta', array( $this, 'update_post_meta' ), 10, 4 );
-		add_action( 'wp_insert_post', array( $this, 'maybe_add_default_meta_data' ), 10, 2 );
-		add_filter( 'post_types_to_delete_with_user', array( $this, 'delete_user_add_job_listings_post_type' ) );
+		add_filter( 'wp_insert_post_data', [ $this, 'fix_post_name' ], 10, 2 );
+		add_action( 'add_post_meta', [ $this, 'maybe_add_geolocation_data' ], 10, 3 );
+		add_action( 'update_post_meta', [ $this, 'update_post_meta' ], 10, 4 );
+		add_action( 'wp_insert_post', [ $this, 'maybe_add_default_meta_data' ], 10, 2 );
+		add_filter( 'post_types_to_delete_with_user', [ $this, 'delete_user_add_job_listings_post_type' ] );
 
-		add_action( 'transition_post_status', array( $this, 'track_job_submission' ), 10, 3 );
+		add_action( 'transition_post_status', [ $this, 'track_job_submission' ], 10, 3 );
 
-		add_action( 'parse_query', array( $this, 'add_feed_query_args' ) );
+		add_action( 'parse_query', [ $this, 'add_feed_query_args' ] );
 
 		// Single job content.
 		$this->job_content_filter( true );
@@ -92,10 +92,10 @@ class WP_Job_Manager_Post_Types {
 	 * Prepare CPTs for special block editor situations.
 	 */
 	public function prepare_block_editor() {
-		add_filter( 'allowed_block_types', array( $this, 'force_classic_block' ), 10, 2 );
+		add_filter( 'allowed_block_types', [ $this, 'force_classic_block' ], 10, 2 );
 
 		if ( false === job_manager_multi_job_type() ) {
-			add_filter( 'rest_prepare_taxonomy', array( $this, 'hide_job_type_block_editor_selector' ), 10, 3 );
+			add_filter( 'rest_prepare_taxonomy', [ $this, 'hide_job_type_block_editor_selector' ], 10, 3 );
 		}
 	}
 
@@ -109,7 +109,7 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function force_classic_block( $allowed_block_types, $post ) {
 		if ( 'job_listing' === $post->post_type ) {
-			return array( 'core/freeform' );
+			return [ 'core/freeform' ];
 		}
 		return $allowed_block_types;
 	}
@@ -155,11 +155,11 @@ class WP_Job_Manager_Post_Types {
 			$plural   = __( 'Job categories', 'wp-job-manager' );
 
 			if ( current_theme_supports( 'job-manager-templates' ) ) {
-				$rewrite = array(
+				$rewrite = [
 					'slug'         => $permalink_structure['category_rewrite_slug'],
 					'with_front'   => false,
 					'hierarchical' => false,
-				);
+				];
 				$public  = true;
 			} else {
 				$rewrite = false;
@@ -168,14 +168,14 @@ class WP_Job_Manager_Post_Types {
 
 			register_taxonomy(
 				'job_listing_category',
-				apply_filters( 'register_taxonomy_job_listing_category_object_type', array( 'job_listing' ) ),
+				apply_filters( 'register_taxonomy_job_listing_category_object_type', [ 'job_listing' ] ),
 				apply_filters(
 					'register_taxonomy_job_listing_category_args',
-					array(
+					[
 						'hierarchical'          => true,
 						'update_count_callback' => '_update_post_term_count',
 						'label'                 => $plural,
-						'labels'                => array(
+						'labels'                => [
 							'name'              => $plural,
 							'singular_name'     => $singular,
 							'menu_name'         => ucwords( $plural ),
@@ -195,21 +195,21 @@ class WP_Job_Manager_Post_Types {
 							'add_new_item'      => sprintf( __( 'Add New %s', 'wp-job-manager' ), $singular ),
 							// translators: Placeholder %s is the singular label of the job listing category taxonomy type.
 							'new_item_name'     => sprintf( __( 'New %s Name', 'wp-job-manager' ), $singular ),
-						),
+						],
 						'show_ui'               => true,
 						'show_tagcloud'         => false,
 						'public'                => $public,
-						'capabilities'          => array(
+						'capabilities'          => [
 							'manage_terms' => $admin_capability,
 							'edit_terms'   => $admin_capability,
 							'delete_terms' => $admin_capability,
 							'assign_terms' => $admin_capability,
-						),
+						],
 						'rewrite'               => $rewrite,
 						'show_in_rest'          => true,
 						'rest_base'             => 'job-categories',
 
-					)
+					]
 				)
 			);
 		}
@@ -219,11 +219,11 @@ class WP_Job_Manager_Post_Types {
 			$plural   = __( 'Job types', 'wp-job-manager' );
 
 			if ( current_theme_supports( 'job-manager-templates' ) ) {
-				$rewrite = array(
+				$rewrite = [
 					'slug'         => $permalink_structure['type_rewrite_slug'],
 					'with_front'   => false,
 					'hierarchical' => false,
-				);
+				];
 				$public  = true;
 			} else {
 				$rewrite = false;
@@ -232,13 +232,13 @@ class WP_Job_Manager_Post_Types {
 
 			register_taxonomy(
 				'job_listing_type',
-				apply_filters( 'register_taxonomy_job_listing_type_object_type', array( 'job_listing' ) ),
+				apply_filters( 'register_taxonomy_job_listing_type_object_type', [ 'job_listing' ] ),
 				apply_filters(
 					'register_taxonomy_job_listing_type_args',
-					array(
+					[
 						'hierarchical'         => true,
 						'label'                => $plural,
-						'labels'               => array(
+						'labels'               => [
 							'name'              => $plural,
 							'singular_name'     => $singular,
 							'menu_name'         => ucwords( $plural ),
@@ -258,35 +258,35 @@ class WP_Job_Manager_Post_Types {
 							'add_new_item'      => sprintf( __( 'Add New %s', 'wp-job-manager' ), $singular ),
 							// translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
 							'new_item_name'     => sprintf( __( 'New %s Name', 'wp-job-manager' ), $singular ),
-						),
+						],
 						'show_ui'              => true,
 						'show_tagcloud'        => false,
 						'public'               => $public,
-						'capabilities'         => array(
+						'capabilities'         => [
 							'manage_terms' => $admin_capability,
 							'edit_terms'   => $admin_capability,
 							'delete_terms' => $admin_capability,
 							'assign_terms' => $admin_capability,
-						),
+						],
 						'rewrite'              => $rewrite,
 						'show_in_rest'         => true,
 						'rest_base'            => 'job-types',
-						'meta_box_sanitize_cb' => array( $this, 'sanitize_job_type_meta_box_input' ),
-					)
+						'meta_box_sanitize_cb' => [ $this, 'sanitize_job_type_meta_box_input' ],
+					]
 				)
 			);
 			if ( function_exists( 'wpjm_job_listing_employment_type_enabled' ) && wpjm_job_listing_employment_type_enabled() ) {
 				register_meta(
 					'term',
 					'employment_type',
-					array(
+					[
 						'object_subtype'    => 'job_listing_type',
 						'show_in_rest'      => true,
 						'type'              => 'string',
 						'single'            => true,
 						'description'       => esc_html__( 'Employment Type', 'wp-job-manager' ),
-						'sanitize_callback' => array( $this, 'sanitize_employment_type' ),
-					)
+						'sanitize_callback' => [ $this, 'sanitize_employment_type' ],
+					]
 				);
 			}
 		}
@@ -310,19 +310,19 @@ class WP_Job_Manager_Post_Types {
 			$has_archive = false;
 		}
 
-		$rewrite = array(
+		$rewrite = [
 			'slug'       => $permalink_structure['job_rewrite_slug'],
 			'with_front' => false,
 			'feeds'      => true,
 			'pages'      => false,
-		);
+		];
 
 		register_post_type(
 			'job_listing',
 			apply_filters(
 				'register_post_type_job_listing',
-				array(
-					'labels'                => array(
+				[
+					'labels'                => [
 						'name'                  => $plural,
 						'singular_name'         => $singular,
 						'menu_name'             => __( 'Job Listings', 'wp-job-manager' ),
@@ -352,7 +352,7 @@ class WP_Job_Manager_Post_Types {
 						'set_featured_image'    => __( 'Set company logo', 'wp-job-manager' ),
 						'remove_featured_image' => __( 'Remove company logo', 'wp-job-manager' ),
 						'use_featured_image'    => __( 'Use as company logo', 'wp-job-manager' ),
-					),
+					],
 					// translators: Placeholder %s is the plural label of the job listing post type.
 					'description'           => sprintf( __( 'This is where you can create and manage %s.', 'wp-job-manager' ), $plural ),
 					'public'                => true,
@@ -364,31 +364,31 @@ class WP_Job_Manager_Post_Types {
 					'hierarchical'          => false,
 					'rewrite'               => $rewrite,
 					'query_var'             => true,
-					'supports'              => array( 'title', 'editor', 'custom-fields', 'publicize', 'thumbnail', 'author' ),
+					'supports'              => [ 'title', 'editor', 'custom-fields', 'publicize', 'thumbnail', 'author' ],
 					'has_archive'           => $has_archive,
 					'show_in_nav_menus'     => false,
 					'delete_with_user'      => true,
 					'show_in_rest'          => true,
 					'rest_base'             => 'job-listings',
 					'rest_controller_class' => 'WP_REST_Posts_Controller',
-					'template'              => array( array( 'core/freeform' ) ),
+					'template'              => [ [ 'core/freeform' ] ],
 					'template_lock'         => 'all',
 					'menu_position'         => 30,
-				)
+				]
 			)
 		);
 
 		/**
 		 * Feeds
 		 */
-		add_feed( self::get_job_feed_name(), array( $this, 'job_feed' ) );
+		add_feed( self::get_job_feed_name(), [ $this, 'job_feed' ] );
 
 		/**
 		 * Post status
 		 */
 		register_post_status(
 			'expired',
-			array(
+			[
 				'label'                     => _x( 'Expired', 'post status', 'wp-job-manager' ),
 				'public'                    => true,
 				'protected'                 => true,
@@ -397,11 +397,11 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin_status_list' => true,
 				// translators: Placeholder %s is the number of expired posts of this type.
 				'label_count'               => _n_noop( 'Expired <span class="count">(%s)</span>', 'Expired <span class="count">(%s)</span>', 'wp-job-manager' ),
-			)
+			]
 		);
 		register_post_status(
 			'preview',
-			array(
+			[
 				'label'                     => _x( 'Preview', 'post status', 'wp-job-manager' ),
 				'public'                    => false,
 				'exclude_from_search'       => true,
@@ -409,7 +409,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin_status_list' => true,
 				// translators: Placeholder %s is the number of posts in a preview state.
 				'label_count'               => _n_noop( 'Preview <span class="count">(%s)</span>', 'Preview <span class="count">(%s)</span>', 'wp-job-manager' ),
-			)
+			]
 		);
 	}
 
@@ -467,8 +467,8 @@ class WP_Job_Manager_Post_Types {
 			'job_manager_kses_allowed_html',
 			array_replace_recursive( // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.array_replace_recursiveFound
 				wp_kses_allowed_html( 'post' ),
-				array(
-					'iframe' => array(
+				[
+					'iframe' => [
 						'src'             => true,
 						'width'           => true,
 						'height'          => true,
@@ -479,8 +479,8 @@ class WP_Job_Manager_Post_Types {
 						'title'           => true,
 						'allow'           => true,
 						'allowfullscreen' => true,
-					),
-				)
+					],
+				]
 			)
 		);
 	}
@@ -506,9 +506,9 @@ class WP_Job_Manager_Post_Types {
 	 */
 	private function job_content_filter( $enable ) {
 		if ( ! $enable ) {
-			remove_filter( 'the_content', array( $this, 'job_content' ) );
+			remove_filter( 'the_content', [ $this, 'job_content' ] );
 		} else {
-			add_filter( 'the_content', array( $this, 'job_content' ) );
+			add_filter( 'the_content', [ $this, 'job_content' ] );
 		}
 	}
 
@@ -554,48 +554,48 @@ class WP_Job_Manager_Post_Types {
 		$job_manager_keyword   = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		$query_args = array(
+		$query_args = [
 			'post_type'           => 'job_listing',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
 			'posts_per_page'      => $input_posts_per_page,
 			'paged'               => absint( get_query_var( 'paged', 1 ) ),
-			'tax_query'           => array(),
-			'meta_query'          => array(),
-		);
+			'tax_query'           => [],
+			'meta_query'          => [],
+		];
 
 		if ( ! empty( $input_search_location ) ) {
-			$location_meta_keys = array( 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' );
-			$location_search    = array( 'relation' => 'OR' );
+			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
+			$location_search    = [ 'relation' => 'OR' ];
 			foreach ( $location_meta_keys as $meta_key ) {
-				$location_search[] = array(
+				$location_search[] = [
 					'key'     => $meta_key,
 					'value'   => $input_search_location,
 					'compare' => 'like',
-				);
+				];
 			}
 			$query_args['meta_query'][] = $location_search;
 		}
 
 		if ( ! empty( $input_job_types ) ) {
-			$query_args['tax_query'][] = array(
+			$query_args['tax_query'][] = [
 				'taxonomy' => 'job_listing_type',
 				'field'    => 'slug',
-				'terms'    => $input_job_types + array( 0 ),
-			);
+				'terms'    => $input_job_types + [ 0 ],
+			];
 		}
 
 		if ( ! empty( $input_job_categories ) ) {
-			$cats                      = $input_job_categories + array( 0 );
+			$cats                      = $input_job_categories + [ 0 ];
 			$field                     = is_numeric( $cats ) ? 'term_id' : 'slug';
 			$operator                  = 'all' === get_option( 'job_manager_category_filter_type', 'all' ) && count( $cats ) > 1 ? 'AND' : 'IN';
-			$query_args['tax_query'][] = array(
+			$query_args['tax_query'][] = [
 				'taxonomy'         => 'job_listing_category',
 				'field'            => $field,
 				'terms'            => $cats,
 				'include_children' => 'AND' !== $operator,
 				'operator'         => $operator,
-			);
+			];
 		}
 
 		if ( ! empty( $job_manager_keyword ) ) {
@@ -613,8 +613,8 @@ class WP_Job_Manager_Post_Types {
 
 		// phpcs:ignore WordPress.WP.DiscouragedFunctions
 		query_posts( apply_filters( 'job_feed_args', $query_args ) );
-		add_action( 'rss2_ns', array( $this, 'job_feed_namespace' ) );
-		add_action( 'rss2_item', array( $this, 'job_feed_item' ) );
+		add_action( 'rss2_ns', [ $this, 'job_feed_namespace' ] );
+		add_action( 'rss2_item', [ $this, 'job_feed_item' ] );
 		do_feed_rss2( false );
 		remove_filter( 'posts_search', 'get_job_listings_keyword_search' );
 	}
@@ -685,30 +685,30 @@ class WP_Job_Manager_Post_Types {
 	public function check_for_expired_jobs() {
 		// Change status to expired.
 		$job_ids = get_posts(
-			array(
+			[
 				'post_type'      => 'job_listing',
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => -1,
-				'meta_query'     => array(
+				'meta_query'     => [
 					'relation' => 'AND',
-					array(
+					[
 						'key'     => '_job_expires',
 						'value'   => 0,
 						'compare' => '>',
-					),
-					array(
+					],
+					[
 						'key'     => '_job_expires',
 						'value'   => date( 'Y-m-d', current_time( 'timestamp' ) ),
 						'compare' => '<',
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		if ( $job_ids ) {
 			foreach ( $job_ids as $job_id ) {
-				$job_data                = array();
+				$job_data                = [];
 				$job_data['ID']          = $job_id;
 				$job_data['post_status'] = 'expired';
 				wp_update_post( $job_data );
@@ -735,18 +735,18 @@ class WP_Job_Manager_Post_Types {
 			$delete_expired_jobs_days = apply_filters( 'job_manager_delete_expired_jobs_days', 30 );
 
 			$job_ids = get_posts(
-				array(
+				[
 					'post_type'      => 'job_listing',
 					'post_status'    => 'expired',
 					'fields'         => 'ids',
-					'date_query'     => array(
-						array(
+					'date_query'     => [
+						[
 							'column' => 'post_modified',
 							'before' => date( 'Y-m-d', strtotime( '-' . $delete_expired_jobs_days . ' days', current_time( 'timestamp' ) ) ),
-						),
-					),
+						],
+					],
 					'posts_per_page' => -1,
-				)
+				]
 			);
 
 			if ( $job_ids ) {
@@ -763,18 +763,18 @@ class WP_Job_Manager_Post_Types {
 	public function delete_old_previews() {
 		// Delete old jobs stuck in preview.
 		$job_ids = get_posts(
-			array(
+			[
 				'post_type'      => 'job_listing',
 				'post_status'    => 'preview',
 				'fields'         => 'ids',
-				'date_query'     => array(
-					array(
+				'date_query'     => [
+					[
 						'column' => 'post_modified',
 						'before' => date( 'Y-m-d', strtotime( '-30 days', current_time( 'timestamp' ) ) ),
-					),
-				),
+					],
+				],
 				'posts_per_page' => -1,
-			)
+			]
 		);
 
 		if ( $job_ids ) {
@@ -838,7 +838,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param stdClass $apply
 	 */
 	public function application_details_email( $apply ) {
-		get_job_manager_template( 'job-application-email.php', array( 'apply' => $apply ) );
+		get_job_manager_template( 'job-application-email.php', [ 'apply' => $apply ] );
 	}
 
 	/**
@@ -847,7 +847,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param stdClass $apply
 	 */
 	public function application_details_url( $apply ) {
-		get_job_manager_template( 'job-application-url.php', array( 'apply' => $apply ) );
+		get_job_manager_template( 'job-application-url.php', [ 'apply' => $apply ] );
 	}
 
 	/**
@@ -899,7 +899,7 @@ class WP_Job_Manager_Post_Types {
 		 */
 		$legacy_permalink_settings = '[]';
 		if ( false !== get_option( 'wpjm_permalinks', false ) ) {
-			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', array() ) );
+			$legacy_permalink_settings = wp_json_encode( get_option( 'wpjm_permalinks', [] ) );
 			delete_option( 'wpjm_permalinks' );
 		}
 
@@ -934,12 +934,12 @@ class WP_Job_Manager_Post_Types {
 
 		$permalinks = wp_parse_args(
 			$permalink_settings,
-			array(
+			[
 				'job_base'      => '',
 				'category_base' => '',
 				'type_base'     => '',
 				'jobs_archive'  => '',
-			)
+			]
 		);
 
 		// Ensure rewrite slugs are set. Use legacy translation options if not.
@@ -1019,18 +1019,18 @@ class WP_Job_Manager_Post_Types {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update post menu order without firing actions.
 			$wpdb->update(
 				$wpdb->posts,
-				array( 'menu_order' => -1 ),
-				array( 'ID' => $object_id )
+				[ 'menu_order' => -1 ],
+				[ 'ID' => $object_id ]
 			);
 		} else {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Update post menu order without firing actions.
 			$wpdb->update(
 				$wpdb->posts,
-				array( 'menu_order' => 0 ),
-				array(
+				[ 'menu_order' => 0 ],
+				[
 					'ID'         => $object_id,
 					'menu_order' => -1,
-				)
+				]
 			);
 		}
 
@@ -1091,9 +1091,9 @@ class WP_Job_Manager_Post_Types {
 			// Track approving a new job listing.
 			WP_Job_Manager_Usage_Tracking::track_job_approval(
 				$post->ID,
-				array(
+				[
 					'source' => $source,
-				)
+				]
 			);
 
 			return;
@@ -1101,10 +1101,10 @@ class WP_Job_Manager_Post_Types {
 
 		WP_Job_Manager_Usage_Tracking::track_job_submission(
 			$post->ID,
-			array(
+			[
 				'source'     => $source,
 				'old_status' => $old_status,
-			)
+			]
 		);
 	}
 
@@ -1171,7 +1171,7 @@ class WP_Job_Manager_Post_Types {
 			register_meta(
 				'post',
 				$meta_key,
-				array(
+				[
 					'type'              => $field['data_type'],
 					'show_in_rest'      => $field['show_in_rest'],
 					'description'       => $field['label'],
@@ -1179,7 +1179,7 @@ class WP_Job_Manager_Post_Types {
 					'auth_callback'     => $field['auth_edit_callback'],
 					'single'            => true,
 					'object_subtype'    => 'job_listing',
-				)
+				]
 			);
 		}
 	}
@@ -1190,22 +1190,22 @@ class WP_Job_Manager_Post_Types {
 	 * @return array See `job_manager_job_listing_data_fields` filter for more documentation.
 	 */
 	public static function get_job_listing_fields() {
-		$default_field = array(
+		$default_field = [
 			'label'              => null,
 			'placeholder'        => null,
 			'description'        => null,
 			'priority'           => 10,
 			'value'              => null,
 			'default'            => null,
-			'classes'            => array(),
+			'classes'            => [],
 			'type'               => 'text',
 			'data_type'          => 'string',
 			'show_in_admin'      => true,
 			'show_in_rest'       => false,
-			'auth_edit_callback' => array( __CLASS__, 'auth_check_can_edit_job_listings' ),
+			'auth_edit_callback' => [ __CLASS__, 'auth_check_can_edit_job_listings' ],
 			'auth_view_callback' => null,
-			'sanitize_callback'  => array( __CLASS__, 'sanitize_meta_field_based_on_input_type' ),
-		);
+			'sanitize_callback'  => [ __CLASS__, 'sanitize_meta_field_based_on_input_type' ],
+		];
 
 		$allowed_application_method     = get_option( 'job_manager_allowed_application_method', '' );
 		$application_method_label       = __( 'Application email/URL', 'wp-job-manager' );
@@ -1219,8 +1219,8 @@ class WP_Job_Manager_Post_Types {
 			$application_method_placeholder = __( 'https://', 'wp-job-manager' );
 		}
 
-		$fields = array(
-			'_job_location'    => array(
+		$fields = [
+			'_job_location'    => [
 				'label'         => __( 'Location', 'wp-job-manager' ),
 				'placeholder'   => __( 'e.g. "London"', 'wp-job-manager' ),
 				'description'   => __( 'Leave this blank if the location is not important.', 'wp-job-manager' ),
@@ -1228,8 +1228,8 @@ class WP_Job_Manager_Post_Types {
 				'data_type'     => 'string',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-			),
-			'_application'     => array(
+			],
+			'_application'     => [
 				'label'             => $application_method_label,
 				'placeholder'       => $application_method_placeholder,
 				'description'       => __( 'This field is required for the "application" area to appear beneath the listing.', 'wp-job-manager' ),
@@ -1237,42 +1237,42 @@ class WP_Job_Manager_Post_Types {
 				'data_type'         => 'string',
 				'show_in_admin'     => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => array( __CLASS__, 'sanitize_meta_field_application' ),
-			),
-			'_company_name'    => array(
+				'sanitize_callback' => [ __CLASS__, 'sanitize_meta_field_application' ],
+			],
+			'_company_name'    => [
 				'label'         => __( 'Company Name', 'wp-job-manager' ),
 				'placeholder'   => '',
 				'priority'      => 3,
 				'data_type'     => 'string',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-			),
-			'_company_website' => array(
+			],
+			'_company_website' => [
 				'label'             => __( 'Company Website', 'wp-job-manager' ),
 				'placeholder'       => '',
 				'priority'          => 4,
 				'data_type'         => 'string',
 				'show_in_admin'     => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => array( __CLASS__, 'sanitize_meta_field_url' ),
-			),
-			'_company_tagline' => array(
+				'sanitize_callback' => [ __CLASS__, 'sanitize_meta_field_url' ],
+			],
+			'_company_tagline' => [
 				'label'         => __( 'Company Tagline', 'wp-job-manager' ),
 				'placeholder'   => __( 'Brief description about the company', 'wp-job-manager' ),
 				'priority'      => 5,
 				'data_type'     => 'string',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-			),
-			'_company_twitter' => array(
+			],
+			'_company_twitter' => [
 				'label'         => __( 'Company Twitter', 'wp-job-manager' ),
 				'placeholder'   => '@yourcompany',
 				'priority'      => 6,
 				'data_type'     => 'string',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-			),
-			'_company_video'   => array(
+			],
+			'_company_video'   => [
 				'label'             => __( 'Company Video', 'wp-job-manager' ),
 				'placeholder'       => __( 'URL to the company video', 'wp-job-manager' ),
 				'type'              => 'file',
@@ -1280,9 +1280,9 @@ class WP_Job_Manager_Post_Types {
 				'data_type'         => 'string',
 				'show_in_admin'     => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => array( __CLASS__, 'sanitize_meta_field_url' ),
-			),
-			'_filled'          => array(
+				'sanitize_callback' => [ __CLASS__, 'sanitize_meta_field_url' ],
+			],
+			'_filled'          => [
 				'label'         => __( 'Position Filled', 'wp-job-manager' ),
 				'type'          => 'checkbox',
 				'priority'      => 9,
@@ -1290,8 +1290,8 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
 				'description'   => __( 'Filled listings will no longer accept applications.', 'wp-job-manager' ),
-			),
-			'_featured'        => array(
+			],
+			'_featured'        => [
 				'label'              => __( 'Featured Listing', 'wp-job-manager' ),
 				'type'               => 'checkbox',
 				'description'        => __( 'Featured listings will be sticky during searches, and can be styled differently.', 'wp-job-manager' ),
@@ -1299,20 +1299,20 @@ class WP_Job_Manager_Post_Types {
 				'data_type'          => 'integer',
 				'show_in_admin'      => true,
 				'show_in_rest'       => true,
-				'auth_edit_callback' => array( __CLASS__, 'auth_check_can_manage_job_listings' ),
-			),
-			'_job_expires'     => array(
+				'auth_edit_callback' => [ __CLASS__, 'auth_check_can_manage_job_listings' ],
+			],
+			'_job_expires'     => [
 				'label'              => __( 'Listing Expiry Date', 'wp-job-manager' ),
 				'priority'           => 11,
 				'show_in_admin'      => true,
 				'show_in_rest'       => true,
 				'data_type'          => 'string',
-				'classes'            => array( 'job-manager-datepicker' ),
-				'auth_edit_callback' => array( __CLASS__, 'auth_check_can_manage_job_listings' ),
-				'auth_view_callback' => array( __CLASS__, 'auth_check_can_edit_job_listings' ),
-				'sanitize_callback'  => array( __CLASS__, 'sanitize_meta_field_date' ),
-			),
-		);
+				'classes'            => [ 'job-manager-datepicker' ],
+				'auth_edit_callback' => [ __CLASS__, 'auth_check_can_manage_job_listings' ],
+				'auth_view_callback' => [ __CLASS__, 'auth_check_can_edit_job_listings' ],
+				'sanitize_callback'  => [ __CLASS__, 'sanitize_meta_field_date' ],
+			],
+		];
 
 		/**
 		 * Filters job listing data fields.

--- a/includes/class-wp-job-manager-rest-api.php
+++ b/includes/class-wp-job-manager-rest-api.php
@@ -21,7 +21,7 @@ class WP_Job_Manager_REST_API {
 	 * @static
 	 */
 	public static function init() {
-		add_filter( 'rest_prepare_job_listing', array( __CLASS__, 'prepare_job_listing' ), 10, 2 );
+		add_filter( 'rest_prepare_job_listing', [ __CLASS__, 'prepare_job_listing' ], 10, 2 );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -50,17 +50,17 @@ class WP_Job_Manager_Shortcodes {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'wp', array( $this, 'shortcode_action_handler' ) );
-		add_action( 'job_manager_job_dashboard_content_edit', array( $this, 'edit_job' ) );
-		add_action( 'job_manager_job_filters_end', array( $this, 'job_filter_job_types' ), 20 );
-		add_action( 'job_manager_job_filters_end', array( $this, 'job_filter_results' ), 30 );
-		add_action( 'job_manager_output_jobs_no_results', array( $this, 'output_no_results' ) );
-		add_shortcode( 'submit_job_form', array( $this, 'submit_job_form' ) );
-		add_shortcode( 'job_dashboard', array( $this, 'job_dashboard' ) );
-		add_shortcode( 'jobs', array( $this, 'output_jobs' ) );
-		add_shortcode( 'job', array( $this, 'output_job' ) );
-		add_shortcode( 'job_summary', array( $this, 'output_job_summary' ) );
-		add_shortcode( 'job_apply', array( $this, 'output_job_apply' ) );
+		add_action( 'wp', [ $this, 'shortcode_action_handler' ] );
+		add_action( 'job_manager_job_dashboard_content_edit', [ $this, 'edit_job' ] );
+		add_action( 'job_manager_job_filters_end', [ $this, 'job_filter_job_types' ], 20 );
+		add_action( 'job_manager_job_filters_end', [ $this, 'job_filter_results' ], 30 );
+		add_action( 'job_manager_output_jobs_no_results', [ $this, 'output_no_results' ] );
+		add_shortcode( 'submit_job_form', [ $this, 'submit_job_form' ] );
+		add_shortcode( 'job_dashboard', [ $this, 'job_dashboard' ] );
+		add_shortcode( 'jobs', [ $this, 'output_jobs' ] );
+		add_shortcode( 'job', [ $this, 'output_job' ] );
+		add_shortcode( 'job_summary', [ $this, 'output_job_summary' ] );
+		add_shortcode( 'job_apply', [ $this, 'output_job_apply' ] );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class WP_Job_Manager_Shortcodes {
 	 * @param array $atts
 	 * @return string|null
 	 */
-	public function submit_job_form( $atts = array() ) {
+	public function submit_job_form( $atts = [] ) {
 		return $GLOBALS['job_manager']->forms->get_form( 'submit-job', $atts );
 	}
 
@@ -152,7 +152,7 @@ class WP_Job_Manager_Shortcodes {
 						$new_job_id = job_manager_duplicate_listing( $job_id );
 
 						if ( $new_job_id ) {
-							wp_safe_redirect( add_query_arg( array( 'job_id' => absint( $new_job_id ) ), job_manager_get_permalink( 'submit_job_form' ) ) );
+							wp_safe_redirect( add_query_arg( [ 'job_id' => absint( $new_job_id ) ], job_manager_get_permalink( 'submit_job_form' ) ) );
 							exit;
 						}
 
@@ -164,7 +164,7 @@ class WP_Job_Manager_Shortcodes {
 						}
 
 						// redirect to post page.
-						wp_safe_redirect( add_query_arg( array( 'job_id' => absint( $job_id ) ), job_manager_get_permalink( 'submit_job_form' ) ) );
+						wp_safe_redirect( add_query_arg( [ 'job_id' => absint( $job_id ) ], job_manager_get_permalink( 'submit_job_form' ) ) );
 						exit;
 					default:
 						do_action( 'job_manager_job_dashboard_do_action_' . $action, $job_id );
@@ -208,9 +208,9 @@ class WP_Job_Manager_Shortcodes {
 		}
 
 		$new_atts       = shortcode_atts(
-			array(
+			[
 				'posts_per_page' => '25',
-			),
+			],
 			$atts
 		);
 		$posts_per_page = $new_atts['posts_per_page'];
@@ -234,16 +234,16 @@ class WP_Job_Manager_Shortcodes {
 		// ....If not show the job dashboard.
 		$args = apply_filters(
 			'job_manager_get_dashboard_jobs_args',
-			array(
+			[
 				'post_type'           => 'job_listing',
-				'post_status'         => array( 'publish', 'expired', 'pending', 'draft', 'preview' ),
+				'post_status'         => [ 'publish', 'expired', 'pending', 'draft', 'preview' ],
 				'ignore_sticky_posts' => 1,
 				'posts_per_page'      => $posts_per_page,
 				'offset'              => ( max( 1, get_query_var( 'paged' ) ) - 1 ) * $posts_per_page,
 				'orderby'             => 'date',
 				'order'               => 'desc',
 				'author'              => get_current_user_id(),
-			)
+			]
 		);
 
 		$jobs = new WP_Query();
@@ -252,21 +252,21 @@ class WP_Job_Manager_Shortcodes {
 
 		$job_dashboard_columns = apply_filters(
 			'job_manager_job_dashboard_columns',
-			array(
+			[
 				'job_title' => __( 'Title', 'wp-job-manager' ),
 				'filled'    => __( 'Filled?', 'wp-job-manager' ),
 				'date'      => __( 'Date Posted', 'wp-job-manager' ),
 				'expires'   => __( 'Listing Expires', 'wp-job-manager' ),
-			)
+			]
 		);
 
 		get_job_manager_template(
 			'job-dashboard.php',
-			array(
+			[
 				'jobs'                  => $jobs->query( $args ),
 				'max_num_pages'         => $jobs->max_num_pages,
 				'job_dashboard_columns' => $job_dashboard_columns,
-			)
+			]
 		);
 
 		return ob_get_clean();
@@ -294,7 +294,7 @@ class WP_Job_Manager_Shortcodes {
 		$atts = shortcode_atts(
 			apply_filters(
 				'job_manager_output_jobs_defaults',
-				array(
+				[
 					'per_page'                  => get_option( 'job_manager_per_page' ),
 					'orderby'                   => 'featured',
 					'order'                     => 'DESC',
@@ -318,7 +318,7 @@ class WP_Job_Manager_Shortcodes {
 					'keywords'                  => '',
 					'selected_category'         => '',
 					'selected_job_types'        => implode( ',', array_values( get_job_listing_types( 'id=>slug' ) ) ),
-				)
+				]
 			),
 			$atts
 		);
@@ -335,11 +335,11 @@ class WP_Job_Manager_Shortcodes {
 		$atts['show_pagination']           = $this->string_to_bool( $atts['show_pagination'] );
 
 		if ( ! is_null( $atts['featured'] ) ) {
-			$atts['featured'] = ( is_bool( $atts['featured'] ) && $atts['featured'] ) || in_array( $atts['featured'], array( 1, '1', 'true', 'yes' ), true );
+			$atts['featured'] = ( is_bool( $atts['featured'] ) && $atts['featured'] ) || in_array( $atts['featured'], [ 1, '1', 'true', 'yes' ], true );
 		}
 
 		if ( ! is_null( $atts['filled'] ) ) {
-			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], array( 1, '1', 'true', 'yes' ), true );
+			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], [ 1, '1', 'true', 'yes' ], true );
 		}
 
 		// Get keywords, location, category and type from querystring if set.
@@ -378,7 +378,7 @@ class WP_Job_Manager_Shortcodes {
 			}
 		}
 
-		$data_attributes = array(
+		$data_attributes = [
 			'location'        => $atts['location'],
 			'keywords'        => $atts['keywords'],
 			'show_filters'    => $atts['show_filters'] ? 'true' : 'false',
@@ -387,12 +387,12 @@ class WP_Job_Manager_Shortcodes {
 			'orderby'         => $atts['orderby'],
 			'order'           => $atts['order'],
 			'categories'      => implode( ',', $atts['categories'] ),
-		);
+		];
 
 		if ( $atts['show_filters'] ) {
 			get_job_manager_template(
 				'job-filters.php',
-				array(
+				[
 					'per_page'                  => $atts['per_page'],
 					'orderby'                   => $atts['orderby'],
 					'order'                     => $atts['order'],
@@ -405,7 +405,7 @@ class WP_Job_Manager_Shortcodes {
 					'keywords'                  => $atts['keywords'],
 					'selected_job_types'        => $atts['selected_job_types'],
 					'show_category_multiselect' => $atts['show_category_multiselect'],
-				)
+				]
 			);
 
 			get_job_manager_template( 'job-listings-start.php' );
@@ -418,7 +418,7 @@ class WP_Job_Manager_Shortcodes {
 			$jobs = get_job_listings(
 				apply_filters(
 					'job_manager_output_jobs_args',
-					array(
+					[
 						'search_location'   => $atts['location'],
 						'search_keywords'   => $atts['keywords'],
 						'post_status'       => $atts['post_status'],
@@ -429,7 +429,7 @@ class WP_Job_Manager_Shortcodes {
 						'posts_per_page'    => $atts['per_page'],
 						'featured'          => $atts['featured'],
 						'filled'            => $atts['filled'],
-					)
+					]
 				)
 			);
 
@@ -509,7 +509,7 @@ class WP_Job_Manager_Shortcodes {
 	 * @return bool
 	 */
 	public function string_to_bool( $value ) {
-		return ( is_bool( $value ) && $value ) || in_array( $value, array( 1, '1', 'true', 'yes' ), true );
+		return ( is_bool( $value ) && $value ) || in_array( $value, [ 1, '1', 'true', 'yes' ], true );
 	}
 
 	/**
@@ -523,11 +523,11 @@ class WP_Job_Manager_Shortcodes {
 
 		get_job_manager_template(
 			'job-filter-job-types.php',
-			array(
+			[
 				'job_types'          => $job_types,
 				'atts'               => $atts,
 				'selected_job_types' => $selected_job_types,
-			)
+			]
 		);
 	}
 
@@ -546,9 +546,9 @@ class WP_Job_Manager_Shortcodes {
 	 */
 	public function output_job( $atts ) {
 		$atts = shortcode_atts(
-			array(
+			[
 				'id' => '',
-			),
+			],
 			$atts
 		);
 
@@ -558,11 +558,11 @@ class WP_Job_Manager_Shortcodes {
 
 		ob_start();
 
-		$args = array(
+		$args = [
 			'post_type'   => 'job_listing',
 			'post_status' => 'publish',
 			'p'           => $atts['id'],
-		);
+		];
 
 		$jobs = new WP_Query( $args );
 
@@ -587,34 +587,34 @@ class WP_Job_Manager_Shortcodes {
 	 */
 	public function output_job_summary( $atts ) {
 		$atts = shortcode_atts(
-			array(
+			[
 				'id'       => '',
 				'width'    => '250px',
 				'align'    => 'left',
 				'featured' => null, // True to show only featured, false to hide featured, leave null to show both (when leaving out id).
 				'limit'    => 1,
-			),
+			],
 			$atts
 		);
 
 		ob_start();
 
-		$args = array(
+		$args = [
 			'post_type'   => 'job_listing',
 			'post_status' => 'publish',
-		);
+		];
 
 		if ( ! $atts['id'] ) {
 			$args['posts_per_page'] = $atts['limit'];
 			$args['orderby']        = 'rand';
 			if ( ! is_null( $atts['featured'] ) ) {
-				$args['meta_query'] = array(
-					array(
+				$args['meta_query'] = [
+					[
 						'key'     => '_featured',
 						'value'   => '1',
 						'compare' => $atts['featured'] ? '=' : '!=',
-					),
-				);
+					],
+				];
 			}
 		} else {
 			$args['p'] = absint( $atts['id'] );
@@ -645,19 +645,19 @@ class WP_Job_Manager_Shortcodes {
 	 */
 	public function output_job_apply( $atts ) {
 		$new_atts = shortcode_atts(
-			array(
+			[
 				'id' => '',
-			),
+			],
 			$atts
 		);
 		$id       = $new_atts['id'];
 
 		ob_start();
 
-		$args = array(
+		$args = [
 			'post_type'   => 'job_listing',
 			'post_status' => 'publish',
-		);
+		];
 
 		if ( ! $id ) {
 			return '';

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -27,14 +27,14 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		$count_posts = wp_count_posts( 'job_listing' );
 
 		if ( taxonomy_exists( 'job_listing_category' ) ) {
-			$categories = wp_count_terms( 'job_listing_category', array( 'hide_empty' => false ) );
+			$categories = wp_count_terms( 'job_listing_category', [ 'hide_empty' => false ] );
 		}
 
-		return array(
+		return [
 			'employers'                   => self::get_employer_count(),
 			'job_categories'              => $categories,
 			'job_categories_desc'         => self::get_job_category_has_description_count(),
-			'job_types'                   => wp_count_terms( 'job_listing_type', array( 'hide_empty' => false ) ),
+			'job_types'                   => wp_count_terms( 'job_listing_type', [ 'hide_empty' => false ] ),
 			'job_types_desc'              => self::get_job_type_has_description_count(),
 			'job_types_emp_type'          => self::get_job_type_has_employment_type_count(),
 			'jobs_type'                   => self::get_job_type_count(),
@@ -62,7 +62,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_by_guests'              => self::get_jobs_by_guests(),
 			'official_extensions'         => self::get_official_extensions_count(),
 			'licensed_extensions'         => self::get_licensed_extensions_count(),
-		);
+		];
 	}
 
 	/**
@@ -72,10 +72,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_employer_count() {
 		$employer_query = new WP_User_Query(
-			array(
+			[
 				'fields' => 'ID',
 				'role'   => 'employer',
-			)
+			]
 		);
 
 		return $employer_query->total_users;
@@ -95,10 +95,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 
 		$count = 0;
 		$terms = get_terms(
-			array(
+			[
 				'taxonomy'   => 'job_listing_category',
 				'hide_empty' => false,
-			)
+			]
 		);
 
 		foreach ( $terms as $term ) {
@@ -122,10 +122,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_job_type_has_description_count() {
 		$count = 0;
 		$terms = get_terms(
-			array(
+			[
 				'taxonomy'   => 'job_listing_type',
 				'hide_empty' => false,
-			)
+			]
 		);
 
 		foreach ( $terms as $term ) {
@@ -149,10 +149,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_job_type_has_employment_type_count() {
 		$count = 0;
 		$terms = get_terms(
-			array(
+			[
 				'taxonomy'   => 'job_listing_type',
 				'hide_empty' => false,
-			)
+			]
 		);
 
 		foreach ( $terms as $term ) {
@@ -177,18 +177,18 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 **/
 	private static function get_jobs_by_type_count( $job_type ) {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'   => 'job_listing',
-				'post_status' => array( 'expired', 'publish' ),
+				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
-				'tax_query'   => array(
-					array(
+				'tax_query'   => [
+					[
 						'field'    => 'slug',
 						'taxonomy' => 'job_listing_type',
 						'terms'    => $job_type,
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		return $query->found_posts;
@@ -203,17 +203,17 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_company_logo_count() {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'   => 'job_listing',
-				'post_status' => array( 'expired', 'publish' ),
+				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
-				'meta_query'  => array(
-					array(
+				'meta_query'  => [
+					[
 						'key'     => '_thumbnail_id',
 						'compare' => 'EXISTS',
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		return $query->found_posts;
@@ -228,17 +228,17 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 **/
 	private static function get_job_type_count() {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'   => 'job_listing',
-				'post_status' => array( 'expired', 'publish' ),
+				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
-				'tax_query'   => array(
-					array(
+				'tax_query'   => [
+					[
 						'taxonomy' => 'job_listing_type',
 						'operator' => 'EXISTS',
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		return $query->found_posts;
@@ -253,18 +253,18 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_jobs_count_with_meta( $meta_key ) {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'   => 'job_listing',
-				'post_status' => array( 'publish', 'expired' ),
+				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
-				'meta_query'  => array(
-					array(
+				'meta_query'  => [
+					[
 						'key'     => $meta_key,
 						'value'   => '[^[:space:]]',
 						'compare' => 'REGEXP',
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		return $query->found_posts;
@@ -280,17 +280,17 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_jobs_count_with_checked_meta( $meta_key ) {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'   => 'job_listing',
-				'post_status' => array( 'publish', 'expired' ),
+				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
-				'meta_query'  => array(
-					array(
+				'meta_query'  => [
+					[
 						'key'   => $meta_key,
 						'value' => '1',
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		return $query->found_posts;
@@ -303,12 +303,12 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_jobs_by_guests() {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'   => 'job_listing',
-				'post_status' => array( 'publish', 'expired' ),
+				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
-				'author__in'  => array( 0 ),
-			)
+				'author__in'  => [ 0 ],
+			]
 		);
 
 		return $query->found_posts;
@@ -371,10 +371,10 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 * @return array
 	 */
 	public static function get_event_logging_base_fields() {
-		$base_fields = array(
+		$base_fields = [
 			'job_listings' => wp_count_posts( 'job_listing' )->publish,
 			'paid'         => self::has_paid_extensions() ? 1 : 0,
-		);
+		];
 
 		/**
 		 * Filter the fields that should be sent with every event that is logged.

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -27,12 +27,12 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		parent::__construct();
 
 		// Add filter for settings.
-		add_filter( 'job_manager_settings', array( $this, 'add_setting_field' ) );
+		add_filter( 'job_manager_settings', [ $this, 'add_setting_field' ] );
 
 		// In the setup wizard, do not display the normal opt-in dialog.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( isset( $_GET['page'] ) && 'job-manager-setup' === $_GET['page'] ) {
-			remove_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
+			remove_action( 'admin_notices', [ $this, 'maybe_display_tracking_opt_in' ] );
 		}
 	}
 
@@ -42,7 +42,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @return array
 	 */
 	protected function get_base_system_data() {
-		$base_data            = array();
+		$base_data            = [];
 		$base_data['version'] = JOB_MANAGER_VERSION;
 
 		return $base_data;
@@ -56,7 +56,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @param string $event_name The name of the event, without the `wpjm` prefix.
 	 * @param array  $properties The event properties to be sent.
 	 */
-	public static function log_event( $event_name, $properties = array() ) {
+	public static function log_event( $event_name, $properties = [] ) {
 		$properties = array_merge(
 			WP_Job_Manager_Usage_Tracking_Data::get_event_logging_base_fields(),
 			$properties
@@ -106,7 +106,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @param int   $post_id    Post ID.
 	 * @param array $properties Default properties to use.
 	 */
-	public static function track_job_submission( $post_id, $properties = array() ) {
+	public static function track_job_submission( $post_id, $properties = [] ) {
 		// Only track the first time a job is submitted.
 		if ( get_post_meta( $post_id, '_tracked_submitted' ) ) {
 			return;
@@ -130,7 +130,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @param int   $post_id    Post ID.
 	 * @param array $properties Default properties to use.
 	 */
-	public static function track_job_approval( $post_id, $properties = array() ) {
+	public static function track_job_approval( $post_id, $properties = [] ) {
 		// Only track the first time a job is approved.
 		if ( get_post_meta( $post_id, '_tracked_approved' ) ) {
 			return;
@@ -245,14 +245,14 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		if ( 1 === preg_match( '/^wp\-job\-manager/', $plugin_slug ) ) {
 			return true;
 		}
-		$third_party_plugins = array(
+		$third_party_plugins = [
 			'all-in-one-seo-pack',
 			'polylang',
 			'jetpack',
 			'wordpress-seo', // Yoast.
 			'sitepress-multilingual-cms', // WPML.
 			'bibblio-related-posts', // Related Posts for WordPress.
-		);
+		];
 		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {
 			return true;
 		}
@@ -316,14 +316,14 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @return array
 	 */
 	public function add_setting_field( $fields ) {
-		$fields['general'][1][] = array(
+		$fields['general'][1][] = [
 			'name'     => self::WPJM_SETTING_NAME,
 			'std'      => '0',
 			'type'     => 'checkbox',
 			'desc'     => '',
 			'label'    => __( 'Enable Usage Tracking', 'wp-job-manager' ),
 			'cb_label' => $this->opt_in_checkbox_text(),
-		);
+		];
 
 		return $fields;
 	}

--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -62,16 +62,16 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	 * Registers widget.
 	 */
 	public function register() {
-		$widget_ops = array(
+		$widget_ops = [
 			'classname'   => $this->widget_cssclass,
 			'description' => $this->widget_description,
-		);
+		];
 
 		parent::__construct( $this->widget_id, $this->widget_name, $widget_ops );
 
-		add_action( 'save_post', array( $this, 'flush_widget_cache' ) );
-		add_action( 'deleted_post', array( $this, 'flush_widget_cache' ) );
-		add_action( 'switch_theme', array( $this, 'flush_widget_cache' ) );
+		add_action( 'save_post', [ $this, 'flush_widget_cache' ] );
+		add_action( 'deleted_post', [ $this, 'flush_widget_cache' ] );
+		add_action( 'switch_theme', [ $this, 'flush_widget_cache' ] );
 	}
 
 	/**
@@ -84,7 +84,7 @@ class WP_Job_Manager_Widget extends WP_Widget {
 		$cache = wp_cache_get( $this->widget_id, 'widget' );
 
 		if ( ! is_array( $cache ) ) {
-			$cache = array();
+			$cache = [];
 		}
 
 		if ( isset( $cache[ $args['widget_id'] ] ) ) {
@@ -201,7 +201,7 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	 * @return array
 	 */
 	protected function get_default_instance() {
-		$defaults = array();
+		$defaults = [];
 		if ( ! empty( $this->settings ) ) {
 			foreach ( $this->settings as $key => $setting ) {
 				$defaults[ $key ] = null;

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -76,26 +76,26 @@ class WP_Job_Manager {
 		self::maybe_schedule_cron_jobs();
 
 		// Switch theme.
-		add_action( 'after_switch_theme', array( 'WP_Job_Manager_Ajax', 'add_endpoint' ), 10 );
-		add_action( 'after_switch_theme', array( $this->post_types, 'register_post_types' ), 11 );
+		add_action( 'after_switch_theme', [ 'WP_Job_Manager_Ajax', 'add_endpoint' ], 10 );
+		add_action( 'after_switch_theme', [ $this->post_types, 'register_post_types' ], 11 );
 		add_action( 'after_switch_theme', 'flush_rewrite_rules', 15 );
 
 		// Actions.
-		add_action( 'after_setup_theme', array( $this, 'load_plugin_textdomain' ) );
-		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
-		add_action( 'widgets_init', array( $this, 'widgets_init' ) );
-		add_action( 'wp_loaded', array( $this, 'register_shared_assets' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
-		add_action( 'admin_init', array( $this, 'updater' ) );
-		add_action( 'admin_init', array( $this, 'add_privacy_policy_content' ) );
-		add_action( 'wp_logout', array( $this, 'cleanup_job_posting_cookies' ) );
-		add_action( 'init', array( 'WP_Job_Manager_Email_Notifications', 'init' ) );
-		add_action( 'rest_api_init', array( $this, 'rest_init' ) );
+		add_action( 'after_setup_theme', [ $this, 'load_plugin_textdomain' ] );
+		add_action( 'after_setup_theme', [ $this, 'include_template_functions' ], 11 );
+		add_action( 'widgets_init', [ $this, 'widgets_init' ] );
+		add_action( 'wp_loaded', [ $this, 'register_shared_assets' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'frontend_scripts' ] );
+		add_action( 'admin_init', [ $this, 'updater' ] );
+		add_action( 'admin_init', [ $this, 'add_privacy_policy_content' ] );
+		add_action( 'wp_logout', [ $this, 'cleanup_job_posting_cookies' ] );
+		add_action( 'init', [ 'WP_Job_Manager_Email_Notifications', 'init' ] );
+		add_action( 'rest_api_init', [ $this, 'rest_init' ] );
 
 		// Filters.
-		add_filter( 'wp_privacy_personal_data_exporters', array( 'WP_Job_Manager_Data_Exporter', 'register_wpjm_user_data_exporter' ) );
+		add_filter( 'wp_privacy_personal_data_exporters', [ 'WP_Job_Manager_Data_Exporter', 'register_wpjm_user_data_exporter' ] );
 
-		add_action( 'init', array( $this, 'usage_tracking_init' ) );
+		add_action( 'init', [ $this, 'usage_tracking_init' ] );
 
 		// Defaults for WPJM core actions.
 		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );
@@ -192,7 +192,7 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-usage-tracking-data.php';
 
 		WP_Job_Manager_Usage_Tracking::get_instance()->set_callback(
-			array( 'WP_Job_Manager_Usage_Tracking_Data', 'get_usage_data' )
+			[ 'WP_Job_Manager_Usage_Tracking_Data', 'get_usage_data' ]
 		);
 
 		if ( is_admin() ) {
@@ -250,15 +250,15 @@ class WP_Job_Manager {
 		global $wp_scripts;
 
 		$jquery_version = isset( $wp_scripts->registered['jquery-ui-core']->ver ) ? $wp_scripts->registered['jquery-ui-core']->ver : '1.9.2';
-		wp_register_style( 'jquery-ui', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.min.css', array(), $jquery_version );
+		wp_register_style( 'jquery-ui', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.min.css', [], $jquery_version );
 	}
 
 	/**
 	 * Registers select2 assets when needed.
 	 */
 	public static function register_select2_assets() {
-		wp_register_script( 'select2', JOB_MANAGER_PLUGIN_URL . '/assets/js/select2/select2.full.min.js', array( 'jquery' ), '4.0.5', false );
-		wp_register_style( 'select2', JOB_MANAGER_PLUGIN_URL . '/assets/js/select2/select2.min.css', array(), '4.0.5' );
+		wp_register_script( 'select2', JOB_MANAGER_PLUGIN_URL . '/assets/js/select2/select2.full.min.js', [ 'jquery' ], '4.0.5', false );
+		wp_register_style( 'select2', JOB_MANAGER_PLUGIN_URL . '/assets/js/select2/select2.min.css', [], '4.0.5' );
 	}
 
 	/**
@@ -269,12 +269,12 @@ class WP_Job_Manager {
 	 */
 	public function frontend_scripts() {
 		$ajax_url         = WP_Job_Manager_Ajax::get_endpoint();
-		$ajax_filter_deps = array( 'jquery', 'jquery-deserialize' );
-		$ajax_data        = array(
+		$ajax_filter_deps = [ 'jquery', 'jquery-deserialize' ];
+		$ajax_data        = [
 			'ajax_url'                => $ajax_url,
 			'is_rtl'                  => is_rtl() ? 1 : 0,
 			'i18n_load_prev_listings' => __( 'Load previous listings', 'wp-job-manager' ),
-		);
+		];
 
 		/**
 		 * Retrieves the current language for use when caching requests.
@@ -285,7 +285,7 @@ class WP_Job_Manager {
 		 */
 		$ajax_data['lang'] = apply_filters( 'wpjm_lang', null );
 
-		$enhanced_select_shortcodes   = array( 'submit_job_form', 'job_dashboard', 'jobs' );
+		$enhanced_select_shortcodes   = [ 'submit_job_form', 'job_dashboard', 'jobs' ];
 		$enhanced_select_used_on_page = has_wpjm_shortcode( null, $enhanced_select_shortcodes );
 
 		/**
@@ -299,8 +299,8 @@ class WP_Job_Manager {
 
 			// Register the script for dependencies that still require it.
 			if ( ! wp_script_is( 'chosen', 'registered' ) ) {
-				wp_register_script( 'chosen', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-chosen/chosen.jquery.min.js', array( 'jquery' ), '1.1.0', true );
-				wp_register_style( 'chosen', JOB_MANAGER_PLUGIN_URL . '/assets/css/chosen.css', array(), '1.1.0' );
+				wp_register_script( 'chosen', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-chosen/chosen.jquery.min.js', [ 'jquery' ], '1.1.0', true );
+				wp_register_style( 'chosen', JOB_MANAGER_PLUGIN_URL . '/assets/css/chosen.css', [], '1.1.0' );
 			}
 
 			// Backwards compatibility for third-party themes/plugins while they transition to Select2.
@@ -309,9 +309,9 @@ class WP_Job_Manager {
 				'job_manager_chosen_multiselect_args',
 				apply_filters(
 					'job_manager_chosen_multiselect_args',
-					array(
+					[
 						'search_contains' => true,
-					)
+					]
 				)
 			);
 
@@ -346,13 +346,13 @@ class WP_Job_Manager {
 		 */
 		if ( apply_filters( 'job_manager_enhanced_select_enabled', $enhanced_select_used_on_page ) ) {
 			self::register_select2_assets();
-			wp_register_script( 'wp-job-manager-term-multiselect', JOB_MANAGER_PLUGIN_URL . '/assets/js/term-multiselect.min.js', array( 'jquery', 'select2' ), JOB_MANAGER_VERSION, true );
-			wp_register_script( 'wp-job-manager-multiselect', JOB_MANAGER_PLUGIN_URL . '/assets/js/multiselect.min.js', array( 'jquery', 'select2' ), JOB_MANAGER_VERSION, true );
+			wp_register_script( 'wp-job-manager-term-multiselect', JOB_MANAGER_PLUGIN_URL . '/assets/js/term-multiselect.min.js', [ 'jquery', 'select2' ], JOB_MANAGER_VERSION, true );
+			wp_register_script( 'wp-job-manager-multiselect', JOB_MANAGER_PLUGIN_URL . '/assets/js/multiselect.min.js', [ 'jquery', 'select2' ], JOB_MANAGER_VERSION, true );
 			wp_enqueue_style( 'select2' );
 
 			$ajax_filter_deps[] = 'select2';
 
-			$select2_args = array();
+			$select2_args = [];
 			if ( is_rtl() ) {
 				$select2_args['dir'] = 'rtl';
 			}
@@ -367,74 +367,74 @@ class WP_Job_Manager {
 		}
 
 		if ( job_manager_user_can_upload_file_via_ajax() ) {
-			wp_register_script( 'jquery-iframe-transport', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-fileupload/jquery.iframe-transport.js', array( 'jquery' ), '9.30.0', true );
-			wp_register_script( 'jquery-fileupload', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-fileupload/jquery.fileupload.js', array( 'jquery', 'jquery-iframe-transport', 'jquery-ui-widget' ), '9.30.0', true );
-			wp_register_script( 'wp-job-manager-ajax-file-upload', JOB_MANAGER_PLUGIN_URL . '/assets/js/ajax-file-upload.min.js', array( 'jquery', 'jquery-fileupload' ), JOB_MANAGER_VERSION, true );
+			wp_register_script( 'jquery-iframe-transport', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-fileupload/jquery.iframe-transport.js', [ 'jquery' ], '9.30.0', true );
+			wp_register_script( 'jquery-fileupload', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-fileupload/jquery.fileupload.js', [ 'jquery', 'jquery-iframe-transport', 'jquery-ui-widget' ], '9.30.0', true );
+			wp_register_script( 'wp-job-manager-ajax-file-upload', JOB_MANAGER_PLUGIN_URL . '/assets/js/ajax-file-upload.min.js', [ 'jquery', 'jquery-fileupload' ], JOB_MANAGER_VERSION, true );
 
 			ob_start();
 			get_job_manager_template(
 				'form-fields/uploaded-file-html.php',
-				array(
+				[
 					'name'      => '',
 					'value'     => '',
 					'extension' => 'jpg',
-				)
+				]
 			);
 			$js_field_html_img = ob_get_clean();
 
 			ob_start();
 			get_job_manager_template(
 				'form-fields/uploaded-file-html.php',
-				array(
+				[
 					'name'      => '',
 					'value'     => '',
 					'extension' => 'zip',
-				)
+				]
 			);
 			$js_field_html = ob_get_clean();
 
 			wp_localize_script(
 				'wp-job-manager-ajax-file-upload',
 				'job_manager_ajax_file_upload',
-				array(
+				[
 					'ajax_url'               => $ajax_url,
 					'js_field_html_img'      => esc_js( str_replace( "\n", '', $js_field_html_img ) ),
 					'js_field_html'          => esc_js( str_replace( "\n", '', $js_field_html ) ),
 					'i18n_invalid_file_type' => esc_html__( 'Invalid file type. Accepted types:', 'wp-job-manager' ),
-				)
+				]
 			);
 		}
 
-		wp_register_script( 'jquery-deserialize', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-deserialize/jquery.deserialize.js', array( 'jquery' ), '1.2.1', true );
+		wp_register_script( 'jquery-deserialize', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-deserialize/jquery.deserialize.js', [ 'jquery' ], '1.2.1', true );
 		wp_register_script( 'wp-job-manager-ajax-filters', JOB_MANAGER_PLUGIN_URL . '/assets/js/ajax-filters.min.js', $ajax_filter_deps, JOB_MANAGER_VERSION, true );
-		wp_register_script( 'wp-job-manager-job-dashboard', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-dashboard.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
-		wp_register_script( 'wp-job-manager-job-application', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-application.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
-		wp_register_script( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-submission.min.js', array( 'jquery' ), JOB_MANAGER_VERSION, true );
+		wp_register_script( 'wp-job-manager-job-dashboard', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-dashboard.min.js', [ 'jquery' ], JOB_MANAGER_VERSION, true );
+		wp_register_script( 'wp-job-manager-job-application', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-application.min.js', [ 'jquery' ], JOB_MANAGER_VERSION, true );
+		wp_register_script( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-submission.min.js', [ 'jquery' ], JOB_MANAGER_VERSION, true );
 		wp_localize_script( 'wp-job-manager-ajax-filters', 'job_manager_ajax_filters', $ajax_data );
 
 		wp_localize_script(
 			'wp-job-manager-job-submission',
 			'job_manager_job_submission',
-			array(
+			[
 				// translators: Placeholder %d is the number of files to that users are limited to.
 				'i18n_over_upload_limit' => esc_html__( 'You are only allowed to upload a maximum of %d files.', 'wp-job-manager' ),
-			)
+			]
 		);
 
 		wp_localize_script(
 			'wp-job-manager-job-dashboard',
 			'job_manager_job_dashboard',
-			array(
+			[
 				'i18n_confirm_delete' => esc_html__( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
-			)
+			]
 		);
 
 		wp_localize_script(
 			'wp-job-manager-job-submission',
 			'job_manager_job_submission',
-			array(
+			[
 				'i18n_required_field' => __( 'This field is required.', 'wp-job-manager' ),
-			)
+			]
 		);
 
 		/**
@@ -462,9 +462,9 @@ class WP_Job_Manager {
 		 * @param bool $is_frontend_style_enabled
 		 */
 		if ( apply_filters( 'job_manager_enqueue_frontend_style', is_wpjm() ) ) {
-			wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css', array(), JOB_MANAGER_VERSION );
+			wp_enqueue_style( 'wp-job-manager-frontend', JOB_MANAGER_PLUGIN_URL . '/assets/css/frontend.css', [], JOB_MANAGER_VERSION );
 		} else {
-			wp_register_style( 'wp-job-manager-job-listings', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-listings.css', array(), JOB_MANAGER_VERSION );
+			wp_register_style( 'wp-job-manager-job-listings', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-listings.css', [], JOB_MANAGER_VERSION );
 		}
 	}
 }

--- a/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
+++ b/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
@@ -126,14 +126,14 @@ class WP_Job_Manager_Email_Employer_Expiring_Job extends WP_Job_Manager_Email_Te
 	 */
 	public static function get_setting_fields() {
 		$fields   = parent::get_setting_fields();
-		$fields[] = array(
+		$fields[] = [
 			'name'       => self::SETTING_NOTICE_PERIOD_NAME,
 			'std'        => self::SETTING_NOTICE_PERIOD_DEFAULT,
 			'label'      => __( 'Notice Period', 'wp-job-manager' ),
 			'type'       => 'number',
 			'after'      => ' ' . __( 'days', 'wp-job-manager' ),
-			'attributes' => array( 'min' => 0 ),
-		);
+			'attributes' => [ 'min' => 0 ],
+		];
 		return $fields;
 	}
 

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -62,8 +62,8 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_action( 'wp', array( $this, 'submit_handler' ) );
-		add_action( 'submit_job_form_start', array( $this, 'output_submit_form_nonce_field' ) );
+		add_action( 'wp', [ $this, 'submit_handler' ] );
+		add_action( 'submit_job_form_start', [ $this, 'output_submit_form_nonce_field' ] );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Check happens later when possible.
 		$this->job_id = ! empty( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : 0;
@@ -88,7 +88,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 	 *
 	 * @param array $atts
 	 */
-	public function output( $atts = array() ) {
+	public function output( $atts = [] ) {
 		if ( ! empty( $this->save_message ) ) {
 			echo '<div class="job-manager-message">' . wp_kses_post( $this->save_message ) . '</div>';
 		}
@@ -124,7 +124,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 						$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_thumbnail_id( $job->ID ) : get_post_meta( $job->ID, '_' . $key, true );
 
 					} elseif ( ! empty( $field['taxonomy'] ) ) {
-						$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, $field['taxonomy'], array( 'fields' => 'ids' ) );
+						$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, $field['taxonomy'], [ 'fields' => 'ids' ] );
 
 					} else {
 						$this->fields[ $group_key ][ $key ]['value'] = get_post_meta( $job->ID, '_' . $key, true );
@@ -149,7 +149,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 
 		get_job_manager_template(
 			'job-submit.php',
-			array(
+			[
 				'form'               => $this->form_name,
 				'job_id'             => $this->get_job_id(),
 				'action'             => $this->get_action(),
@@ -157,7 +157,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 				'company_fields'     => $this->get_fields( 'company' ),
 				'step'               => $this->get_step(),
 				'submit_button_text' => $save_button_text,
-			)
+			]
 		);
 	}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -64,42 +64,42 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'wp', array( $this, 'process' ) );
-		add_action( 'submit_job_form_start', array( $this, 'output_submit_form_nonce_field' ) );
-		add_action( 'preview_job_form_start', array( $this, 'output_preview_form_nonce_field' ) );
-		add_action( 'job_manager_job_submitted', array( $this, 'track_job_submission' ) );
+		add_action( 'wp', [ $this, 'process' ] );
+		add_action( 'submit_job_form_start', [ $this, 'output_submit_form_nonce_field' ] );
+		add_action( 'preview_job_form_start', [ $this, 'output_preview_form_nonce_field' ] );
+		add_action( 'job_manager_job_submitted', [ $this, 'track_job_submission' ] );
 
 		if ( $this->use_recaptcha_field() ) {
-			add_action( 'submit_job_form_end', array( $this, 'display_recaptcha_field' ) );
-			add_filter( 'submit_job_form_validate_fields', array( $this, 'validate_recaptcha_field' ) );
-			add_filter( 'submit_draft_job_form_validate_fields', array( $this, 'validate_recaptcha_field' ) );
+			add_action( 'submit_job_form_end', [ $this, 'display_recaptcha_field' ] );
+			add_filter( 'submit_job_form_validate_fields', [ $this, 'validate_recaptcha_field' ] );
+			add_filter( 'submit_draft_job_form_validate_fields', [ $this, 'validate_recaptcha_field' ] );
 		}
 
 		$this->steps = (array) apply_filters(
 			'submit_job_steps',
-			array(
-				'submit'  => array(
+			[
+				'submit'  => [
 					'name'     => __( 'Submit Details', 'wp-job-manager' ),
-					'view'     => array( $this, 'submit' ),
-					'handler'  => array( $this, 'submit_handler' ),
+					'view'     => [ $this, 'submit' ],
+					'handler'  => [ $this, 'submit_handler' ],
 					'priority' => 10,
-				),
-				'preview' => array(
+				],
+				'preview' => [
 					'name'     => __( 'Preview', 'wp-job-manager' ),
-					'view'     => array( $this, 'preview' ),
-					'handler'  => array( $this, 'preview_handler' ),
+					'view'     => [ $this, 'preview' ],
+					'handler'  => [ $this, 'preview_handler' ],
 					'priority' => 20,
-				),
-				'done'    => array(
+				],
+				'done'    => [
 					'name'     => __( 'Done', 'wp-job-manager' ),
-					'before'   => array( $this, 'done_before' ),
-					'view'     => array( $this, 'done' ),
+					'before'   => [ $this, 'done_before' ],
+					'view'     => [ $this, 'done' ],
 					'priority' => 30,
-				),
-			)
+				],
+			]
 		);
 
-		uasort( $this->steps, array( $this, 'sort_by_priority' ) );
+		uasort( $this->steps, [ $this, 'sort_by_priority' ] );
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing,  WordPress.Security.NonceVerification.Recommended -- Check happens later when possible. Input is used safely.
 		// Get step/job.
@@ -150,7 +150,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					$this->job_id = 0;
 					$this->step   = 0;
 				}
-			} elseif ( ! in_array( $job_status, apply_filters( 'job_manager_valid_submit_job_statuses', array( 'preview', 'draft' ) ), true ) ) {
+			} elseif ( ! in_array( $job_status, apply_filters( 'job_manager_valid_submit_job_statuses', [ 'preview', 'draft' ] ), true ) ) {
 				$this->job_id = 0;
 				$this->step   = 0;
 			}
@@ -200,24 +200,24 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 		$this->fields = apply_filters(
 			'submit_job_form_fields',
-			array(
-				'job'     => array(
-					'job_title'       => array(
+			[
+				'job'     => [
+					'job_title'       => [
 						'label'       => __( 'Job Title', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => true,
 						'placeholder' => '',
 						'priority'    => 1,
-					),
-					'job_location'    => array(
+					],
+					'job_location'    => [
 						'label'       => __( 'Location', 'wp-job-manager' ),
 						'description' => __( 'Leave this blank if the location is not important', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
 						'placeholder' => __( 'e.g. "London"', 'wp-job-manager' ),
 						'priority'    => 2,
-					),
-					'job_type'        => array(
+					],
+					'job_type'        => [
 						'label'       => __( 'Job type', 'wp-job-manager' ),
 						'type'        => $job_type,
 						'required'    => true,
@@ -225,8 +225,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'priority'    => 3,
 						'default'     => 'full-time',
 						'taxonomy'    => 'job_listing_type',
-					),
-					'job_category'    => array(
+					],
+					'job_category'    => [
 						'label'       => __( 'Job category', 'wp-job-manager' ),
 						'type'        => 'term-multiselect',
 						'required'    => true,
@@ -234,62 +234,62 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'priority'    => 4,
 						'default'     => '',
 						'taxonomy'    => 'job_listing_category',
-					),
-					'job_description' => array(
+					],
+					'job_description' => [
 						'label'    => __( 'Description', 'wp-job-manager' ),
 						'type'     => 'wp-editor',
 						'required' => true,
 						'priority' => 5,
-					),
-					'application'     => array(
+					],
+					'application'     => [
 						'label'       => $application_method_label,
 						'type'        => 'text',
 						'sanitizer'   => $application_method_sanitizer,
 						'required'    => true,
 						'placeholder' => $application_method_placeholder,
 						'priority'    => 6,
-					),
-				),
-				'company' => array(
-					'company_name'    => array(
+					],
+				],
+				'company' => [
+					'company_name'    => [
 						'label'       => __( 'Company name', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => true,
 						'placeholder' => __( 'Enter the name of the company', 'wp-job-manager' ),
 						'priority'    => 1,
-					),
-					'company_website' => array(
+					],
+					'company_website' => [
 						'label'       => __( 'Website', 'wp-job-manager' ),
 						'type'        => 'text',
 						'sanitizer'   => 'url',
 						'required'    => false,
 						'placeholder' => __( 'http://', 'wp-job-manager' ),
 						'priority'    => 2,
-					),
-					'company_tagline' => array(
+					],
+					'company_tagline' => [
 						'label'       => __( 'Tagline', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
 						'placeholder' => __( 'Briefly describe your company', 'wp-job-manager' ),
 						'maxlength'   => 64,
 						'priority'    => 3,
-					),
-					'company_video'   => array(
+					],
+					'company_video'   => [
 						'label'       => __( 'Video', 'wp-job-manager' ),
 						'type'        => 'text',
 						'sanitizer'   => 'url',
 						'required'    => false,
 						'placeholder' => __( 'A link to a video about your company', 'wp-job-manager' ),
 						'priority'    => 4,
-					),
-					'company_twitter' => array(
+					],
+					'company_twitter' => [
 						'label'       => __( 'Twitter username', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
 						'placeholder' => __( '@yourcompany', 'wp-job-manager' ),
 						'priority'    => 5,
-					),
-					'company_logo'    => array(
+					],
+					'company_logo'    => [
 						'label'              => __( 'Logo', 'wp-job-manager' ),
 						'type'               => 'file',
 						'required'           => false,
@@ -297,15 +297,15 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'priority'           => 6,
 						'ajax'               => true,
 						'multiple'           => false,
-						'allowed_mime_types' => array(
+						'allowed_mime_types' => [
 							'jpg'  => 'image/jpeg',
 							'jpeg' => 'image/jpeg',
 							'gif'  => 'image/gif',
 							'png'  => 'image/png',
-						),
-					),
-				),
-			)
+						],
+					],
+				],
+			]
 		);
 
 		if ( ! get_option( 'job_manager_enable_categories' ) || 0 === intval( wp_count_terms( 'job_listing_category' ) ) ) {
@@ -342,11 +342,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					// translators: Placeholder %s is the label for the required field.
 					return new WP_Error( 'validation-error', sprintf( __( '%s is a required field', 'wp-job-manager' ), $field['label'] ) );
 				}
-				if ( ! empty( $field['taxonomy'] ) && in_array( $field['type'], array( 'term-checklist', 'term-select', 'term-multiselect' ), true ) ) {
+				if ( ! empty( $field['taxonomy'] ) && in_array( $field['type'], [ 'term-checklist', 'term-select', 'term-multiselect' ], true ) ) {
 					if ( is_array( $values[ $group_key ][ $key ] ) ) {
 						$check_value = $values[ $group_key ][ $key ];
 					} else {
-						$check_value = empty( $values[ $group_key ][ $key ] ) ? array() : array( $values[ $group_key ][ $key ] );
+						$check_value = empty( $values[ $group_key ][ $key ] ) ? [] : [ $values[ $group_key ][ $key ] ];
 					}
 					foreach ( $check_value as $term ) {
 						if ( ! term_exists( $term, $field['taxonomy'] ) ) {
@@ -359,14 +359,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					if ( is_array( $values[ $group_key ][ $key ] ) ) {
 						$check_value = array_filter( $values[ $group_key ][ $key ] );
 					} else {
-						$check_value = array_filter( array( $values[ $group_key ][ $key ] ) );
+						$check_value = array_filter( [ $values[ $group_key ][ $key ] ] );
 					}
 					if ( ! empty( $check_value ) ) {
 						foreach ( $check_value as $file_url ) {
 							if ( is_numeric( $file_url ) ) {
 								continue;
 							}
-							$file_url = esc_url( $file_url, array( 'http', 'https' ) );
+							$file_url = esc_url( $file_url, [ 'http', 'https' ] );
 							if ( empty( $file_url ) ) {
 								throw new Exception( __( 'Invalid attachment provided.', 'wp-job-manager' ) );
 							}
@@ -377,7 +377,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					if ( is_array( $values[ $group_key ][ $key ] ) ) {
 						$check_value = array_filter( $values[ $group_key ][ $key ] );
 					} else {
-						$check_value = array_filter( array( $values[ $group_key ][ $key ] ) );
+						$check_value = array_filter( [ $values[ $group_key ][ $key ] ] );
 					}
 					if ( ! empty( $check_value ) ) {
 						foreach ( $check_value as $file_url ) {
@@ -399,7 +399,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					if ( is_array( $values[ $group_key ][ $key ] ) ) {
 						$check_value = array_filter( $values[ $group_key ][ $key ] );
 					} else {
-						$check_value = array_filter( array( $values[ $group_key ][ $key ] ) );
+						$check_value = array_filter( [ $values[ $group_key ][ $key ] ] );
 					}
 					if ( count( $check_value ) > $file_limit ) {
 						// translators: Placeholder %d is the number of files to that users are limited to.
@@ -464,14 +464,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 */
 	protected function enqueue_job_form_assets() {
 		wp_enqueue_script( 'wp-job-manager-job-submission' );
-		wp_enqueue_style( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-submission.css', array(), JOB_MANAGER_VERSION );
+		wp_enqueue_style( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-submission.css', [], JOB_MANAGER_VERSION );
 
 		// Register datepicker JS. It will be enqueued if needed when a date.
 		// field is rendered.
-		wp_register_script( 'wp-job-manager-datepicker', JOB_MANAGER_PLUGIN_URL . '/assets/js/datepicker.min.js', array( 'jquery', 'jquery-ui-datepicker' ), JOB_MANAGER_VERSION, true );
+		wp_register_script( 'wp-job-manager-datepicker', JOB_MANAGER_PLUGIN_URL . '/assets/js/datepicker.min.js', [ 'jquery', 'jquery-ui-datepicker' ], JOB_MANAGER_VERSION, true );
 
 		// Localize scripts after the fields are rendered.
-		add_action( 'submit_job_form_end', array( $this, 'localize_job_form_scripts' ) );
+		add_action( 'submit_job_form_end', [ $this, 'localize_job_form_scripts' ] );
 	}
 
 	/**
@@ -485,10 +485,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			wp_localize_script(
 				'wp-job-manager-datepicker',
 				'job_manager_datepicker',
-				array(
+				[
 					/* translators: jQuery date format, see http://api.jqueryui.com/datepicker/#utility-formatDate */
 					'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker.', 'wp-job-manager' ),
-				)
+				]
 			);
 		}
 	}
@@ -499,7 +499,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @return array
 	 */
 	private function job_types() {
-		$options = array();
+		$options = [];
 		$terms   = get_job_listing_types();
 		foreach ( $terms as $term ) {
 			$options[ $term->slug ] = $term->name;
@@ -526,13 +526,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 							$this->fields[ $group_key ][ $key ]['value'] = $job->post_content;
 							break;
 						case 'job_type':
-							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_type', array( 'fields' => 'ids' ) );
+							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_type', [ 'fields' => 'ids' ] );
 							if ( ! job_manager_multi_job_type() ) {
 								$this->fields[ $group_key ][ $key ]['value'] = current( $this->fields[ $group_key ][ $key ]['value'] );
 							}
 							break;
 						case 'job_category':
-							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_category', array( 'fields' => 'ids' ) );
+							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_category', [ 'fields' => 'ids' ] );
 							break;
 						case 'company_logo':
 							$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_thumbnail_id( $job->ID ) : get_post_meta( $job->ID, '_' . $key, true );
@@ -566,7 +566,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$this->enqueue_job_form_assets();
 		get_job_manager_template(
 			'job-submit.php',
-			array(
+			[
 				'form'               => $this->form_name,
 				'job_id'             => $this->get_job_id(),
 				'resume_edit'        => $this->resume_edit,
@@ -576,7 +576,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				'step'               => $this->get_step(),
 				'can_continue_later' => $this->can_continue_later(),
 				'submit_button_text' => apply_filters( 'submit_job_form_submit_button_text', __( 'Preview', 'wp-job-manager' ) ),
-			)
+			]
 		);
 	}
 
@@ -663,12 +663,12 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 					if ( ! empty( $input_create_account_email ) ) {
 						$create_account = wp_job_manager_create_account(
-							array(
+							[
 								'username' => ( job_manager_generate_username_from_email() || empty( $input_create_account_username ) ) ? '' : $input_create_account_username,
 								'password' => ( wpjm_use_standard_password_setup_email() || empty( $input_create_account_password ) ) ? '' : $input_create_account_password,
 								'email'    => sanitize_text_field( wp_unslash( $input_create_account_email ) ),
 								'role'     => get_option( 'job_manager_registration_role' ),
-							)
+							]
 						);
 					}
 				}
@@ -722,16 +722,16 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @param  array  $values
 	 * @param  bool   $update_slug
 	 */
-	protected function save_job( $post_title, $post_content, $status = 'preview', $values = array(), $update_slug = true ) {
-		$job_data = array(
+	protected function save_job( $post_title, $post_content, $status = 'preview', $values = [], $update_slug = true ) {
+		$job_data = [
 			'post_title'     => $post_title,
 			'post_content'   => $post_content,
 			'post_type'      => 'job_listing',
 			'comment_status' => 'closed',
-		);
+		];
 
 		if ( $update_slug ) {
-			$job_slug = array();
+			$job_slug = [];
 
 			// Prepend with company name.
 			if ( apply_filters( 'submit_job_form_prefix_post_name_with_company', true ) && ! empty( $values['company']['company_name'] ) ) {
@@ -798,7 +798,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		include_once ABSPATH . 'wp-admin/includes/media.php';
 
 		$upload_dir     = wp_upload_dir();
-		$attachment_url = esc_url( $attachment_url, array( 'http', 'https' ) );
+		$attachment_url = esc_url( $attachment_url, [ 'http', 'https' ] );
 		if ( empty( $attachment_url ) ) {
 			return 0;
 		}
@@ -812,18 +812,18 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		$attachment_url = sprintf( '%s://%s%s', $attachment_url_parts['scheme'], $attachment_url_parts['host'], $attachment_url_parts['path'] );
 
-		$attachment_url = str_replace( array( $upload_dir['baseurl'], WP_CONTENT_URL, site_url( '/' ) ), array( $upload_dir['basedir'], WP_CONTENT_DIR, ABSPATH ), $attachment_url );
+		$attachment_url = str_replace( [ $upload_dir['baseurl'], WP_CONTENT_URL, site_url( '/' ) ], [ $upload_dir['basedir'], WP_CONTENT_DIR, ABSPATH ], $attachment_url );
 		if ( empty( $attachment_url ) || ! is_string( $attachment_url ) ) {
 			return 0;
 		}
 
-		$attachment = array(
+		$attachment = [
 			'post_title'   => wpjm_get_the_job_title( $this->job_id ),
 			'post_content' => '',
 			'post_status'  => 'inherit',
 			'post_parent'  => $this->job_id,
 			'guid'         => $attachment_url,
-		);
+		];
 
 		$info = wp_check_filetype( $attachment_url );
 		if ( $info ) {
@@ -850,7 +850,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		add_post_meta( $this->job_id, '_filled', 0, true );
 		add_post_meta( $this->job_id, '_featured', 0, true );
 
-		$maybe_attach = array();
+		$maybe_attach = [];
 
 		// Loop fields and save meta and term data.
 		foreach ( $this->fields as $group_key => $group_fields ) {
@@ -860,7 +860,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					if ( is_array( $values[ $group_key ][ $key ] ) ) {
 						wp_set_object_terms( $this->job_id, $values[ $group_key ][ $key ], $field['taxonomy'], false );
 					} else {
-						wp_set_object_terms( $this->job_id, array( $values[ $group_key ][ $key ] ), $field['taxonomy'], false );
+						wp_set_object_terms( $this->job_id, [ $values[ $group_key ][ $key ] ], $field['taxonomy'], false );
 					}
 
 					// Company logo is a featured image.
@@ -897,7 +897,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( count( $maybe_attach ) && apply_filters( 'job_manager_attach_uploaded_files', true ) ) {
 			// Get attachments.
 			$attachments     = get_posts( 'post_parent=' . $this->job_id . '&post_type=attachment&fields=ids&numberposts=-1' );
-			$attachment_urls = array();
+			$attachment_urls = [];
 
 			// Loop attachments already attached to the job.
 			foreach ( $attachments as $attachment_id ) {
@@ -939,9 +939,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 			get_job_manager_template(
 				'job-preview.php',
-				array(
+				[
 					'form' => $this,
-				)
+				]
 			);
 
 			wp_reset_postdata();
@@ -968,12 +968,12 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( ! empty( $_POST['continue'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
 			$job = get_post( $this->job_id );
 
-			if ( in_array( $job->post_status, array( 'preview', 'expired' ), true ) ) {
+			if ( in_array( $job->post_status, [ 'preview', 'expired' ], true ) ) {
 				// Reset expiry.
 				delete_post_meta( $job->ID, '_job_expires' );
 
 				// Update job listing.
-				$update_job                  = array();
+				$update_job                  = [];
 				$update_job['ID']            = $job->ID;
 				$update_job['post_status']   = apply_filters( 'submit_job_post_status', get_option( 'job_manager_submission_requires_approval' ) ? 'pending' : 'publish', $job );
 				$update_job['post_date']     = current_time( 'mysql' );
@@ -1044,7 +1044,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * Displays the final screen after a job listing has been submitted.
 	 */
 	public function done() {
-		get_job_manager_template( 'job-submitted.php', array( 'job' => get_post( $this->job_id ) ) );
+		get_job_manager_template( 'job-submitted.php', [ 'job' => get_post( $this->job_id ) ] );
 	}
 
 	/**
@@ -1090,10 +1090,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	public function track_job_submission( $post_id ) {
 		WP_Job_Manager_Usage_Tracking::track_job_submission(
 			$post_id,
-			array(
+			[
 				'source'     => 'frontend',
 				'old_status' => 'preview',
-			)
+			]
 		);
 	}
 }

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -107,38 +107,38 @@ class WP_Job_Manager_Helper_API {
 	 * @return array|bool|mixed|object
 	 */
 	protected function request( $args, $return_error = false ) {
-		$defaults = array(
+		$defaults = [
 			'instance'       => $this->get_site_url(),
 			'plugin_name'    => '',
 			'version'        => '',
 			'api_product_id' => '',
 			'licence_key'    => '',
 			'email'          => '',
-		);
+		];
 
 		$args    = wp_parse_args( $args, $defaults );
 		$request = wp_safe_remote_get(
 			$this->get_api_base_url() . '?' . http_build_query( $args, '', '&' ),
-			array(
+			[
 				'timeout' => 10,
-				'headers' => array(
+				'headers' => [
 					'Accept' => 'application/json',
-				),
-			)
+				],
+			]
 		);
 
 		if ( is_wp_error( $request ) || 200 !== wp_remote_retrieve_response_code( $request ) ) {
 			if ( $return_error ) {
 				if ( is_wp_error( $request ) ) {
-					return array(
+					return [
 						'error_code' => $request->get_error_code(),
 						'error'      => $request->get_error_message(),
-					);
+					];
 				}
-				return array(
+				return [
 					'error_code' => wp_remote_retrieve_response_code( $request ),
 					'error'      => 'Error code: ' . wp_remote_retrieve_response_code( $request ),
-				);
+				];
 			}
 			return false;
 		}

--- a/includes/helper/class-wp-job-manager-helper-options.php
+++ b/includes/helper/class-wp-job-manager-helper-options.php
@@ -27,7 +27,7 @@ class WP_Job_Manager_Helper_Options {
 	public static function update( $product_slug, $key, $value ) {
 		$options = self::get_master_option();
 		if ( ! isset( $options[ $product_slug ] ) ) {
-			$options[ $product_slug ] = array();
+			$options[ $product_slug ] = [];
 		}
 		$options[ $product_slug ][ $key ] = $value;
 		return self::update_master_option( $options );
@@ -64,7 +64,7 @@ class WP_Job_Manager_Helper_Options {
 	public static function delete( $product_slug, $key ) {
 		$options = self::get_master_option();
 		if ( ! isset( $options[ $product_slug ] ) ) {
-			$options[ $product_slug ] = array();
+			$options[ $product_slug ] = [];
 		}
 		unset( $options[ $product_slug ][ $key ] );
 		return self::update_master_option( $options );
@@ -80,9 +80,9 @@ class WP_Job_Manager_Helper_Options {
 	private static function attempt_legacy_restore( $product_slug ) {
 		$options = self::get_master_option();
 		if ( ! isset( $options[ $product_slug ] ) ) {
-			$options[ $product_slug ] = array();
+			$options[ $product_slug ] = [];
 		}
-		foreach ( array( 'licence_key', 'email', 'errors', 'hide_key_notice' ) as $key ) {
+		foreach ( [ 'licence_key', 'email', 'errors', 'hide_key_notice' ] as $key ) {
 			$option_value = get_option( $product_slug . '_' . $key, false );
 			if ( ! empty( $option_value ) ) {
 				$options[ $product_slug ][ $key ] = $option_value;
@@ -100,9 +100,9 @@ class WP_Job_Manager_Helper_Options {
 	 */
 	private static function get_master_option() {
 		if ( is_multisite() || is_network_admin() ) {
-			return get_site_option( self::OPTION_NAME, array() );
+			return get_site_option( self::OPTION_NAME, [] );
 		}
-		return get_option( self::OPTION_NAME, array() );
+		return get_option( self::OPTION_NAME, [] );
 	}
 
 	/**

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -21,7 +21,7 @@ class WP_Job_Manager_Helper {
 	 *
 	 * @var array Messages when updating licences.
 	 */
-	protected $licence_messages = array();
+	protected $licence_messages = [];
 
 	/**
 	 * API object.
@@ -69,24 +69,24 @@ class WP_Job_Manager_Helper {
 
 		$this->api = WP_Job_Manager_Helper_API::instance();
 
-		add_action( 'job_manager_helper_output', array( $this, 'licence_output' ) );
+		add_action( 'job_manager_helper_output', [ $this, 'licence_output' ] );
 
-		add_filter( 'job_manager_addon_core_version_check', array( $this, 'addon_core_version_check' ), 10, 2 );
-		add_filter( 'extra_plugin_headers', array( $this, 'extra_headers' ) );
-		add_filter( 'plugins_api', array( $this, 'plugins_api' ), 20, 3 );
-		add_action( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_updates' ) );
+		add_filter( 'job_manager_addon_core_version_check', [ $this, 'addon_core_version_check' ], 10, 2 );
+		add_filter( 'extra_plugin_headers', [ $this, 'extra_headers' ] );
+		add_filter( 'plugins_api', [ $this, 'plugins_api' ], 20, 3 );
+		add_action( 'pre_set_site_transient_update_plugins', [ $this, 'check_for_updates' ] );
 
-		add_action( 'activated_plugin', array( $this, 'plugin_activated' ) );
-		add_action( 'deactivated_plugin', array( $this, 'plugin_deactivated' ) );
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		add_action( 'activated_plugin', [ $this, 'plugin_activated' ] );
+		add_action( 'deactivated_plugin', [ $this, 'plugin_deactivated' ] );
+		add_action( 'admin_init', [ $this, 'admin_init' ] );
 	}
 
 	/**
 	 * Initializes admin-only actions.
 	 */
 	public function admin_init() {
-		add_action( 'plugin_action_links', array( $this, 'plugin_links' ), 10, 2 );
-		add_action( 'admin_notices', array( $this, 'licence_error_notices' ) );
+		add_action( 'plugin_action_links', [ $this, 'plugin_links' ], 10, 2 );
+		add_action( 'admin_notices', [ $this, 'licence_error_notices' ] );
 		$this->handle_admin_request();
 	}
 
@@ -123,7 +123,7 @@ class WP_Job_Manager_Helper {
 
 		// We only want to show the notices on the plugins page and main job listing admin page.
 		$screen = get_current_screen();
-		if ( null === $screen || ! in_array( $screen->id, array( 'plugins', 'edit-job_listing' ), true ) ) {
+		if ( null === $screen || ! in_array( $screen->id, [ 'plugins', 'edit-job_listing' ], true ) ) {
 			return false;
 		}
 
@@ -181,13 +181,13 @@ class WP_Job_Manager_Helper {
 		}
 
 		$response = $this->api->plugin_update_check(
-			array(
+			[
 				'plugin_name'    => $plugin_data['Name'],
 				'version'        => $plugin_data['Version'],
 				'api_product_id' => $product_slug,
 				'licence_key'    => $licence['licence_key'],
 				'email'          => $licence['email'],
-			)
+			]
 		);
 
 		$this->handle_api_errors( $product_slug, $response );
@@ -363,11 +363,11 @@ class WP_Job_Manager_Helper {
 		$activation_email = WP_Job_Manager_Helper_Options::get( $product_slug, 'email' );
 		$errors           = WP_Job_Manager_Helper_Options::get( $product_slug, 'errors' );
 
-		return array(
+		return [
 			'licence_key' => $licence_key,
 			'email'       => $activation_email,
 			'errors'      => $errors,
-		);
+		];
 	}
 
 	/**
@@ -418,7 +418,7 @@ class WP_Job_Manager_Helper {
 			self::$cleared_plugin_cache = true;
 		}
 
-		$wpjm_plugins = array();
+		$wpjm_plugins = [];
 		$plugins      = get_plugins();
 
 		foreach ( $plugins as $filename => $data ) {
@@ -456,7 +456,7 @@ class WP_Job_Manager_Helper {
 	 */
 	public function licence_error_notices() {
 		$screen = get_current_screen();
-		if ( null === $screen || in_array( $screen->id, array( 'job_listing_page_job-manager-addons' ), true ) ) {
+		if ( null === $screen || in_array( $screen->id, [ 'job_listing_page_job-manager-addons' ], true ) ) {
 			return;
 		}
 		foreach ( $this->get_installed_plugins() as $product_slug => $plugin_data ) {
@@ -513,11 +513,11 @@ class WP_Job_Manager_Helper {
 	 */
 	private function activate_licence( $product_slug, $licence_key, $email ) {
 		$response = $this->api->activate(
-			array(
+			[
 				'api_product_id' => $product_slug,
 				'licence_key'    => $licence_key,
 				'email'          => $email,
-			)
+			]
 		);
 
 		$error = false;
@@ -538,7 +538,7 @@ class WP_Job_Manager_Helper {
 			$this->add_error( $product_slug, __( 'An unknown error occurred while attempting to activate the license', 'wp-job-manager' ) );
 		}
 
-		$event_properties = array( 'slug' => $product_slug );
+		$event_properties = [ 'slug' => $product_slug ];
 		if ( false !== $error ) {
 			$event_properties['error'] = $error;
 			self::log_event( 'license_activation_error', $event_properties );
@@ -559,11 +559,11 @@ class WP_Job_Manager_Helper {
 			return;
 		}
 		$this->api->deactivate(
-			array(
+			[
 				'api_product_id' => $product_slug,
 				'licence_key'    => $licence['licence_key'],
 				'email'          => $licence['email'],
-			)
+			]
 		);
 
 		WP_Job_Manager_Helper_Options::delete( $product_slug, 'licence_key' );
@@ -575,9 +575,9 @@ class WP_Job_Manager_Helper {
 
 		self::log_event(
 			'license_deactivated',
-			array(
+			[
 				'slug' => $product_slug,
-			)
+			]
 		);
 	}
 
@@ -593,8 +593,8 @@ class WP_Job_Manager_Helper {
 			return;
 		}
 
-		$errors         = ! empty( $response['errors'] ) ? $response['errors'] : array();
-		$allowed_errors = array( 'no_activation', 'expired_key', 'expiring_soon' );
+		$errors         = ! empty( $response['errors'] ) ? $response['errors'] : [];
+		$allowed_errors = [ 'no_activation', 'expired_key', 'expiring_soon' ];
 		$ignored_errors = array_diff( array_keys( $errors ), $allowed_errors );
 
 		foreach ( $ignored_errors as $key ) {
@@ -637,12 +637,12 @@ class WP_Job_Manager_Helper {
 	 */
 	private function add_message( $type, $product_slug, $message ) {
 		if ( ! isset( $this->licence_messages[ $product_slug ] ) ) {
-			$this->licence_messages[ $product_slug ] = array();
+			$this->licence_messages[ $product_slug ] = [];
 		}
-		$this->licence_messages[ $product_slug ][] = array(
+		$this->licence_messages[ $product_slug ][] = [
 			'type'    => $type,
 			'message' => $message,
-		);
+		];
 	}
 
 	/**
@@ -653,7 +653,7 @@ class WP_Job_Manager_Helper {
 	 */
 	public function get_messages( $product_slug ) {
 		if ( ! isset( $this->licence_messages[ $product_slug ] ) ) {
-			$this->licence_messages[ $product_slug ] = array();
+			$this->licence_messages[ $product_slug ] = [];
 		}
 
 		return $this->licence_messages[ $product_slug ];
@@ -665,7 +665,7 @@ class WP_Job_Manager_Helper {
 	 * @param string $event_name The name of the event, without the `wpjm` prefix.
 	 * @param array  $properties The event properties to be sent.
 	 */
-	private function log_event( $event_name, $properties = array() ) {
+	private function log_event( $event_name, $properties = [] ) {
 		if ( ! class_exists( 'WP_Job_Manager_Usage_Tracking' ) ) {
 			return;
 		}

--- a/includes/helper/views/html-licences.php
+++ b/includes/helper/views/html-licences.php
@@ -33,12 +33,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php
 				$notices = WP_Job_Manager_Helper::get_messages( $product_slug );
 				if ( empty( $notices ) && ! empty( $licence['errors'] ) ) {
-					$notices = array();
+					$notices = [];
 					foreach ( $licence['errors'] as $key => $error_message ) {
-						$notices[] = array(
+						$notices[] = [
 							'type'    => 'error',
 							'message' => $error_message,
-						);
+						];
 					}
 				}
 				foreach ( $notices as $message ) {

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -28,47 +28,47 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 		$this->widget_cssclass    = 'job_manager widget_featured_jobs';
 		$this->widget_description = __( 'Display a list of featured listings on your site.', 'wp-job-manager' );
 		$this->widget_id          = 'widget_featured_jobs';
-		$this->settings           = array(
-			'title'     => array(
+		$this->settings           = [
+			'title'     => [
 				'type'  => 'text',
 				// translators: Placeholder %s is the plural label for the job listing post type.
 				'std'   => sprintf( __( 'Featured %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name ),
 				'label' => __( 'Title', 'wp-job-manager' ),
-			),
-			'number'    => array(
+			],
+			'number'    => [
 				'type'  => 'number',
 				'step'  => 1,
 				'min'   => 1,
 				'max'   => '',
 				'std'   => 10,
 				'label' => __( 'Number of listings to show', 'wp-job-manager' ),
-			),
-			'orderby'   => array(
+			],
+			'orderby'   => [
 				'type'    => 'select',
 				'std'     => 'date',
 				'label'   => __( 'Sort By', 'wp-job-manager' ),
-				'options' => array(
+				'options' => [
 					'date'          => __( 'Date', 'wp-job-manager' ),
 					'title'         => __( 'Title', 'wp-job-manager' ),
 					'author'        => __( 'Author', 'wp-job-manager' ),
 					'rand_featured' => __( 'Random', 'wp-job-manager' ),
-				),
-			),
-			'order'     => array(
+				],
+			],
+			'order'     => [
 				'type'    => 'select',
 				'std'     => 'DESC',
 				'label'   => __( 'Sort Direction', 'wp-job-manager' ),
-				'options' => array(
+				'options' => [
 					'ASC'  => __( 'Ascending', 'wp-job-manager' ),
 					'DESC' => __( 'Descending', 'wp-job-manager' ),
-				),
-			),
-			'show_logo' => array(
+				],
+			],
+			'show_logo' => [
 				'type'  => 'checkbox',
 				'std'   => 0,
 				'label' => esc_html__( 'Show Company Logo', 'wp-job-manager' ),
-			),
-		);
+			],
+		];
 		parent::__construct();
 	}
 
@@ -97,12 +97,12 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 		$title          = apply_filters( 'widget_title', $title_instance, $instance, $this->id_base );
 		$show_logo      = absint( $instance['show_logo'] );
 		$jobs           = get_job_listings(
-			array(
+			[
 				'posts_per_page' => $number,
 				'orderby'        => $orderby,
 				'order'          => $order,
 				'featured'       => true,
-			)
+			]
 		);
 
 		if ( $jobs->have_posts() ) : ?>
@@ -122,7 +122,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 					$jobs->the_post();
 					?>
 
-					<?php get_job_manager_template( 'content-widget-job_listing.php', array( 'show_logo' => $show_logo ) ); ?>
+					<?php get_job_manager_template( 'content-widget-job_listing.php', [ 'show_logo' => $show_logo ] ); ?>
 
 				<?php endwhile; ?>
 

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -28,37 +28,37 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 		$this->widget_cssclass    = 'job_manager widget_recent_jobs';
 		$this->widget_description = __( 'Display a list of recent listings on your site, optionally matching a keyword and location.', 'wp-job-manager' );
 		$this->widget_id          = 'widget_recent_jobs';
-		$this->settings           = array(
-			'title'     => array(
+		$this->settings           = [
+			'title'     => [
 				'type'  => 'text',
 				// translators: Placeholder %s is the plural label for the job listing post type.
 				'std'   => sprintf( __( 'Recent %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name ),
 				'label' => __( 'Title', 'wp-job-manager' ),
-			),
-			'keyword'   => array(
+			],
+			'keyword'   => [
 				'type'  => 'text',
 				'std'   => '',
 				'label' => __( 'Keyword', 'wp-job-manager' ),
-			),
-			'location'  => array(
+			],
+			'location'  => [
 				'type'  => 'text',
 				'std'   => '',
 				'label' => __( 'Location', 'wp-job-manager' ),
-			),
-			'number'    => array(
+			],
+			'number'    => [
 				'type'  => 'number',
 				'step'  => 1,
 				'min'   => 1,
 				'max'   => '',
 				'std'   => 10,
 				'label' => __( 'Number of listings to show', 'wp-job-manager' ),
-			),
-			'show_logo' => array(
+			],
+			'show_logo' => [
 				'type'  => 'checkbox',
 				'std'   => 0,
 				'label' => esc_html__( 'Show Company Logo', 'wp-job-manager' ),
-			),
-		);
+			],
+		];
 
 		parent::__construct();
 	}
@@ -84,13 +84,13 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 		$title     = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 		$number    = absint( $instance['number'] );
 		$jobs      = get_job_listings(
-			array(
+			[
 				'search_location' => $instance['location'],
 				'search_keywords' => $instance['keyword'],
 				'posts_per_page'  => $number,
 				'orderby'         => 'date',
 				'order'           => 'DESC',
-			)
+			]
 		);
 		$show_logo = absint( $instance['show_logo'] );
 
@@ -122,7 +122,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 					$jobs->the_post();
 					?>
 
-					<?php get_job_manager_template( 'content-widget-job_listing.php', array( 'show_logo' => $show_logo ) ); ?>
+					<?php get_job_manager_template( 'content-widget-job_listing.php', [ 'show_logo' => $show_logo ] ); ?>
 
 				<?php endwhile; ?>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,6 +30,18 @@
 	<rule ref="WordPress.Security.ValidatedSanitizedInput" />
 	<rule ref="WordPress.DB.DirectDatabaseQuery" />
 
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
+		<exclude-pattern>includes/class-wp-job-manager-dependency-checker.php</exclude-pattern>
+		<exclude-pattern>/wp-job-manager.php</exclude-pattern>
+		<exclude-pattern>/uninstall.php</exclude-pattern>
+	</rule>
+
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
+		<include-pattern>includes/class-wp-job-manager-dependency-checker.php</include-pattern>
+		<include-pattern>/wp-job-manager.php</include-pattern>
+		<include-pattern>/uninstall.php</include-pattern>
+	</rule>
+
 	<!-- Temporary Rule Exclusions -->
 	<rule ref="VariableAnalysis">
 		<exclude-pattern>includes/admin/views/</exclude-pattern>

--- a/templates/account-signin.php
+++ b/templates/account-signin.php
@@ -62,7 +62,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<label
 					for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $field[ 'label' ] ) . wp_kses_post( apply_filters( 'submit_job_form_required_label', $field[ 'required' ] ? '' : ' <small>' . __( '(optional)', 'wp-job-manager' ) . '</small>', $field ) ); ?></label>
 				<div class="field <?php echo $field[ 'required' ] ? 'required-field draft-required' : ''; ?>">
-					<?php get_job_manager_template( 'form-fields/' . $field[ 'type' ] . '-field.php', array( 'key'   => $key, 'field' => $field ) ); ?>
+					<?php get_job_manager_template( 'form-fields/' . $field[ 'type' ] . '-field.php', [ 'key'   => $key, 'field' => $field ] ); ?>
 				</div>
 			</fieldset>
 			<?php

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$style_vars                   = array();
+$style_vars                   = [];
 $style_vars['color_bg']       = '#fff';
 $style_vars['color_fg']       = '#000';
 $style_vars['color_light']    = '#eee';

--- a/templates/form-fields/file-field.php
+++ b/templates/form-fields/file-field.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$classes            = array( 'input-text' );
+$classes            = [ 'input-text' ];
 $allowed_mime_types = array_keys( ! empty( $field['allowed_mime_types'] ) ? $field['allowed_mime_types'] : get_allowed_mime_types() );
 $field_name         = isset( $field['name'] ) ? $field['name'] : $key;
 $field_name         .= ! empty( $field['multiple'] ) ? '[]' : '';
@@ -34,10 +34,10 @@ if ( ! empty( $field['ajax'] ) && job_manager_user_can_upload_file_via_ajax() ) 
 	<?php if ( ! empty( $field['value'] ) ) : ?>
 		<?php if ( is_array( $field['value'] ) ) : ?>
 			<?php foreach ( $field['value'] as $value ) : ?>
-				<?php get_job_manager_template( 'form-fields/uploaded-file-html.php', array( 'key' => $key, 'name' => 'current_' . $field_name, 'value' => $value, 'field' => $field ) ); ?>
+				<?php get_job_manager_template( 'form-fields/uploaded-file-html.php', [ 'key' => $key, 'name' => 'current_' . $field_name, 'value' => $value, 'field' => $field ] ); ?>
 			<?php endforeach; ?>
 		<?php elseif ( $value = $field['value'] ) : ?>
-			<?php get_job_manager_template( 'form-fields/uploaded-file-html.php', array( 'key' => $key, 'name' => 'current_' . $field_name, 'value' => $value, 'field' => $field ) ); ?>
+			<?php get_job_manager_template( 'form-fields/uploaded-file-html.php', [ 'key' => $key, 'name' => 'current_' . $field_name, 'value' => $value, 'field' => $field ] ); ?>
 		<?php endif; ?>
 	<?php endif; ?>
 </div>

--- a/templates/form-fields/term-checklist-field.php
+++ b/templates/form-fields/term-checklist-field.php
@@ -23,13 +23,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$field['default'] = '';
 	}
 
-	$args = array(
+	$args = [
 		'descendants_and_self'  => 0,
-		'selected_cats'         => isset( $field['value'] ) ? $field['value'] : ( is_array( $field['default'] ) ? $field['default'] : array( $field['default'] ) ),
+		'selected_cats'         => isset( $field['value'] ) ? $field['value'] : ( is_array( $field['default'] ) ? $field['default'] : [ $field['default'] ] ),
 		'popular_cats'          => false,
 		'taxonomy'              => $field['taxonomy'],
 		'checked_ontop'         => false
-	);
+	];
 
 	// $field['post_id'] needs to be passed via the args so we can get the existing terms.
 	ob_start();

--- a/templates/form-fields/term-multiselect-field.php
+++ b/templates/form-fields/term-multiselect-field.php
@@ -28,14 +28,14 @@ if ( isset( $field['value'] ) ) {
 
 wp_enqueue_script( 'wp-job-manager-term-multiselect' );
 
-$args = array(
+$args = [
 	'taxonomy'     => $field['taxonomy'],
 	'hierarchical' => 1,
 	'name'         => isset( $field['name'] ) ? $field['name'] : $key,
 	'orderby'      => 'name',
 	'selected'     => $selected,
 	'hide_empty'   => false
-);
+];
 
 if ( isset( $field['placeholder'] ) && ! empty( $field['placeholder'] ) ) $args['placeholder'] = $field['placeholder'];
 

--- a/templates/form-fields/term-select-field.php
+++ b/templates/form-fields/term-select-field.php
@@ -31,7 +31,7 @@ if ( is_array( $selected ) ) {
 	$selected = current( $selected );
 }
 
-wp_dropdown_categories( apply_filters( 'job_manager_term_select_field_wp_dropdown_categories_args', array(
+wp_dropdown_categories( apply_filters( 'job_manager_term_select_field_wp_dropdown_categories_args', [
 	'taxonomy'         => $field['taxonomy'],
 	'hierarchical'     => 1,
 	'show_option_all'  => false,
@@ -40,5 +40,5 @@ wp_dropdown_categories( apply_filters( 'job_manager_term_select_field_wp_dropdow
 	'orderby'          => 'name',
 	'selected'         => $selected,
 	'hide_empty'       => false
-), $key, $field ) );
+], $key, $field ) );
 if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>

--- a/templates/form-fields/wp-editor-field.php
+++ b/templates/form-fields/wp-editor-field.php
@@ -15,12 +15,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$editor = apply_filters( 'submit_job_form_wp_editor_args', array(
+$editor = apply_filters( 'submit_job_form_wp_editor_args', [
 	'textarea_name' => isset( $field['name'] ) ? $field['name'] : $key,
 	'media_buttons' => false,
 	'textarea_rows' => 8,
 	'quicktags'     => false,
-	'tinymce'       => array(
+	'tinymce'       => [
 		'plugins'                       => 'lists,paste,tabfocus,wplink,wordpress',
 		'paste_as_text'                 => true,
 		'paste_auto_cleanup_on_paste'   => true,
@@ -32,7 +32,7 @@ $editor = apply_filters( 'submit_job_form_wp_editor_args', array(
 		'toolbar2'                      => '',
 		'toolbar3'                      => '',
 		'toolbar4'                      => ''
-	),
-) );
+	],
+] );
 wp_editor( isset( $field['value'] ) ? wp_kses_post( $field['value'] ) : '', $key, $editor );
 if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -44,43 +44,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 									<?php echo is_position_featured( $job ) ? '<span class="featured-job-icon" title="' . esc_attr__( 'Featured Job', 'wp-job-manager' ) . '"></span>' : ''; ?>
 									<ul class="job-dashboard-actions">
 										<?php
-											$actions = array();
+											$actions = [];
 
 											switch ( $job->post_status ) {
 												case 'publish' :
 													if ( wpjm_user_can_edit_published_submissions() ) {
-														$actions[ 'edit' ] = array( 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false );
+														$actions[ 'edit' ] = [ 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false ];
 													}
 													if ( is_position_filled( $job ) ) {
-														$actions['mark_not_filled'] = array( 'label' => __( 'Mark not filled', 'wp-job-manager' ), 'nonce' => true );
+														$actions['mark_not_filled'] = [ 'label' => __( 'Mark not filled', 'wp-job-manager' ), 'nonce' => true ];
 													} else {
-														$actions['mark_filled'] = array( 'label' => __( 'Mark filled', 'wp-job-manager' ), 'nonce' => true );
+														$actions['mark_filled'] = [ 'label' => __( 'Mark filled', 'wp-job-manager' ), 'nonce' => true ];
 													}
 
-													$actions['duplicate'] = array( 'label' => __( 'Duplicate', 'wp-job-manager' ), 'nonce' => true );
+													$actions['duplicate'] = [ 'label' => __( 'Duplicate', 'wp-job-manager' ), 'nonce' => true ];
 													break;
 												case 'expired' :
 													if ( job_manager_get_permalink( 'submit_job_form' ) ) {
-														$actions['relist'] = array( 'label' => __( 'Relist', 'wp-job-manager' ), 'nonce' => true );
+														$actions['relist'] = [ 'label' => __( 'Relist', 'wp-job-manager' ), 'nonce' => true ];
 													}
 													break;
 												case 'pending_payment' :
 												case 'pending' :
 													if ( job_manager_user_can_edit_pending_submissions() ) {
-														$actions['edit'] = array( 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false );
+														$actions['edit'] = [ 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false ];
 													}
 												break;
 												case 'draft' :
 												case 'preview' :
-													$actions['continue'] = array( 'label' => __( 'Continue Submission', 'wp-job-manager' ), 'nonce' => true );
+													$actions['continue'] = [ 'label' => __( 'Continue Submission', 'wp-job-manager' ), 'nonce' => true ];
 													break;
 											}
 
-											$actions['delete'] = array( 'label' => __( 'Delete', 'wp-job-manager' ), 'nonce' => true );
+											$actions['delete'] = [ 'label' => __( 'Delete', 'wp-job-manager' ), 'nonce' => true ];
 											$actions           = apply_filters( 'job_manager_my_job_actions', $actions, $job );
 
 											foreach ( $actions as $action => $value ) {
-												$action_url = add_query_arg( array( 'action' => $action, 'job_id' => $job->ID ) );
+												$action_url = add_query_arg( [ 'action' => $action, 'job_id' => $job->ID ] );
 												if ( $value['nonce'] ) {
 													$action_url = wp_nonce_url( $action_url, 'job_manager_my_job_actions' );
 												}
@@ -104,5 +104,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php endif; ?>
 		</tbody>
 	</table>
-	<?php get_job_manager_template( 'pagination.php', array( 'max_num_pages' => $max_num_pages ) ); ?>
+	<?php get_job_manager_template( 'pagination.php', [ 'max_num_pages' => $max_num_pages ] ); ?>
 </div>

--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -42,13 +42,13 @@ do_action( 'job_manager_job_filters_before', $atts );
 			<?php foreach ( $categories as $category ) : ?>
 				<input type="hidden" name="search_categories[]" value="<?php echo esc_attr( sanitize_title( $category ) ); ?>" />
 			<?php endforeach; ?>
-		<?php elseif ( $show_categories && ! is_tax( 'job_listing_category' ) && get_terms( array( 'taxonomy' => 'job_listing_category' ) ) ) : ?>
+		<?php elseif ( $show_categories && ! is_tax( 'job_listing_category' ) && get_terms( [ 'taxonomy' => 'job_listing_category' ] ) ) : ?>
 			<div class="search_categories">
 				<label for="search_categories"><?php esc_html_e( 'Category', 'wp-job-manager' ); ?></label>
 				<?php if ( $show_category_multiselect ) : ?>
-					<?php job_manager_dropdown_categories( array( 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'hide_empty' => true ) ); ?>
+					<?php job_manager_dropdown_categories( [ 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'hide_empty' => true ] ); ?>
 				<?php else : ?>
-					<?php job_manager_dropdown_categories( array( 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'show_option_all' => __( 'Any category', 'wp-job-manager' ), 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'multiple' => false, 'hide_empty' => true ) ); ?>
+					<?php job_manager_dropdown_categories( [ 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'show_option_all' => __( 'Any category', 'wp-job-manager' ), 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'multiple' => false, 'hide_empty' => true ] ); ?>
 				<?php endif; ?>
 			</div>
 		<?php endif; ?>

--- a/templates/job-submit.php
+++ b/templates/job-submit.php
@@ -42,7 +42,7 @@ global $job_manager;
 			<fieldset class="fieldset-<?php echo esc_attr( $key ); ?> fieldset-type-<?php echo esc_attr( $field['type'] ); ?>">
 				<label for="<?php echo esc_attr( $key ); ?>"><?php echo wp_kses_post( $field['label'] ) . wp_kses_post( apply_filters( 'submit_job_form_required_label', $field['required'] ? '' : ' <small>' . __( '(optional)', 'wp-job-manager' ) . '</small>', $field ) ); ?></label>
 				<div class="field <?php echo $field['required'] ? 'required-field' : ''; ?>">
-					<?php get_job_manager_template( 'form-fields/' . $field['type'] . '-field.php', array( 'key' => $key, 'field' => $field ) ); ?>
+					<?php get_job_manager_template( 'form-fields/' . $field['type'] . '-field.php', [ 'key' => $key, 'field' => $field ] ); ?>
 				</div>
 			</fieldset>
 		<?php endforeach; ?>
@@ -59,7 +59,7 @@ global $job_manager;
 				<fieldset class="fieldset-<?php echo esc_attr( $key ); ?> fieldset-type-<?php echo esc_attr( $field['type'] ); ?>">
 					<label for="<?php echo esc_attr( $key ); ?>"><?php echo wp_kses_post( $field['label'] ) . wp_kses_post( apply_filters( 'submit_job_form_required_label', $field['required'] ? '' : ' <small>' . __( '(optional)', 'wp-job-manager' ) . '</small>', $field ) ); ?></label>
 					<div class="field <?php echo $field['required'] ? 'required-field' : ''; ?>">
-						<?php get_job_manager_template( 'form-fields/' . $field['type'] . '-field.php', array( 'key' => $key, 'field' => $field ) ); ?>
+						<?php get_job_manager_template( 'form-fields/' . $field['type'] . '-field.php', [ 'key' => $key, 'field' => $field ] ); ?>
 					</div>
 				</fieldset>
 			<?php endforeach; ?>

--- a/templates/pagination.php
+++ b/templates/pagination.php
@@ -21,7 +21,7 @@ if ( $max_num_pages <= 1 ) {
 ?>
 <nav class="job-manager-pagination">
 	<?php
-		echo paginate_links( apply_filters( 'job_manager_pagination_args', array(
+		echo paginate_links( apply_filters( 'job_manager_pagination_args', [
 			'base'      => esc_url_raw( str_replace( 999999999, '%#%', get_pagenum_link( 999999999, false ) ) ),
 			'format'    => '',
 			'current'   => max( 1, get_query_var('paged') ),
@@ -31,6 +31,6 @@ if ( $max_num_pages <= 1 ) {
 			'type'      => 'list',
 			'end_size'  => 3,
 			'mid_size'  => 3
-		) ) );
+		] ) );
 	?>
 </nav>

--- a/tests/bin/get-wp-version.php
+++ b/tests/bin/get-wp-version.php
@@ -20,7 +20,7 @@ function offer_version_sort( $first, $second ) {
 
 uasort( $versions, 'offer_version_sort' );
 
-$version_stack = array();
+$version_stack = [];
 
 foreach ( $versions as $offer ) {
 	list( $major, $minor ) = explode( '.',  $offer->version );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -31,7 +31,7 @@ class WPJM_Unit_Tests_Bootstrap {
 		ini_set( 'display_errors', 'on' );
 
 		error_reporting( E_ALL );
-		set_error_handler( array( $this, 'convert_to_exception' ), E_ALL );
+		set_error_handler( [ $this, 'convert_to_exception' ], E_ALL );
 
 		$this->tests_dir    = dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'tests';
 		$this->includes_dir = dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'includes';
@@ -42,10 +42,10 @@ class WPJM_Unit_Tests_Bootstrap {
 		require_once $this->wp_tests_dir . '/includes/functions.php';
 
 		// load WPJM.
-		tests_add_filter( 'muplugins_loaded', array( $this, 'load_plugin' ) );
+		tests_add_filter( 'muplugins_loaded', [ $this, 'load_plugin' ] );
 
 		// install WPJM.
-		tests_add_filter( 'setup_theme', array( $this, 'install_plugin' ) );
+		tests_add_filter( 'setup_theme', [ $this, 'install_plugin' ] );
 
 		// load the WP testing environment.
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
@@ -125,15 +125,15 @@ class WPJM_Unit_Tests_Bootstrap {
 			define( 'E_DEPRECATED', 8192 );
 		}
 
-		$error_descriptions = array(
+		$error_descriptions = [
 			E_WARNING    => 'Warning',
 			E_ERROR      => 'Error',
 			E_PARSE      => 'Parse Error',
 			E_NOTICE     => 'Notice',
 			E_STRICT     => 'Strict Notice',
 			E_DEPRECATED => 'PHP Deprecated',
-		);
-		if ( in_array( $errno, array( E_RECOVERABLE_ERROR ) ) ) {
+		];
+		if ( in_array( $errno, [ E_RECOVERABLE_ERROR ] ) ) {
 			return;
 		}
 		$description = 'Unknown Error: ';

--- a/tests/php/includes/class-requests-transport-faker.php
+++ b/tests/php/includes/class-requests-transport-faker.php
@@ -2,8 +2,8 @@
 
 class Requests_Transport_Faker implements Requests_Transport {
 	public $headers_matter = false;
-	private $_log          = array();
-	private $_responses    = array();
+	private $_log          = [];
+	private $_responses    = [];
 
 	/**
 	 * Adds a fake request and response.
@@ -12,13 +12,13 @@ class Requests_Transport_Faker implements Requests_Transport {
 	 * @param array $response
 	 */
 	public function add_fake_request( $request, $response ) {
-		$response_arr = array();
+		$response_arr = [];
 		if ( is_array( $request ) ) {
 			$response_arr['request'] = $request;
 			$request                 = self::make_request_signature(
 				isset( $request['url'] ) ? $request['url'] : '',
-				isset( $request['headers'] ) ? $request['headers'] : array(),
-				isset( $request['data'] ) ? $request['data'] : array()
+				isset( $request['headers'] ) ? $request['headers'] : [],
+				isset( $request['data'] ) ? $request['data'] : []
 			);
 		}
 		if ( is_array( $response ) ) {
@@ -37,17 +37,17 @@ class Requests_Transport_Faker implements Requests_Transport {
 	 *
 	 * @return string
 	 */
-	public static function make_request_signature( $url, $headers = array(), $data = array() ) {
+	public static function make_request_signature( $url, $headers = [], $data = [] ) {
 		if ( empty( $headers ) ) {
-			$headers = array();
+			$headers = [];
 		}
 		if ( empty( $data ) ) {
-			$data = array();
+			$data = [];
 		}
 		if ( is_object( $url ) && $url instanceof Requests_IRI ) {
 			$url = $url->__toString();
 		}
-		return sha1( json_encode( array( $url, $headers, $data ) ) );
+		return sha1( json_encode( [ $url, $headers, $data ] ) );
 	}
 
 	/**
@@ -58,7 +58,7 @@ class Requests_Transport_Faker implements Requests_Transport {
 	 */
 	public static function build_response( $response ) {
 		if ( ! isset( $response['headers'] ) ) {
-			$response['headers'] = array( 'HTTP/1.1 200 OK' );
+			$response['headers'] = [ 'HTTP/1.1 200 OK' ];
 		}
 		if ( ! isset( $response['body'] ) ) {
 			$response['body'] = '';
@@ -96,17 +96,17 @@ class Requests_Transport_Faker implements Requests_Transport {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function request( $url, $headers = array(), $data = array(), $options = array() ) {
+	public function request( $url, $headers = [], $data = [], $options = [] ) {
 		if ( $this->headers_matter ) {
 			$signature = self::make_request_signature( $url, $headers, $data );
 		} else {
-			$signature = self::make_request_signature( $url, array(), $data );
+			$signature = self::make_request_signature( $url, [], $data );
 		}
-		$this->_log[ $signature ] = array(
+		$this->_log[ $signature ] = [
 			'url'     => $url,
 			'headers' => $headers,
 			'data'    => $data,
-		);
+		];
 		if ( ! isset( $this->_responses[ $signature ] ) ) {
 			throw new Requests_Exception( 'Computer says no', 'test' );
 		}
@@ -117,20 +117,20 @@ class Requests_Transport_Faker implements Requests_Transport {
 	 * {@inheritdoc}
 	 */
 	public function request_multiple( $requests, $options ) {
-		$responses = array();
+		$responses = [];
 		$class     = get_class( $this );
 		foreach ( $requests as $id => $request ) {
 			try {
 				$handler          = new $class();
 				$responses[ $id ] = $handler->request( $request['url'], $request['headers'], $request['data'], $request['options'] );
 
-				$request['options']['hooks']->dispatch( 'transport.internal.parse_response', array( &$responses[ $id ], $request ) );
+				$request['options']['hooks']->dispatch( 'transport.internal.parse_response', [ &$responses[ $id ], $request ] );
 			} catch ( Requests_Exception $e ) {
 				$responses[ $id ] = $e;
 			}
 
 			if ( ! is_string( $responses[ $id ] ) ) {
-				$request['options']['hooks']->dispatch( 'multiple.request.complete', array( &$responses[ $id ], $id ) );
+				$request['options']['hooks']->dispatch( 'multiple.request.complete', [ &$responses[ $id ], $id ] );
 			}
 		}
 

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -59,7 +59,7 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function return_do_not_die() {
-		return array( $this, 'do_not_die' );
+		return [ $this, 'do_not_die' ];
 	}
 
 	/**
@@ -75,28 +75,28 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	 * Helper to disable manage job listings capability.
 	 */
 	protected function disable_update_plugins_cap() {
-		remove_filter( 'user_has_cap', array( $this, 'add_manage_update_plugins_cap' ) );
+		remove_filter( 'user_has_cap', [ $this, 'add_manage_update_plugins_cap' ] );
 	}
 
 	/**
 	 * Helper to enable manage job listings capability.
 	 */
 	protected function enable_update_plugins_cap() {
-		add_filter( 'user_has_cap', array( $this, 'add_manage_update_plugins_cap' ) );
+		add_filter( 'user_has_cap', [ $this, 'add_manage_update_plugins_cap' ] );
 	}
 
 	/**
 	 * Helper to disable update plugins capability.
 	 */
 	protected function disable_manage_job_listings_cap() {
-		remove_filter( 'user_has_cap', array( $this, 'add_manage_job_listing_cap' ) );
+		remove_filter( 'user_has_cap', [ $this, 'add_manage_job_listing_cap' ] );
 	}
 
 	/**
 	 * Helper to enable update plugins capability.
 	 */
 	protected function enable_manage_job_listings_cap() {
-		add_filter( 'user_has_cap', array( $this, 'add_manage_job_listing_cap' ) );
+		add_filter( 'user_has_cap', [ $this, 'add_manage_job_listing_cap' ] );
 	}
 
 	/**
@@ -116,14 +116,14 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	}
 
 	protected function disable_transport_faker() {
-		remove_action( 'requests-requests.before_request', array( $this, 'overload_request_transport' ), 10 );
+		remove_action( 'requests-requests.before_request', [ $this, 'overload_request_transport' ], 10 );
 		remove_filter( 'job_manager_geolocation_api_key', '__return_empty_string', 10 );
-		add_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
+		add_filter( 'job_manager_geolocation_api_key', [ $this, 'get_google_maps_api_key' ], 10 );
 	}
 
 	protected function enable_transport_faker() {
-		add_action( 'requests-requests.before_request', array( $this, 'overload_request_transport' ), 10, 5 );
-		remove_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
+		add_action( 'requests-requests.before_request', [ $this, 'overload_request_transport' ], 10, 5 );
+		remove_filter( 'job_manager_geolocation_api_key', [ $this, 'get_google_maps_api_key' ], 10 );
 		add_filter( 'job_manager_geolocation_api_key', '__return_empty_string', 10 );
 	}
 

--- a/tests/php/includes/class-wpjm-helper-base-test.php
+++ b/tests/php/includes/class-wpjm-helper-base-test.php
@@ -4,29 +4,29 @@ require_once JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-hel
 
 class WPJM_Helper_Base_Test extends WPJM_BaseTest {
 	protected function plugin_data_with_update() {
-		return array(
-			'test' => array(
+		return [
+			'test' => [
 				'_product_slug' => 'test',
 				'_filename'     => 'test/test.php',
 				'Version'       => '1.0.0',
 				'Name'          => 'Test',
-			),
-		);
+			],
+		];
 	}
 
 	protected function plugin_data_without_update() {
-		return array(
-			'test' => array(
+		return [
+			'test' => [
 				'_product_slug' => 'test',
 				'_filename'     => 'test/test.php',
 				'Version'       => '1.1.0',
 				'Name'          => 'Test',
-			),
-		);
+			],
+		];
 	}
 
 	protected function result_plugin_information() {
-		return array(
+		return [
 			'slug'          => 'test',
 			'plugin'        => 'test/test.php',
 			'version'       => '1.1.0',
@@ -34,10 +34,10 @@ class WPJM_Helper_Base_Test extends WPJM_BaseTest {
 			'author'        => 'Test',
 			'requires'      => '4.1',
 			'tested'        => '4.8',
-			'sections'      => array(),
+			'sections'      => [],
 			'homepage'      => 'http://test.dev',
 			'download_link' => 'http://test.dev',
-		);
+		];
 	}
 
 	protected function getMockHelper( $plugins = null ) {
@@ -49,7 +49,7 @@ class WPJM_Helper_Base_Test extends WPJM_BaseTest {
 		WP_Job_Manager_Helper_Options::update( 'test', 'email', 'test@local.dev' );
 
 		$mock = $this->getMockBuilder( 'WP_Job_Manager_Helper' )
-					 ->setMethods( array( 'get_installed_plugins', '_get_api' ) )
+					 ->setMethods( [ 'get_installed_plugins', '_get_api' ] )
 					 ->getMock();
 		$api  = $this->getMockHelperApi();
 		$this->setProtectedProperty( $mock, 'api', $api );
@@ -60,30 +60,30 @@ class WPJM_Helper_Base_Test extends WPJM_BaseTest {
 
 	protected function getMockHelperApi() {
 		$mock = $this->getMockBuilder( 'WP_Job_Manager_Helper_API' )
-					 ->setMethods( array( 'plugin_update_check', 'plugin_information', 'activate', 'deactivate' ) )
+					 ->setMethods( [ 'plugin_update_check', 'plugin_information', 'activate', 'deactivate' ] )
 					 ->getMock();
 
 		$mock->method( 'plugin_update_check' )->willReturn(
-			array(
+			[
 				'slug'        => 'test',
 				'plugin'      => 'test',
 				'new_version' => '1.1.0',
 				'url'         => 'http://test.dev',
 				'package'     => 'http://test.dev',
-			)
+			]
 		);
 		$mock->method( 'plugin_information' )->willReturn( $this->result_plugin_information() );
 		$mock->method( 'activate' )->willReturn(
-			array(
+			[
 				'success'   => true,
 				'activated' => true,
 				'remaining' => -1,
-			)
+			]
 		);
 		$mock->method( 'deactivate' )->willReturn(
-			array(
+			[
 				'success' => true,
-			)
+			]
 		);
 		return $mock;
 	}

--- a/tests/php/includes/class-wpjm-rest-testcase.php
+++ b/tests/php/includes/class-wpjm-rest-testcase.php
@@ -114,7 +114,7 @@ class WPJM_REST_TestCase extends WPJM_BaseTest {
 	 * @param array  $args_or_body Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	protected function request( $endpoint, $method, $args_or_body = array() ) {
+	protected function request( $endpoint, $method, $args_or_body = [] ) {
 		$this->beforeRequest();
 
 		$request = new WP_REST_Request( $method, $endpoint );
@@ -135,7 +135,7 @@ class WPJM_REST_TestCase extends WPJM_BaseTest {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	protected function get( $endpoint, $args = array() ) {
+	protected function get( $endpoint, $args = [] ) {
 		return $this->request( $endpoint, 'GET', $args );
 	}
 
@@ -146,7 +146,7 @@ class WPJM_REST_TestCase extends WPJM_BaseTest {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	protected function post( $endpoint, $args = array() ) {
+	protected function post( $endpoint, $args = [] ) {
 		return $this->request( $endpoint, 'POST', $args );
 	}
 
@@ -157,7 +157,7 @@ class WPJM_REST_TestCase extends WPJM_BaseTest {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	protected function put( $endpoint, $args = array() ) {
+	protected function put( $endpoint, $args = [] ) {
 		return $this->request( $endpoint, 'PUT', $args );
 	}
 
@@ -168,7 +168,7 @@ class WPJM_REST_TestCase extends WPJM_BaseTest {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	protected function delete( $endpoint, $args = array() ) {
+	protected function delete( $endpoint, $args = [] ) {
 		return $this->request( $endpoint, 'DELETE', $args );
 	}
 

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -1,11 +1,11 @@
 <?php
 
 class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
-	protected $default_job_listing_meta = array();
+	protected $default_job_listing_meta = [];
 
 	function __construct( $factory = null ) {
 		parent::__construct( $factory );
-		$this->default_job_listing_meta       = array(
+		$this->default_job_listing_meta       = [
 			'_job_location'    => '',
 			'_job_type'        => 'full-time',
 			'_application'     => 'test@example.com',
@@ -17,14 +17,14 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 			'_company_logo'    => '',
 			'_filled'          => '0',
 			'_featured'        => '0',
-		);
-		$this->default_generation_definitions = array(
+		];
+		$this->default_generation_definitions = [
 			'post_status'  => 'publish',
 			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Job Listing title %s' ),
 			'post_content' => new WP_UnitTest_Generator_Sequence( 'Job Listing content %s' ),
 			'post_excerpt' => new WP_UnitTest_Generator_Sequence( 'Job Listing excerpt %s' ),
 			'post_type'    => 'job_listing',
-		);
+		];
 	}
 
 	/**
@@ -34,7 +34,7 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 	 */
 	function create_object( $args ) {
 		if ( ! isset( $args['meta_input'] ) ) {
-			$args['meta_input'] = array();
+			$args['meta_input'] = [];
 		}
 		$args['meta_input'] = $this->generate_args( $args['meta_input'], $this->default_job_listing_meta );
 		if ( ! empty( $args['meta_input']['_featured'] ) ) {
@@ -53,11 +53,11 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 		$mod_date = date( 'Y-m-d', strtotime( $age ) );
 		$wpdb->update(
 			$wpdb->posts,
-			array(
+			[
 				'post_modified'     => $mod_date,
 				'post_modified_gmt' => $mod_date,
-			),
-			array( 'ID' => $post_id )
+			],
+			[ 'ID' => $post_id ]
 		);
 	}
 }

--- a/tests/php/includes/stubs/class-wp-job-manager-form-test.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-form-test.php
@@ -17,7 +17,7 @@ class WP_Job_Manager_Form_Test extends WP_Job_Manager_Form {
 		return null !== self::$instance;
 	}
 
-	public function output( $atts = array() ) {
+	public function output( $atts = [] ) {
 		echo 'success';
 	}
 }

--- a/tests/php/includes/stubs/class-wpjm-ajax-action-stub.php
+++ b/tests/php/includes/stubs/class-wpjm-ajax-action-stub.php
@@ -5,7 +5,7 @@ class WPJM_Ajax_Action_Stub {
 	public $fired  = false;
 
 	public function __construct() {
-		add_action( 'job_manager_ajax_' . $this->action, array( $this, 'ajax_handler' ) );
+		add_action( 'job_manager_ajax_' . $this->action, [ $this, 'ajax_handler' ] );
 	}
 
 	public function ajax_handler() {

--- a/tests/php/includes/stubs/class-wpjm-api-handler-stub.php
+++ b/tests/php/includes/stubs/class-wpjm-api-handler-stub.php
@@ -4,7 +4,7 @@ class WPJM_Api_Handler_Stub {
 	public $fired = false;
 
 	public function __construct() {
-		add_action( 'job_manager_api_' . strtolower( get_class( $this ) ), array( $this, 'api_handler' ) );
+		add_action( 'job_manager_api_' . strtolower( get_class( $this ) ), [ $this, 'api_handler' ] );
 	}
 
 	public function api_handler() {

--- a/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email-template.php
+++ b/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email-template.php
@@ -17,13 +17,13 @@ class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
 	 */
 	public function test_get_rich_content() {
 		$job           = get_post( $this->factory->job_listing->create() );
-		$args          = array( 'job' => $job );
+		$args          = [ 'job' => $job ];
 		$test          = new WP_Job_Manager_Email_Template_Valid( $args, $this->get_base_settings() );
 		$test_expected = "<strong>Rich Test Email: {$job->post_title}</strong>";
 
-		add_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		add_filter( 'job_manager_locate_template', [ $this, 'use_rich_test_template' ] );
 		$test_value = $test->get_rich_content();
-		remove_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		remove_filter( 'job_manager_locate_template', [ $this, 'use_rich_test_template' ] );
 		$this->assertStringStartsWith( $test_expected, $test_value );
 	}
 
@@ -35,12 +35,12 @@ class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
 	 */
 	public function test_get_plain_content() {
 		$job           = get_post( $this->factory->job_listing->create() );
-		$args          = array( 'job' => $job );
+		$args          = [ 'job' => $job ];
 		$test          = new WP_Job_Manager_Email_Template_Valid( $args, $this->get_base_settings() );
 		$test_expected = "Plain Test Email: {$job->post_title}";
-		add_filter( 'job_manager_locate_template', array( $this, 'use_plain_test_template' ) );
+		add_filter( 'job_manager_locate_template', [ $this, 'use_plain_test_template' ] );
 		$test_value = $test->get_plain_content();
-		remove_filter( 'job_manager_locate_template', array( $this, 'use_plain_test_template' ) );
+		remove_filter( 'job_manager_locate_template', [ $this, 'use_plain_test_template' ] );
 		$this->assertStringStartsWith( $test_expected, $test_value );
 	}
 
@@ -54,12 +54,12 @@ class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
 	public function test_get_plain_content_rich_fallback() {
 		$this->fake_pass = 0;
 		$job             = get_post( $this->factory->job_listing->create() );
-		$args            = array( 'job' => $job );
+		$args            = [ 'job' => $job ];
 		$test            = new WP_Job_Manager_Email_Template_Valid( $args, $this->get_base_settings() );
 		$test_expected   = "Rich Test Email: {$job->post_title}";
-		add_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		add_filter( 'job_manager_locate_template', [ $this, 'use_fake_test_template' ] );
 		$test_value = $test->get_plain_content();
-		remove_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		remove_filter( 'job_manager_locate_template', [ $this, 'use_fake_test_template' ] );
 		$this->assertStringStartsWith( $test_expected, $test_value );
 	}
 
@@ -69,11 +69,11 @@ class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
 	 */
 	public function test_has_template_rich() {
 		$this->fake_pass = 0;
-		$args            = array( 'job' => '' );
+		$args            = [ 'job' => '' ];
 		$test            = new WP_Job_Manager_Email_Template_Valid( $args, $this->get_base_settings() );
-		add_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		add_filter( 'job_manager_locate_template', [ $this, 'use_rich_test_template' ] );
 		$test_value = $test->has_template();
-		remove_filter( 'job_manager_locate_template', array( $this, 'use_rich_test_template' ) );
+		remove_filter( 'job_manager_locate_template', [ $this, 'use_rich_test_template' ] );
 		$this->assertTrue( $test_value );
 	}
 
@@ -83,11 +83,11 @@ class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
 	 */
 	public function test_has_template_plain_fake() {
 		$this->fake_pass = 0;
-		$args            = array( 'job' => '' );
+		$args            = [ 'job' => '' ];
 		$test            = new WP_Job_Manager_Email_Template_Valid( $args, $this->get_base_settings() );
-		add_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		add_filter( 'job_manager_locate_template', [ $this, 'use_fake_test_template' ] );
 		$test_value = $test->has_template( true );
-		remove_filter( 'job_manager_locate_template', array( $this, 'use_fake_test_template' ) );
+		remove_filter( 'job_manager_locate_template', [ $this, 'use_fake_test_template' ] );
 		$this->assertFalse( $test_value );
 	}
 
@@ -124,9 +124,9 @@ class WP_Test_WP_Job_Manager_Email_Template extends WPJM_BaseTest {
 	}
 
 	protected function get_base_settings() {
-		return array(
+		return [
 			'enabled'    => '1',
 			'plain_text' => '0',
-		);
+		];
 	}
 }

--- a/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email.php
+++ b/tests/php/tests/includes/abstracts/test_class.wp-job-manager-email.php
@@ -11,15 +11,15 @@ class WP_Test_WP_Job_Manager_Email extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Email::get_attachments()
 	 */
 	public function test_get_attachments() {
-		$test = new WP_Job_Manager_Email_Valid( array(), $this->get_base_settings() );
-		$this->assertEquals( array(), $test->get_attachments() );
+		$test = new WP_Job_Manager_Email_Valid( [], $this->get_base_settings() );
+		$this->assertEquals( [], $test->get_attachments() );
 	}
 
 	/**
 	 * @covers WP_Job_Manager_Email::get_cc()
 	 */
 	public function test_get_cc() {
-		$test = new WP_Job_Manager_Email_Valid( array(), $this->get_base_settings() );
+		$test = new WP_Job_Manager_Email_Valid( [], $this->get_base_settings() );
 		$this->assertNull( $test->get_cc() );
 	}
 
@@ -27,23 +27,23 @@ class WP_Test_WP_Job_Manager_Email extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Email::get_headers()
 	 */
 	public function test_get_headers() {
-		$test = new WP_Job_Manager_Email_Valid( array(), $this->get_base_settings() );
-		$this->assertEquals( array(), $test->get_headers() );
+		$test = new WP_Job_Manager_Email_Valid( [], $this->get_base_settings() );
+		$this->assertEquals( [], $test->get_headers() );
 	}
 
 	/**
 	 * @covers WP_Job_Manager_Email::get_plain_content()
 	 */
 	public function test_get_plain_contents() {
-		$args = array( 'test' => md5( microtime( true ) ) );
+		$args = [ 'test' => md5( microtime( true ) ) ];
 		$test = new WP_Job_Manager_Email_Valid( $args, $this->get_base_settings() );
 		$this->assertEquals( $args['test'], $test->get_plain_content() );
 	}
 
 	protected function get_base_settings() {
-		return array(
+		return [
 			'enabled'    => '1',
 			'plain_text' => '0',
-		);
+		];
 	}
 }

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-admin-notices.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-admin-notices.php
@@ -21,7 +21,7 @@ class WP_Test_WP_Job_Manager_Admin_Notices extends WPJM_BaseTest {
 
 		WP_Job_Manager_Admin_Notices::reset_notices();
 
-		$this->assertEquals( array(), $this->get_raw_state() );
+		$this->assertEquals( [], $this->get_raw_state() );
 	}
 
 	public function test_add_notice_simple() {
@@ -79,27 +79,27 @@ class WP_Test_WP_Job_Manager_Admin_Notices extends WPJM_BaseTest {
 
 	public function test_is_admin_on_standard_job_manager_screen_non_admin() {
 		$this->login_as_admin();
-		$this->assertTrue( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( array( '' ) ) );
+		$this->assertTrue( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( [ '' ] ) );
 
 		$this->login_as_employer();
-		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( array( '' ) ) );
+		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( [ '' ] ) );
 	}
 
 	public function test_is_admin_on_standard_job_manager_screen_uncommon_screen_test() {
 		$this->login_as_admin();
-		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( array( 'dinosaur' ) ) );
+		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( [ 'dinosaur' ] ) );
 		set_current_screen( 'dinosaur' );
 
-		$this->assertTrue( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( array( 'dinosaur' ) ) );
-		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( array( 'dogs' ) ) );
+		$this->assertTrue( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( [ 'dinosaur' ] ) );
+		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( [ 'dogs' ] ) );
 	}
 
 	public function test_is_admin_on_standard_job_manager_screen_common_screen_test() {
 		$this->login_as_admin();
-		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( array() ) );
+		$this->assertFalse( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( [] ) );
 		set_current_screen( 'edit-job_listing' );
 
-		$this->assertTrue( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( array() ) );
+		$this->assertTrue( WP_Job_Manager_Admin_Notices::is_admin_on_standard_job_manager_screen( [] ) );
 	}
 
 	private function get_raw_state() {

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
@@ -22,28 +22,28 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 
 		// Create some listings.
 		$listing_notfilled_notfeatured_id = $this->create_listing_with_meta(
-			array(
+			[
 				'_filled'   => '0',
 				'_featured' => '0',
-			)
+			]
 		);
 		$listing_notfilled_featured_id    = $this->create_listing_with_meta(
-			array(
+			[
 				'_filled'   => '0',
 				'_featured' => '1',
-			)
+			]
 		);
 		$listing_filled_notfeatured_id    = $this->create_listing_with_meta(
-			array(
+			[
 				'_filled'   => '1',
 				'_featured' => '0',
-			)
+			]
 		);
 		$listing_filled_featured_id       = $this->create_listing_with_meta(
-			array(
+			[
 				'_filled'   => '1',
 				'_featured' => '1',
-			)
+			]
 		);
 
 		// Simulate viewing the edit.php page.
@@ -51,10 +51,10 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 
 		// When no filters are given.
 		$query = new WP_Query(
-			array(
+			[
 				'post_type' => 'job_listing',
 				'fields'    => 'ids',
-			)
+			]
 		);
 		$this->assertContains( $listing_notfilled_notfeatured_id, $query->posts );
 		$this->assertContains( $listing_notfilled_featured_id, $query->posts );
@@ -64,10 +64,10 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		// Filtering on Filled.
 		$_GET['job_listing_filled'] = '1';
 		$query                      = new WP_Query(
-			array(
+			[
 				'post_type' => 'job_listing',
 				'fields'    => 'ids',
-			)
+			]
 		);
 		$this->assertNotContains( $listing_notfilled_notfeatured_id, $query->posts );
 		$this->assertNotContains( $listing_notfilled_featured_id, $query->posts );
@@ -78,10 +78,10 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		$_GET['job_listing_filled']   = '';
 		$_GET['job_listing_featured'] = '0';
 		$query                        = new WP_Query(
-			array(
+			[
 				'post_type' => 'job_listing',
 				'fields'    => 'ids',
-			)
+			]
 		);
 		$this->assertContains( $listing_notfilled_notfeatured_id, $query->posts );
 		$this->assertNotContains( $listing_notfilled_featured_id, $query->posts );
@@ -101,7 +101,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 
 		// Create some listings.
 		$listing_id = $this->factory->post->create(
-			array( 'post_type' => 'job_listing' )
+			[ 'post_type' => 'job_listing' ]
 		);
 
 		// Simulate viewing some other page.
@@ -111,10 +111,10 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		$_GET['job_listing_filled']   = '1';
 		$_GET['job_listing_featured'] = '1';
 		$query                        = new WP_Query(
-			array(
+			[
 				'post_type' => 'job_listing',
 				'fields'    => 'ids',
-			)
+			]
 		);
 		$this->assertContains( $listing_id, $query->posts );
 	}
@@ -123,7 +123,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 
 	private function create_listing_with_meta( $meta ) {
 		$id = $this->factory->post->create(
-			array( 'post_type' => 'job_listing' )
+			[ 'post_type' => 'job_listing' ]
 		);
 
 		foreach ( $meta as $meta_key => $meta_value ) {

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
@@ -15,150 +15,150 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 		$duration     = absint( get_option( 'job_manager_submission_duration' ) );
 		$auto_date    = date( 'Y-m-d', strtotime( "+{$duration} days", current_time( 'timestamp' ) ) );
 
-		return array(
+		return [
 			/**
 			 * Tests to make sure auto-expiring works.
 			 */
-			'autoexpire_publish_future_publish'      => array(
+			'autoexpire_publish_future_publish'      => [
 				// On published post, set to future date and expect published.
-				array(
+				[
 					'original' => 'publish',
 					'new'      => null,
 					'expected' => 'publish',
-				),
-				array(
+				],
+				[
 					'original' => $future_date,
 					'new'      => $future_date,
 					'expected' => $future_date,
-				),
-			),
-			'autoexpire_publish_past_expired'        => array(
+				],
+			],
+			'autoexpire_publish_past_expired'        => [
 				// On published post, set to past date and expect expired.
-				array(
+				[
 					'original' => 'publish',
 					'new'      => 'publish',
 					'expected' => 'expired',
-				),
-				array(
+				],
+				[
 					'original' => $future_date,
 					'new'      => $expired_date,
 					'expected' => $expired_date,
-				),
-			),
-			'autoexpire_draft_past_expired'          => array(
+				],
+			],
+			'autoexpire_draft_past_expired'          => [
 				// On draft post, set to past date and expect expired.
-				array(
+				[
 					'original' => 'draft',
 					'new'      => 'publish',
 					'expected' => 'expired',
-				),
-				array(
+				],
+				[
 					'original' => $future_date,
 					'new'      => $expired_date,
 					'expected' => $expired_date,
-				),
-			),
-			'autoexpire_draft_future_publish'        => array(
+				],
+			],
+			'autoexpire_draft_future_publish'        => [
 				// On draft post, set to future date and expect expired.
-				array(
+				[
 					'original' => 'draft',
 					'new'      => 'publish',
 					'expected' => 'publish',
-				),
-				array(
+				],
+				[
 					'original' => $future_date,
 					'new'      => $future_date,
 					'expected' => $future_date,
-				),
-			),
-			'autoexpire_expired_future_keep_expired' => array(
+				],
+			],
+			'autoexpire_expired_future_keep_expired' => [
 				// On expired post, set to future date and expect expired to be preserved.
-				array(
+				[
 					'original' => 'expired',
 					'new'      => null,
 					'expected' => 'expired',
-				),
-				array(
+				],
+				[
 					'original' => $expired_date,
 					'new'      => $future_date,
 					'expected' => $future_date,
-				),
-			),
+				],
+			],
 
 			/**
 			 * Tests to make sure changes to draft is preserved.
 			*/
-			'draft_publish_draft'                    => array(
+			'draft_publish_draft'                    => [
 				// From publish to draft (not touching expiration date) we should get a draft.
-				array(
+				[
 					'original' => 'publish',
 					'new'      => 'draft',
 					'expected' => 'draft',
-				),
+				],
 				null,
-			),
-			'draft_expired_draft'                    => array(
+			],
+			'draft_expired_draft'                    => [
 				// From expired to draft (not touching expiration date) we should get a draft.
-				array(
+				[
 					'original' => 'expired',
 					'new'      => 'draft',
 					'expected' => 'draft',
-				),
+				],
 				null,
-			),
-			'draft_publish_draft_set_expired_date'   => array(
+			],
+			'draft_publish_draft_set_expired_date'   => [
 				// From publish to draft (setting an expired expiration date) we should get a draft.
-				array(
+				[
 					'original' => 'publish',
 					'new'      => 'draft',
 					'expected' => 'draft',
-				),
-				array(
+				],
+				[
 					'original' => $future_date,
 					'new'      => $expired_date,
 					'expected' => $expired_date,
-				),
-			),
-			'draft_publish_draft_keep_expired_date'  => array(
+				],
+			],
+			'draft_publish_draft_keep_expired_date'  => [
 				// From publish to draft (keeping an expired expiration date) we should get a draft.
-				array(
+				[
 					'original' => 'publish',
 					'new'      => 'draft',
 					'expected' => 'draft',
-				),
-				array(
+				],
+				[
 					'original' => $expired_date,
 					'new'      => $expired_date,
 					'expected' => $expired_date,
-				),
-			),
-			'draft_expired_draft_set_expired'        => array(
+				],
+			],
+			'draft_expired_draft_set_expired'        => [
 				// From expired to draft (setting an expired expiration date) we should get a draft.
-				array(
+				[
 					'original' => 'expired',
 					'new'      => 'draft',
 					'expected' => 'draft',
-				),
-				array(
+				],
+				[
 					'original' => $future_date,
 					'new'      => $expired_date,
 					'expected' => $expired_date,
-				),
-			),
-			'draft_expired_draft_keep_expired'       => array(
+				],
+			],
+			'draft_expired_draft_keep_expired'       => [
 				// From expired to draft (keeping an expired expiration date) we should get a draft.
-				array(
+				[
 					'original' => 'expired',
 					'new'      => 'draft',
 					'expected' => 'draft',
-				),
-				array(
+				],
+				[
 					'original' => $expired_date,
 					'new'      => $expired_date,
 					'expected' => $expired_date,
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -169,18 +169,18 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 		$writepanels = WP_Job_Manager_Writepanels::instance();
 
 		$this->login_as_admin();
-		$original_job_data = array();
+		$original_job_data = [];
 		if ( null !== $status_data && null !== $status_data['original'] ) {
 			$original_job_data['post_status'] = $status_data['original'];
 		}
 		if ( null !== $expires_data && null !== $expires_data['original'] ) {
-			$original_job_data['meta_input'] = array( '_job_expires' => $expires_data['original'] );
+			$original_job_data['meta_input'] = [ '_job_expires' => $expires_data['original'] ];
 		}
 		if ( null !== $status_data ) {
-			$new_job_data = array(
+			$new_job_data = [
 				'original_post_status' => $status_data['original'],
 				'post_status'          => $status_data['new'],
-			);
+			];
 		}
 		if ( null !== $expires_data && null !== $expires_data['new'] ) {
 			$new_job_data['_job_expires'] = $expires_data['new'];
@@ -188,10 +188,10 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 		$job = $this->mock_writepanel_save_request( $new_job_data, $original_job_data );
 		if ( null !== $status_data && null !== $status_data['new'] ) {
 			wp_update_post(
-				array(
+				[
 					'ID'          => $job->ID,
 					'post_status' => $status_data['new'],
-				)
+				]
 			);
 		}
 
@@ -204,13 +204,13 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 		}
 	}
 
-	private function mock_writepanel_save_request( $new_job_data = array(), $original_job_data = array() ) {
+	private function mock_writepanel_save_request( $new_job_data = [], $original_job_data = [] ) {
 		global $post;
 		$job_id = $this->factory->job_listing->create( $original_job_data );
 		$job    = get_post( $job_id );
 		$post   = $job;
 
-		$_POST                     = array();
+		$_POST                     = [];
 		$_POST['_job_expires']     = $job->_job_expires;
 		$_POST['_job_location']    = $job->_job_location;
 		$_POST['_job_author']      = $job->_job_author;

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -39,15 +39,15 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 	public function test_plugin_update_check_valid() {
 		$base_args = $this->get_base_args();
 		$this->set_expected_response(
-			array(
+			[
 				'args' => wp_parse_args(
-					array(
+					[
 						'wc-api'  => 'wp_plugin_licencing_update_api',
 						'request' => 'pluginupdatecheck',
-					),
+					],
 					$base_args
 				),
-			)
+			]
 		);
 		$instance = new WP_Job_Manager_Helper_API();
 		$response = $instance->plugin_update_check( $base_args );
@@ -75,15 +75,15 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 	public function test_plugin_information_valid() {
 		$base_args = $this->get_base_args();
 		$this->set_expected_response(
-			array(
+			[
 				'args' => wp_parse_args(
-					array(
+					[
 						'wc-api'  => 'wp_plugin_licencing_update_api',
 						'request' => 'plugininformation',
-					),
+					],
 					$base_args
 				),
-			)
+			]
 		);
 		$instance = new WP_Job_Manager_Helper_API();
 		$response = $instance->plugin_information( $base_args );
@@ -111,15 +111,15 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 	public function test_activate_valid() {
 		$base_args = $this->get_base_args();
 		$this->set_expected_response(
-			array(
+			[
 				'args' => wp_parse_args(
-					array(
+					[
 						'wc-api'  => 'wp_plugin_licencing_activation_api',
 						'request' => 'activate',
-					),
+					],
 					$base_args
 				),
-			)
+			]
 		);
 		$instance = new WP_Job_Manager_Helper_API();
 		$response = $instance->activate( $base_args );
@@ -148,15 +148,15 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 	public function test_deactivate_valid() {
 		$base_args = $this->get_base_args();
 		$this->set_expected_response(
-			array(
+			[
 				'args' => wp_parse_args(
-					array(
+					[
 						'wc-api'  => 'wp_plugin_licencing_activation_api',
 						'request' => 'deactivate',
-					),
+					],
 					$base_args
 				),
-			)
+			]
 		);
 		$instance = new WP_Job_Manager_Helper_API();
 		$response = $instance->deactivate( $base_args );
@@ -178,45 +178,45 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_Helper_Base_Test {
 	}
 
 	private function get_base_args() {
-		return array(
+		return [
 			'instance'       => site_url(),
 			'plugin_name'    => 'test',
 			'version'        => '1.0.0',
 			'api_product_id' => 'test',
 			'licence_key'    => 'abcd',
 			'email'          => 'test@local.dev',
-		);
+		];
 	}
 
 	protected function set_expected_response( $test_data ) {
 		$transport = $this->get_request_transport();
 		if ( ! isset( $test_data['request'] ) ) {
-			$test_data['request'] = array();
+			$test_data['request'] = [];
 		}
 		if ( ! isset( $test_data['request']['url'] ) ) {
 			$test_data['request']['url'] = $this->build_url( $test_data['args'] );
 		}
 		if ( ! isset( $test_data['request']['headers'] ) ) {
-			$test_data['request']['headers'] = array(
+			$test_data['request']['headers'] = [
 				'Accept' => 'application/json',
-			);
+			];
 		}
 		if ( ! isset( $test_data['response'] ) ) {
 			$test_data['response'] = $this->default_valid_response();
 		}
-		$transport->add_fake_request( $test_data['request'], array( 'body' => $test_data['response'] ) );
+		$transport->add_fake_request( $test_data['request'], [ 'body' => $test_data['response'] ] );
 	}
 
 	protected function default_valid_response() {
-		return array( 'status' => 1 );
+		return [ 'status' => 1 ];
 	}
 
 	protected function default_invalid_response() {
 		// Prebaked response in Requests_Transport_Faker.
-		return array(
+		return [
 			'error_code' => 'http_request_failed',
 			'error'      => 'Computer says no',
-		);
+		];
 	}
 
 	protected function build_url( $args ) {

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-options.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-options.php
@@ -77,19 +77,19 @@ class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_Helper_Base_Test {
 
 	private function setup_master_option( $value = null ) {
 		if ( null === $value ) {
-			$value = array(
-				'test' => array(
+			$value = [
+				'test' => [
 					'licence_key'     => 'abcd',
 					'email'           => 'local@local.dev',
 					'errors'          => null,
 					'hide_key_notice' => false,
-				),
-			);
+				],
+			];
 		}
 		update_option( 'job_manager_helper', $value );
 	}
 
 	private function get_master_option() {
-		return get_option( 'job_manager_helper', array() );
+		return get_option( 'job_manager_helper', [] );
 	}
 }

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
@@ -97,7 +97,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	public function test_check_for_updates_has_update() {
 		$instance       = $this->getMockHelper( $this->plugin_data_with_update() );
 		$data           = new stdClass();
-		$data->response = array();
+		$data->response = [];
 		$instance->check_for_updates( $data );
 		$this->assertTrue( isset( $data->response['test/test.php'] ) );
 	}
@@ -112,7 +112,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	public function test_check_for_updates_no_update() {
 		$instance       = $this->getMockHelper( $this->plugin_data_without_update() );
 		$data           = new stdClass();
-		$data->response = array();
+		$data->response = [];
 		$instance->check_for_updates( $data );
 		$this->assertEmpty( $data->response );
 	}
@@ -131,7 +131,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 		WP_Job_Manager_Helper_Options::delete( 'test', 'email' );
 
 		$data           = new stdClass();
-		$data->response = array();
+		$data->response = [];
 		$instance->check_for_updates( $data );
 		$this->assertEmpty( $data->response );
 	}
@@ -226,7 +226,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 		$response    = new stdClass();
 		$args        = new stdClass();
 		$args->slug  = $plugin_slug;
-		$args        = new stdClass( array( 'slug' => $plugin_slug ) );
+		$args        = new stdClass( [ 'slug' => $plugin_slug ] );
 		$result      = $instance->plugins_api( $response, 'what_the_what', $args );
 		$this->assertSame( $response, $result );
 	}
@@ -256,7 +256,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	public function test_plugin_links_valid_plugin_valid_license() {
 		$instance = $this->getMockHelper();
 		$this->enable_update_plugins_cap();
-		$actions = $instance->plugin_links( array(), 'test/test.php' );
+		$actions = $instance->plugin_links( [], 'test/test.php' );
 		$this->disable_update_plugins_cap();
 		$this->assertCount( 1, $actions );
 		$this->assertContains( __( 'Manage License', 'wp-job-manager' ), $actions[0] );
@@ -272,7 +272,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 		$this->enable_update_plugins_cap();
 		WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
 		WP_Job_Manager_Helper_Options::delete( 'test', 'email' );
-		$actions = $instance->plugin_links( array(), 'test/test.php' );
+		$actions = $instance->plugin_links( [], 'test/test.php' );
 		$this->disable_update_plugins_cap();
 		$this->assertCount( 1, $actions );
 		$this->assertContains( __( 'Activate License', 'wp-job-manager' ), $actions[0] );
@@ -286,7 +286,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	public function test_plugin_links_invalid_plugin() {
 		$instance = $this->getMockHelper();
 		$this->enable_update_plugins_cap();
-		$actions = $instance->plugin_links( array(), 'rhino/rhino.php' );
+		$actions = $instance->plugin_links( [], 'rhino/rhino.php' );
 		$this->disable_update_plugins_cap();
 		$this->assertCount( 0, $actions );
 	}
@@ -298,7 +298,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	 */
 	public function test_plugin_links_invalid_cap() {
 		$instance = $this->getMockHelper();
-		$actions  = $instance->plugin_links( array(), 'test/test.php' );
+		$actions  = $instance->plugin_links( [], 'test/test.php' );
 		$this->assertCount( 0, $actions );
 	}
 
@@ -332,7 +332,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	 */
 	public function test_has_licenced_products_true() {
 		// Simulate no installed plugins.
-		$instance = $this->getMockHelper( array() );
+		$instance = $this->getMockHelper( [] );
 		$this->assertFalse( $instance->has_licenced_products() );
 	}
 
@@ -344,7 +344,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	 */
 	public function test_has_licenced_products_false() {
 		// Simulate a installed plugin.
-		$instance = $this->getMockHelper( array( 'test' => array() ) );
+		$instance = $this->getMockHelper( [ 'test' => [] ] );
 		$this->assertTrue( $instance->has_licenced_products() );
 	}
 
@@ -361,11 +361,11 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 		WP_Job_Manager_Helper_Options::delete( 'rhino', 'licence_key' );
 		WP_Job_Manager_Helper_Options::delete( 'rhino', 'email' );
 		WP_Job_Manager_Helper_Options::delete( 'rhino', 'errors' );
-		$expected = array(
+		$expected = [
 			'licence_key' => '1234',
 			'email'       => 'test@local.dev',
 			'errors'      => null,
-		);
+		];
 		$this->assertEquals( $expected, $result );
 	}
 
@@ -376,11 +376,11 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	public function test_get_plugin_license_invalid() {
 		$instance = new WP_Job_Manager_Helper();
 		$result   = $instance->get_plugin_licence( 'rhino' );
-		$expected = array(
+		$expected = [
 			'licence_key' => null,
 			'email'       => null,
 			'errors'      => null,
-		);
+		];
 		$this->assertEquals( $expected, $result );
 	}
 
@@ -390,8 +390,8 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 	 */
 	public function test_extra_headers() {
 		$instance = new WP_Job_Manager_Helper();
-		$result   = $instance->extra_headers( array() );
-		$expected = array( 'WPJM-Product' );
+		$result   = $instance->extra_headers( [] );
+		$expected = [ 'WPJM-Product' ];
 		$this->assertEquals( $expected, $result );
 	}
 }

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
@@ -33,7 +33,7 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_guest_delete_job_categories_fail() {
 		$this->logout();
 		$term_id  = $this->get_job_category();
-		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 401 );
 	}
 
@@ -41,10 +41,10 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->post(
 			'/wp/v2/job-categories',
-			array(
+			[
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 401 );
@@ -55,9 +55,9 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->put(
 			sprintf( '/wp/v2/job-categories/%d', $term_id ),
-			array(
+			[
 				'name'   => 'Software Engineer 2',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 401 );
@@ -79,7 +79,7 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_employer_delete_job_categories_fail() {
 		$this->login_as_employer();
 		$term_id  = $this->get_job_category();
-		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 403 );
 	}
 
@@ -87,10 +87,10 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 		$this->login_as_employer();
 		$response = $this->post(
 			'/wp/v2/job-categories',
-			array(
+			[
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 403 );
@@ -101,9 +101,9 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 		$this->login_as_employer();
 		$response = $this->put(
 			sprintf( '/wp/v2/job-categories/%d', $term_id ),
-			array(
+			[
 				'name'   => 'Software Engineer 2',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 403 );
@@ -119,9 +119,9 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->post(
 			'/wp/v2/job-categories',
-			array(
+			[
 				'name' => 'REST Test' . microtime( true ),
-			)
+			]
 		);
 		$this->assertResponseStatus( $response, 401 );
 	}
@@ -130,9 +130,9 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 		$this->login_as_admin();
 		$response = $this->post(
 			'/wp/v2/job-categories',
-			array(
+			[
 				'name' => 'REST Test' . microtime( true ),
-			)
+			]
 		);
 		$this->assertResponseStatus( $response, 201 );
 	}
@@ -141,9 +141,9 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 		$this->login_as_default_user();
 		$response = $this->post(
 			'/wp/v2/job-categories',
-			array(
+			[
 				'name' => 'REST Test' . microtime( true ),
-			)
+			]
 		);
 		$this->assertResponseStatus( $response, 401 );
 	}
@@ -158,14 +158,14 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	public function test_delete_fail_as_default_user() {
 		$this->login_as_default_user();
 		$term_id  = $this->get_job_category();
-		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 401 );
 	}
 
 	public function test_delete_succeed_as_admin_user() {
 		$this->login_as_admin();
 		$term_id  = $this->get_job_category();
-		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-categories/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 200 );
 	}
 
@@ -186,6 +186,6 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	}
 
 	protected function get_job_category() {
-		return $this->factory->term->create( array( 'taxonomy' => 'job_listing_category' ) );
+		return $this->factory->term->create( [ 'taxonomy' => 'job_listing_category' ] );
 	}
 }

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -38,7 +38,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	public function test_guest_get_unpublished_job_listing_fail() {
 		$this->logout();
-		$post_id  = $this->get_job_listing( array( 'post_status' => 'draft' ) );
+		$post_id  = $this->get_job_listing( [ 'post_status' => 'draft' ] );
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		$this->assertResponseStatus( $response, 401 );
 	}
@@ -46,7 +46,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	public function test_guest_delete_job_listings_fail() {
 		$this->logout();
 		$post_id  = $this->get_job_listing();
-		$response = $this->delete( sprintf( '/wp/v2/job-listings/%d', $post_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-listings/%d', $post_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 401 );
 	}
 
@@ -54,10 +54,10 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->post(
 			'/wp/v2/job-listings',
-			array(
+			[
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 401 );
@@ -68,9 +68,9 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->put(
 			sprintf( '/wp/v2/job-listings/%d', $post_id ),
-			array(
+			[
 				'post_title' => 'Software Engineer 2',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 401 );
@@ -90,7 +90,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_employer_get_unpublished_job_listing_fail() {
-		$post_id = $this->get_job_listing( array( 'post_status' => 'draft' ) );
+		$post_id = $this->get_job_listing( [ 'post_status' => 'draft' ] );
 		$this->login_as_employer();
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		$this->assertResponseStatus( $response, 403 );
@@ -98,22 +98,22 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	public function test_employer_get_their_own_unpublished_job_listing_success() {
 		$this->login_as_employer();
-		$post_id  = $this->get_job_listing( array( 'post_status' => 'draft' ) );
+		$post_id  = $this->get_job_listing( [ 'post_status' => 'draft' ] );
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		$this->assertResponseStatus( $response, 200 );
 	}
 
 	public function test_employer_publish_their_own_unpublished_job_listing_success() {
 		$this->login_as_employer();
-		$post_id      = $this->get_job_listing( array( 'post_status' => 'draft' ) );
+		$post_id      = $this->get_job_listing( [ 'post_status' => 'draft' ] );
 		$response_get = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
 		$this->assertResponseStatus( $response_get, 200 );
 
 		$response_post = $this->put(
 			sprintf( '/wp/v2/job-listings/%d', $post_id ),
-			array(
+			[
 				'post_status' => 'publish',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response_post, 403 );
@@ -122,7 +122,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	public function test_employer_delete_job_listings_fail() {
 		$this->login_as_employer();
 		$post_id  = $this->get_job_listing();
-		$response = $this->delete( sprintf( '/wp/v2/job-listings/%d', $post_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-listings/%d', $post_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 403 );
 	}
 
@@ -130,10 +130,10 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$this->login_as_employer();
 		$response = $this->post(
 			'/wp/v2/job-listings',
-			array(
+			[
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 403 );
@@ -144,9 +144,9 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		$this->login_as_employer();
 		$response = $this->put(
 			sprintf( '/wp/v2/job-listings/%d', $post_id ),
-			array(
+			[
 				'post_title' => 'Software Engineer 2',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 403 );
@@ -171,8 +171,8 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	 * Tests to make sure public meta fields are exposed to guest users and private meta fields are hidden.
 	 */
 	public function test_guest_can_read_only_public_fields() {
-		$public_fields  = array( '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' );
-		$private_fields = array( '_job_expires' );
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' ];
+		$private_fields = [ '_job_expires' ];
 		$this->logout();
 		$post_id = $this->get_job_listing();
 
@@ -192,7 +192,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_same_employer_read_access_to_private_meta_fields() {
-		$available_fields = array( '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires' );
+		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires' ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();
 
@@ -207,8 +207,8 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_different_employer_read_access_to_private_meta_fields() {
-		$public_fields  = array( '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' );
-		$private_fields = array( '_job_expires' );
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' ];
+		$private_fields = [ '_job_expires' ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();
 		$this->login_as_employer_b();
@@ -228,12 +228,12 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_legacy_custom_fields_do_not_show_up_in_rest() {
-		add_filter( 'job_manager_job_listing_data_fields', array( $this, 'add_legacy_field' ) );
+		add_filter( 'job_manager_job_listing_data_fields', [ $this, 'add_legacy_field' ] );
 		$this->reset_meta_keys();
 		$this->login_as_admin();
 		$post_id  = $this->get_job_listing();
 		$response = $this->get( sprintf( '/wp/v2/job-listings/%d', $post_id ) );
-		remove_filter( 'job_manager_job_listing_data_fields', array( $this, 'add_legacy_field' ) );
+		remove_filter( 'job_manager_job_listing_data_fields', [ $this, 'add_legacy_field' ] );
 
 		$this->assertResponseStatus( $response, 200 );
 		$this->assertFalse( empty( $response->data['meta'] ) );
@@ -242,7 +242,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	public function test_admin_can_set_meta_fields() {
 		$this->login_as_admin();
-		$test_meta = array(
+		$test_meta = [
 			'_job_location'    => 'Location A',
 			'_application'     => 'example@example.com',
 			'_company_name'    => 'Test Company',
@@ -253,15 +253,15 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 			'_filled'          => 0,
 			'_featured'        => 0,
 			'_job_expires'     => date( 'Y-m-d', strtotime( '+45 days' ) ),
-		);
+		];
 
 		$response = $this->post(
 			'/wp/v2/job-listings',
-			array(
+			[
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 				'meta'       => $test_meta,
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 201 );
@@ -283,22 +283,22 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	public function test_admin_can_delete_meta_fields() {
 		$this->login_as_admin();
 		$post_id = $this->get_job_listing(
-			array(
-			'meta_input' => array(
+			[
+			'meta_input' => [
 				'_company_name' => 'Test Company',
-			 )
-			)
+			 ]
+			]
 		);
 
 		$this->assertEquals( 'Test Company', get_post_meta( $post_id, '_company_name', true ) );
 
 		$response = $this->put(
 			'/wp/v2/job-listings/' . $post_id,
-			array(
-				'meta'       => array(
+			[
+				'meta'       => [
 					'_company_name' => null,
-				),
-			)
+				],
+			]
 		);
 
 		$this->assertResponseStatus( $response, 200 );
@@ -307,61 +307,61 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 	public function test_meta_input_sterilized() {
 		$this->login_as_admin();
-		$test_meta = array(
-			'_job_location'    => array(
+		$test_meta = [
+			'_job_location'    => [
 				'sent'     => '<a href="http://example.com">Location A</a>',
 				'expected' => 'Location A',
-			),
-			'_application'     => array(
+			],
+			'_application'     => [
 				'sent'     => 'chrome://net=internals',
 				'expected' => '',
-			),
-			'_company_name'    => array(
+			],
+			'_company_name'    => [
 				'sent'     => 'Test Company 🐵 🙈 🙉 🙊',
 				'expected' => 'Test Company 🐵 🙈 🙉 🙊',
-			),
-			'_company_website' => array(
+			],
+			'_company_website' => [
 				'sent'     => 'https://www.example.com/awesome#nice',
 				'expected' => 'https://www.example.com/awesome#nice',
-			),
-			'_company_tagline' => array(
+			],
+			'_company_tagline' => [
 				'sent'     => 'Best Example Money Can Buy<script\\x20type=\"text/javascript\">javascript:alert(1);</script>',
 				'expected' => 'Best Example Money Can Buy',
-			),
-			'_company_twitter' => array(
+			],
+			'_company_twitter' => [
 				'sent'     => '    @exampledotcom ',
 				'expected' => '@exampledotcom',
-			),
-			'_company_video'   => array(
+			],
+			'_company_video'   => [
 				'sent'     => 'http://example.com/index.php?search="><script>alert(0)</script>',
 				'expected' => 'http://example.com/index.php?search=scriptalert(0)/script',
-			),
-			'_filled'          => array(
+			],
+			'_filled'          => [
 				'sent'     => 11,
 				'expected' => 1,
-			),
-			'_featured'        => array(
+			],
+			'_featured'        => [
 				'sent'     => 0x0,
 				'expected' => 0,
-			),
-			'_job_expires'     => array(
+			],
+			'_job_expires'     => [
 				'sent'     => '01-01-2018',
 				'expected' => '',
-			),
-		);
+			],
+		];
 
-		$test_meta_values = array();
+		$test_meta_values = [];
 		foreach ( $test_meta as $meta_key => $values ) {
 			$test_meta_values[ $meta_key ] = $values['sent'];
 		}
 
 		$response = $this->post(
 			'/wp/v2/job-listings',
-			array(
+			[
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 				'meta'       => $test_meta_values,
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 201 );
@@ -380,23 +380,23 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	 * @return array
 	 */
 	public function data_provider_test_meta_input_bad_data_type() {
-		return array(
-			array(
-				array(
+		return [
+			[
+				[
 					'_filled' => 'yes',
-				),
-			),
-			array(
-				array(
+				],
+			],
+			[
+				[
 					'_featured' => 'true',
-				),
-			),
-			array(
-				array(
-					'_job_location' => array( 'Seattle', 'WA' ),
-				),
-			),
-		);
+				],
+			],
+			[
+				[
+					'_job_location' => [ 'Seattle', 'WA' ],
+				],
+			],
+		];
 	}
 
 	/**
@@ -407,23 +407,23 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 
 		$response = $this->post(
 			'/wp/v2/job-listings',
-			array(
+			[
 				'post_title' => 'Software Engineer',
 				'post_name'  => 'software-engineer',
 				'meta'       => $test_meta,
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 400 );
 	}
 
 	public function add_legacy_field( $fields ) {
-		$fields['_favorite_dog'] = array(
+		$fields['_favorite_dog'] = [
 			'label'         => 'Favorite Dog',
 			'placeholder'   => 'Layla',
 			'priority'      => 6,
 			'data_type'     => 'string',
-		);
+		];
 
 		return $fields;
 	}
@@ -436,7 +436,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 		WP_Job_Manager_Post_Types::instance()->register_meta_fields();
 	}
 
-	private function get_job_listing( $args = array() ) {
+	private function get_job_listing( $args = [] ) {
 		return $this->factory()->job_listing->create_and_get( $args )->ID;
 	}
 }

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
@@ -43,7 +43,7 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	public function test_guest_delete_job_types_fail() {
 		$this->logout();
 		$term_id  = $this->get_job_type();
-		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 401 );
 	}
 
@@ -51,10 +51,10 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->post(
 			'/wp/v2/job-types',
-			array(
+			[
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 401 );
@@ -65,9 +65,9 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		$this->logout();
 		$response = $this->put(
 			sprintf( '/wp/v2/job-types/%d', $term_id ),
-			array(
+			[
 				'name'   => 'Software Engineer 2',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 401 );
@@ -89,7 +89,7 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	public function test_employer_delete_job_types_fail() {
 		$this->login_as_employer();
 		$term_id  = $this->get_job_type();
-		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 403 );
 	}
 
@@ -97,10 +97,10 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		$this->login_as_employer();
 		$response = $this->post(
 			'/wp/v2/job-types',
-			array(
+			[
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 403 );
@@ -111,9 +111,9 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		$this->login_as_employer();
 		$response = $this->put(
 			sprintf( '/wp/v2/job-types/%d', $term_id ),
-			array(
+			[
 				'name'   => 'Software Engineer 2',
-			)
+			]
 		);
 
 		$this->assertResponseStatus( $response, 403 );
@@ -128,14 +128,14 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	public function test_delete_fail_as_default_user() {
 		$this->login_as_default_user();
 		$term_id  = $this->get_job_type();
-		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 401 );
 	}
 
 	public function test_delete_succeed_as_admin_user() {
 		$this->login_as_admin();
 		$term_id  = $this->get_job_type();
-		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), array( 'force' => 1 ) );
+		$response = $this->delete( sprintf( '/wp/v2/job-types/%d', $term_id ), [ 'force' => 1 ] );
 		$this->assertResponseStatus( $response, 200 );
 	}
 
@@ -151,13 +151,13 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		$this->login_as_admin();
 		$response = $this->post(
 			'/wp/v2/job-types',
-			array(
+			[
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
-				'meta' => array(
+				'meta' => [
 					'employment_type' => 'FULL_TIME',
-				),
-			)
+				],
+			]
 		);
 
 		$this->assertResponseStatus( $response, 201 );
@@ -174,13 +174,13 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 		$this->login_as_admin();
 		$response = $this->post(
 			'/wp/v2/job-types',
-			array(
+			[
 				'name'   => 'Software Engineer',
 				'slug'   => 'software-engineer',
-				'meta' => array(
+				'meta' => [
 					'employment_type' => 'FULL_TIME',
-				),
-			)
+				],
+			]
 		);
 
 		$this->assertResponseStatus( $response, 201 );
@@ -193,6 +193,6 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	}
 
 	protected function get_job_type() {
-		return $this->factory->term->create( array( 'taxonomy' => 'job_listing_type' ) );
+		return $this->factory->term->create( [ 'taxonomy' => 'job_listing_type' ] );
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
@@ -49,12 +49,12 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		include_once $bootstrap->includes_dir . '/stubs/class-wpjm-ajax-action-stub.php';
 		$this->assertTrue( class_exists( 'WPJM_Ajax_Action_Stub' ) );
 		$handler = new WPJM_Ajax_Action_Stub();
-		add_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		$wp_query->set( 'jm-ajax', $handler->action );
 		$this->assertFalse( $handler->fired );
 		WP_Job_Manager_Ajax::do_jm_ajax();
 		$this->assertTrue( $handler->fired );
-		remove_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 	}
 
 	/**
@@ -66,19 +66,19 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		$published = $this->factory->job_listing->create_many( 2 );
 		$draft     = $this->factory->job_listing->create_many(
 			2,
-			array(
+			[
 				'post_status' => 'expired',
-				'meta_input'  => array(),
-			)
+				'meta_input'  => [],
+			]
 		);
 		$instance  = WP_Job_Manager_Ajax::instance();
 
 		// Run the action.
-		add_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		ob_start();
 		$instance->get_listings();
 		$result = json_decode( ob_get_clean(), true );
-		remove_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		$this->tear_down_job_listing_search_request();
 
 		// Check result.
@@ -109,23 +109,23 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		$published = $this->factory->job_listing->create_many( 2 );
 		$draft     = $this->factory->job_listing->create_many(
 			2,
-			array(
+			[
 				'post_status' => 'expired',
-				'meta_input'  => array(),
-			)
+				'meta_input'  => [],
+			]
 		);
 		$instance  = WP_Job_Manager_Ajax::instance();
 
 		// Add no extra filters.
 		add_filter( 'job_manager_ajax_get_jobs_html_results', '__return_false' );
-		add_filter( 'job_manager_get_listings_result', array( $this, 'load_last_jobs_result' ), 10, 2 );
+		add_filter( 'job_manager_get_listings_result', [ $this, 'load_last_jobs_result' ], 10, 2 );
 
 		// Run the action.
-		add_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		ob_start();
 		$instance->get_listings();
 		$result = json_decode( ob_get_clean(), true );
-		remove_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		$this->tear_down_job_listing_search_request();
 
 		$this->assertInternalType( 'array', $result );
@@ -135,7 +135,7 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		$this->assertTrue( $result['found_jobs'] );
 		$this->assertEmpty( $result['showing'] );
 
-		$job_ids = array();
+		$job_ids = [];
 		/**
 		 * @var WP_Post $post
 		 */
@@ -161,25 +161,25 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 
 		copy( $iptc_file, $tmp_name );
 
-		$_FILES['upload'] = array(
+		$_FILES['upload'] = [
 			'tmp_name' => $tmp_name,
 			'name'     => 'test-image-iptc.jpg',
 			'type'     => 'image/jpeg',
 			'error'    => 0,
 			'size'     => filesize( $iptc_file ),
-		);
+		];
 		$this->assertFileExists( $tmp_name );
 
 		// Add extra filters.
 		add_filter( 'job_manager_user_can_upload_file_via_ajax', '__return_true' );
-		add_filter( 'submit_job_wp_handle_upload_overrides', array( $this, 'override_upload_action' ) );
+		add_filter( 'submit_job_wp_handle_upload_overrides', [ $this, 'override_upload_action' ] );
 
 		// Run the action.
-		add_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		ob_start();
 		$instance->upload_file();
 		$result = json_decode( ob_get_clean(), true );
-		remove_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		unset( $_FILES['upload'] );
 
 		// Check result.
@@ -208,25 +208,25 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 
 		copy( $iptc_file, $tmp_name );
 
-		$_FILES['upload'] = array(
+		$_FILES['upload'] = [
 			'tmp_name' => $tmp_name,
 			'name'     => 'test-image-iptc.jpg',
 			'type'     => 'image/jpeg',
 			'error'    => 0,
 			'size'     => filesize( $iptc_file ),
-		);
+		];
 		$this->assertFileExists( $tmp_name );
 
 		// Add extra filters.
 		add_filter( 'job_manager_user_can_upload_file_via_ajax', '__return_false' );
-		add_filter( 'submit_job_wp_handle_upload_overrides', array( $this, 'override_upload_action' ) );
+		add_filter( 'submit_job_wp_handle_upload_overrides', [ $this, 'override_upload_action' ] );
 
 		// Run the action.
-		add_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		ob_start();
 		$instance->upload_file();
 		$result = json_decode( ob_get_clean(), true );
-		remove_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		unset( $_FILES['upload'] );
 
 		// Check result.
@@ -243,24 +243,24 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 	public function test_upload_bad_file() {
 		$instance = WP_Job_Manager_Ajax::instance();
 
-		$_FILES['upload'] = array(
+		$_FILES['upload'] = [
 			'tmp_name' => null,
 			'name'     => 'test-image-iptc-bad.jpg',
 			'type'     => 'image/jpeg',
 			'error'    => 1,
 			'size'     => 0,
-		);
+		];
 
 		// Add extra filters.
 		add_filter( 'job_manager_user_can_upload_file_via_ajax', '__return_true' );
-		add_filter( 'submit_job_wp_handle_upload_overrides', array( $this, 'override_upload_action' ) );
+		add_filter( 'submit_job_wp_handle_upload_overrides', [ $this, 'override_upload_action' ] );
 
 		// Run the action.
-		add_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		ob_start();
 		$instance->upload_file();
 		$result = json_decode( ob_get_clean(), true );
-		remove_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		unset( $_FILES['upload'] );
 
 		$this->assertNotEmpty( $result );

--- a/tests/php/tests/includes/test_class.wp-job-manager-api.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-api.php
@@ -22,7 +22,7 @@ class WP_Test_WP_Job_Manager_API extends WPJM_BaseTest {
 	 */
 	public function test_add_query_vars() {
 		$instance = WP_Job_Manager_API::instance();
-		$vars     = array( 'existing-var' );
+		$vars     = [ 'existing-var' ];
 		$new_vars = $instance->add_query_vars( $vars );
 		$this->assertCount( 2, $new_vars );
 		$this->assertContains( 'job-manager-api', $new_vars );
@@ -41,11 +41,11 @@ class WP_Test_WP_Job_Manager_API extends WPJM_BaseTest {
 		$this->assertTrue( class_exists( 'WPJM_Api_Handler_Stub' ) );
 		$handler     = new WPJM_Api_Handler_Stub();
 		$handler_tag = strtolower( get_class( $handler ) );
-		add_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		$wp->query_vars['job-manager-api'] = $handler_tag;
 		$this->assertFalse( $handler->fired );
 		$instance->api_requests();
 		$this->assertTrue( $handler->fired );
-		remove_filter( 'wp_die_ajax_handler', array( $this, 'return_do_not_die' ) );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-cache-helper.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-cache-helper.php
@@ -127,7 +127,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 
 		$taxonomy_slug     = 'post_tag';
 		$cache_key         = self::GROUP_CACHE_KEY_PREFIX_JOB_TERMS . sanitize_text_field( $taxonomy_slug );
-		$taxonomy_term_ids = array( $term->ID );
+		$taxonomy_term_ids = [ $term->ID ];
 
 		$initial_version = WP_Job_Manager_Cache_Helper::get_transient_version( $cache_key );
 		$this->assertGreaterThanOrEqual( time() - 1, $initial_version );
@@ -138,7 +138,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		$this->assertEquals( $initial_version, $middle_version );
 
 		// wp_set_object_terms( $post->ID, $term->ID, $taxonomy_slug );.
-		WP_Job_Manager_Cache_Helper::set_term( $post->ID, 'a_test_term', array( $term ), $taxonomy_slug );
+		WP_Job_Manager_Cache_Helper::set_term( $post->ID, 'a_test_term', [ $term ], $taxonomy_slug );
 
 		$after_version = WP_Job_Manager_Cache_Helper::get_transient_version( $cache_key );
 		$this->assertLessThan( $after_version, $initial_version );
@@ -161,7 +161,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 
 		$taxonomy_slug     = 'post_tag';
 		$cache_key         = self::GROUP_CACHE_KEY_PREFIX_JOB_TERMS . sanitize_text_field( $taxonomy_slug );
-		$taxonomy_term_ids = array( $term->ID );
+		$taxonomy_term_ids = [ $term->ID ];
 
 		$initial_version = WP_Job_Manager_Cache_Helper::get_transient_version( $cache_key );
 		$this->assertGreaterThanOrEqual( time() - 1, $initial_version );
@@ -171,7 +171,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		$middle_version = WP_Job_Manager_Cache_Helper::get_transient_version( $cache_key );
 		$this->assertEquals( $initial_version, $middle_version );
 
-		WP_Job_Manager_Cache_Helper::edited_term( $post->ID, array( $term ), $taxonomy_slug );
+		WP_Job_Manager_Cache_Helper::edited_term( $post->ID, [ $term ], $taxonomy_slug );
 
 		$after_version = WP_Job_Manager_Cache_Helper::get_transient_version( $cache_key );
 		$this->assertLessThan( $after_version, $initial_version );
@@ -201,9 +201,9 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 	 */
 	public function test_get_listings_count_default_args() {
 		global $wpdb;
-		$posts_pending   = $this->factory->job_listing->create_many( 3, array( 'post_status' => 'pending' ) );
-		$posts_published = $this->factory->job_listing->create_many( 5, array( 'post_status' => 'publish' ) );
-		$posts_shifted   = array();
+		$posts_pending   = $this->factory->job_listing->create_many( 3, [ 'post_status' => 'pending' ] );
+		$posts_published = $this->factory->job_listing->create_many( 5, [ 'post_status' => 'publish' ] );
+		$posts_shifted   = [];
 
 		$initial_count = WP_Job_Manager_Cache_Helper::get_listings_count();
 		$this->assertEquals( count( $posts_pending ), $initial_count );
@@ -211,7 +211,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		$this->wee_sleep();
 
 		// Create posts with normal actions fired.
-		$posts_pending_round_two = $this->factory->job_listing->create_many( 2, array( 'post_status' => 'pending' ) );
+		$posts_pending_round_two = $this->factory->job_listing->create_many( 2, [ 'post_status' => 'pending' ] );
 
 		$middle_count = WP_Job_Manager_Cache_Helper::get_listings_count();
 		$this->assertEquals( count( $posts_pending ) + count( $posts_pending_round_two ), $middle_count );
@@ -219,7 +219,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		// Covertly change post from published to pending.
 		$this->wee_sleep();
 		$published_post_id = $posts_shifted[] = array_pop( $posts_published );
-		$wpdb->update( $wpdb->posts, array( 'post_status' => 'pending' ), array( 'ID' => $published_post_id ) );
+		$wpdb->update( $wpdb->posts, [ 'post_status' => 'pending' ], [ 'ID' => $published_post_id ] );
 
 		$second_middle_count = WP_Job_Manager_Cache_Helper::get_listings_count();
 		$this->assertEquals( $middle_count, $second_middle_count );
@@ -237,11 +237,11 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 	 */
 	public function test_get_listings_count_nonstandard_args() {
 		global $wpdb;
-		add_filter( 'wpjm_count_cache_supported_post_types', array( $this, 'helper_add_post_type' ) );
-		add_filter( 'wpjm_count_cache_supported_statuses', array( $this, 'helper_add_pending_status' ) );
-		$posts_pending   = $this->factory->post->create_many( 4, array( 'post_status' => 'pending' ) );
-		$posts_published = $this->factory->post->create_many( 2, array( 'post_status' => 'publish' ) );
-		$posts_shifted   = array();
+		add_filter( 'wpjm_count_cache_supported_post_types', [ $this, 'helper_add_post_type' ] );
+		add_filter( 'wpjm_count_cache_supported_statuses', [ $this, 'helper_add_pending_status' ] );
+		$posts_pending   = $this->factory->post->create_many( 4, [ 'post_status' => 'pending' ] );
+		$posts_published = $this->factory->post->create_many( 2, [ 'post_status' => 'publish' ] );
+		$posts_shifted   = [];
 
 		$initial_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'post', 'publish' );
 		$this->assertEquals( count( $posts_published ), $initial_count );
@@ -249,7 +249,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		$this->wee_sleep();
 
 		// Create posts with normal actions fired.
-		$posts_published_round_two = $this->factory->post->create_many( 2, array( 'post_status' => 'publish' ) );
+		$posts_published_round_two = $this->factory->post->create_many( 2, [ 'post_status' => 'publish' ] );
 
 		$middle_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'post', 'publish' );
 		$this->assertEquals( count( $posts_published ) + count( $posts_published_round_two ), $middle_count );
@@ -257,7 +257,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		// Covertly change post from published to pending.
 		$this->wee_sleep();
 		$published_post_id = $posts_shifted[] = array_pop( $posts_published );
-		$wpdb->update( $wpdb->posts, array( 'post_status' => 'pending' ), array( 'ID' => $published_post_id ) );
+		$wpdb->update( $wpdb->posts, [ 'post_status' => 'pending' ], [ 'ID' => $published_post_id ] );
 
 		$second_middle_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'post', 'publish' );
 		$this->assertEquals( $middle_count, $second_middle_count );
@@ -272,10 +272,10 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 	 */
 	public function test_maybe_clear_count_transients() {
 		global $wpdb;
-		$posts_pending   = $this->factory->job_listing->create_many( 3, array( 'post_status' => 'pending' ) );
-		$posts_published = $this->factory->job_listing->create_many( 5, array( 'post_status' => 'publish' ) );
-		$posts_expired   = $this->factory->job_listing->create_many( 5, array( 'post_status' => 'expired' ) );
-		$posts_shifted   = array();
+		$posts_pending   = $this->factory->job_listing->create_many( 3, [ 'post_status' => 'pending' ] );
+		$posts_published = $this->factory->job_listing->create_many( 5, [ 'post_status' => 'publish' ] );
+		$posts_expired   = $this->factory->job_listing->create_many( 5, [ 'post_status' => 'expired' ] );
+		$posts_shifted   = [];
 
 		$expired_count   = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'expired' );
 		$published_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'publish' );
@@ -285,10 +285,10 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		// Covertly change post from published to pending.
 		$this->wee_sleep();
 		$published_post_id = $posts_shifted[] = array_pop( $posts_published );
-		$wpdb->update( $wpdb->posts, array( 'post_status' => 'pending' ), array( 'ID' => $published_post_id ) );
+		$wpdb->update( $wpdb->posts, [ 'post_status' => 'pending' ], [ 'ID' => $published_post_id ] );
 
 		$published_to_expired_post_id = array_pop( $posts_published );
-		$wpdb->update( $wpdb->posts, array( 'post_status' => 'expired' ), array( 'ID' => $published_to_expired_post_id ) );
+		$wpdb->update( $wpdb->posts, [ 'post_status' => 'expired' ], [ 'ID' => $published_to_expired_post_id ] );
 
 		$second_middle_count = WP_Job_Manager_Cache_Helper::get_listings_count();
 		$this->assertEquals( count( $posts_pending ), $second_middle_count );
@@ -298,7 +298,7 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		$middle_expired_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'expired' );
 		$this->assertEquals( $expired_count, $middle_expired_count );
 
-		add_filter( 'wpjm_count_cache_supported_statuses', array( $this, 'helper_add_expired_status' ) );
+		add_filter( 'wpjm_count_cache_supported_statuses', [ $this, 'helper_add_expired_status' ] );
 
 		WP_Job_Manager_Cache_Helper::maybe_clear_count_transients( 'expired', 'publish', get_post( $published_post_id ) );
 		$second_middle_expired_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'expired' );

--- a/tests/php/tests/includes/test_class.wp-job-manager-category-walker.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-category-walker.php
@@ -28,17 +28,17 @@ class WP_Test_WP_Job_Manager_Category_Walker extends WPJM_BaseTest {
 			$test_output_b,
 			$terms[0],
 			11,
-			array(
+			[
 				'show_count'   => true,
 				'hierarchical' => true,
-			)
+			]
 		);
 		$this->assertContains( '&nbsp;(0)', $test_output_b );
 		$this->assertContains( str_repeat( '&nbsp;', 33 ), $test_output_b );
 
 		// With selected.
 		$test_output_c = '';
-		$walker->start_el( $test_output_c, $terms[0], 0, array( 'selected' => $terms[0]->slug ) );
+		$walker->start_el( $test_output_c, $terms[0], 0, [ 'selected' => $terms[0]->slug ] );
 		$this->assertContains( 'selected="selected"', $test_output_c );
 	}
 
@@ -48,7 +48,7 @@ class WP_Test_WP_Job_Manager_Category_Walker extends WPJM_BaseTest {
 
 	private function get_terms() {
 		$terms                = $this->setup_terms();
-		$args                 = array();
+		$args                 = [];
 		$args['taxonomy']     = WP_UnitTest_Factory_For_Term::DEFAULT_TAXONOMY;
 		$args['pad_counts']   = 1;
 		$args['hierarchical'] = 1;

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -31,36 +31,36 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		// Create some regular posts.
 		$this->post_ids = $this->factory->post->create_many(
 			2,
-			array(
+			[
 				'post_status' => 'publish',
 				'post_type'   => 'post',
-			)
+			]
 		);
 
 		// Create an unrelated CPT to ensure its posts do not get deleted.
 		register_post_type(
 			'biography',
-			array(
+			[
 				'label'       => 'Biographies',
 				'description' => 'A biography of a famous person (for testing)',
 				'public'      => true,
-			)
+			]
 		);
 		$this->biography_ids = $this->factory->post->create_many(
 			4,
-			array(
+			[
 				'post_status' => 'publish',
 				'post_type'   => 'biography',
-			)
+			]
 		);
 
 		// Create some Job Listings.
 		$this->job_listing_ids = $this->factory->post->create_many(
 			8,
-			array(
+			[
 				'post_status' => 'publish',
 				'post_type'   => 'job_listing',
-			)
+			]
 		);
 	}
 
@@ -70,7 +70,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 	 */
 	private function setupTaxonomyTerms() {
 		// Setup some job types.
-		$this->job_listing_types = array();
+		$this->job_listing_types = [];
 
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$this->job_listing_types[] = wp_insert_term( 'Job Type ' . $i, 'job_listing_type' );
@@ -78,32 +78,32 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		wp_set_object_terms(
 			$this->course_ids[0],
-			array(
+			[
 				$this->job_listing_types[0]['term_id'],
 				$this->job_listing_types[1]['term_id'],
-			),
+			],
 			'job_listing_type'
 		);
 		wp_set_object_terms(
 			$this->course_ids[1],
-			array(
+			[
 				$this->job_listing_types[1]['term_id'],
 				$this->job_listing_types[2]['term_id'],
-			),
+			],
 			'job_listing_type'
 		);
 		wp_set_object_terms(
 			$this->course_ids[2],
-			array(
+			[
 				$this->job_listing_types[0]['term_id'],
 				$this->job_listing_types[1]['term_id'],
 				$this->job_listing_types[2]['term_id'],
-			),
+			],
 			'job_listing_type'
 		);
 
 		// Setup some categories.
-		$this->categories = array();
+		$this->categories = [];
 
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$this->categories[] = wp_insert_term( 'Category ' . $i, 'category' );
@@ -111,37 +111,37 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		wp_set_object_terms(
 			$this->course_ids[0],
-			array(
+			[
 				$this->categories[0]['term_id'],
 				$this->categories[1]['term_id'],
-			),
+			],
 			'category'
 		);
 		wp_set_object_terms(
 			$this->post_ids[0],
-			array(
+			[
 				$this->categories[1]['term_id'],
 				$this->categories[2]['term_id'],
-			),
+			],
 			'category'
 		);
 		wp_set_object_terms(
 			$this->biography_ids[2],
-			array(
+			[
 				$this->categories[0]['term_id'],
 				$this->categories[1]['term_id'],
 				$this->categories[2]['term_id'],
-			),
+			],
 			'category'
 		);
 
 		// Setup a custom taxonomy.
 		register_taxonomy( 'age', 'biography' );
 
-		$this->ages = array(
+		$this->ages = [
 			wp_insert_term( 'Old', 'age' ),
 			wp_insert_term( 'New', 'age' ),
-		);
+		];
 
 		wp_set_object_terms( $this->biography_ids[0], $this->ages[0]['term_id'], 'age' );
 		wp_set_object_terms( $this->biography_ids[1], $this->ages[1]['term_id'], 'age' );
@@ -163,36 +163,36 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		// Create some regular pages.
 		$this->regular_page_ids = $this->factory->post->create_many(
 			2,
-			array(
+			[
 				'post_type'  => 'page',
 				'post_title' => 'Normal page',
-			)
+			]
 		);
 
 		// Create the Submit Job page.
 		$this->submit_job_form_page_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'  => 'page',
 				'post_title' => 'Submit Job Page',
-			)
+			]
 		);
 		update_option( 'job_manager_submit_job_form_page_id', $this->submit_job_form_page_id );
 
 		// Create the Job Dashboard page.
 		$this->job_dashboard_page_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'  => 'page',
 				'post_title' => 'Job Dashboard Page',
-			)
+			]
 		);
 		update_option( 'job_manager_job_dashboard_page_id', $this->job_dashboard_page_id );
 
 		// Create the Submit Job page.
 		$this->jobs_page_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'  => 'page',
 				'post_title' => 'Jobs Page',
-			)
+			]
 		);
 		update_option( 'job_manager_jobs_page_id', $this->jobs_page_id );
 	}
@@ -207,13 +207,13 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		WP_Job_Manager_Install::install();
 
 		// Create a regular user and assign some caps.
-		$this->regular_user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$this->regular_user_id = $this->factory->user->create( [ 'role' => 'author' ] );
 		$regular_user          = get_user_by( 'id', $this->regular_user_id );
 		$regular_user->add_cap( 'edit_others_posts' );
 		$regular_user->add_cap( 'manage_job_listings' );
 
 		// Create a teacher user and assign some caps.
-		$this->employer_user_id = $this->factory->user->create( array( 'role' => 'employer' ) );
+		$this->employer_user_id = $this->factory->user->create( [ 'role' => 'employer' ] );
 		$employer_user          = get_user_by( 'id', $this->employer_user_id );
 		$employer_user->add_cap( 'edit_others_posts' );
 		$employer_user->add_cap( 'manage_job_listings' );
@@ -283,7 +283,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 			// Ensure the data is deleted from all the relevant DB tables.
 			$this->assertEquals(
-				array(),
+				[],
 				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->termmeta WHERE term_id = %s",
@@ -294,7 +294,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 			);
 
 			$this->assertEquals(
-				array(),
+				[],
 				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->terms WHERE term_id = %s",
@@ -305,7 +305,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 			);
 
 			$this->assertEquals(
-				array(),
+				[],
 				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->term_taxonomy WHERE term_taxonomy_id = %s",
@@ -316,7 +316,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 			);
 
 			$this->assertEquals(
-				array(),
+				[],
 				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT * from $wpdb->term_relationships WHERE term_taxonomy_id = %s",
@@ -341,14 +341,14 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		// Check "Category 1".
 		$this->assertEquals(
-			array( $this->biography_ids[2] ),
+			[ $this->biography_ids[2] ],
 			$this->getPostIdsWithTerm( $this->categories[0]['term_id'], 'category' ),
 			'Category 1 should not be deleted'
 		);
 
 		// Check "Category 2". Sort the arrays because the ordering doesn't.
 		// matter.
-		$expected = array( $this->post_ids[0], $this->biography_ids[2] );
+		$expected = [ $this->post_ids[0], $this->biography_ids[2] ];
 		$actual   = $this->getPostIdsWithTerm( $this->categories[1]['term_id'], 'category' );
 		sort( $expected );
 		sort( $actual );
@@ -360,7 +360,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		// Check "Category 3". Sort the arrays because the ordering doesn't.
 		// matter.
-		$expected = array( $this->post_ids[0], $this->biography_ids[2] );
+		$expected = [ $this->post_ids[0], $this->biography_ids[2] ];
 		$actual   = $this->getPostIdsWithTerm( $this->categories[2]['term_id'], 'category' );
 		sort( $expected );
 		sort( $actual );
@@ -372,14 +372,14 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		// Check "Old" biographies.
 		$this->assertEquals(
-			array( $this->biography_ids[0] ),
+			[ $this->biography_ids[0] ],
 			$this->getPostIdsWithTerm( $this->ages[0]['term_id'], 'age' ),
 			'"Old" should not be deleted'
 		);
 
 		// Check "New" biographies.
 		$this->assertEquals(
-			array( $this->biography_ids[1] ),
+			[ $this->biography_ids[1] ],
 			$this->getPostIdsWithTerm( $this->ages[1]['term_id'], 'age' ),
 			'"New" should not be deleted'
 		);
@@ -498,25 +498,25 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_user_meta
 	 */
 	public function testCleanupUserMeta() {
-		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
 
-		$keep_meta_keys = array(
+		$keep_meta_keys = [
 			'company_logo',
 			'company_name',
 			'company_website',
 			'company_tagline',
 			'company_twitter',
 			'company_video',
-		);
+		];
 
-		$remove_meta_keys = array(
+		$remove_meta_keys = [
 			'_company_logo',
 			'_company_name',
 			'_company_website',
 			'_company_tagline',
 			'_company_twitter',
 			'_company_video',
-		);
+		];
 
 		foreach ( array_merge( $keep_meta_keys, $remove_meta_keys ) as $meta_key ) {
 			update_user_meta( $user_id, $meta_key, 'test_value' );
@@ -542,16 +542,16 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 	 * @covers WP_Job_Manager_Data_Cleaner::cleanup_cron_jobs
 	 */
 	public function testJobManagerCronJobsRemoved() {
-		$wpjm_jobs     = array(
+		$wpjm_jobs     = [
 			'job_manager_check_for_expired_jobs',
 			'job_manager_delete_old_previews',
 			'job_manager_clear_expired_transients',
 			'job_manager_usage_tracking_send_usage_data',
-		);
-		$non_wpjm_jobs = array(
+		];
+		$non_wpjm_jobs = [
 			'another_job',
 			'random_job',
-		);
+		];
 
 		foreach ( array_merge( $wpjm_jobs, $non_wpjm_jobs ) as $job ) {
 			wp_schedule_event( time() + 3600, 'daily', $job );
@@ -574,17 +574,17 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 
 	private function getPostIdsWithTerm( $term_id, $taxonomy ) {
 		return get_posts(
-			array(
+			[
 				'fields'    => 'ids',
 				'post_type' => 'any',
-				'tax_query' => array(
-					array(
+				'tax_query' => [
+					[
 						'field'    => 'term_id',
 						'terms'    => $term_id,
 						'taxonomy' => $taxonomy,
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
@@ -21,16 +21,16 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 	 */
 	private function setupUserMeta( $args, &$expected ) {
 		$user_id = $this->factory()->user->create(
-			array(
+			[
 				'user_login' => 'johndoe',
 				'user_email' => 'johndoe@example.com',
 				'role'       => 'subscriber',
-			)
+			]
 		);
 
 		if ( isset( $args['_company_logo'] ) ) {
 			$args['_company_logo']                   = $this->factory()->post->create(
-				array( 'post_type' => 'attachment' )
+				[ 'post_type' => 'attachment' ]
 			);
 			$expected['data'][0]['data'][0]['value'] = $args['_company_logo'];
 		}
@@ -97,104 +97,104 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 	 * @return array
 	 */
 	public function data_provider() {
-		return array(
-			array(
-				array(
+		return [
+			[
+				[
 					'_company_logo'    => 'https://example.com/company/logo',
 					'_company_name'    => 'Example',
 					'_company_website' => 'https://example.com/',
 					'_company_tagline' => 'Just another tagline',
 					'_company_twitter' => 'https://twitter.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
 					'_company_video'   => 'https://example.com/company/video',
-				),
-				array(
-					'data' => array(
-						array(
+				],
+				[
+					'data' => [
+						[
 							'group_id'    => 'wpjm-user-data',
 							'group_label' => __( 'WP Job Manager User Data' ),
 							'item_id'     => '', // the item_id depends on the ID of the user.
-							'data'        => array(
-								array(
+							'data'        => [
+								[
 									'name'  => 'Company Logo',
 									'value' => true, // specify that attachment should be created.
-								),
-								array(
+								],
+								[
 									'name'  => 'Company Name',
 									'value' => 'Example',
-								),
-								array(
+								],
+								[
 									'name'  => 'Company Website',
 									'value' => 'https://example.com/',
-								),
-								array(
+								],
+								[
 									'name'  => 'Company Tagline',
 									'value' => 'Just another tagline',
-								),
-								array(
+								],
+								[
 									'name'  => 'Company Twitter',
 									'value' => 'https://twitter.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
-								),
-								array(
+								],
+								[
 									'name'  => 'Company Video',
 									'value' => 'https://example.com/company/video',
-								),
-							),
-						),
-					),
+								],
+							],
+						],
+					],
 					'done' => true,
-				),
-			), // End of first set of parameters.
-			array(
-				array(
+				],
+			], // End of first set of parameters.
+			[
+				[
 					'_company_name'    => 'Example',
 					'_company_website' => 'https://example.com/',
 					'_company_tagline' => 'Just another tagline',
-				),
-				array(
-					'data' => array(
-						array(
+				],
+				[
+					'data' => [
+						[
 							'group_id'    => 'wpjm-user-data',
 							'group_label' => __( 'WP Job Manager User Data' ),
-							'data'        => array(
-								array(
+							'data'        => [
+								[
 									'name'  => 'Company Name',
 									'value' => 'Example',
-								),
-								array(
+								],
+								[
 									'name'  => 'Company Website',
 									'value' => 'https://example.com/',
-								),
-								array(
+								],
+								[
 									'name'  => 'Company Tagline',
 									'value' => 'Just another tagline',
-								),
-							),
-						),
-					),
+								],
+							],
+						],
+					],
 					'done' => true,
-				),
-			), // End of second set of parameters.
-			array(
-				array(
+				],
+			], // End of second set of parameters.
+			[
+				[
 					'_company_logo',
 					'_company_name',
 					'_company_website',
 					'_company_tagline',
 					'_company_twitter',
 					'_company_video',
-				),
-				array(
-					'data' => array(
-						array(
+				],
+				[
+					'data' => [
+						[
 							'group_id'    => 'wpjm-user-data',
 							'group_label' => __( 'WP Job Manager User Data' ),
 							'item_id'     => '', // the item_id depends on the ID of the user.
-							'data'        => array(),
-						),
-					),
+							'data'        => [],
+						],
+					],
 					'done' => true,
-				),
-			), // End of third set of parameters.
-		);
+				],
+			], // End of third set of parameters.
+		];
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -24,7 +24,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	public function tearDown() {
 		reset_phpmailer_instance();
 		WP_Job_Manager_Email_Notifications::clear_deferred_notifications();
-		remove_action( 'shutdown', array( 'WP_Job_Manager_Email_Notifications', 'send_deferred_notifications' ) );
+		remove_action( 'shutdown', [ 'WP_Job_Manager_Email_Notifications', 'send_deferred_notifications' ] );
 		parent::tearDown();
 	}
 
@@ -35,14 +35,14 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @covers \WP_Job_Manager_Email_Notifications::send_employer_expiring_notice
 	 */
 	public function test_send_employer_expiring_notice() {
-		$new_jobs                 = array();
+		$new_jobs                 = [];
 		$new_jobs['none']        = $this->factory->job_listing->create();
 		delete_post_meta( $new_jobs['none'], '_job_expires' );
 		$new_jobs['empty']         = $this->factory->job_listing->create();
 		update_post_meta( $new_jobs['empty'], '_job_expires', '' );
-		$new_jobs['invalid-none'] = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => '0000-00-00' ) ) );
-		$new_jobs['today']        = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d' ) ) ) );
-		$new_jobs['tomorrow']    = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ) ) );
+		$new_jobs['invalid-none'] = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '0000-00-00' ] ] );
+		$new_jobs['today']        = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d' ) ] ] );
+		$new_jobs['tomorrow']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ] ] );
 
 		$this->assertEquals( 0, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 		add_filter( 'job_manager_email_is_email_notification_enabled', '__return_true' );
@@ -50,7 +50,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		remove_filter( 'job_manager_email_is_email_notification_enabled', '__return_true' );
 		$this->assertEquals( 1, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 
-		$this->assertNotificationSent( WP_Job_Manager_Email_Employer_Expiring_Job::get_key(), array( 'job_id' => $new_jobs['tomorrow'] ) );
+		$this->assertNotificationSent( WP_Job_Manager_Email_Employer_Expiring_Job::get_key(), [ 'job_id' => $new_jobs['tomorrow'] ] );
 	}
 
 	/**
@@ -60,14 +60,14 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @covers \WP_Job_Manager_Email_Notifications::send_employer_expiring_notice
 	 */
 	public function test_send_admin_expiring_notice() {
-		$new_jobs                 = array();
+		$new_jobs                 = [];
 		$new_jobs['none']        = $this->factory->job_listing->create();
 		delete_post_meta( $new_jobs['none'], '_job_expires' );
 		$new_jobs['empty']         = $this->factory->job_listing->create();
 		update_post_meta( $new_jobs['empty'], '_job_expires', '' );
-		$new_jobs['invalid-none'] = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => '0000-00-00' ) ) );
-		$new_jobs['today']        = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d' ) ) ) );
-		$new_jobs['tomorrow']    = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ) ) );
+		$new_jobs['invalid-none'] = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '0000-00-00' ] ] );
+		$new_jobs['today']        = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d' ) ] ] );
+		$new_jobs['tomorrow']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ] ] );
 
 		$this->assertEquals( 0, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 		add_filter( 'job_manager_email_is_email_notification_enabled', '__return_true' );
@@ -75,7 +75,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		remove_filter( 'job_manager_email_is_email_notification_enabled', '__return_true' );
 		$this->assertEquals( 1, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 
-		$this->assertNotificationSent( WP_Job_Manager_Email_Admin_Expiring_Job::get_key(), array( 'job_id' => $new_jobs['tomorrow'] ) );
+		$this->assertNotificationSent( WP_Job_Manager_Email_Admin_Expiring_Job::get_key(), [ 'job_id' => $new_jobs['tomorrow'] ] );
 	}
 
 	/**
@@ -88,10 +88,10 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		WP_Job_Manager_Email_Notifications::schedule_notification( 'test-notification' );
 		$this->assertEquals( 1, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 
-		WP_Job_Manager_Email_Notifications::schedule_notification( 'test-notification', array( 'test' => 'test' ) );
+		WP_Job_Manager_Email_Notifications::schedule_notification( 'test-notification', [ 'test' => 'test' ] );
 		$this->assertEquals( 2, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 
-		do_action( 'job_manager_send_notification', 'test-notification-action', array( 'test' => 'test' ) );
+		do_action( 'job_manager_send_notification', 'test-notification-action', [ 'test' => 'test' ] );
 		$this->assertEquals( 3, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 	}
 
@@ -102,10 +102,10 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	public function test_send_deferred_notifications_valid_email() {
 		$mailer = tests_retrieve_phpmailer_instance();
 		$this->assertFalse( $mailer->get_sent() );
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
-		do_action( 'job_manager_send_notification', 'valid_email', array( 'test' => 'test' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_email', [ 'test' => 'test' ] );
 		WP_Job_Manager_Email_Notifications::send_deferred_notifications();
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
 
 		$sent_email = $mailer->get_sent();
 		$this->assertNotFalse( $sent_email );
@@ -126,10 +126,10 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	public function test_send_deferred_notifications_unknown_email() {
 		$mailer = tests_retrieve_phpmailer_instance();
 		$this->assertFalse( $mailer->get_sent() );
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
-		do_action( 'job_manager_send_notification', 'invalid_email', array( 'test' => 'test' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_ordinary' ] );
+		do_action( 'job_manager_send_notification', 'invalid_email', [ 'test' => 'test' ] );
 		WP_Job_Manager_Email_Notifications::send_deferred_notifications();
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_ordinary' ] );
 		$this->assertFalse( $mailer->get_sent() );
 	}
 
@@ -140,10 +140,10 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	public function test_send_deferred_notifications_invalid_args() {
 		$mailer = tests_retrieve_phpmailer_instance();
 		$this->assertFalse( $mailer->get_sent() );
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
-		do_action( 'job_manager_send_notification', 'valid_email', array( 'nope' => 'test' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_email', [ 'nope' => 'test' ] );
 		WP_Job_Manager_Email_Notifications::send_deferred_notifications();
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
 		$this->assertFalse( $mailer->get_sent() );
 	}
 
@@ -157,7 +157,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		$this->assertEquals( count( $core_email_notifications ), count( $emails ) );
 
 		foreach ( $core_email_notifications as $email_notification_class ) {
-			$email_notification_key = call_user_func( array( $email_notification_class, 'get_key' ) );
+			$email_notification_key = call_user_func( [ $email_notification_class, 'get_key' ] );
 			$this->assertArrayHasKey( $email_notification_key, $emails );
 			$this->assertValidEmailNotificationConfig( $emails[ $email_notification_key ] );
 		}
@@ -168,9 +168,9 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
 	 */
 	public function test_get_email_notifications_inject_bad_ordinary_class() {
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_ordinary' ] );
 		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_ordinary' ) );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_ordinary' ] );
 		$this->assertArrayNotHasKey( 'invalid_email', $emails );
 	}
 
@@ -179,9 +179,9 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
 	 */
 	public function test_get_email_notifications_inject_bad_class_unknown() {
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_unknown' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_unknown' ] );
 		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_unknown' ) );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_unknown' ] );
 		$this->assertArrayNotHasKey( 'invalid_email', $emails );
 	}
 
@@ -190,9 +190,9 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Email_Notifications::is_email_notification_valid()
 	 */
 	public function test_get_email_notifications_inject_malformed_class() {
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_setup' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_setup' ] );
 		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_invalid_class_setup' ) );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_invalid_class_setup' ] );
 		$this->assertArrayNotHasKey( 'invalid_email', $emails );
 	}
 
@@ -254,10 +254,10 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 */
 	public function test_add_email_settings() {
 
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
 		$emails   = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
-		$settings = WP_Job_Manager_Email_Notifications::add_email_settings( array(), WP_Job_Manager_Email::get_context() );
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		$settings = WP_Job_Manager_Email_Notifications::add_email_settings( [], WP_Job_Manager_Email::get_context() );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
 
 		$this->assertArrayHasKey( 'email_notifications', $settings );
 		$email_notifications_settings = $settings['email_notifications'];
@@ -275,12 +275,12 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		foreach ( $settings as $key => $setting ) {
 			$email_class              = $email_classes[ $key ];
 			$email_key                = $email_keys[ $key ];
-			$email_settings           = call_user_func( array( $email_class, 'get_setting_fields' ) );
-			$email_is_default_enabled = call_user_func( array( $email_class, 'is_default_enabled' ) );
-			$defaults                 = array(
+			$email_settings           = call_user_func( [ $email_class, 'get_setting_fields' ] );
+			$email_is_default_enabled = call_user_func( [ $email_class, 'is_default_enabled' ] );
+			$defaults                 = [
 				'enabled'    => $email_is_default_enabled ? '1' : '0',
 				'plain_text' => '0',
-			);
+			];
 			foreach ( $email_settings as $email_setting ) {
 				$defaults[ $email_setting['name'] ] = $email_setting['std'];
 			}
@@ -329,28 +329,28 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	}
 
 	protected function get_valid_emails() {
-		add_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
 		$emails = WP_Job_Manager_Email_Notifications::get_email_notifications( false );
-		remove_filter( 'job_manager_email_notifications', array( $this, 'inject_email_config_valid_email' ) );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
 		return $emails;
 	}
 
 	protected function get_valid_job() {
 		$full_time_term = wp_create_term( 'Full Time', 'job_listing_type' );
 		$weird_cat_term = wp_create_term( 'Weird', 'job_listing_category' );
-		$job_args       = array(
+		$job_args       = [
 			'post_title'   => 'Job Post-' . md5( microtime( true ) ),
 			'post_content' => 'Job Description-' . md5( microtime( true ) ),
-			'meta_input'   => array(
+			'meta_input'   => [
 				'_job_location'    => 'Job Location-' . md5( microtime( true ) ),
 				'_company_name'    => 'Company-' . md5( microtime( true ) ),
 				'_company_website' => 'http://' . md5( microtime( true ) ) . '.com',
-			),
-			'tax_input'    => array(
+			],
+			'tax_input'    => [
 				'job_listing_type'     => $full_time_term['term_id'],
 				'job_listing_category' => $weird_cat_term['term_id'],
-			),
-		);
+			],
+		];
 		return get_post( $this->factory->job_listing->create( $job_args ) );
 	}
 
@@ -363,8 +363,8 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		$this->assertTrue( is_subclass_of( $core_email_class, 'WP_Job_Manager_Email' ) );
 
 		// // PHP 5.2: Using `call_user_func()` but `$core_email_class::get_key()` preferred.
-		$this->assertTrue( is_string( call_user_func( array( $core_email_class, 'get_key' ) ) ) );
-		$this->assertTrue( is_string( call_user_func( array( $core_email_class, 'get_name' ) ) ) );
+		$this->assertTrue( is_string( call_user_func( [ $core_email_class, 'get_key' ] ) ) );
+		$this->assertTrue( is_string( call_user_func( [ $core_email_class, 'get_name' ] ) ) );
 	}
 
 	/**
@@ -374,7 +374,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @param array  $args         Notification arguments sent.
 	 */
 	public function assertNotificationSent( $notification, $args ) {
-		$hash = sha1( json_encode( array( $notification, $args ) ) );
+		$hash = sha1( json_encode( [ $notification, $args ] ) );
 
 		$this->assertContains( $hash, WP_Job_Manager_Email_Notifications::get_deferred_notification_hashes(), "Email '{$notification}' was meant to be sent with arguments '" . json_encode( $args ) . "'" );
 	}
@@ -386,7 +386,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	 * @param array  $args         Notification arguments sent.
 	 */
 	public function assertNotificationNotSent( $notification, $args ) {
-		$hash = sha1( wp_json_encode( array( $notification, $args ) ) );
+		$hash = sha1( wp_json_encode( [ $notification, $args ] ) );
 
 		$this->assertNotContains( $hash, WP_Job_Manager_Email_Notifications::get_deferred_notification_hashes(), "Email '{$notification}' was NOT meant to be sent with arguments '" . json_encode( $args ) . "'" );
 	}

--- a/tests/php/tests/includes/test_class.wp-job-manager-geocode.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-geocode.php
@@ -7,7 +7,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 
 	public function setUp() {
 		parent::setUp();
-		add_filter( 'job_manager_geolocation_api_key', array( $this, 'get_google_maps_api_key' ), 10 );
+		add_filter( 'job_manager_geolocation_api_key', [ $this, 'get_google_maps_api_key' ], 10 );
 		add_filter( 'job_manager_geolocation_enabled', '__return_true' );
 		$this->enable_transport_faker();
 	}
@@ -36,7 +36,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 		$this->set_expected_responses( $test_data );
 		$instance = WP_Job_Manager_Geocode::instance();
 		$job_id   = $this->factory->job_listing->create();
-		$values   = array( 'job' => array( 'job_location' => $test_data['location'] ) );
+		$values   = [ 'job' => [ 'job_location' => $test_data['location'] ] ];
 		$instance->update_location_data( $job_id, $values );
 		$this->check_test_data( $job_id, $test_data );
 	}
@@ -50,7 +50,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 		$this->set_expected_responses( $test_data );
 		$instance = WP_Job_Manager_Geocode::instance();
 		$job_id   = $this->factory->job_listing->create();
-		$values   = array( 'job' => array( 'job_location' => $test_data['location'] ) );
+		$values   = [ 'job' => [ 'job_location' => $test_data['location'] ] ];
 		add_filter( 'job_manager_geolocation_enabled', '__return_false' );
 		$instance->update_location_data( $job_id, $values );
 		add_filter( 'job_manager_geolocation_enabled', '__return_true' );
@@ -64,7 +64,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 	public function test_update_location_data_not_set() {
 		$instance = WP_Job_Manager_Geocode::instance();
 		$job_id   = $this->factory->job_listing->create();
-		$values   = array( 'job' => array() );
+		$values   = [ 'job' => [] ];
 		$instance->update_location_data( $job_id, $values );
 		$this->check_test_data( $job_id, $this->get_invalid_location_data() );
 	}
@@ -82,7 +82,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 		$job_id   = $this->factory->job_listing->create();
 
 		// Set the initial location data.
-		$values = array( 'job' => array( 'job_location' => $other_test_data['location'] ) );
+		$values = [ 'job' => [ 'job_location' => $other_test_data['location'] ] ];
 		$instance->update_location_data( $job_id, $values );
 		$this->check_test_data( $job_id, $other_test_data );
 
@@ -100,7 +100,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 		$this->set_expected_responses( $test_data );
 		$instance = WP_Job_Manager_Geocode::instance();
 		$job_id   = $this->factory->job_listing->create();
-		$values   = array( 'job' => array( 'job_location' => $test_data['location'] ) );
+		$values   = [ 'job' => [ 'job_location' => $test_data['location'] ] ];
 		$instance->update_location_data( $job_id, $values );
 		$this->assertNotEmpty( get_post_meta( $job_id, 'geolocation_city', true ) );
 		$this->assertTrue( WP_Job_Manager_Geocode::has_location_data( $job_id ) );
@@ -148,7 +148,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 	 */
 	public function test_save_location_data() {
 		$job_id    = $this->factory->job_listing->create();
-		$test_data = array(
+		$test_data = [
 			'city'              => 'City',
 			'country_long'      => 'Country Long',
 			'country_short'     => 'Country',
@@ -161,7 +161,7 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 			'street_number'     => '30',
 			'zipcode'           => '11111',
 			'postcode'          => '22222',
-		);
+		];
 		WP_Job_Manager_Geocode::save_location_data( $job_id, $test_data );
 		foreach ( $test_data as $key => $value ) {
 			$this->assertEquals( $value, get_post_meta( $job_id, 'geolocation_' . $key, true ) );
@@ -188,12 +188,12 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 		$test_url      = 'http://www.example.com/provider';
 		$test_location = 'Mars 00000';
 		$instance      = WP_Job_Manager_Geocode::instance();
-		add_filter( 'job_manager_geolocation_api_key', array( $this, 'helper_add_api_key' ) );
-		add_filter( 'job_manager_geolocation_region_cctld', array( $this, 'helper_add_region_cctld' ) );
+		add_filter( 'job_manager_geolocation_api_key', [ $this, 'helper_add_api_key' ] );
+		add_filter( 'job_manager_geolocation_region_cctld', [ $this, 'helper_add_region_cctld' ] );
 		$result = $instance->add_geolocation_endpoint_query_args( $test_url, $test_location );
 
-		remove_filter( 'job_manager_geolocation_api_key', array( $this, 'helper_add_api_key' ) );
-		remove_filter( 'job_manager_geolocation_region_cctld', array( $this, 'helper_add_region_cctld' ) );
+		remove_filter( 'job_manager_geolocation_api_key', [ $this, 'helper_add_api_key' ] );
+		remove_filter( 'job_manager_geolocation_region_cctld', [ $this, 'helper_add_region_cctld' ] );
 		$this->assertContains( $test_url, $result );
 		$this->assertContains( urlencode( $test_location ), $result );
 		$this->assertContains( 'key=' . urlencode( $this->helper_add_api_key( '' ) ), $result );
@@ -315,41 +315,41 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 		if ( isset( $test_data['fake_response'] ) ) {
 			$transport = $this->get_request_transport();
 			if ( ! isset( $test_data['fake_response']['request'] ) ) {
-				$test_data['fake_response']['request'] = array( 'url' => $this->build_geocode_url( $test_data['location'] ) );
+				$test_data['fake_response']['request'] = [ 'url' => $this->build_geocode_url( $test_data['location'] ) ];
 			}
 			if ( ! isset( $test_data['fake_response']['response'] ) && isset( $test_data['fake_response']['data'] ) ) {
-				$test_data['fake_response']['response'] = array(
-					'results' => array(
-						array(
+				$test_data['fake_response']['response'] = [
+					'results' => [
+						[
 							'address_components' => $test_data['fake_response']['data'],
 							'formatted_address'  => $test_data['location'],
-							'geometry'           => array(
-								'location' => array(
+							'geometry'           => [
+								'location' => [
 									'lat' => 0,
 									'lng' => 0,
-								),
-							),
-						),
-					),
+								],
+							],
+						],
+					],
 					'status'  => 'OK',
-				);
+				];
 			}
-			$transport->add_fake_request( $test_data['fake_response']['request'], array( 'body' => $test_data['fake_response']['response'] ) );
+			$transport->add_fake_request( $test_data['fake_response']['request'], [ 'body' => $test_data['fake_response']['response'] ] );
 		}
 	}
 
 	public function get_location_data() {
-		return array(
-			array( $this->get_invalid_location_data() ),
-			array( $this->get_valid_location_data() ),
-		);
+		return [
+			[ $this->get_invalid_location_data() ],
+			[ $this->get_valid_location_data() ],
+		];
 	}
 
 	protected function get_invalid_location_data() {
-		return array(
+		return [
 			'location'              => '',
 			'expects_location_data' => false,
-			'location_data'         => array(
+			'location_data'         => [
 				'city'              => '',
 				'country_long'      => '',
 				'country_short'     => '',
@@ -362,78 +362,78 @@ class WP_Test_WP_Job_Manager_Geocode extends WPJM_BaseTest {
 				'street_number'     => '',
 				'zipcode'           => '',
 				'postcode'          => '',
-			),
-		);
+			],
+		];
 	}
 
 	private function build_geocode_url( $location ) {
-		$invalid_chars = array(
+		$invalid_chars = [
 			' ' => '+',
 			',' => '',
 			'?' => '',
 			'&' => '',
 			'=' => '',
 			'#' => '',
-		);
+		];
 		$location      = trim( strtolower( str_replace( array_keys( $invalid_chars ), array_values( $invalid_chars ), $location ) ) );
 		return apply_filters( 'job_manager_geolocation_endpoint', WP_Job_Manager_Geocode::GOOGLE_MAPS_GEOCODE_API_URL, $location );
 	}
 
 	protected function get_valid_location_data() {
-		return array(
+		return [
 			'location'              => 'Seattle, WA, USA',
 			'expects_location_data' => true,
-			'location_data'         => array(
+			'location_data'         => [
 				'city' => 'Seattle',
-			),
-			'fake_response'         => array(
-				'data' => array(
-					array(
+			],
+			'fake_response'         => [
+				'data' => [
+					[
 						'short_name' => 'Seattle',
 						'long_name'  => 'Seattle',
-						'types'      => array( 'locality', 'political' ),
-					),
-					array(
+						'types'      => [ 'locality', 'political' ],
+					],
+					[
 						'short_name' => 'WA',
 						'long_name'  => 'Washington',
-						'types'      => array( 'administrative_area_level_1', 'political' ),
-					),
-					array(
+						'types'      => [ 'administrative_area_level_1', 'political' ],
+					],
+					[
 						'short_name' => 'US',
 						'long_name'  => 'United States',
-						'types'      => array( 'country', 'political' ),
-					),
-				),
-			),
-		);
+						'types'      => [ 'country', 'political' ],
+					],
+				],
+			],
+		];
 	}
 
 	protected function get_other_valid_location_data() {
-		return array(
+		return [
 			'location'              => 'Chicago, IL, USA',
 			'expects_location_data' => true,
-			'location_data'         => array(
+			'location_data'         => [
 				'city' => 'Chicago',
-			),
-			'fake_response'         => array(
-				'data' => array(
-					array(
+			],
+			'fake_response'         => [
+				'data' => [
+					[
 						'short_name' => 'Chicago',
 						'long_name'  => 'Chicago',
-						'types'      => array( 'locality', 'political' ),
-					),
-					array(
+						'types'      => [ 'locality', 'political' ],
+					],
+					[
 						'short_name' => 'IL',
 						'long_name'  => 'Illinois',
-						'types'      => array( 'administrative_area_level_1', 'political' ),
-					),
-					array(
+						'types'      => [ 'administrative_area_level_1', 'political' ],
+					],
+					[
 						'short_name' => 'US',
 						'long_name'  => 'United States',
-						'types'      => array( 'country', 'political' ),
-					),
-				),
-			),
-		);
+						'types'      => [ 'country', 'political' ],
+					],
+				],
+			],
+		];
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -21,9 +21,9 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 */
 	public function test_output_kses_post_simple() {
 		$job_id = $this->factory->job_listing->create(
-			array(
+			[
 			'post_content' => '<p>This is a simple job listing</p>',
-			)
+			]
 		);
 
 		$test_content = wpjm_get_the_job_description( $job_id );
@@ -41,9 +41,9 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 */
 	public function test_output_kses_post_allow_embeds() {
 		$job_id = $this->factory->job_listing->create(
-			array(
+			[
 			'post_content' => '<p>This is a simple job listing</p><p>https://www.youtube.com/watch?v=S_GVbuddri8</p>',
-			)
+			]
 		);
 
 		$test_content = wpjm_get_the_job_description( $job_id );
@@ -83,10 +83,10 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$post_id  = $this->factory->post->create();
 
 		$jobs = $wp_query = new WP_Query(
-			array(
+			[
 				'p'         => $job_id,
 				'post_type' => 'job_listing',
-			)
+			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
 		$this->assertTrue( $jobs->is_single );
@@ -154,25 +154,25 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_job_feed_location_search() {
 		$this->factory->job_listing->create_many(
 			5,
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					'_job_location' => 'Portland, OR, USA',
-				),
-			)
+				],
+			]
 		);
 		$seattle_job_id = $this->factory->job_listing->create(
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					'_job_location' => 'Seattle, WA, USA',
-				),
-			)
+				],
+			]
 		);
 		$chicago_job_id = $this->factory->job_listing->create(
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					'_job_location' => 'Chicago, IL, USA',
-				),
-			)
+				],
+			]
 		);
 
 		$_GET['search_location'] = 'Seattle';
@@ -195,14 +195,14 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_job_feed_keyword_search() {
 		$this->factory->job_listing->create_many( 3 );
 		$dog_job_id  = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dog Whisperer',
-			)
+			]
 		);
 		$dino_job_id = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Whisperer Pro',
-			)
+			]
 		);
 
 		$_GET['search_keywords'] = 'Dinosaur';
@@ -276,43 +276,43 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 */
 	public function test_job_feed_item() {
 		$instance       = WP_Job_Manager_Post_Types::instance();
-		$new_jobs       = array();
+		$new_jobs       = [];
 		$type_a         = wp_create_term( 'Job Type A', 'job_listing_type' );
 		$type_b         = wp_create_term( 'Job Type B', 'job_listing_type' );
-		$new_job_args   = array();
-		$new_job_args[] = array(
-			'meta_input' => array(
+		$new_job_args   = [];
+		$new_job_args[] = [
+			'meta_input' => [
 				'_company_name' => 'Custom Company A',
-			),
-			'tax_input'  => array(
+			],
+			'tax_input'  => [
 				'job_listing_type' => $type_a['term_id'],
-			),
-		);
-		$new_job_args[] = array(
-			'meta_input' => array(
+			],
+		];
+		$new_job_args[] = [
+			'meta_input' => [
 				'_job_location' => 'Custom Location B',
 				'_company_name' => '',
-			),
-			'tax_input'  => array(
+			],
+			'tax_input'  => [
 				'job_listing_type' => $type_b['term_id'],
-			),
-		);
-		$new_job_args[] = array(
-			'meta_input' => array(
+			],
+		];
+		$new_job_args[] = [
+			'meta_input' => [
 				'_job_location' => 'Custom Location A',
 				'_company_name' => 'Custom Company B',
-			),
-			'tax_input'  => array(),
-		);
+			],
+			'tax_input'  => [],
+		];
 		$new_jobs[]     = $this->factory->job_listing->create( $new_job_args[0] );
 		$new_jobs[]     = $this->factory->job_listing->create( $new_job_args[1] );
 		$new_jobs[]     = $this->factory->job_listing->create( $new_job_args[2] );
 		$jobs           = $wp_query = new WP_Query(
-			array(
+			[
 				'post_type' => 'job_listing',
 				'orderby'   => 'ID',
 				'order'     => 'ASC',
-			)
+			]
 		);
 		$this->assertEquals( count( $new_jobs ), $jobs->post_count );
 
@@ -366,18 +366,18 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::check_for_expired_jobs
 	 */
 	public function test_check_for_expired_jobs() {
-		$new_jobs                 = array();
+		$new_jobs                 = [];
 		$new_jobs['none']        = $this->factory->job_listing->create();
 		delete_post_meta( $new_jobs['none'], '_job_expires' );
 		$new_jobs['empty']         = $this->factory->job_listing->create();
 		update_post_meta( $new_jobs['empty'], '_job_expires', '' );
-		$new_jobs['invalid-none'] = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => '0000-00-00' ) ) );
-		$new_jobs['today']        = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d' ) ) ) );
-		$new_jobs['yesterday']    = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d', strtotime( '-1 day' ) ) ) ) );
-		$new_jobs['ancient']      = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d', strtotime( '-100 day' ) ) ) ) );
-		$new_jobs['tomorrow']     = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ) ) );
-		$new_jobs['30daysago']    = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d', strtotime( '-30 day' ) ) ) ) );
-		$new_jobs['31daysago']    = $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => date( 'Y-m-d', strtotime( '-31 day' ) ) ) ) );
+		$new_jobs['invalid-none'] = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '0000-00-00' ] ] );
+		$new_jobs['today']        = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d' ) ] ] );
+		$new_jobs['yesterday']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '-1 day' ) ) ] ] );
+		$new_jobs['ancient']      = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '-100 day' ) ) ] ] );
+		$new_jobs['tomorrow']     = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ] ] );
+		$new_jobs['30daysago']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '-30 day' ) ) ] ] );
+		$new_jobs['31daysago']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '-31 day' ) ) ] ] );
 
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$this->assertNotExpired( $new_jobs['none'] );
@@ -422,37 +422,37 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::delete_old_previews
 	 */
 	public function test_delete_old_previews() {
-		$new_jobs              = array();
-		$new_jobs['now']       = $this->factory->job_listing->create( array( 'post_status' => 'preview' ) );
+		$new_jobs              = [];
+		$new_jobs['now']       = $this->factory->job_listing->create( [ 'post_status' => 'preview' ] );
 		$new_jobs['yesterday'] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_status' => 'preview',
 				'age'         => '-1 day',
-			)
+			]
 		);
 		$new_jobs['29days']    = $this->factory->job_listing->create(
-			array(
+			[
 				'post_status' => 'preview',
 				'age'         => '-29 days',
-			)
+			]
 		);
 		$new_jobs['30days']    = $this->factory->job_listing->create(
-			array(
+			[
 				'post_status' => 'preview',
 				'age'         => '-30 days',
-			)
+			]
 		);
 		$new_jobs['31days']    = $this->factory->job_listing->create(
-			array(
+			[
 				'post_status' => 'preview',
 				'age'         => '-31 days',
-			)
+			]
 		);
 		$new_jobs['60days']    = $this->factory->job_listing->create(
-			array(
+			[
 				'post_status' => 'preview',
 				'age'         => '-60 days',
-			)
+			]
 		);
 		$this->assertPostStatus( 'preview', $new_jobs['now'] );
 		$this->assertPostStatus( 'preview', $new_jobs['yesterday'] );
@@ -501,7 +501,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::set_expiry
 	 */
 	public function test_set_expiry_calculate() {
-		$post             = get_post( $this->factory->job_listing->create( array( 'meta_input' => array( '_job_duration' => 77 ) ) ) );
+		$post             = get_post( $this->factory->job_listing->create( [ 'meta_input' => [ '_job_duration' => 77 ] ] ) );
 		$instance         = WP_Job_Manager_Post_Types::instance();
 		$expire_date      = date( 'Y-m-d', strtotime( '+77 days', current_time( 'timestamp' ) ) );
 		$expire_date_calc = calculate_job_expiry( $post->ID );
@@ -515,7 +515,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::set_expiry
 	 */
 	public function test_set_expiry_past() {
-		$post     = get_post( $this->factory->job_listing->create( array( 'meta_input' => array( '_job_expires' => '2008-01-01' ) ) ) );
+		$post     = get_post( $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '2008-01-01' ] ] ) );
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$instance->set_expiry( $post );
 		$this->assertEquals( '', get_post_meta( $post->ID, '_job_expires', true ) );
@@ -528,34 +528,34 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_fix_post_name() {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		// Legit.
-		$data                 = array(
+		$data                 = [
 			'post_type'   => 'job_listing',
 			'post_status' => 'pending',
 			'post_name'   => 'Bad ABC',
-		);
-		$postarr              = array();
+		];
+		$postarr              = [];
 		$postarr['post_name'] = 'TEST 123';
 		$data_fixed           = $instance->fix_post_name( $data, $postarr );
 		$this->assertEquals( $postarr['post_name'], $data_fixed['post_name'] );
 
 		// Bad Post Type.
-		$data                 = array(
+		$data                 = [
 			'post_type'   => 'post',
 			'post_status' => 'pending',
 			'post_name'   => 'Bad ABC',
-		);
-		$postarr              = array();
+		];
+		$postarr              = [];
 		$postarr['post_name'] = 'TEST 123';
 		$data_fixed           = $instance->fix_post_name( $data, $postarr );
 		$this->assertEquals( $data['post_name'], $data_fixed['post_name'] );
 
 		// Bad Post Status.
-		$data                 = array(
+		$data                 = [
 			'post_type'   => 'job_listing',
 			'post_status' => 'publish',
 			'post_name'   => 'Bad ABC',
-		);
-		$postarr              = array();
+		];
+		$postarr              = [];
 		$postarr['post_name'] = 'TEST 123';
 		$data_fixed           = $instance->fix_post_name( $data, $postarr );
 		$this->assertEquals( $data['post_name'], $data_fixed['post_name'] );
@@ -566,11 +566,11 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::maybe_add_geolocation_data
 	 */
 	public function test_get_permalink_structure() {
-		$permalink_test = array(
+		$permalink_test = [
 			'job_base'      => 'job-test-a',
 			'category_base' => 'job-cat-b',
 			'type_base'     => 'job-type-c',
-		);
+		];
 		update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_test ) );
 		$permalinks = WP_Job_Manager_Post_Types::get_permalink_structure();
 		delete_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME );
@@ -587,19 +587,19 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$bad_post = get_post(
 			$this->factory->post->create(
-				array(
+				[
 					'menu_order' => 10,
-					'meta_input' => array( '_featured' => 0 ),
-				)
+					'meta_input' => [ '_featured' => 0 ],
+				]
 			)
 		);
 
 		$post = get_post(
 			$this->factory->job_listing->create(
-				array(
+				[
 					'menu_order' => 10,
-					'meta_input' => array( '_featured' => 0 ),
-				)
+					'meta_input' => [ '_featured' => 0 ],
+				]
 			)
 		);
 
@@ -625,10 +625,10 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$post     = get_post(
 			$this->factory->job_listing->create(
-				array(
+				[
 					'menu_order' => 10,
-					'meta_input' => array( '_featured' => 0 ),
-				)
+					'meta_input' => [ '_featured' => 0 ],
+				]
 			)
 		);
 		unset( $wp_actions['job_manager_job_location_edited'] );
@@ -645,10 +645,10 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$post     = get_post(
 			$this->factory->job_listing->create(
-				array(
+				[
 					'menu_order' => 10,
-					'meta_input' => array( '_featured' => 0 ),
-				)
+					'meta_input' => [ '_featured' => 0 ],
+				]
 			)
 		);
 
@@ -679,10 +679,10 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_maybe_add_default_meta_data() {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$post     = wp_insert_post(
-			array(
+			[
 				'post_type'  => 'job_listing',
 				'post_title' => 'Hello A',
-			)
+			]
 		);
 		delete_post_meta( $post, '_featured' );
 		delete_post_meta( $post, '_filled' );
@@ -700,10 +700,10 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_maybe_add_default_meta_data_non_job_listing() {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$post     = wp_insert_post(
-			array(
+			[
 				'post_type'  => 'post',
 				'post_title' => 'Hello B',
-			)
+			]
 		);
 		delete_post_meta( $post, '_featured' );
 		delete_post_meta( $post, '_filled' );
@@ -725,10 +725,10 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$post_id  = $this->factory->post->create();
 
 		$jobs = $wp_query = new WP_Query(
-			array(
+			[
 				'p'         => $job_id,
 				'post_type' => 'job_listing',
-			)
+			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
 		$this->assertTrue( $jobs->is_single );
@@ -750,14 +750,14 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_noindex_expired_filled_job_listings_expired() {
 		global $wp_query;
 		$instance = WP_Job_Manager_Post_Types::instance();
-		$job_id   = $this->factory->job_listing->create( array( 'post_status' => 'expired ' ) );
+		$job_id   = $this->factory->job_listing->create( [ 'post_status' => 'expired ' ] );
 		$post_id  = $this->factory->post->create();
 
 		$jobs = $wp_query = new WP_Query(
-			array(
+			[
 				'p'         => $job_id,
 				'post_type' => 'job_listing',
-			)
+			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
 		$this->assertTrue( $jobs->is_single );
@@ -783,10 +783,10 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$post_id  = $this->factory->post->create();
 
 		$jobs = $wp_query = new WP_Query(
-			array(
+			[
 				'p'         => $job_id,
 				'post_type' => 'job_listing',
-			)
+			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
 		$this->assertTrue( $jobs->is_single );
@@ -810,14 +810,14 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_output_structured_data_expired() {
 		global $wp_query;
 		$instance = WP_Job_Manager_Post_Types::instance();
-		$job_id   = $this->factory->job_listing->create( array( 'post_status' => 'expired ' ) );
+		$job_id   = $this->factory->job_listing->create( [ 'post_status' => 'expired ' ] );
 		$post_id  = $this->factory->post->create();
 
 		$jobs = $wp_query = new WP_Query(
-			array(
+			[
 				'p'         => $job_id,
 				'post_type' => 'job_listing',
-			)
+			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
 		$this->assertTrue( $jobs->is_single );
@@ -880,44 +880,44 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_based_on_input_type
 	 */
 	public function test_sanitize_meta_field_based_on_input_type_text() {
-		$strings = array(
-			array(
+		$strings = [
+			[
 				'expected' => 'This is a test.',
 				'test'     => 'This is a test. <script>alert("bad");</script>',
-			),
-			array(
+			],
+			[
 				'expected' => 0,
 				'test'     => 0,
-			),
-			array(
+			],
+			[
 				'expected' => '',
 				'test'     => false,
-			),
-			array(
+			],
+			[
 				'expected' => '',
 				'test'     => '%AB%BC%DE',
-			),
-			array(
+			],
+			[
 				'expected' => 'САПР',
 				'test'     => 'САПР',
-			),
-			array(
+			],
+			[
 				'expected' => 'Standard String',
 				'test'     => 'Standard String',
-			),
-			array(
+			],
+			[
 				'expected' => 'My iframe:',
 				'test'     => 'My iframe: <iframe src="http://example.com"></iframe>',
-			),
-		);
+			],
+		];
 
 		$this->set_up_custom_job_listing_data_feilds();
-		$results = array();
+		$results = [];
 		foreach ( $strings as $str ) {
-			$results[] = array(
+			$results[] = [
 				'expected' => $str['expected'],
 				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_based_on_input_type( $str['test'], '_text' ),
-			);
+			];
 		}
 
 		foreach ( $results as $result ) {
@@ -929,44 +929,44 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_based_on_input_type
 	 */
 	public function test_sanitize_meta_field_based_on_input_type_textarea() {
-		$strings = array(
-			array(
+		$strings = [
+			[
 				'expected' => 'This is a test. alert("bad");',
 				'test'     => 'This is a test. <script>alert("bad");</script>',
-			),
-			array(
+			],
+			[
 				'expected' => 0,
 				'test'     => 0,
-			),
-			array(
+			],
+			[
 				'expected' => '',
 				'test'     => false,
-			),
-			array(
+			],
+			[
 				'expected' => '%AB%BC%DE',
 				'test'     => '%AB%BC%DE',
-			),
-			array(
+			],
+			[
 				'expected' => 'САПР',
 				'test'     => 'САПР',
-			),
-			array(
+			],
+			[
 				'expected' => 'Standard String',
 				'test'     => 'Standard String',
-			),
-			array(
+			],
+			[
 				'expected' => 'My iframe: ',
 				'test'     => 'My iframe: <iframe src="http://example.com"></iframe>',
-			),
-		);
+			],
+		];
 
 		$this->set_up_custom_job_listing_data_feilds();
-		$results = array();
+		$results = [];
 		foreach ( $strings as $str ) {
-			$results[] = array(
+			$results[] = [
 				'expected' => $str['expected'],
 				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_based_on_input_type( $str['test'], '_textarea' ),
-			);
+			];
 		}
 
 		foreach ( $results as $result ) {
@@ -978,32 +978,32 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_based_on_input_type
 	 */
 	public function test_sanitize_meta_field_based_on_input_type_checkbox() {
-		$strings = array(
-			array(
+		$strings = [
+			[
 				'expected' => 1,
 				'test'     => 'false',
-			),
-			array(
+			],
+			[
 				'expected' => 0,
 				'test'     => '',
-			),
-			array(
+			],
+			[
 				'expected' => 0,
 				'test'     => false,
-			),
-			array(
+			],
+			[
 				'expected' => 1,
 				'test'     => true,
-			),
-		);
+			],
+		];
 
 		$this->set_up_custom_job_listing_data_feilds();
-		$results = array();
+		$results = [];
 		foreach ( $strings as $str ) {
-			$results[] = array(
+			$results[] = [
 				'expected' => $str['expected'],
 				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_based_on_input_type( $str['test'], '_checkbox' ),
-			);
+			];
 		}
 		$this->remove_custom_job_listing_data_feilds();
 
@@ -1016,32 +1016,32 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_application
 	 */
 	public function test_sanitize_meta_field_application() {
-		$strings = array(
-			array(
+		$strings = [
+			[
 				'expected' => 'http://test%20email@example.com',
 				'test'     => 'test email@example.com',
-			),
-			array(
+			],
+			[
 				'expected' => 'http://awesome',
 				'test'     => 'awesome',
-			),
-			array(
+			],
+			[
 				'expected' => 'https://example.com',
 				'test'     => 'https://example.com',
-			),
-			array(
+			],
+			[
 				'expected' => 'example@example.com',
 				'test'     => 'example@example.com',
-			),
-		);
+			],
+		];
 
 		$this->set_up_custom_job_listing_data_feilds();
-		$results = array();
+		$results = [];
 		foreach ( $strings as $str ) {
-			$results[] = array(
+			$results[] = [
 				'expected' => $str['expected'],
 				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_application( $str['test'], '_application' ),
-			);
+			];
 		}
 		$this->remove_custom_job_listing_data_feilds();
 
@@ -1054,32 +1054,32 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_url
 	 */
 	public function test_sanitize_meta_field_url() {
-		$strings = array(
-			array(
+		$strings = [
+			[
 				'expected' => 'http://example.com',
 				'test'     => 'http://example.com',
-			),
-			array(
+			],
+			[
 				'expected' => '',
 				'test'     => 'slack://custom-url',
-			),
-			array(
+			],
+			[
 				'expected' => 'http://example.com',
 				'test'     => 'example.com',
-			),
-			array(
+			],
+			[
 				'expected' => 'http://example.com/?baz=bar&foo%5Bbar%5D=baz',
 				'test'     => 'http://example.com/?baz=bar&foo[bar]=baz',
-			),
-		);
+			],
+		];
 
 		$this->set_up_custom_job_listing_data_feilds();
-		$results = array();
+		$results = [];
 		foreach ( $strings as $str ) {
-			$results[] = array(
+			$results[] = [
 				'expected' => $str['expected'],
 				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_url( $str['test'] ),
-			);
+			];
 		}
 		$this->remove_custom_job_listing_data_feilds();
 
@@ -1092,32 +1092,32 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_date
 	 */
 	public function test_sanitize_meta_field_date() {
-		$strings = array(
-			array(
+		$strings = [
+			[
 				'expected' => '',
 				'test'     => 'http://example.com',
-			),
-			array(
+			],
+			[
 				'expected' => '',
 				'test'     => 'January 1, 2019',
-			),
-			array(
+			],
+			[
 				'expected' => '',
 				'test'     => '01-01-2019',
-			),
-			array(
+			],
+			[
 				'expected' => '2019-01-01',
 				'test'     => '2019-01-01',
-			),
-		);
+			],
+		];
 
 		$this->set_up_custom_job_listing_data_feilds();
-		$results = array();
+		$results = [];
 		foreach ( $strings as $str ) {
-			$results[] = array(
+			$results[] = [
 				'expected' => $str['expected'],
 				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_date( $str['test'] ),
-			);
+			];
 		}
 		$this->remove_custom_job_listing_data_feilds();
 
@@ -1127,16 +1127,16 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	private function set_up_custom_job_listing_data_feilds() {
-		add_filter( 'job_manager_job_listing_data_fields', array( $this, 'custom_job_listing_data_fields' ) );
+		add_filter( 'job_manager_job_listing_data_fields', [ $this, 'custom_job_listing_data_fields' ] );
 	}
 
 	private function remove_custom_job_listing_data_feilds() {
-		remove_filter( 'job_manager_job_listing_data_fields', array( $this, 'custom_job_listing_data_fields' ) );
+		remove_filter( 'job_manager_job_listing_data_fields', [ $this, 'custom_job_listing_data_fields' ] );
 	}
 
 	public function custom_job_listing_data_fields() {
-		return array(
-			'_text'    => array(
+		return [
+			'_text'    => [
 				'label'         => 'Text Field',
 				'placeholder'   => 'Text Field',
 				'description'   => 'Text Field',
@@ -1145,8 +1145,8 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				'data_type'     => 'string',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-			),
-			'_textarea'    => array(
+			],
+			'_textarea'    => [
 				'label'         => 'Textarea Field',
 				'placeholder'   => 'Textarea Field',
 				'description'   => 'Textarea Field',
@@ -1155,8 +1155,8 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				'data_type'     => 'string',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-			),
-			'_url'    => array(
+			],
+			'_url'    => [
 				'label'         => 'URL Field',
 				'placeholder'   => 'URL Field',
 				'description'   => 'URL Field',
@@ -1165,9 +1165,9 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				'data_type'     => 'string',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-				'sanitize_callback' => array( 'WP_Job_Manager_Post_Types', 'sanitize_meta_field_url' ),
-			),
-			'_checkbox'    => array(
+				'sanitize_callback' => [ 'WP_Job_Manager_Post_Types', 'sanitize_meta_field_url' ],
+			],
+			'_checkbox'    => [
 				'label'         => 'Checkbox Field',
 				'placeholder'   => 'Checkbox Field',
 				'description'   => 'Checkbox Field',
@@ -1176,26 +1176,26 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				'data_type'     => 'integer',
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
-			),
-			'_date'    => array(
+			],
+			'_date'    => [
 				'label'             => 'Checkbox Field',
 				'placeholder'       => 'Checkbox Field',
 				'description'       => 'Checkbox Field',
 				'priority'          => 1,
 				'show_in_admin'     => true,
 				'show_in_rest'      => true,
-				'classes'           => array( 'job-manager-datepicker' ),
-				'sanitize_callback' => array( 'WP_Job_Manager_Post_Types', 'sanitize_meta_field_date' ),
-			),
-			'_application'    => array(
+				'classes'           => [ 'job-manager-datepicker' ],
+				'sanitize_callback' => [ 'WP_Job_Manager_Post_Types', 'sanitize_meta_field_date' ],
+			],
+			'_application'    => [
 				'label'             => 'Application Field',
 				'placeholder'       => 'Application Field',
 				'description'       => 'Application Field',
 				'priority'          => 1,
 				'show_in_admin'     => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => array( 'WP_Job_Manager_Post_Types', 'sanitize_meta_field_application' ),
-			),
-		);
+				'sanitize_callback' => [ 'WP_Job_Manager_Post_Types', 'sanitize_meta_field_application' ],
+			],
+		];
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -59,27 +59,27 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	private function create_default_job_listings() {
 		$this->draft           = $this->factory->job_listing->create_many(
 			2,
-			array( 'post_status' => 'draft' )
+			[ 'post_status' => 'draft' ]
 		);
 		$this->expired         = $this->factory->job_listing->create_many(
 			10,
-			array( 'post_status' => 'expired' )
+			[ 'post_status' => 'expired' ]
 		);
 		$this->preview         = $this->factory->job_listing->create_many(
 			1,
-			array( 'post_status' => 'preview' )
+			[ 'post_status' => 'preview' ]
 		);
 		$this->pending         = $this->factory->job_listing->create_many(
 			8,
-			array( 'post_status' => 'pending' )
+			[ 'post_status' => 'pending' ]
 		);
 		$this->pending_payment = $this->factory->job_listing->create_many(
 			3,
-			array( 'post_status' => 'pending_payment' )
+			[ 'post_status' => 'pending_payment' ]
 		);
 		$this->publish         = $this->factory->job_listing->create_many(
 			15,
-			array( 'post_status' => 'publish' )
+			[ 'post_status' => 'publish' ]
 		);
 	}
 
@@ -96,11 +96,11 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 		$this->factory->user->create_many(
 			$employer_count,
-			array( 'role' => 'employer' )
+			[ 'role' => 'employer' ]
 		);
 		$this->factory->user->create_many(
 			$subscriber_count,
-			array( 'role' => 'subscriber' )
+			[ 'role' => 'subscriber' ]
 		);
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
@@ -114,7 +114,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_job_categories_count() {
-		$terms = $this->factory->term->create_many( 14, array( 'taxonomy' => 'job_listing_category' ) );
+		$terms = $this->factory->term->create_many( 14, [ 'taxonomy' => 'job_listing_category' ] );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -144,16 +144,16 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		// Create some terms with varying descriptions.
 		$valid   = $this->factory->term->create_many(
 			2,
-			array(
+			[
 				'taxonomy'    => 'job_listing_category',
 				'description' => ' Valid description ',
-			)
+			]
 		);
 		$invalid = $this->factory->term->create(
-			array(
+			[
 				'taxonomy'    => 'job_listing_category',
 				'description' => "\t\n",
-			)
+			]
 		);
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
@@ -181,7 +181,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_job_types_count() {
-		$terms = $this->factory->term->create_many( 14, array( 'taxonomy' => 'job_listing_type' ) );
+		$terms = $this->factory->term->create_many( 14, [ 'taxonomy' => 'job_listing_type' ] );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -199,16 +199,16 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		// Create some terms with varying descriptions.
 		$valid   = $this->factory->term->create_many(
 			2,
-			array(
+			[
 				'taxonomy'    => 'job_listing_type',
 				'description' => ' Valid description ',
-			)
+			]
 		);
 		$invalid = $this->factory->term->create(
-			array(
+			[
 				'taxonomy'    => 'job_listing_type',
 				'description' => "\t\n",
-			)
+			]
 		);
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
@@ -224,7 +224,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_type_has_employment_type_count
 	 */
 	public function test_get_job_type_has_employment_type_count() {
-		$terms = $this->factory->term->create_many( 5, array( 'taxonomy' => 'job_listing_type' ) );
+		$terms = $this->factory->term->create_many( 5, [ 'taxonomy' => 'job_listing_type' ] );
 
 		// Set the employment type for some terms.
 		add_term_meta( $terms[1], 'employment_type', 'FULL_TIME' );
@@ -424,10 +424,10 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		// Create some media attachments.
 		$media = $this->factory->attachment->create_many(
 			6,
-			array(
+			[
 				'post_type'   => 'job_listing',
 				'post_status' => 'publish',
-			)
+			]
 		);
 
 		// Add logos to some listings with varying statuses.
@@ -453,7 +453,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 */
 	public function test_get_job_type_count() {
 		$this->create_default_job_listings();
-		$terms = $this->factory->term->create_many( 6, array( 'taxonomy' => 'job_listing_type' ) );
+		$terms = $this->factory->term->create_many( 6, [ 'taxonomy' => 'job_listing_type' ] );
 
 		// Assign job types to some jobs.
 		wp_set_object_terms( $this->draft[0], $terms[0], 'job_listing_type', false );
@@ -616,7 +616,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings_with_meta( '_filled', '1', $published, $expired, array( '0' ) );
+		$this->create_job_listings_with_meta( '_filled', '1', $published, $expired, [ '0' ] );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_filled'] );
@@ -633,7 +633,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$published = 3;
 		$expired   = 2;
 
-		$this->create_job_listings_with_meta( '_featured', '1', $published, $expired, array( '0' ) );
+		$this->create_job_listings_with_meta( '_featured', '1', $published, $expired, [ '0' ] );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 		$this->assertEquals( $published + $expired, $data['jobs_featured'] );
@@ -653,27 +653,27 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		// Create published listings.
 		$this->factory->job_listing->create_many(
 			$published_by_guest,
-			array(
+			[
 				'post_author' => '0',
-			)
+			]
 		);
 
 		// Create expired listings.
 		$this->factory->job_listing->create_many(
 			$expired_by_guest,
-			array(
+			[
 				'post_author' => '0',
 				'post_status' => 'expired',
-			)
+			]
 		);
 
 		// Create guest listings with other statuses.
-		$statuses = array( 'future', 'draft', 'pending', 'private', 'trash' );
+		$statuses = [ 'future', 'draft', 'pending', 'private', 'trash' ];
 		foreach ( $statuses as $status ) {
-			$params = array(
+			$params = [
 				'post_author' => '0',
 				'post_status' => $status,
-			);
+			];
 
 			if ( 'future' === $status ) {
 				$params['post_date'] = '3018-02-15 00:00:00';
@@ -683,13 +683,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		}
 
 		// Create listings with other author.
-		$all_statuses = array_merge( $statuses, array( 'publish', 'expired' ) );
+		$all_statuses = array_merge( $statuses, [ 'publish', 'expired' ] );
 		$author_id    = $this->factory->user->create();
 		foreach ( $all_statuses as $status ) {
-			$params = array(
+			$params = [
 				'post_author' => $author_id,
 				'post_status' => $status,
-			);
+			];
 
 			if ( 'future' === $status ) {
 				$params['post_date'] = '3018-02-15 00:00:00';
@@ -768,7 +768,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	private function set_fake_license() {
 		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'licence_key', 'FAKE-LICENSE' );
 		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'email', 'fake@example.com' );
-		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'errors', array() );
+		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'errors', [] );
 	}
 
 	/**
@@ -785,7 +785,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 */
 	private function restore_default_plugins() {
 		wp_clean_plugins_cache();
-		update_option( 'active_plugins', array() );
+		update_option( 'active_plugins', [] );
 		remove_filter( 'job_manager_clear_plugin_cache', '__return_false' );
 	}
 
@@ -794,8 +794,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 */
 	private function set_fake_plugins() {
 		add_filter( 'job_manager_clear_plugin_cache', '__return_false' );
-		$plugins = array (
-			'hello.php' => array (
+		$plugins =  [
+			'hello.php' =>  [
 				'WPJM-Product' => '',
 				'Name' => 'Hello Dolly',
 				'PluginURI' => 'http://wordpress.org/plugins/hello-dolly/',
@@ -808,8 +808,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 				'Network' => false,
 				'Title' => 'Hello Dolly',
 				'AuthorName' => 'Matt Mullenweg',
-			),
-			'wp-job-manager-tester/wp-job-manager-tester.php' => array (
+			],
+			'wp-job-manager-tester/wp-job-manager-tester.php' =>  [
 				'WPJM-Product' => '',
 				'Name' => 'WP Job Manager Tester',
 				'PluginURI' => 'http://wordpress.org/plugins/wp-job-manager-tester/',
@@ -822,8 +822,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 				'Network' => false,
 				'Title' => 'WP Job Manager Tester',
 				'AuthorName' => 'Example',
-			),
-			'wp-job-manager-official-tester/wp-job-manager-official-tester.php' => array (
+			],
+			'wp-job-manager-official-tester/wp-job-manager-official-tester.php' =>  [
 				'WPJM-Product' => 'wp-job-manager-official-tester',
 				'Name' => 'WP Job Manager Official Tester',
 				'PluginURI' => 'http://wpjobmanager.com',
@@ -836,8 +836,8 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 				'Network' => false,
 				'Title' => 'WP Job Manager Official Tester',
 				'AuthorName' => 'Example',
-			),
-			'wp-job-manager-official-licensed-tester/wp-job-manager-official-licensed-tester.php' => array (
+			],
+			'wp-job-manager-official-licensed-tester/wp-job-manager-official-licensed-tester.php' =>  [
 				'WPJM-Product' => 'wp-job-manager-official-licensed-tester',
 				'Name' => 'WP Job Manager Official Licensed Tester',
 				'PluginURI' => 'http://wpjobmanager.com',
@@ -850,11 +850,11 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 				'Network' => false,
 				'Title' => 'WP Job Manager Official Licensed Tester',
 				'AuthorName' => 'Example',
-			),
-		);
+			],
+		];
 
 		update_option( 'active_plugins', array_keys( $plugins ) );
-		wp_cache_set( 'plugins', array( '' => $plugins ), 'plugins' );
+		wp_cache_set( 'plugins', [ '' => $plugins ], 'plugins' );
 	}
 
 	/**
@@ -870,49 +870,49 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @param int    $expired the number of expired listings to create.
 	 * @param int    $other_values other values for which to create listings (optional).
 	 */
-	private function create_job_listings_with_meta( $meta_name, $meta_value, $published, $expired, $other_values = array() ) {
+	private function create_job_listings_with_meta( $meta_name, $meta_value, $published, $expired, $other_values = [] ) {
 		// Create published listings.
 		$this->factory->job_listing->create_many(
 			$published,
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					$meta_name => $meta_value,
-				),
-			)
+				],
+			]
 		);
 
 		// Create expired listings.
 		$this->factory->job_listing->create_many(
 			$expired,
-			array(
+			[
 				'post_status' => 'expired',
-				'meta_input'  => array(
+				'meta_input'  => [
 					$meta_name => $meta_value,
-				),
-			)
+				],
+			]
 		);
 
 		// Create listings with empty values.
-		$empty_values = array( '', '   ', "\n\t", " \n \t " );
+		$empty_values = [ '', '   ', "\n\t", " \n \t " ];
 		foreach ( $empty_values as $val ) {
 			$this->factory->job_listing->create(
-				array(
-					'meta_input' => array(
+				[
+					'meta_input' => [
 						$meta_name => $val,
-					),
-				)
+					],
+				]
 			);
 		}
 
 		// Create listings with other statuses.
-		$statuses = array( 'future', 'draft', 'pending', 'private', 'trash' );
+		$statuses = [ 'future', 'draft', 'pending', 'private', 'trash' ];
 		foreach ( $statuses as $status ) {
-			$params = array(
+			$params = [
 				'post_status' => $status,
-				'meta_input'  => array(
+				'meta_input'  => [
 					$meta_name => $meta_value,
-				),
-			);
+				],
+			];
 
 			if ( 'future' === $status ) {
 				$params['post_date'] = '3018-02-15 00:00:00';
@@ -924,11 +924,11 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		// Create listings with other values.
 		foreach ( $other_values as $val ) {
 			$this->factory->job_listing->create(
-				array(
-					'meta_input' => array(
+				[
+					'meta_input' => [
 						$meta_name => $val,
-					),
-				)
+					],
+				]
 			);
 		}
 	}

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -23,31 +23,31 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_keywords() {
-		$keywords                = array(
-			'saurkraut' => array(),
-			'dinosaur'  => array(),
-			'saur'      => array(),
-			'boom'      => array(),
-		);
+		$keywords                = [
+			'saurkraut' => [],
+			'dinosaur'  => [],
+			'saur'      => [],
+			'boom'      => [],
+		];
 		$keywords['saurkraut'][] = $keywords['saur'][] = $keywords['boom'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'A Saurkraut Boom',
-			)
+			]
 		);
 		$keywords['dinosaur'][]  = $keywords['saur'][] = $keywords['boom'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Boom',
-			)
+			]
 		);
 		$keywords['dinosaur'][]  = $keywords['saur'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur',
-			)
+			]
 		);
 
-		$dinosaur_job_listings = get_job_listings( array( 'search_keywords' => 'Dinosaur' ) );
-		$saur_job_listings     = get_job_listings( array( 'search_keywords' => 'Saur' ) );
-		$boom_job_listings     = get_job_listings( array( 'search_keywords' => 'Boom' ) );
+		$dinosaur_job_listings = get_job_listings( [ 'search_keywords' => 'Dinosaur' ] );
+		$saur_job_listings     = get_job_listings( [ 'search_keywords' => 'Saur' ] );
+		$boom_job_listings     = get_job_listings( [ 'search_keywords' => 'Boom' ] );
 
 		$this->assertEqualSets( $keywords['dinosaur'], wp_list_pluck( $dinosaur_job_listings->posts, 'ID' ) );
 		$this->assertEqualSets( $keywords['saur'], wp_list_pluck( $saur_job_listings->posts, 'ID' ) );
@@ -59,99 +59,99 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_location() {
-		$locations               = array(
-			'seattle'  => array(),
-			'portland' => array(),
-			'oregon'   => array(),
-			'london'   => array(),
-		);
+		$locations               = [
+			'seattle'  => [],
+			'portland' => [],
+			'oregon'   => [],
+			'london'   => [],
+		];
 		$locations['seattle'][]  = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Seattle-A',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'Seattle, WA, USA',
-				),
-			)
+				],
+			]
 		);
 		$locations['seattle'][]  = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Seattle-B',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'seattle, wa',
-				),
-			)
+				],
+			]
 		);
 		$locations['seattle'][]  = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Seattle-C',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'Seattle, Washington',
-				),
-			)
+				],
+			]
 		);
 		$locations['portland'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Portland-A',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'Portland, Maine',
-				),
-			)
+				],
+			]
 		);
 		$locations['portland'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Portland-B',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'Portland, OR',
-				),
-			)
+				],
+			]
 		);
 		$locations['portland'][] = $locations['oregon'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Portland-C',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'Portland, Oregon',
-				),
-			)
+				],
+			]
 		);
 		$locations['london'][]   = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test London',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'London, UK',
-				),
-			)
+				],
+			]
 		);
 		$this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Test London',
-				'meta_input' => array(
+				'meta_input' => [
 					'_job_location' => 'London, UK',
-				),
-			)
+				],
+			]
 		);
 		$this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Seattle',
-			)
+			]
 		);
 
 		$seattle_job_listings  = get_job_listings(
-			array(
+			[
 				'search_keywords' => 'Dinosaur',
 				'search_location' => 'Seattle',
-			)
+			]
 		);
 		$portland_job_listings = get_job_listings(
-			array(
+			[
 				'search_keywords' => 'Dinosaur',
 				'search_location' => 'Portland',
-			)
+			]
 		);
 		$london_job_listings   = get_job_listings(
-			array(
+			[
 				'search_keywords' => 'Dinosaur',
 				'search_location' => 'London',
-			)
+			]
 		);
 
 		$this->assertEqualSets( $locations['seattle'], wp_list_pluck( $seattle_job_listings->posts, 'ID' ) );
@@ -164,63 +164,63 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_post_status() {
-		$post_statuses              = array(
-			'publish' => array(),
-			'expired' => array(),
-			'preview' => array(),
-		);
+		$post_statuses              = [
+			'publish' => [],
+			'expired' => [],
+			'preview' => [],
+		];
 		$post_statuses['publish'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Pub-A',
-			)
+			]
 		);
 		$post_statuses['publish'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title' => 'Dinosaur Test Pub-B',
-			)
+			]
 		);
 		$post_statuses['expired'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title'  => 'Dinosaur Test Ex-A',
 				'post_status' => 'expired',
-			)
+			]
 		);
 		$post_statuses['expired'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title'  => 'Dinosaur Test Ex-B',
 				'post_status' => 'expired',
-			)
+			]
 		);
 		$post_statuses['expired'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title'  => 'Dinosaur Test Ex-C',
 				'post_status' => 'expired',
-			)
+			]
 		);
 		$post_statuses['preview'][] = $this->factory->job_listing->create(
-			array(
+			[
 				'post_title'  => 'Dinosaur Test Preview-A',
 				'post_status' => 'preview',
-			)
+			]
 		);
 
 		$published_job_listings         = get_job_listings(
-			array(
+			[
 				'search_keywords' => 'Dinosaur',
-				'post_status'     => array( 'publish' ),
-			)
+				'post_status'     => [ 'publish' ],
+			]
 		);
 		$published_preview_job_listings = get_job_listings(
-			array(
+			[
 				'search_keywords' => 'Dinosaur',
-				'post_status'     => array( 'publish', 'preview' ),
-			)
+				'post_status'     => [ 'publish', 'preview' ],
+			]
 		);
 		$expired_job_listings           = get_job_listings(
-			array(
+			[
 				'search_keywords' => 'Dinosaur',
-				'post_status'     => array( 'expired' ),
-			)
+				'post_status'     => [ 'expired' ],
+			]
 		);
 
 		$this->assertEqualSets( $post_statuses['publish'], wp_list_pluck( $published_job_listings->posts, 'ID' ) );
@@ -235,14 +235,14 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	public function test_get_job_listings_categories() {
 		$this->assertTrue( taxonomy_exists( 'job_listing_category' ) );
 		$this->assertTrue( current_user_can( get_taxonomy( 'job_listing_category' )->cap->assign_terms ) );
-		$categories      = array(
-			'main'  => array(),
-			'weird' => array(),
-			'happy' => array(),
-			'all'   => array(),
-			'none'  => array(),
-		);
-		$terms           = array();
+		$categories      = [
+			'main'  => [],
+			'weird' => [],
+			'happy' => [],
+			'all'   => [],
+			'none'  => [],
+		];
+		$terms           = [];
 		$terms['jazz']   = $categories['main'][] = $categories['all'][] = wp_create_term( 'jazz', 'job_listing_category' );
 		$terms['swim']   = $categories['main'][] = $categories['all'][] = wp_create_term( 'swim', 'job_listing_category' );
 		$terms['dev']    = $categories['main'][] = $categories['all'][] = wp_create_term( 'dev', 'job_listing_category' );
@@ -252,95 +252,95 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			$categories[ $k ] = wp_list_pluck( $category, 'term_id' );
 		}
 
-		$post_categories = array(
-			'empty' => array(),
-			'main'  => array(),
-			'weird' => array(),
-			'all'   => array(),
-		);
+		$post_categories = [
+			'empty' => [],
+			'main'  => [],
+			'weird' => [],
+			'all'   => [],
+		];
 
 		$post_categories['main']  = $this->factory->job_listing->create_many(
 			3,
-			array(
-				'tax_input' => array(
+			[
+				'tax_input' => [
 					'job_listing_category' => $categories['main'],
-				),
-			)
+				],
+			]
 		);
 		$post_categories['weird'] = $this->factory->job_listing->create_many(
 			2,
-			array(
-				'tax_input' => array(
+			[
+				'tax_input' => [
 					'job_listing_category' => $categories['weird'],
-				),
-			)
+				],
+			]
 		);
 		$post_categories['happy'] = $this->factory->job_listing->create_many(
 			2,
-			array(
-				'tax_input' => array(
+			[
+				'tax_input' => [
 					'job_listing_category' => $categories['happy'],
-				),
-			)
+				],
+			]
 		);
 		$post_categories['none']  = $this->factory->job_listing->create_many( 5 );
-		$results                  = array();
-		$results['jazz']          = array(
+		$results                  = [];
+		$results['jazz']          = [
 			'expected' => array_merge( $post_categories['all'], $post_categories['main'] ),
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords'   => '',
-					'search_categories' => array( 'jazz' ),
-				)
+					'search_categories' => [ 'jazz' ],
+				]
 			),
-		);
-		$results['potato']        = array(
+		];
+		$results['potato']        = [
 			'expected' => $post_categories['weird'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords'   => '',
-					'search_categories' => array( 'potato' ),
-				)
+					'search_categories' => [ 'potato' ],
+				]
 			),
-		);
+		];
 		update_option( 'job_manager_category_filter_type', 'some' );
-		$results['potato_coffee_some'] = array(
+		$results['potato_coffee_some'] = [
 			'expected' => array_merge( $post_categories['weird'], $post_categories['happy'] ),
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords'   => '',
-					'search_categories' => array( 'potato', 'coffee' ),
-				)
+					'search_categories' => [ 'potato', 'coffee' ],
+				]
 			),
-		);
-		$results['potato_coffee_some'] = array(
+		];
+		$results['potato_coffee_some'] = [
 			'expected' => $post_categories['main'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords'   => '',
-					'search_categories' => array( 'jazz', 'swim' ),
-				)
+					'search_categories' => [ 'jazz', 'swim' ],
+				]
 			),
-		);
+		];
 		update_option( 'job_manager_category_filter_type', 'all' );
-		$results['potato_coffee_all'] = array(
-			'expected' => array(),
+		$results['potato_coffee_all'] = [
+			'expected' => [],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords'   => '',
-					'search_categories' => array( 'potato', 'coffee' ),
-				)
+					'search_categories' => [ 'potato', 'coffee' ],
+				]
 			),
-		);
-		$results['potato_coffee_all'] = array(
+		];
+		$results['potato_coffee_all'] = [
 			'expected' => $post_categories['main'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords'   => '',
-					'search_categories' => array( 'jazz', 'swim' ),
-				)
+					'search_categories' => [ 'jazz', 'swim' ],
+				]
 			),
-		);
+		];
 
 		foreach ( $results as $key => $result ) {
 			$this->assertEqualSets( $result['expected'], wp_list_pluck( $result['results']->posts, 'ID' ), "{$key} doesn't match" );
@@ -354,14 +354,14 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	public function test_get_job_listings_job_types() {
 		$this->assertTrue( taxonomy_exists( 'job_listing_type' ) );
 		$this->assertTrue( current_user_can( get_taxonomy( 'job_listing_type' )->cap->assign_terms ) );
-		$tags            = array(
-			'main'  => array(),
-			'weird' => array(),
-			'happy' => array(),
-			'all'   => array(),
-			'none'  => array(),
-		);
-		$terms           = array();
+		$tags            = [
+			'main'  => [],
+			'weird' => [],
+			'happy' => [],
+			'all'   => [],
+			'none'  => [],
+		];
+		$terms           = [];
 		$terms['jazz']   = $tags['main'][] = $tags['all'][] = wp_create_term( 'jazz', 'job_listing_type' );
 		$terms['swim']   = $tags['main'][] = $tags['all'][] = wp_create_term( 'swim', 'job_listing_type' );
 		$terms['dev']    = $tags['main'][] = $tags['all'][] = wp_create_term( 'dev', 'job_listing_type' );
@@ -371,75 +371,75 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			$tags[ $k ] = wp_list_pluck( $category, 'term_id' );
 		}
 
-		$post_job_types = array(
-			'empty' => array(),
-			'main'  => array(),
-			'weird' => array(),
-			'all'   => array(),
-		);
+		$post_job_types = [
+			'empty' => [],
+			'main'  => [],
+			'weird' => [],
+			'all'   => [],
+		];
 
 		$post_job_types['main']   = $this->factory->job_listing->create_many(
 			3,
-			array(
-				'tax_input' => array(
+			[
+				'tax_input' => [
 					'job_listing_type' => $tags['main'],
-				),
-			)
+				],
+			]
 		);
 		$post_job_types['weird']  = $this->factory->job_listing->create_many(
 			2,
-			array(
-				'tax_input' => array(
+			[
+				'tax_input' => [
 					'job_listing_type' => $tags['weird'],
-				),
-			)
+				],
+			]
 		);
 		$post_job_types['happy']  = $this->factory->job_listing->create_many(
 			2,
-			array(
-				'tax_input' => array(
+			[
+				'tax_input' => [
 					'job_listing_type' => $tags['happy'],
-				),
-			)
+				],
+			]
 		);
 		$post_job_types['none']   = $this->factory->job_listing->create_many( 5 );
-		$results                  = array();
-		$results['jazz']          = array(
+		$results                  = [];
+		$results['jazz']          = [
 			'expected' => array_merge( $post_job_types['all'], $post_job_types['main'] ),
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
-					'job_types'       => array( 'jazz' ),
-				)
+					'job_types'       => [ 'jazz' ],
+				]
 			),
-		);
-		$results['potato']        = array(
+		];
+		$results['potato']        = [
 			'expected' => $post_job_types['weird'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
-					'job_types'       => array( 'potato' ),
-				)
+					'job_types'       => [ 'potato' ],
+				]
 			),
-		);
-		$results['potato_coffee'] = array(
+		];
+		$results['potato_coffee'] = [
 			'expected' => array_merge( $post_job_types['weird'], $post_job_types['happy'] ),
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
-					'job_types'       => array( 'potato', 'coffee' ),
-				)
+					'job_types'       => [ 'potato', 'coffee' ],
+				]
 			),
-		);
-		$results['potato_coffee'] = array(
+		];
+		$results['potato_coffee'] = [
 			'expected' => $post_job_types['main'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
-					'job_types'       => array( 'jazz', 'swim' ),
-				)
+					'job_types'       => [ 'jazz', 'swim' ],
+				]
 			),
-		);
+		];
 
 		foreach ( $results as $key => $result ) {
 			$this->assertEqualSets( $result['expected'], wp_list_pluck( $result['results']->posts, 'ID' ), "{$key} doesn't match" );
@@ -451,46 +451,46 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_featured() {
-		$featured_flag = array(
-			'featured'     => array(),
-			'not-featured' => array(),
-		);
+		$featured_flag = [
+			'featured'     => [],
+			'not-featured' => [],
+		];
 
 		$featured_flag['featured']     = $this->factory->job_listing->create_many(
 			3,
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					'_featured' => 1,
-				),
-			)
+				],
+			]
 		);
 		$featured_flag['not-featured'] = $this->factory->job_listing->create_many(
 			2,
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					'_featured' => 0,
-				),
-			)
+				],
+			]
 		);
-		$results                       = array();
-		$results['featured']           = array(
+		$results                       = [];
+		$results['featured']           = [
 			'expected' => $featured_flag['featured'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
 					'featured'        => true,
-				)
+				]
 			),
-		);
-		$results['not-featured']       = array(
+		];
+		$results['not-featured']       = [
 			'expected' => $featured_flag['not-featured'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
 					'featured'        => false,
-				)
+				]
 			),
-		);
+		];
 
 		foreach ( $results as $key => $result ) {
 			$this->assertEqualSets( $result['expected'], wp_list_pluck( $result['results']->posts, 'ID' ), "{$key} doesn't match" );
@@ -503,37 +503,37 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 */
 	public function test_get_job_listings_featured_rand_cache() {
 		$this->enable_job_listing_cache();
-		$featured_flag = array(
-			'featured'     => array(),
-			'not-featured' => array(),
-		);
+		$featured_flag = [
+			'featured'     => [],
+			'not-featured' => [],
+		];
 
 		$featured_flag['featured']     = $this->factory->job_listing->create_many(
 			5,
-			array(
+			[
 				'post_title' => 'Featured Post',
-				'meta_input' => array(
+				'meta_input' => [
 					'_featured' => 1,
-				),
-			)
+				],
+			]
 		);
 		$featured_flag['not-featured'] = $this->factory->job_listing->create_many(
 			5,
-			array(
+			[
 				'post_title' => 'Not Featured Post',
-				'meta_input' => array(
+				'meta_input' => [
 					'_featured' => 0,
-				),
-			)
+				],
+			]
 		);
 
 		// Try 10x, verfying first 5 are always job listings.
 		for ( $i = 1; $i <= 10; $i++ ) {
 			$results = get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
 					'orderby'         => 'rand_featured',
-				)
+				]
 			);
 			$tc      = 0;
 			foreach ( $results->posts as $result ) {
@@ -555,37 +555,37 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 */
 	public function test_get_job_listings_featured_rand_no_cache() {
 		$this->disable_job_listing_cache();
-		$featured_flag = array(
-			'featured'     => array(),
-			'not-featured' => array(),
-		);
+		$featured_flag = [
+			'featured'     => [],
+			'not-featured' => [],
+		];
 
 		$featured_flag['featured']     = $this->factory->job_listing->create_many(
 			5,
-			array(
+			[
 				'post_title' => 'Featured Post',
-				'meta_input' => array(
+				'meta_input' => [
 					'_featured' => 1,
-				),
-			)
+				],
+			]
 		);
 		$featured_flag['not-featured'] = $this->factory->job_listing->create_many(
 			5,
-			array(
+			[
 				'post_title' => 'Not Featured Post',
-				'meta_input' => array(
+				'meta_input' => [
 					'_featured' => 0,
-				),
-			)
+				],
+			]
 		);
 
 		// Try 10x, verifying first 5 are always job listings.
 		for ( $i = 1; $i <= 10; $i++ ) {
 			$results = get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
 					'orderby'         => 'rand_featured',
-				)
+				]
 			);
 			$tc      = 0;
 			foreach ( $results->posts as $result ) {
@@ -606,46 +606,46 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_filled() {
-		$featured_flag = array(
-			'featured'     => array(),
-			'not-featured' => array(),
-		);
+		$featured_flag = [
+			'featured'     => [],
+			'not-featured' => [],
+		];
 
 		$featured_flag['filled']     = $this->factory->job_listing->create_many(
 			3,
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					'_filled' => 1,
-				),
-			)
+				],
+			]
 		);
 		$featured_flag['not-filled'] = $this->factory->job_listing->create_many(
 			2,
-			array(
-				'meta_input' => array(
+			[
+				'meta_input' => [
 					'_filled' => 0,
-				),
-			)
+				],
+			]
 		);
-		$results                     = array();
-		$results['filled']           = array(
+		$results                     = [];
+		$results['filled']           = [
 			'expected' => $featured_flag['filled'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
 					'filled'          => true,
-				)
+				]
 			),
-		);
-		$results['not-filled']       = array(
+		];
+		$results['not-filled']       = [
 			'expected' => $featured_flag['not-filled'],
 			'results'  => get_job_listings(
-				array(
+				[
 					'search_keywords' => '',
 					'filled'          => false,
-				)
+				]
 			),
-		);
+		];
 
 		foreach ( $results as $key => $result ) {
 			$this->assertEqualSets( $result['expected'], wp_list_pluck( $result['results']->posts, 'ID' ), "{$key} doesn't match" );
@@ -806,11 +806,11 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 
 	protected function set_up_request_normal_page() {
 		$page = $this->factory->post->create(
-			array(
+			[
 				'post_type'    => 'page',
 				'post_title'   => 'Cool',
 				'post_content' => 'Awesome',
-			)
+			]
 		);
 		$this->go_to( get_post_permalink( $page ) );
 	}
@@ -826,11 +826,11 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 
 	protected function create_shortcode_page( $title, $tag ) {
 		return $this->factory->post->create(
-			array(
+			[
 				'post_type'    => 'page',
 				'post_title'   => $title,
 				'post_content' => '[' . $tag . ']',
-			)
+			]
 		);
 	}
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -15,17 +15,17 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 	 * @param string|array|object $args Arguments used to retrieve job listings.
 	 * @return WP_Query
 	 */
-	function get_job_listings( $args = array() ) {
+	function get_job_listings( $args = [] ) {
 		global $job_manager_keyword;
 
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'search_location'   => '',
 				'search_keywords'   => '',
-				'search_categories' => array(),
-				'job_types'         => array(),
-				'post_status'       => array(),
+				'search_categories' => [],
+				'job_types'         => [],
+				'post_status'       => [],
 				'offset'            => 0,
 				'posts_per_page'    => 20,
 				'orderby'           => 'date',
@@ -33,7 +33,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 				'featured'          => null,
 				'filled'            => null,
 				'fields'            => 'all',
-			)
+			]
 		);
 
 		/**
@@ -48,12 +48,12 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		if ( ! empty( $args['post_status'] ) ) {
 			$post_status = $args['post_status'];
 		} elseif ( 0 === intval( get_option( 'job_manager_hide_expired', get_option( 'job_manager_hide_expired_content', 1 ) ) ) ) {
-			$post_status = array( 'publish', 'expired' );
+			$post_status = [ 'publish', 'expired' ];
 		} else {
 			$post_status = 'publish';
 		}
 
-		$query_args = array(
+		$query_args = [
 			'post_type'              => 'job_listing',
 			'post_status'            => $post_status,
 			'ignore_sticky_posts'    => 1,
@@ -61,80 +61,80 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			'posts_per_page'         => intval( $args['posts_per_page'] ),
 			'orderby'                => $args['orderby'],
 			'order'                  => $args['order'],
-			'tax_query'              => array(),
-			'meta_query'             => array(),
+			'tax_query'              => [],
+			'meta_query'             => [],
 			'update_post_term_cache' => false,
 			'update_post_meta_cache' => false,
 			'cache_results'          => false,
 			'fields'                 => $args['fields'],
-		);
+		];
 
 		if ( $args['posts_per_page'] < 0 ) {
 			$query_args['no_found_rows'] = true;
 		}
 
 		if ( ! empty( $args['search_location'] ) ) {
-			$location_meta_keys = array( 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' );
-			$location_search    = array( 'relation' => 'OR' );
+			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
+			$location_search    = [ 'relation' => 'OR' ];
 			foreach ( $location_meta_keys as $meta_key ) {
-				$location_search[] = array(
+				$location_search[] = [
 					'key'     => $meta_key,
 					'value'   => $args['search_location'],
 					'compare' => 'like',
-				);
+				];
 			}
 			$query_args['meta_query'][] = $location_search;
 		}
 
 		if ( ! is_null( $args['featured'] ) ) {
-			$query_args['meta_query'][] = array(
+			$query_args['meta_query'][] = [
 				'key'     => '_featured',
 				'value'   => '1',
 				'compare' => $args['featured'] ? '=' : '!=',
-			);
+			];
 		}
 
 		if ( ! is_null( $args['filled'] ) || 1 === absint( get_option( 'job_manager_hide_filled_positions' ) ) ) {
-			$query_args['meta_query'][] = array(
+			$query_args['meta_query'][] = [
 				'key'     => '_filled',
 				'value'   => '1',
 				'compare' => $args['filled'] ? '=' : '!=',
-			);
+			];
 		}
 
 		if ( ! empty( $args['job_types'] ) ) {
-			$query_args['tax_query'][] = array(
+			$query_args['tax_query'][] = [
 				'taxonomy' => 'job_listing_type',
 				'field'    => 'slug',
 				'terms'    => $args['job_types'],
-			);
+			];
 		}
 
 		if ( ! empty( $args['search_categories'] ) ) {
 			$field                     = is_numeric( $args['search_categories'][0] ) ? 'term_id' : 'slug';
 			$operator                  = 'all' === get_option( 'job_manager_category_filter_type', 'all' ) && count( $args['search_categories'] ) > 1 ? 'AND' : 'IN';
-			$query_args['tax_query'][] = array(
+			$query_args['tax_query'][] = [
 				'taxonomy'         => 'job_listing_category',
 				'field'            => $field,
 				'terms'            => array_values( $args['search_categories'] ),
 				'include_children' => 'AND' !== $operator,
 				'operator'         => $operator,
-			);
+			];
 		}
 
 		if ( 'featured' === $args['orderby'] ) {
-			$query_args['orderby'] = array(
+			$query_args['orderby'] = [
 				'menu_order' => 'ASC',
 				'date'       => 'DESC',
 				'ID'         => 'DESC',
-			);
+			];
 		}
 
 		if ( 'rand_featured' === $args['orderby'] ) {
-			$query_args['orderby'] = array(
+			$query_args['orderby'] = [
 				'menu_order' => 'ASC',
 				'rand'       => 'ASC',
-			);
+			];
 		}
 
 		$job_manager_keyword = sanitize_text_field( $args['search_keywords'] );
@@ -179,7 +179,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 					&& isset( $cached_query_posts->posts )
 					&& is_array( $cached_query_posts->posts )
 				) {
-					if ( in_array( $query_args['fields'], array( 'ids', 'id=>parent' ), true ) ) {
+					if ( in_array( $query_args['fields'], [ 'ids', 'id=>parent' ], true ) ) {
 						// For these special requests, just return the array of results as set.
 						$posts = $cached_query_posts->posts;
 					} else {
@@ -199,7 +199,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 				$result               = new WP_Query( $query_args );
 				$cached_query_results = false;
 
-				$cacheable_result                  = array();
+				$cacheable_result                  = [];
 				$cacheable_result['posts']         = array_values( $result->posts );
 				$cacheable_result['found_posts']   = $result->found_posts;
 				$cacheable_result['max_num_pages'] = $result->max_num_pages;
@@ -264,7 +264,7 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 		global $wpdb, $job_manager_keyword;
 
 		// Searchable Meta Keys: set to empty to search all meta keys.
-		$searchable_meta_keys = array(
+		$searchable_meta_keys = [
 			'_job_location',
 			'_company_name',
 			'_application',
@@ -272,12 +272,12 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 			'_company_tagline',
 			'_company_website',
 			'_company_twitter',
-		);
+		];
 
 		$searchable_meta_keys = apply_filters( 'job_listing_searchable_meta_keys', $searchable_meta_keys );
 
 		// Set Search DB Conditions.
-		$conditions = array();
+		$conditions = [];
 
 		// Search Post Meta.
 		if ( apply_filters( 'job_listing_search_post_meta', true ) ) {
@@ -330,14 +330,14 @@ if ( ! function_exists( 'get_job_listing_post_statuses' ) ) :
 	function get_job_listing_post_statuses() {
 		return apply_filters(
 			'job_listing_post_statuses',
-			array(
+			[
 				'draft'           => _x( 'Draft', 'post status', 'wp-job-manager' ),
 				'expired'         => _x( 'Expired', 'post status', 'wp-job-manager' ),
 				'preview'         => _x( 'Preview', 'post status', 'wp-job-manager' ),
 				'pending'         => _x( 'Pending approval', 'post status', 'wp-job-manager' ),
 				'pending_payment' => _x( 'Pending payment', 'post status', 'wp-job-manager' ),
 				'publish'         => _x( 'Active', 'post status', 'wp-job-manager' ),
-			)
+			]
 		);
 	}
 endif;
@@ -351,7 +351,7 @@ if ( ! function_exists( 'get_featured_job_ids' ) ) :
 	 */
 	function get_featured_job_ids() {
 		return get_posts(
-			array(
+			[
 				'posts_per_page'   => -1,
 				'suppress_filters' => false,
 				'post_type'        => 'job_listing',
@@ -359,7 +359,7 @@ if ( ! function_exists( 'get_featured_job_ids' ) ) :
 				'meta_key'         => '_featured',
 				'meta_value'       => '1',
 				'fields'           => 'ids',
-			)
+			]
 		);
 	}
 endif;
@@ -374,14 +374,14 @@ if ( ! function_exists( 'get_job_listing_types' ) ) :
 	 */
 	function get_job_listing_types( $fields = 'all' ) {
 		if ( ! get_option( 'job_manager_enable_types' ) ) {
-			return array();
+			return [];
 		} else {
-			$args = array(
+			$args = [
 				'fields'     => $fields,
 				'hide_empty' => false,
 				'order'      => 'ASC',
 				'orderby'    => 'name',
-			);
+			];
 
 			$args = apply_filters( 'get_job_listing_types_args', $args );
 
@@ -402,14 +402,14 @@ if ( ! function_exists( 'get_job_listing_categories' ) ) :
 	 */
 	function get_job_listing_categories() {
 		if ( ! get_option( 'job_manager_enable_categories' ) ) {
-			return array();
+			return [];
 		}
 
-		$args = array(
+		$args = [
 			'orderby'    => 'name',
 			'order'      => 'ASC',
 			'hide_empty' => false,
-		);
+		];
 
 		/**
 		 * Change the category query arguments.
@@ -435,8 +435,8 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 	 * @param array $args
 	 * @return string
 	 */
-	function job_manager_get_filtered_links( $args = array() ) {
-		$job_categories = array();
+	function job_manager_get_filtered_links( $args = [] ) {
+		$job_categories = [];
 		$types          = get_job_listing_types();
 
 		// Convert to slugs.
@@ -455,26 +455,26 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 
 		$links = apply_filters(
 			'job_manager_job_filters_showing_jobs_links',
-			array(
-				'reset'    => array(
+			[
+				'reset'    => [
 					'name' => __( 'Reset', 'wp-job-manager' ),
 					'url'  => '#',
-				),
-				'rss_link' => array(
+				],
+				'rss_link' => [
 					'name' => __( 'RSS', 'wp-job-manager' ),
 					'url'  => get_job_listing_rss_link(
 						apply_filters(
 							'job_manager_get_listings_custom_filter_rss_args',
-							array(
+							[
 								'job_types'       => isset( $args['filter_job_types'] ) ? implode( ',', $args['filter_job_types'] ) : '',
 								'search_location' => $args['search_location'],
 								'job_categories'  => implode( ',', $job_categories ),
 								'search_keywords' => $args['search_keywords'],
-							)
+							]
 						)
 					),
-				),
-			),
+				],
+			],
 			$args
 		);
 
@@ -506,8 +506,8 @@ if ( ! function_exists( 'get_job_listing_rss_link' ) ) :
 	 * @param array $args
 	 * @return string
 	 */
-	function get_job_listing_rss_link( $args = array() ) {
-		$rss_link = add_query_arg( urlencode_deep( array_merge( array( 'feed' => WP_Job_Manager_Post_Types::get_job_feed_name() ), $args ) ), home_url() );
+	function get_job_listing_rss_link( $args = [] ) {
+		$rss_link = add_query_arg( urlencode_deep( array_merge( [ 'feed' => WP_Job_Manager_Post_Types::get_job_feed_name() ], $args ) ), home_url() );
 		return $rss_link;
 	}
 endif;
@@ -548,19 +548,19 @@ if ( ! function_exists( 'wp_job_manager_create_account' ) ) :
 	function wp_job_manager_create_account( $args, $deprecated = '' ) {
 		// Soft Deprecated in 1.20.0.
 		if ( ! is_array( $args ) ) {
-			$args = array(
+			$args = [
 				'username' => '',
 				'password' => false,
 				'email'    => $args,
 				'role'     => $deprecated,
-			);
+			];
 		} else {
-			$defaults = array(
+			$defaults = [
 				'username' => '',
 				'email'    => '',
 				'password' => false,
 				'role'     => get_option( 'default_role' ),
-			);
+			];
 
 			$args = wp_parse_args( $args, $defaults );
 		}
@@ -604,12 +604,12 @@ if ( ! function_exists( 'wp_job_manager_create_account' ) ) :
 		}
 
 		// Create account.
-		$new_user = array(
+		$new_user = [
 			'user_login' => $username,
 			'user_pass'  => $args['password'],
 			'user_email' => $email,
 			'role'       => $args['role'],
-		);
+		];
 
 		// User is forced to set up account with email sent to them. This password will remain a secret.
 		if ( empty( $new_user['user_pass'] ) ) {
@@ -756,11 +756,11 @@ function is_wpjm_page() {
 
 	if ( ! $is_wpjm_page ) {
 		$wpjm_page_ids = array_filter(
-			array(
+			[
 				get_option( 'job_manager_submit_job_form_page_id', false ),
 				get_option( 'job_manager_job_dashboard_page_id', false ),
 				get_option( 'job_manager_jobs_page_id', false ),
-			)
+			]
 		);
 
 		/**
@@ -803,7 +803,7 @@ function has_wpjm_shortcode( $content = null, $tag = null ) {
 	}
 
 	if ( ! empty( $content ) ) {
-		$wpjm_shortcodes = array( 'submit_job_form', 'job_dashboard', 'jobs', 'job', 'job_summary', 'job_apply' );
+		$wpjm_shortcodes = [ 'submit_job_form', 'job_dashboard', 'jobs', 'job', 'job_summary', 'job_apply' ];
 		/**
 		 * Filters a list of all shortcodes associated with WPJM.
 		 *
@@ -815,7 +815,7 @@ function has_wpjm_shortcode( $content = null, $tag = null ) {
 
 		if ( null !== $tag ) {
 			if ( ! is_array( $tag ) ) {
-				$tag = array( $tag );
+				$tag = [ $tag ];
 			}
 			$wpjm_shortcodes = array_intersect( $wpjm_shortcodes, $tag );
 		}
@@ -846,7 +846,7 @@ function has_wpjm_shortcode( $content = null, $tag = null ) {
  * @return bool
  */
 function is_wpjm_job_listing() {
-	return is_singular( array( 'job_listing' ) );
+	return is_singular( [ 'job_listing' ] );
 }
 
 /**
@@ -889,7 +889,7 @@ function wpjm_use_standard_password_setup_email() {
  * @return array
  */
 function wpjm_job_listing_employment_type_options() {
-	$employment_types               = array();
+	$employment_types               = [];
 	$employment_types['FULL_TIME']  = __( 'Full Time', 'wp-job-manager' );
 	$employment_types['PART_TIME']  = __( 'Part Time', 'wp-job-manager' );
 	$employment_types['CONTRACTOR'] = __( 'Contractor', 'wp-job-manager' );
@@ -1031,7 +1031,7 @@ function wpjm_user_can_edit_published_submissions() {
 	 *
 	 * @param bool $can_edit_published_submissions
 	 */
-	return apply_filters( 'job_manager_user_can_edit_published_submissions', in_array( get_option( 'job_manager_user_edit_published_submissions' ), array( 'yes', 'yes_moderated' ), true ) );
+	return apply_filters( 'job_manager_user_can_edit_published_submissions', in_array( get_option( 'job_manager_user_edit_published_submissions' ), [ 'yes', 'yes_moderated' ], true ) );
 }
 
 /**
@@ -1064,7 +1064,7 @@ function wpjm_published_submission_edits_require_moderation() {
  * @return string
  */
 function job_manager_dropdown_categories( $args = '' ) {
-	$defaults = array(
+	$defaults = [
 		'orderby'         => 'id',
 		'order'           => 'ASC',
 		'show_count'      => 0,
@@ -1086,7 +1086,7 @@ function job_manager_dropdown_categories( $args = '' ) {
 		'placeholder'     => __( 'Choose a category&hellip;', 'wp-job-manager' ),
 		'no_results_text' => __( 'No results match', 'wp-job-manager' ),
 		'multiple_text'   => __( 'Select Some Options', 'wp-job-manager' ),
-	);
+	];
 
 	$r = wp_parse_args( $args, $defaults );
 
@@ -1103,7 +1103,7 @@ function job_manager_dropdown_categories( $args = '' ) {
 
 	if ( empty( $categories ) ) {
 		$categories = get_terms(
-			array(
+			[
 				'taxonomy'     => $r['taxonomy'],
 				'orderby'      => $r['orderby'],
 				'order'        => $r['order'],
@@ -1112,7 +1112,7 @@ function job_manager_dropdown_categories( $args = '' ) {
 				'child_of'     => $r['child_of'],
 				'exclude'      => $r['exclude'],
 				'hierarchical' => $r['hierarchical'],
-			)
+			]
 		);
 		set_transient( $categories_hash, $categories, DAY_IN_SECONDS * 7 );
 	}
@@ -1225,19 +1225,19 @@ add_filter( 'upload_dir', 'job_manager_upload_dir' );
  * @return array
  */
 function job_manager_prepare_uploaded_files( $file_data ) {
-	$files_to_upload = array();
+	$files_to_upload = [];
 
 	if ( is_array( $file_data['name'] ) ) {
 		foreach ( $file_data['name'] as $file_data_key => $file_data_value ) {
 			if ( $file_data['name'][ $file_data_key ] ) {
 				$type              = wp_check_filetype( $file_data['name'][ $file_data_key ] ); // Map mime type to one WordPress recognises.
-				$files_to_upload[] = array(
+				$files_to_upload[] = [
 					'name'     => $file_data['name'][ $file_data_key ],
 					'type'     => $type['type'],
 					'tmp_name' => $file_data['tmp_name'][ $file_data_key ],
 					'error'    => $file_data['error'][ $file_data_key ],
 					'size'     => $file_data['size'][ $file_data_key ],
-				);
+				];
 			}
 		}
 	} else {
@@ -1257,7 +1257,7 @@ function job_manager_prepare_uploaded_files( $file_data ) {
  * @param  string|array|object $args Optional arguments.
  * @return stdClass|WP_Error Object containing file information, or error.
  */
-function job_manager_upload_file( $file, $args = array() ) {
+function job_manager_upload_file( $file, $args = [] ) {
 	global $job_manager_upload, $job_manager_uploading_file;
 
 	include_once ABSPATH . 'wp-admin/includes/file.php';
@@ -1265,11 +1265,11 @@ function job_manager_upload_file( $file, $args = array() ) {
 
 	$args = wp_parse_args(
 		$args,
-		array(
+		[
 			'file_key'           => '',
 			'file_label'         => '',
 			'allowed_mime_types' => '',
-		)
+		]
 	);
 
 	$job_manager_upload         = true;
@@ -1311,7 +1311,7 @@ function job_manager_upload_file( $file, $args = array() ) {
 			return new WP_Error( 'upload', sprintf( __( 'Uploaded files need to be one of the following file types: %s', 'wp-job-manager' ), $allowed_file_extensions ) );
 		}
 	} else {
-		$upload = wp_handle_upload( $file, apply_filters( 'submit_job_wp_handle_upload_overrides', array( 'test_form' => false ) ) );
+		$upload = wp_handle_upload( $file, apply_filters( 'submit_job_wp_handle_upload_overrides', [ 'test_form' => false ] ) );
 		if ( ! empty( $upload['error'] ) ) {
 			return new WP_Error( 'upload', $upload['error'] );
 		} else {
@@ -1339,20 +1339,20 @@ function job_manager_upload_file( $file, $args = array() ) {
  */
 function job_manager_get_allowed_mime_types( $field = '' ) {
 	if ( 'company_logo' === $field ) {
-		$allowed_mime_types = array(
+		$allowed_mime_types = [
 			'jpg|jpeg|jpe' => 'image/jpeg',
 			'gif'          => 'image/gif',
 			'png'          => 'image/png',
-		);
+		];
 	} else {
-		$allowed_mime_types = array(
+		$allowed_mime_types = [
 			'jpg|jpeg|jpe' => 'image/jpeg',
 			'gif'          => 'image/gif',
 			'png'          => 'image/png',
 			'pdf'          => 'application/pdf',
 			'doc'          => 'application/msword',
 			'docx'         => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		);
+		];
 	}
 
 	/**
@@ -1417,7 +1417,7 @@ function job_manager_duplicate_listing( $post_id ) {
 	 * Duplicate the post.
 	 */
 	$new_post_id = wp_insert_post(
-		array(
+		[
 			'comment_status' => $post->comment_status,
 			'ping_status'    => $post->ping_status,
 			'post_author'    => $post->post_author,
@@ -1431,7 +1431,7 @@ function job_manager_duplicate_listing( $post_id ) {
 			'post_type'      => $post->post_type,
 			'to_ping'        => $post->to_ping,
 			'menu_order'     => $post->menu_order,
-		)
+		]
 	);
 
 	/**
@@ -1440,7 +1440,7 @@ function job_manager_duplicate_listing( $post_id ) {
 	$taxonomies = get_object_taxonomies( $post->post_type );
 
 	foreach ( $taxonomies as $taxonomy ) {
-		$post_terms = wp_get_object_terms( $post_id, $taxonomy, array( 'fields' => 'slugs' ) );
+		$post_terms = wp_get_object_terms( $post_id, $taxonomy, [ 'fields' => 'slugs' ] );
 		wp_set_object_terms( $new_post_id, $post_terms, $taxonomy, false );
 	}
 
@@ -1454,7 +1454,7 @@ function job_manager_duplicate_listing( $post_id ) {
 	if ( ! empty( $post_meta ) ) {
 		$post_meta = wp_list_pluck( $post_meta, 'meta_value', 'meta_key' );
 
-		$default_duplicate_ignore_keys = array( '_filled', '_featured', '_job_expires', '_job_duration', '_package_id', '_user_package_id' );
+		$default_duplicate_ignore_keys = [ '_filled', '_featured', '_job_expires', '_job_duration', '_package_id', '_user_package_id' ];
 		$duplicate_ignore_keys         = apply_filters( 'job_manager_duplicate_listing_ignore_keys', $default_duplicate_ignore_keys, true );
 
 		foreach ( $post_meta as $meta_key => $meta_value ) {

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -19,7 +19,7 @@
  * @param string $template_path (default: '').
  * @param string $default_path (default: '').
  */
-function get_job_manager_template( $template_name, $args = array(), $template_path = 'job_manager', $default_path = '' ) {
+function get_job_manager_template( $template_name, $args = [], $template_path = 'job_manager', $default_path = '' ) {
 	if ( $args && is_array( $args ) ) {
 		// phpcs:ignore WordPress.PHP.DontExtract.extract_extract -- Please, forgive us.
 		extract( $args );
@@ -45,10 +45,10 @@ function get_job_manager_template( $template_name, $args = array(), $template_pa
 function locate_job_manager_template( $template_name, $template_path = 'job_manager', $default_path = '' ) {
 	// Look within passed path within the theme - this is priority.
 	$template = locate_template(
-		array(
+		[
 			trailingslashit( $template_path ) . $template_name,
 			$template_name,
-		)
+		]
 	);
 
 	// Get default template.
@@ -117,10 +117,10 @@ function get_job_listing_pagination( $max_num_pages, $current_page = 1 ) {
 	ob_start();
 	get_job_manager_template(
 		'job-pagination.php',
-		array(
+		[
 			'max_num_pages' => $max_num_pages,
 			'current_page'  => absint( $current_page ),
-		)
+		]
 	);
 	return ob_get_clean();
 }
@@ -191,7 +191,7 @@ function is_position_featured( $post = null ) {
  */
 function candidates_can_apply( $post = null ) {
 	$post = get_post( $post );
-	return apply_filters( 'job_manager_candidates_can_apply', ( ! is_position_filled() && ! in_array( $post->post_status, array( 'preview', 'expired' ), true ) ), $post );
+	return apply_filters( 'job_manager_candidates_can_apply', ( ! is_position_filled() && ! in_array( $post->post_status, [ 'preview', 'expired' ], true ) ), $post );
 }
 
 /**
@@ -270,7 +270,7 @@ function wpjm_get_job_employment_types( $post = null ) {
 	if ( ! wpjm_job_listing_employment_type_enabled() ) {
 		return false;
 	}
-	$employment_types = array();
+	$employment_types = [];
 	$job_types        = wpjm_get_the_job_types( $post );
 
 	if ( ! empty( $job_types ) ) {
@@ -367,7 +367,7 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		return false;
 	}
 
-	$data               = array();
+	$data               = [];
 	$data['@context']   = 'http://schema.org/';
 	$data['@type']      = 'JobPosting';
 	$data['datePosted'] = get_post_time( 'c', false, $post );
@@ -385,7 +385,7 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		$data['employmentType'] = $employment_types;
 	}
 
-	$data['hiringOrganization']          = array();
+	$data['hiringOrganization']          = [];
 	$data['hiringOrganization']['@type'] = 'Organization';
 	$data['hiringOrganization']['name']  = get_the_company_name( $post );
 
@@ -400,14 +400,14 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		$data['hiringOrganization']['logo'] = $company_logo;
 	}
 
-	$data['identifier']          = array();
+	$data['identifier']          = [];
 	$data['identifier']['@type'] = 'PropertyValue';
 	$data['identifier']['name']  = get_the_company_name( $post );
 	$data['identifier']['value'] = get_the_guid( $post );
 
 	$location = get_the_job_location( $post );
 	if ( ! empty( $location ) ) {
-		$data['jobLocation']            = array();
+		$data['jobLocation']            = [];
 		$data['jobLocation']['@type']   = 'Place';
 		$data['jobLocation']['address'] = wpjm_get_job_listing_location_structured_data( $post );
 		if ( empty( $data['jobLocation']['address'] ) ) {
@@ -441,18 +441,18 @@ function wpjm_get_job_listing_location_structured_data( $post ) {
 		return false;
 	}
 
-	$mapping                    = array();
-	$mapping['streetAddress']   = array( 'street_number', 'street' );
+	$mapping                    = [];
+	$mapping['streetAddress']   = [ 'street_number', 'street' ];
 	$mapping['addressLocality'] = 'city';
 	$mapping['addressRegion']   = 'state_short';
 	$mapping['postalCode']      = 'postcode';
 	$mapping['addressCountry']  = 'country_short';
 
-	$address          = array();
+	$address          = [];
 	$address['@type'] = 'PostalAddress';
 	foreach ( $mapping as $schema_key => $geolocation_key ) {
 		if ( is_array( $geolocation_key ) ) {
-			$values = array();
+			$values = [];
 			foreach ( $geolocation_key as $sub_geo_key ) {
 				$geo_value = get_post_meta( $post->ID, 'geolocation_' . $sub_geo_key, true );
 				if ( ! empty( $geo_value ) ) {
@@ -600,12 +600,12 @@ function wpjm_get_the_job_types( $post = null ) {
 	$types = get_the_terms( $post->ID, 'job_listing_type' );
 
 	if ( empty( $types ) || is_wp_error( $types ) ) {
-		$types = array();
+		$types = [];
 	}
 
 	// Return single if not enabled.
 	if ( ! empty( $types ) && ! job_manager_multi_job_type() ) {
-		$types = array( current( $types ) );
+		$types = [ current( $types ) ];
 	}
 
 	/**
@@ -659,7 +659,7 @@ function wpjm_get_the_job_categories( $post = null ) {
 	$categories = get_the_terms( $post->ID, 'job_listing_category' );
 
 	if ( empty( $categories ) || is_wp_error( $categories ) ) {
-		$categories = array();
+		$categories = [];
 	}
 
 	/**
@@ -685,42 +685,42 @@ function wpjm_get_registration_fields() {
 	$use_standard_password_setup_email = wpjm_use_standard_password_setup_email();
 	$account_required                  = job_manager_user_requires_account();
 
-	$registration_fields = array();
+	$registration_fields = [];
 	if ( job_manager_enable_registration() ) {
-		$registration_fields['create_account_email'] = array(
+		$registration_fields['create_account_email'] = [
 			'type'        => 'text',
 			'label'       => esc_html__( 'Your email', 'wp-job-manager' ),
 			'placeholder' => __( 'you@yourdomain.com', 'wp-job-manager' ),
 			'required'    => $account_required,
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Just used to populate value when validation failed.
 			'value'       => isset( $_POST['create_account_email'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_email'] ) ) : '',
-		);
+		];
 		if ( ! $generate_username_from_email ) {
-			$registration_fields['create_account_username'] = array(
+			$registration_fields['create_account_username'] = [
 				'type'     => 'text',
 				'label'    => esc_html__( 'Username', 'wp-job-manager' ),
 				'required' => $account_required,
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Just used to populate value when validation failed.
 				'value'    => isset( $_POST['create_account_username'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_username'] ) ) : '',
-			);
+			];
 		}
 		if ( ! $use_standard_password_setup_email ) {
-			$registration_fields['create_account_password'] = array(
+			$registration_fields['create_account_password'] = [
 				'type'         => 'password',
 				'label'        => esc_html__( 'Password', 'wp-job-manager' ),
 				'autocomplete' => false,
 				'required'     => $account_required,
-			);
+			];
 			$password_hint                                  = wpjm_get_password_rules_hint();
 			if ( $password_hint ) {
 				$registration_fields['create_account_password']['description'] = $password_hint;
 			}
-			$registration_fields['create_account_password_verify'] = array(
+			$registration_fields['create_account_password_verify'] = [
 				'type'         => 'password',
 				'label'        => esc_html__( 'Verify Password', 'wp-job-manager' ),
 				'autocomplete' => false,
 				'required'     => $account_required,
-			);
+			];
 		}
 	}
 
@@ -881,10 +881,10 @@ function job_manager_get_resized_image( $logo, $size ) {
 	if (
 		'full' !== $size
 		&& strstr( $logo, WP_CONTENT_URL )
-		&& ( isset( $_wp_additional_image_sizes[ $size ] ) || in_array( $size, array( 'thumbnail', 'medium', 'large' ), true ) )
+		&& ( isset( $_wp_additional_image_sizes[ $size ] ) || in_array( $size, [ 'thumbnail', 'medium', 'large' ], true ) )
 	) {
 
-		if ( in_array( $size, array( 'thumbnail', 'medium', 'large' ), true ) ) {
+		if ( in_array( $size, [ 'thumbnail', 'medium', 'large' ], true ) ) {
 			$img_width  = get_option( $size . '_size_w' );
 			$img_height = get_option( $size . '_size_h' );
 			$img_crop   = get_option( $size . '_size_crop' );
@@ -895,7 +895,7 @@ function job_manager_get_resized_image( $logo, $size ) {
 		}
 
 		$upload_dir        = wp_upload_dir();
-		$logo_path         = str_replace( array( $upload_dir['baseurl'], $upload_dir['url'], WP_CONTENT_URL ), array( $upload_dir['basedir'], $upload_dir['path'], WP_CONTENT_DIR ), $logo );
+		$logo_path         = str_replace( [ $upload_dir['baseurl'], $upload_dir['url'], WP_CONTENT_URL ], [ $upload_dir['basedir'], $upload_dir['path'], WP_CONTENT_DIR ], $logo );
 		$path_parts        = pathinfo( $logo_path );
 		$dims              = $img_width . 'x' . $img_height;
 		$resized_logo_path = str_replace( '.' . $path_parts['extension'], '-' . $dims . '.' . $path_parts['extension'], $logo_path );
@@ -948,7 +948,7 @@ function the_company_video( $post = null ) {
 		if ( shortcode_exists( 'flowplayer' ) ) {
 			$video_embed = '[flowplayer src="' . esc_url( $video ) . '"]';
 		} elseif ( ! empty( $filetype['ext'] ) ) {
-			$video_embed = wp_video_shortcode( array( 'src' => $video ) );
+			$video_embed = wp_video_shortcode( [ 'src' => $video ] );
 		} else {
 			$video_embed = wp_oembed_get( $video );
 		}
@@ -1164,10 +1164,10 @@ function get_job_listing_class( $class = '', $post_id = null ) {
 	$post = get_post( $post_id );
 
 	if ( empty( $post ) || 'job_listing' !== $post->post_type ) {
-		return array();
+		return [];
 	}
 
-	$classes = array();
+	$classes = [];
 
 	if ( ! empty( $class ) ) {
 		if ( ! is_array( $class ) ) {
@@ -1225,7 +1225,7 @@ add_action( 'post_class', 'wpjm_add_post_class', 10, 3 );
  * @since 1.14.0
  */
 function job_listing_meta_display() {
-	get_job_manager_template( 'content-single-job_listing-meta.php', array() );
+	get_job_manager_template( 'content-single-job_listing-meta.php', [] );
 }
 add_action( 'single_job_listing_start', 'job_listing_meta_display', 20 );
 
@@ -1235,6 +1235,6 @@ add_action( 'single_job_listing_start', 'job_listing_meta_display', 20 );
  * @since 1.14.0
  */
 function job_listing_company_display() {
-	get_job_manager_template( 'content-single-job_listing-company.php', array() );
+	get_job_manager_template( 'content-single-job_listing-company.php', [] );
 }
 add_action( 'single_job_listing_start', 'job_listing_company_display', 30 );


### PR DESCRIPTION
I've been waiting for this my entire [WPJM] life.

#### Changes proposed in this Pull Request:

* Updates all possible plugin files from long-array to short-array syntax. 
* Exceptions: `wp-job-manager.php`, `includes/class-wp-job-manager-dependency-checker.php`, and `uninstall.php`. Let's keep these as long-array so people can be properly warned if using PHP 5.2 and be able to uninstall.
 