### PR TITLE
Standardize datepicker enqueueing logic

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -93,8 +93,8 @@ class WP_Job_Manager_Admin {
 			wp_enqueue_style( 'jquery-ui' );
 			wp_enqueue_style( 'select2' );
 			wp_enqueue_style( 'job_manager_admin_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/admin.css', [], JOB_MANAGER_VERSION );
+			wp_enqueue_script( 'wp-job-manager-datepicker' );
 			wp_register_script( 'jquery-tiptip', JOB_MANAGER_PLUGIN_URL . '/assets/js/jquery-tiptip/jquery.tipTip.min.js', [ 'jquery' ], JOB_MANAGER_VERSION, true );
-			wp_enqueue_script( 'job_manager_datepicker_js', JOB_MANAGER_PLUGIN_URL . '/assets/js/datepicker.min.js', [ 'jquery', 'jquery-ui-datepicker' ], JOB_MANAGER_VERSION, true );
 			wp_enqueue_script( 'job_manager_admin_js', JOB_MANAGER_PLUGIN_URL . '/assets/js/admin.min.js', [ 'jquery', 'jquery-tiptip', 'select2' ], JOB_MANAGER_VERSION, true );
 
 			wp_localize_script(
@@ -113,17 +113,6 @@ class WP_Job_Manager_Admin {
 					'search_users_nonce'     => wp_create_nonce( 'search-users' ),
 				]
 			);
-
-			if ( ! function_exists( 'wp_localize_jquery_ui_datepicker' ) || ! has_action( 'admin_enqueue_scripts', 'wp_localize_jquery_ui_datepicker' ) ) {
-				wp_localize_script(
-					'job_manager_datepicker_js',
-					'job_manager_datepicker',
-					[
-						/* translators: jQuery date format, see http://api.jqueryui.com/datepicker/#utility-formatDate */
-						'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker.', 'wp-job-manager' ),
-					]
-				);
-			}
 		}
 
 		wp_enqueue_style( 'job_manager_admin_menu_css', JOB_MANAGER_PLUGIN_URL . '/assets/css/menu.css', [], JOB_MANAGER_VERSION );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -465,32 +465,16 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	protected function enqueue_job_form_assets() {
 		wp_enqueue_script( 'wp-job-manager-job-submission' );
 		wp_enqueue_style( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-submission.css', [], JOB_MANAGER_VERSION );
-
-		// Register datepicker JS. It will be enqueued if needed when a date.
-		// field is rendered.
-		wp_register_script( 'wp-job-manager-datepicker', JOB_MANAGER_PLUGIN_URL . '/assets/js/datepicker.min.js', [ 'jquery', 'jquery-ui-datepicker' ], JOB_MANAGER_VERSION, true );
-
-		// Localize scripts after the fields are rendered.
-		add_action( 'submit_job_form_end', [ $this, 'localize_job_form_scripts' ] );
 	}
 
 	/**
 	 * Localize frontend scripts that have been enqueued. This should be called
 	 * after the fields are rendered, in case some of them enqueue new scripts.
+	 *
+	 * @deprecated 1.34.1 No longer needed.
 	 */
 	public function localize_job_form_scripts() {
-		if ( function_exists( 'wp_localize_jquery_ui_datepicker' ) ) {
-			wp_localize_jquery_ui_datepicker();
-		} else {
-			wp_localize_script(
-				'wp-job-manager-datepicker',
-				'job_manager_datepicker',
-				[
-					/* translators: jQuery date format, see http://api.jqueryui.com/datepicker/#utility-formatDate */
-					'date_format' => _x( 'yy-mm-dd', 'Date format for jQuery datepicker.', 'wp-job-manager' ),
-				]
-			);
-		}
+		_deprecated_function( __METHOD__, '1.34.1' );
 	}
 
 	/**


### PR DESCRIPTION
In investigating an issue for Applications, I noticed we are registering the same script with a different handle for admin vs frontend use. I've brought them together.

### Testing Instructions
- Add multiple date fields to the submission form. 
```
add_filter( 'submit_job_form_fields', function( $fields ) {
  $fields['job']['date_a'] = [
	'label'              => __( 'Date A', 'wp-job-manager' ),
	'type'               => 'date',
	'required'           => false,
	'placeholder'        => '',
	'priority'           => 6,
  ];
  $fields['job']['date_b'] = [
	'label'              => __( 'Date B', 'wp-job-manager' ),
	'type'               => 'date',
	'required'           => false,
	'placeholder'        => '',
	'priority'           => 6,
  ];
  
  return $fields;
} );
```
- In one tab, open WP Admin > General Settings. In another tab, open the frontend job submission form.
- Change the date format in General Settings. Refresh frontend submission form, select dates, verify selected date matches format.
- On backend, edit a job listing. Verify Job Expires field date picker works and selected date matches format.