### PR TITLE
Add ability to force email notifications to be enabled

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-email.php
+++ b/includes/abstracts/abstract-wp-job-manager-email.php
@@ -210,6 +210,15 @@ abstract class WP_Job_Manager_Email {
 	}
 
 	/**
+	 * Force the email notification to be enabled or disabled.
+	 *
+	 * @return bool|null True to force enabled; False to force disabled; Null to not force a value.
+	 */
+	public static function get_enabled_force_value() {
+		return null;
+	}
+
+	/**
 	 * Returns the args that the email notification was sent with.
 	 *
 	 * @return array

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -516,9 +516,12 @@ class WP_Job_Manager_Settings {
 	 * @param string $ignored_placeholder
 	 */
 	protected function input_checkbox( $option, $attributes, $value, $ignored_placeholder ) {
+		if ( ! isset( $option['hidden_value'] ) ) {
+			$option['hidden_value'] = '0';
+		}
 		?>
 		<label>
-		<input type="hidden" name="<?php echo esc_attr( $option['name'] ); ?>" value="0" />
+		<input type="hidden" name="<?php echo esc_attr( $option['name'] ); ?>" value="<?php echo esc_attr( $option['hidden_value'] ); ?>" />
 		<input
 			id="setting-<?php echo esc_attr( $option['name'] ); ?>"
 			name="<?php echo esc_attr( $option['name'] ); ?>"
@@ -826,11 +829,12 @@ class WP_Job_Manager_Settings {
 
 		if ( isset( $enable_option['force_value'] ) && is_bool( $enable_option['force_value'] ) ) {
 			if ( true === $enable_option['force_value'] ) {
-				$enable_option['value'] = 1;
+				$values[ $option['enable_field']['name'] ] = '1';
 			} elseif ( false === $enable_option['force_value'] ) {
-				$enable_option['value'] = 0;
+				$values[ $option['enable_field']['name'] ] = '0';
 			}
 
+			$enable_option['hidden_value'] = $values[ $option['enable_field']['name'] ];
 			$enable_option['attributes'][] = 'disabled="disabled"';
 		}
 

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -830,7 +830,7 @@ class WP_Job_Manager_Settings {
 		if ( isset( $enable_option['force_value'] ) && is_bool( $enable_option['force_value'] ) ) {
 			if ( true === $enable_option['force_value'] ) {
 				$values[ $option['enable_field']['name'] ] = '1';
-			} elseif ( false === $enable_option['force_value'] ) {
+			} else {
 				$values[ $option['enable_field']['name'] ] = '0';
 			}
 

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -823,6 +823,17 @@ class WP_Job_Manager_Settings {
 		$enable_option['name']       = $option['name'] . '[' . $enable_option['name'] . ']';
 		$enable_option['type']       = 'checkbox';
 		$enable_option['attributes'] = [ 'class="sub-settings-expander"' ];
+
+		if ( isset( $enable_option['force_value'] ) && is_bool( $enable_option['force_value'] ) ) {
+			if ( true === $enable_option['force_value'] ) {
+				$enable_option['value'] = 1;
+			} elseif ( false === $enable_option['force_value'] ) {
+				$enable_option['value'] = 0;
+			}
+
+			$enable_option['attributes'][] = 'disabled="disabled"';
+		}
+
 		$this->input_checkbox( $enable_option, $enable_option['attributes'], $values[ $option['enable_field']['name'] ], null );
 
 		echo '<div class="sub-settings-expandable">';

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -416,7 +416,7 @@ final class WP_Job_Manager_Email_Notifications {
 		$email_settings      = [];
 
 		foreach ( $email_notifications as $email_notification_key => $email_class ) {
-			$email_notification_context = call_user_func( [ $email_class, 'get_context' ] );
+			$email_notification_context = $email_class::get_context();
 			if ( $context !== $email_notification_context ) {
 				continue;
 			}
@@ -424,11 +424,12 @@ final class WP_Job_Manager_Email_Notifications {
 			$email_settings[] = [
 				'type'         => 'multi_enable_expand',
 				'class'        => 'email-setting-row no-separator',
-				'name'         => self::EMAIL_SETTING_PREFIX . call_user_func( [ $email_class, 'get_key' ] ),
+				'name'         => self::EMAIL_SETTING_PREFIX . $email_class::get_key(),
 				'enable_field' => [
-					'name'     => self::EMAIL_SETTING_ENABLED,
-					'cb_label' => call_user_func( [ $email_class, 'get_name' ] ),
-					'desc'     => call_user_func( [ $email_class, 'get_description' ] ),
+					'name'        => self::EMAIL_SETTING_ENABLED,
+					'cb_label'    => $email_class::get_name(),
+					'desc'        => $email_class::get_description(),
+					'force_value' => $email_class::get_enabled_force_value(),
 				],
 				'label'        => false,
 				'std'          => self::get_email_setting_defaults( $email_notification_key ),
@@ -456,9 +457,15 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @return bool
 	 */
 	public static function is_email_notification_enabled( $email_notification_key ) {
-		$settings = self::get_email_settings( $email_notification_key );
+		$settings    = self::get_email_settings( $email_notification_key );
+		$email_class = self::get_email_class( $email_notification_key );
 
+		$enabled_force_value           = $email_class ? $email_class::get_enabled_force_value() : null;
 		$is_email_notification_enabled = ! empty( $settings[ self::EMAIL_SETTING_ENABLED ] );
+
+		if ( is_bool( $enabled_force_value ) ) {
+			$is_email_notification_enabled = $enabled_force_value;
+		}
 
 		/**
 		 * Filter whether an notification email is enabled.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Some emails must stay enabled if they are critical to a plugin behavior or disabled if a pre-condition of their use is not met. This allows for us force certain email notifications to stay either enabled or disabled. 

#### Testing instructions:

* Test _Apply With Resume_ notification settings in Resumes plugin (on `master`). 