### PR TITLE
Send emails with multiple recipients separately

### DIFF
--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -752,7 +752,19 @@ final class WP_Job_Manager_Email_Notifications {
 		if ( ! apply_filters( 'job_manager_email_do_send_notification', true, $email, $args, $content, $headers ) ) {
 			return false;
 		}
-		return wp_mail( $args['to'], $args['subject'], $content, $headers, $args['attachments'] );
+
+		if ( ! is_array( $args['to'] ) ) {
+			$args['to'] = array_filter( array_map( 'sanitize_email', preg_split( '/[,|;]\s?/', $args['to'] ) ) );
+		}
+
+		$is_success = ! empty( $args['to'] );
+		foreach ( $args['to'] as $to_email ) {
+			if ( ! wp_mail( $to_email, $args['subject'], $content, $headers, $args['attachments'] ) ) {
+				$is_success = false;
+			}
+		}
+
+		return $is_success;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -477,7 +477,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @since 1.31.0
 	 * @since 1.34.1 Added arguments to allow for per-recipient customization.
 	 *
-	 * @param string $email_notification_key  Unique ID for this email notificsation.
+	 * @param string $email_notification_key  Unique ID for this email notification.
 	 * @param array  $args                    Email arguments.
 	 * @return bool
 	 */
@@ -492,7 +492,7 @@ final class WP_Job_Manager_Email_Notifications {
 		 * @since 1.31.0
 		 *
 		 * @param bool   $send_as_plain_text      Whether to send this email as plain text.
-		 * @param string $email_notification_key  Unique ID for this email notificsation.
+		 * @param string $email_notification_key  Unique ID for this email notification.
 		 * @param array  $args                    Email arguments.
 		 */
 		return apply_filters( 'job_manager_email_send_as_plain_text', $send_as_plain_text, $email_notification_key, $args );

--- a/tests/php/includes/stubs/class-wp-job-manager-email-valid.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-email-valid.php
@@ -43,6 +43,11 @@ class WP_Job_Manager_Email_Valid extends WP_Job_Manager_Email {
 	 * @return string|array
 	 */
 	public function get_to() {
+		$args = $this->get_args();
+		if ( isset( $args['to'] ) ) {
+			return $args['to'];
+		}
+
 		return 'to@example.com';
 	}
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -121,6 +121,52 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Test multiple recipients separated by comma.
+	 *
+	 * @covers WP_Job_Manager_Email_Notifications::send_deferred_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_deferred_notifications_multiple_recipients_comma() {
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertFalse( $mailer->get_sent() );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_email', [ 'test' => 'test', 'to' => 'testa@example.com, testb@example.com' ] );
+		WP_Job_Manager_Email_Notifications::send_deferred_notifications();
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+
+		$this->assertNotFalse( $mailer->get_sent( 0 ) );
+		$this->assertNotFalse( $mailer->get_sent( 1 ) );
+		$this->assertFalse( $mailer->get_sent( 2 ) );
+
+		$this->assertEquals( 'testa@example.com', $mailer->get_recipient( 'to', 0 )->address );
+		$this->assertEquals( 'testb@example.com', $mailer->get_recipient( 'to', 1 )->address );
+	}
+
+	/**
+	 * Test multiple recipients separated by semicolon.
+	 *
+	 * @covers WP_Job_Manager_Email_Notifications::send_deferred_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_deferred_notifications_multiple_recipients_semicolon() {
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertFalse( $mailer->get_sent() );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_email', [ 'test' => 'test', 'to' => 'testa@example.com; testb@example.com; testc@example.com' ] );
+		WP_Job_Manager_Email_Notifications::send_deferred_notifications();
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+
+		$this->assertNotFalse( $mailer->get_sent( 0 ) );
+		$this->assertNotFalse( $mailer->get_sent( 1 ) );
+		$this->assertNotFalse( $mailer->get_sent( 2 ) );
+		$this->assertFalse( $mailer->get_sent( 3 ) );
+
+		$this->assertEquals( 'testa@example.com', $mailer->get_recipient( 'to', 0 )->address );
+		$this->assertEquals( 'testb@example.com', $mailer->get_recipient( 'to', 1 )->address );
+		$this->assertEquals( 'testc@example.com', $mailer->get_recipient( 'to', 2 )->address );
+	}
+
+	/**
 	 * @covers WP_Job_Manager_Email_Notifications::send_deferred_notifications()
 	 */
 	public function test_send_deferred_notifications_unknown_email() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Sends emails too multiple recipients separately. 

#### Testing instructions:

* Add this filter: 
```
add_filter( 'job_manager_email_admin_new_job_to', function() {
  return 'emaila@example.com, emailb@example.com';
});
```
* Submit a new job listing. Verify separate emails are sent to each email address.

#### To Do
- [ ] Unit tests