### PR TITLE
Add Post a Job success messages css selector

### DIFF
--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.31.1
+ * @version     1.31.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,21 +19,21 @@ global $wp_post_types;
 
 switch ( $job->post_status ) :
 	case 'publish' :
-		echo wp_kses_post(
+		echo '<div class="job-manager-message">' . wp_kses_post(
 			sprintf(
 				__( '%s listed successfully. To view your listing <a href="%s">click here</a>.', 'wp-job-manager' ),
 				esc_html( $wp_post_types['job_listing']->labels->singular_name ),
 				get_permalink( $job->ID )
 			)
-		);
+		) . '</div>';
 	break;
 	case 'pending' :
-		echo wp_kses_post(
+		echo '<div class="job-manager-message">' . wp_kses_post(
 			sprintf(
 				esc_html__( '%s submitted successfully. Your listing will be visible once approved.', 'wp-job-manager' ),
 				esc_html( $wp_post_types['job_listing']->labels->singular_name )
 			)
-		);
+		) . '</div>';
 	break;
 	default :
 		do_action( 'job_manager_job_submitted_content_' . str_replace( '-', '_', sanitize_title( $job->post_status ) ), $job );

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.31.2
+ * @version     1.34.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Fixes #1898 

#### Changes proposed in this Pull Request:

* Wrap the listed and submitted successful messages in a div with the .job-manager-message class.

#### Testing instructions:

* Go to Post a Job.
* Fill in Title/Description and click Preview button.
* Click Submit Listing button and view the source for the success message and make sure it is wrapped in the .job-manager-message div. 
* Go to Job Manager Settings -> Job Submission.
* Go to "Moderate New Listings" and check or uncheck (whatever is the opposite).
* Repeat the first 3 steps.

#### Proposed changelog entry for your changes:
Wrapped the Post A Job success messages in a div with the .job-manager-message class.
