### PR TITLE
Allow for links on the settings page that references another tab

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -444,6 +444,13 @@ class WP_Job_Manager_Settings {
 			</form>
 		</div>
 		<script type="text/javascript">
+			jQuery('.nav-internal').click(function (e) {
+				e.preventDefault();
+				jQuery('.nav-tab-wrapper a[href="' + jQuery(this).attr('href') + '"]').click();
+
+				return false;
+			});
+
 			jQuery('.nav-tab-wrapper a').click(function() {
 				if ( '#' !== jQuery(this).attr( 'href' ).substr( 0, 1 ) ) {
 					return false;


### PR DESCRIPTION
Small change to allow for references to another settings tab.

To use, for example, add a setting description like so:
```
<a href="#settings-email_notifications" class="nav-internal">Email Notifications</a>
```