### PR TITLE
Allow notifications to be sent immediatly and get response back

### DIFF
--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -100,6 +100,39 @@ final class WP_Job_Manager_Email_Notifications {
 	}
 
 	/**
+	 * Send email notifications for a specific email now and return the status. Not usually necessary but useful if you
+	 * need to check to make sure a notification was sent.
+	 *
+	 * @param string $email_key Email key to send notifications for.
+	 * @return bool True if an email notification was sent.
+	 */
+	public static function send_notifications( $email_key ) {
+		$email_sent = false;
+		$email_notifications = self::get_email_notifications( true );
+		foreach ( self::$deferred_notifications as $index => $email ) {
+			if (
+				! is_string( $email[0] )
+				|| ! isset( $email_notifications[ $email[0] ] )
+				|| $email[0] !== $email_key
+			) {
+				continue;
+			}
+
+			$email_class            = $email_notifications[ $email[0] ];
+			$email_notification_key = $email[0];
+			$email_args             = is_array( $email[1] ) ? $email[1] : [];
+
+			if ( self::send_email( $email[0], new $email_class( $email_args, self::get_email_settings( $email_notification_key ) ) ) ) {
+				$email_sent = true;
+			}
+
+			unset( self::$deferred_notifications[ $index ] );
+		}
+
+		return $email_sent;
+	}
+
+	/**
 	 * Initialize if necessary.
 	 */
 	public static function maybe_init() {

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -107,7 +107,7 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @return bool True if an email notification was sent.
 	 */
 	public static function send_notifications( $email_key ) {
-		$email_sent = false;
+		$email_sent          = false;
 		$email_notifications = self::get_email_notifications( true );
 		foreach ( self::$deferred_notifications as $index => $email ) {
 			if (

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -118,11 +118,10 @@ final class WP_Job_Manager_Email_Notifications {
 				continue;
 			}
 
-			$email_class            = $email_notifications[ $email[0] ];
-			$email_notification_key = $email[0];
-			$email_args             = is_array( $email[1] ) ? $email[1] : [];
+			$email_class = $email_notifications[ $email[0] ];
+			$email_args  = is_array( $email[1] ) ? $email[1] : [];
 
-			if ( self::send_email( $email[0], new $email_class( $email_args, self::get_email_settings( $email_notification_key ) ) ) ) {
+			if ( self::send_email( $email[0], new $email_class( $email_args, self::get_email_settings( $email_key ) ) ) ) {
 				$email_sent = true;
 			}
 

--- a/tests/php/includes/stubs/class-wp-job-manager-email-valid-secondary.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-email-valid-secondary.php
@@ -1,0 +1,68 @@
+<?php
+class WP_Job_Manager_Email_Valid_Secondary extends WP_Job_Manager_Email {
+	/**
+	 * Get the unique email notification key.
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return 'valid_secondary_email';
+	}
+
+	/**
+	 * Get the friendly name for this email notification.
+	 *
+	 * @return string
+	 * @throws Exception When it hasn't been implemented in a subclass.
+	 */
+	public static function get_name() {
+		return 'Another Test Email Notification';
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		return 'Another Test Subject';
+	}
+
+	/**
+	 * Get `From:` address header value. Can be simple email or formatted `Firstname Lastname <email@example.com>`.
+	 *
+	 * @return string|bool Email from value or false to use WordPress' default.
+	 */
+	public function get_from() {
+		return 'From Name <from@example.com>';
+	}
+
+	/**
+	 * Get array or comma-separated list of email addresses to send message.
+	 *
+	 * @return string|array
+	 */
+	public function get_to() {
+		return 'to@example.com';
+	}
+
+	/**
+	 * Get the rich text version of the email content.
+	 *
+	 * @return string
+	 */
+	public function get_rich_content() {
+		$args = $this->get_args();
+		return '<strong>' . wp_kses_post( $args['test'] ) . '</strong>';
+	}
+
+	/**
+	 * Checks the arguments and returns whether the email notification is properly set up.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		$args = $this->get_args();
+		return isset( $args['test'] );
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -1,5 +1,6 @@
 <?php
 require_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-email-valid.php';
+require_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-email-valid-secondary.php';
 require_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-email-invalid.php';
 
 /**
@@ -145,6 +146,107 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		WP_Job_Manager_Email_Notifications::send_deferred_notifications();
 		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
 		$this->assertFalse( $mailer->get_sent() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Email_Notifications::send_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_notifications_valid_key() {
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// Enqueue valid email.
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_email', [ 'test' => 'test' ] );
+
+		$email_sent = WP_Job_Manager_Email_Notifications::send_notifications( 'valid_email' );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+
+		$this->assertTrue( $email_sent, 'An email should have been sent' );
+		$sent_email = $mailer->get_sent();
+		$this->assertNotFalse( $sent_email );
+
+		// No emails should be deferred.
+		$this->assertEmpty( WP_Job_Manager_Email_Notifications::get_deferred_notification_hashes(), 'No emails should still be enqueued' );
+	}
+
+	/**
+	 * Tests to make sure that only the requested emails are sent immediately.
+	 *
+	 * @covers WP_Job_Manager_Email_Notifications::send_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_notifications_non_queued_key() {
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// Enqueue valid email.
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_secondary_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_secondary_email', [ 'test' => 'test' ] );
+
+		$email_sent = WP_Job_Manager_Email_Notifications::send_notifications( 'valid_email' );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_secondary_valid_email' ] );
+
+		$this->assertFalse( $email_sent, 'An email should NOT have been sent' );
+		$sent_email = $mailer->get_sent();
+		$this->assertFalse( $sent_email );
+
+		// One email should still be deferred.
+		$this->assertCount( 1, WP_Job_Manager_Email_Notifications::get_deferred_notification_hashes(), 'One email should still be enqueued' );
+	}
+
+	/**
+	 * Tests to make sure that emails are only sent the first time if no new emails were enqueued.
+	 *
+	 * @covers WP_Job_Manager_Email_Notifications::send_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_notifications_double_enqueued() {
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// Enqueue valid email.
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_email', [ 'test' => 'test' ] );
+
+		$email_sent = WP_Job_Manager_Email_Notifications::send_notifications( 'valid_email' );
+		$email_sent_twice = WP_Job_Manager_Email_Notifications::send_notifications( 'valid_email' );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+
+		$this->assertTrue( $email_sent, 'An email should have been sent' );
+		$this->assertFalse( $email_sent_twice, 'An email should NOT have been sent the second time this was called' );
+
+		$sent_email = $mailer->get_sent();
+		$this->assertNotFalse( $sent_email );
+
+		// No email should be deferred.
+		$this->assertCount( 0, WP_Job_Manager_Email_Notifications::get_deferred_notification_hashes(), 'No email should be enqueued' );
+	}
+
+
+	/**
+	 * Tests to make sure that invalid emails are not sent.
+	 *
+	 * @covers WP_Job_Manager_Email_Notifications::send_notifications()
+	 * @covers WP_Job_Manager_Email_Notifications::send_email()
+	 */
+	public function test_send_notifications_invalid_args() {
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// Enqueue valid email.
+		add_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+		do_action( 'job_manager_send_notification', 'valid_email', [ 'invalid' => 'test' ] );
+
+		$email_sent = WP_Job_Manager_Email_Notifications::send_notifications( 'valid_email' );
+		remove_filter( 'job_manager_email_notifications', [ $this, 'inject_email_config_valid_email' ] );
+
+		$this->assertFalse( $email_sent, 'An email should NOT have been sent' );
+
+		$sent_email = $mailer->get_sent();
+		$this->assertFalse( $sent_email );
+
+		// No email should be deferred.
+		$this->assertCount( 0, WP_Job_Manager_Email_Notifications::get_deferred_notification_hashes(), 'No email should be enqueued' );
 	}
 
 	/**
@@ -320,6 +422,11 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 
 	public function inject_email_config_valid_email( $emails ) {
 		$emails[] = 'WP_Job_Manager_Email_Valid';
+		return $emails;
+	}
+
+	public function inject_email_config_secondary_valid_email( $emails ) {
+		$emails[] = 'WP_Job_Manager_Email_Valid_Secondary';
 		return $emails;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* In Resumes we needed to be able to send notifications right away and be told if we were successful. This adds a public method to the email notifications class to allow us to do that. 

NOTE: Failed test is the geolocation test (unrelated to this PR). I think we went over our quota today.

#### To Do
* [x] Unit  tests