### PR TITLE
Added Duplicate action for expired listing

### DIFF
--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -63,6 +63,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 													if ( job_manager_get_permalink( 'submit_job_form' ) ) {
 														$actions['relist'] = [ 'label' => __( 'Relist', 'wp-job-manager' ), 'nonce' => true ];
 													}
+													$actions['duplicate'] = [ 'label' => __('Duplicate', 'wp-job-manager'), 'nonce' => true ];
 													break;
 												case 'pending_payment' :
 												case 'pending' :


### PR DESCRIPTION
Fixes #1918

#### Changes proposed in this Pull Request:

* Added 'Duplicate' action for an expired listing.

#### Testing instructions:

* Mark any Job listing to 'Expired'.
* Go to 'Job Dashboard'.
* Click on 'Duplicate' action. This should duplicate the current job listing with all the fields populated.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Added 'Duplicate' action for an expired job listing.