### PR TITLE
[WIP] Send emails with multiple recipients separately

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -210,6 +210,15 @@ abstract class WP_Job_Manager_Email {
 	}
 
 	/**
+	 * Force the email notification to be enabled or disabled.
+	 *
+	 * @return bool|null True to force enabled; False to force disabled; Null to not force a value.
+	 */
+	public static function get_enabled_force_value() {
+		return null;
+	}
+
+	/**
 	 * Returns the args that the email notification was sent with.
 	 *
 	 * @return array

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -509,9 +509,12 @@ class WP_Job_Manager_Settings {
 	 * @param string $ignored_placeholder
 	 */
 	protected function input_checkbox( $option, $attributes, $value, $ignored_placeholder ) {
+		if ( ! isset( $option['hidden_value'] ) ) {
+			$option['hidden_value'] = '0';
+		}
 		?>
 		<label>
-		<input type="hidden" name="<?php echo esc_attr( $option['name'] ); ?>" value="0" />
+		<input type="hidden" name="<?php echo esc_attr( $option['name'] ); ?>" value="<?php echo esc_attr( $option['hidden_value'] ); ?>" />
 		<input
 			id="setting-<?php echo esc_attr( $option['name'] ); ?>"
 			name="<?php echo esc_attr( $option['name'] ); ?>"
@@ -819,11 +822,12 @@ class WP_Job_Manager_Settings {
 
 		if ( isset( $enable_option['force_value'] ) && is_bool( $enable_option['force_value'] ) ) {
 			if ( true === $enable_option['force_value'] ) {
-				$enable_option['value'] = 1;
+				$values[ $option['enable_field']['name'] ] = '1';
 			} elseif ( false === $enable_option['force_value'] ) {
-				$enable_option['value'] = 0;
+				$values[ $option['enable_field']['name'] ] = '0';
 			}
 
+			$enable_option['hidden_value'] = $values[ $option['enable_field']['name'] ];
 			$enable_option['attributes'][] = 'disabled="disabled"';
 		}
 

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -816,6 +816,17 @@ class WP_Job_Manager_Settings {
 		$enable_option['name']       = $option['name'] . '[' . $enable_option['name'] . ']';
 		$enable_option['type']       = 'checkbox';
 		$enable_option['attributes'] = [ 'class="sub-settings-expander"' ];
+
+		if ( isset( $enable_option['force_value'] ) && is_bool( $enable_option['force_value'] ) ) {
+			if ( true === $enable_option['force_value'] ) {
+				$enable_option['value'] = 1;
+			} elseif ( false === $enable_option['force_value'] ) {
+				$enable_option['value'] = 0;
+			}
+
+			$enable_option['attributes'][] = 'disabled="disabled"';
+		}
+
 		$this->input_checkbox( $enable_option, $enable_option['attributes'], $values[ $option['enable_field']['name'] ], null );
 
 		echo '<div class="sub-settings-expandable">';

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -100,6 +100,39 @@ final class WP_Job_Manager_Email_Notifications {
 	}
 
 	/**
+	 * Send email notifications for a specific email now and return the status. Not usually necessary but useful if you
+	 * need to check to make sure a notification was sent.
+	 *
+	 * @param string $email_key Email key to send notifications for.
+	 * @return bool True if an email notification was sent.
+	 */
+	public static function send_notifications( $email_key ) {
+		$email_sent = false;
+		$email_notifications = self::get_email_notifications( true );
+		foreach ( self::$deferred_notifications as $index => $email ) {
+			if (
+				! is_string( $email[0] )
+				|| ! isset( $email_notifications[ $email[0] ] )
+				|| $email[0] !== $email_key
+			) {
+				continue;
+			}
+
+			$email_class            = $email_notifications[ $email[0] ];
+			$email_notification_key = $email[0];
+			$email_args             = is_array( $email[1] ) ? $email[1] : [];
+
+			if ( self::send_email( $email[0], new $email_class( $email_args, self::get_email_settings( $email_notification_key ) ) ) ) {
+				$email_sent = true;
+			}
+
+			unset( self::$deferred_notifications[ $index ] );
+		}
+
+		return $email_sent;
+	}
+
+	/**
 	 * Initialize if necessary.
 	 */
 	public static function maybe_init() {

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -752,7 +752,19 @@ final class WP_Job_Manager_Email_Notifications {
 		if ( ! apply_filters( 'job_manager_email_do_send_notification', true, $email, $args, $content, $headers ) ) {
 			return false;
 		}
-		return wp_mail( $args['to'], $args['subject'], $content, $headers, $args['attachments'] );
+
+		if ( ! is_array( $args['to'] ) ) {
+			$args['to'] = array_filter( array_map( 'sanitize_email', preg_split( '/[,|;]\s?/', $args['to'] ) ) );
+		}
+
+		$is_success = ! empty( $args['to'] );
+		foreach ( $args['to'] as $to_email ) {
+			if ( ! wp_mail( $to_email, $args['subject'], $content, $headers, $args['attachments'] ) ) {
+				$is_success = false;
+			}
+		}
+
+		return $is_success;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -416,7 +416,7 @@ final class WP_Job_Manager_Email_Notifications {
 		$email_settings      = [];
 
 		foreach ( $email_notifications as $email_notification_key => $email_class ) {
-			$email_notification_context = call_user_func( [ $email_class, 'get_context' ] );
+			$email_notification_context = $email_class::get_context();
 			if ( $context !== $email_notification_context ) {
 				continue;
 			}
@@ -424,11 +424,12 @@ final class WP_Job_Manager_Email_Notifications {
 			$email_settings[] = [
 				'type'         => 'multi_enable_expand',
 				'class'        => 'email-setting-row no-separator',
-				'name'         => self::EMAIL_SETTING_PREFIX . call_user_func( [ $email_class, 'get_key' ] ),
+				'name'         => self::EMAIL_SETTING_PREFIX . $email_class::get_key(),
 				'enable_field' => [
-					'name'     => self::EMAIL_SETTING_ENABLED,
-					'cb_label' => call_user_func( [ $email_class, 'get_name' ] ),
-					'desc'     => call_user_func( [ $email_class, 'get_description' ] ),
+					'name'        => self::EMAIL_SETTING_ENABLED,
+					'cb_label'    => $email_class::get_name(),
+					'desc'        => $email_class::get_description(),
+					'force_value' => $email_class::get_enabled_force_value(),
 				],
 				'label'        => false,
 				'std'          => self::get_email_setting_defaults( $email_notification_key ),
@@ -456,9 +457,15 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @return bool
 	 */
 	public static function is_email_notification_enabled( $email_notification_key ) {
-		$settings = self::get_email_settings( $email_notification_key );
+		$settings    = self::get_email_settings( $email_notification_key );
+		$email_class = self::get_email_class( $email_notification_key );
 
+		$enabled_force_value           = $email_class ? $email_class::get_enabled_force_value() : null;
 		$is_email_notification_enabled = ! empty( $settings[ self::EMAIL_SETTING_ENABLED ] );
+
+		if ( is_bool( $enabled_force_value ) ) {
+			$is_email_notification_enabled = $enabled_force_value;
+		}
 
 		/**
 		 * Filter whether an notification email is enabled.

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -61,6 +61,11 @@ a {
 	margin-bottom: 10px;
 }
 
+th.section-header {
+	vertical-align: middle;
+	font-weight: bold;
+}
+
 td.detail-label,
 td.detail-value {
 	vertical-align: middle;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When an email notification has multiple recipients, send the emails separately.

#### Testing instructions:

* Use this snippet to add multiple recipients to email for new submissions:
```
// You can also separate by commas.
add_filter( 'job_manager_email_admin_new_job_to', function( $value ) {
	return 'recA@example.com; recB@example.com; recC@example.com';
} );
```
* Submit a job listing.
* Verify using Mailhog or similar that email is sent to the recipients separately.

# To Do
- [ ] Unit tests.