### PR TITLE
Do not trailingslash ajax endpoint when using Plain permalink structure

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -78,8 +78,9 @@ class WP_Job_Manager_Ajax {
 		} elseif ( get_option( 'permalink_structure' ) ) {
 			$endpoint = trailingslashit( home_url( '/jm-ajax/' . $request . '/', 'relative' ) );
 		} else {
-			$endpoint = add_query_arg( 'jm-ajax', $request, trailingslashit( home_url( '', 'relative' ) ) );
+			$endpoint = add_query_arg( 'jm-ajax', $request, home_url( '/', 'relative' ) );
 		}
+
 		return esc_url_raw( $endpoint );
 	}
 


### PR DESCRIPTION
This was breaking WPML when permalink is on parameter mode. Props to @vukvukovich for tracking this down and finding the fix.

#### Changes proposed in this Pull Request:

* Remove `trailingslashit` around WPJM's ajax endpoint method.

#### Testing instructions:

* Switch permalink structure to `Plain`.
* Activate WPML with multiple languages.
* Create job listings in with versions in both the primary language and at least one other language.
* Visit the `[jobs]` page.
* From default language, make sure that language's listings are displayed. 
* From the other language, make sure that language's listings are displayed.

* Bonus (I've tested this scenario): Test above with a subdirectory WP install.