### PR TITLE
Prevent some jobs from being edited on the frontend

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -868,6 +868,37 @@ class WP_Job_Manager_Post_Types {
 		return $data;
 	}
 
+
+	/**
+	 * Check if a job is editable.
+	 *
+	 * @since 1.34.1
+	 *
+	 * @param int  $job_id Job ID to check.
+	 * @return bool
+	 */
+	public static function job_is_editable( $job_id ) {
+		$job_is_editable = true;
+		$post_status     = get_post_status( $job_id );
+
+		if (
+			( 'publish' === $post_status && ! wpjm_user_can_edit_published_submissions() )
+			|| ( 'publish' !== $post_status && ! job_manager_user_can_edit_pending_submissions() )
+		) {
+			$job_is_editable = false;
+		}
+
+		/**
+		 * Allows filtering on whether a job can be edited after it has gone past the `preview` stage.
+		 *
+		 * @since 1.34.1
+		 *
+		 * @param bool $job_is_editable If the job is editable.
+		 * @param int  $job_id          Job ID to check.
+		 */
+		return apply_filters( 'job_manager_job_is_editable', $job_is_editable, $job_id );
+	}
+
 	/**
 	 * Returns the name of the job RSS feed.
 	 *

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -868,7 +868,6 @@ class WP_Job_Manager_Post_Types {
 		return $data;
 	}
 
-
 	/**
 	 * Check if a job is editable.
 	 *

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -73,11 +73,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 		}
 
 		if ( ! empty( $this->job_id ) ) {
-			$post_status = get_post_status( $this->job_id );
-			if (
-				( 'publish' === $post_status && ! wpjm_user_can_edit_published_submissions() )
-				|| ( 'publish' !== $post_status && ! job_manager_user_can_edit_pending_submissions() )
-			) {
+			if ( ! WP_Job_Manager_Post_Types::job_is_editable( $this->job_id ) ) {
 				$this->job_id = 0;
 			}
 		}

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.32.0
+ * @version     1.34.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -48,7 +48,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 											switch ( $job->post_status ) {
 												case 'publish' :
-													if ( wpjm_user_can_edit_published_submissions() ) {
+													if ( WP_Job_Manager_Post_Types::job_is_editable( $job->ID ) ) {
 														$actions[ 'edit' ] = [ 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false ];
 													}
 													if ( is_position_filled( $job ) ) {
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 													break;
 												case 'pending_payment' :
 												case 'pending' :
-													if ( job_manager_user_can_edit_pending_submissions() ) {
+													if ( WP_Job_Manager_Post_Types::job_is_editable( $job->ID ) ) {
 														$actions['edit'] = [ 'label' => __( 'Edit', 'wp-job-manager' ), 'nonce' => false ];
 													}
 												break;


### PR DESCRIPTION
Not to be confused with `job_manager_user_can_edit_job()`, which checks if a particular _user_ can edit a job listing, this allows for blocking certain listings from being edited on the frontend.

To test, you can play with this filter:
```
add_filter( 'job_manager_job_is_editable', function( $job_is_editable, $job_id ) {
    return false;
}, 10, 2 );
```

Make sure the `Edit` links goes away from the `[job_dashboard]` listing. If you temporarily disable snippet and then, load `[job_dashboard]` page, and then re-enable the snippet, the `Edit` links shouldn't work when you click on them.