### PR TITLE
Added support for Terms & Condition field on Job submission

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -369,6 +369,13 @@ class WP_Job_Manager_Settings {
 							'desc'  => __( 'Select the page where you\'ve used the [jobs] shortcode. This lets the plugin know the location of the job listings page.', 'wp-job-manager' ),
 							'type'  => 'page',
 						],
+						[
+                            'name'  => 'job_manager_terms_page_id',
+                            'std'   => '',
+                            'label' => __('Terms & Condition Page', 'wp-job-manager'),
+                            'desc'  => __('Select the page where you\'ve placed Terms & Conditions for Job Submission. If this is set it will be shown on Job submission page', 'wp-job-manager'),
+                            'type'  => 'page',
+                        ],
 					],
 				],
 			]

--- a/templates/form-fields/terms-field.php
+++ b/templates/form-fields/terms-field.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Shows the `Terms & Condition` form field on job listing forms.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/form-fields/terms-field.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     wp-job-manager
+ * @category    Template
+ *
+ */
+
+if (! defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+?>
+<fieldset class="fieldset-<?php echo esc_attr($key); ?>">
+	<label for="<?php echo esc_attr($key); ?>"><?php echo esc_html($field['label']); ?></label>
+	<div class="field <?php echo $field['required'] ? 'required-field' : ''; ?>">
+    <input type="checkbox" class="input-checkbox" name="<?php echo esc_attr(isset($field['name']) ? $field['name'] : $key); ?>" id="<?php echo esc_attr($key); ?>" <?php checked(! empty($field['value']), true); ?> value="1" <?php if (! empty($field['required'])) {
+    echo 'required';
+} ?> />
+<?php if (! empty($field['description'])) : ?><?php echo wp_kses_post($field['description']); ?><?php endif; ?>
+	</div>
+</fieldset>


### PR DESCRIPTION
Fixes #1921

#### Changes proposed in this Pull Request:

* Added 'Terms & Condition' page setting in the Pages tab.
* If the setting is enabled, 'Accept Terms & Condition' checkbox will be displayed on the Job submission page.
* Added validation to accept the Terms & Condition.

#### Testing instructions:

* Set 'Terms & Condition' page in the Settings --> Pages --> Terms & Condition.
* Verify JS & PHP validation on Submit Job page.
* If no page is set for Terms & Condition, there will be no checkbox on Job submission page.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Settings for Terms & Condition page. 
Support added for accepting Terms & Condition on the Job submission page.