### PR TITLE
Release 1.34.1 beta.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -299,7 +299,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( 'package-unsafe', [ 'build-package-unsafe', 'zip' ] );
 
 	// Register tasks
-	grunt.registerTask( 'default', [ 'build-assets', 'wp_readme_to_markdown' ] );
+	grunt.registerTask( 'default', [ 'build', 'wp_readme_to_markdown' ] );
 
 	// Just an alias for pot file generation
 	grunt.registerTask( 'pot', [ 'makepot' ] );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,15 @@
+= 1.34.1 =
+* Templates Updated: `job-submitted.php`, `job-dashboard.php`.
+* Enhancement: Email notifications are sent separately if multiple recipients are listed.
+* Enhancement: Notices at end of job submission process are now displayed as a styled notice.
+* Fix: Resuming job listing submission at a particular step is now fixed.
+* Fix: Issue with some permalink structures and WPMU would cause issues on `[jobs]` page.
+* Dev: Adds the ability to block some jobs from being edited in the frontend.
+* Dev: Adds ability to force some email notifications to be enabled. 
+* Dev: Allows email notifications to be sent immediately.
+* Dev: Adds ability for settings to reference other settings tabs.
+* Dev: Standardizes jQuery UI datepicker script IDs in frontend and backend. Plugins and themes should enqueue `wp-job-manager-datepicker` if they need jQuery UI datepicker.
+
 = 1.34.0 =
 * Templates Updated: `content-job_listing.php`, `job-submitted.php`.
 * Enhancement: Add support for pre-selecting categories in `[jobs]` using category slugs in query string (e.g. `/jobs?search_category=developer,pm,senior`).

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 1.34.0\n"
+"Project-Id-Version: WP Job Manager 1.34.1\n"
 "Report-Msgid-Bugs-To: https://github.com/Automattic/WP-Job-Manager/issues\n"
-"POT-Creation-Date: 2019-10-01 09:58:35+00:00\n"
+"POT-Creation-Date: 2019-10-30 18:24:14+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -31,7 +31,7 @@ msgid "\"%s\" check failed. Please try again."
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-addons.php:125
-#: includes/admin/class-wp-job-manager-admin.php:139
+#: includes/admin/class-wp-job-manager-admin.php:128
 #: includes/admin/views/html-admin-page-addons.php:12
 msgid "WP Job Manager Add-ons"
 msgstr ""
@@ -49,11 +49,11 @@ msgstr ""
 msgid "You don&#8217;t have permission to do this."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:136
+#: includes/admin/class-wp-job-manager-admin.php:125
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:139
+#: includes/admin/class-wp-job-manager-admin.php:128
 msgid "Add-ons"
 msgstr ""
 
@@ -200,8 +200,8 @@ msgid "Type"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-cpt.php:497
-#: includes/class-wp-job-manager-email-notifications.php:238
-#: includes/class-wp-job-manager-post-types.php:1224
+#: includes/class-wp-job-manager-email-notifications.php:270
+#: includes/class-wp-job-manager-post-types.php:1254
 #: includes/forms/class-wp-job-manager-form-submit-job.php:213
 #: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:46
 #: templates/job-filters.php:35 templates/job-filters.php:36
@@ -712,11 +712,11 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:633
+#: includes/admin/class-wp-job-manager-settings.php:643
 msgid "--no page--"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:639
+#: includes/admin/class-wp-job-manager-settings.php:649
 msgid "Select a page&hellip;"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgid "Employment Type"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-writepanels.php:64
-#: includes/class-wp-job-manager-email-notifications.php:292
+#: includes/class-wp-job-manager-email-notifications.php:324
 msgid "Posted by"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgid "Add file"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-writepanels.php:471
-#: includes/class-wp-job-manager-ajax.php:418
+#: includes/class-wp-job-manager-ajax.php:419
 #. translators: Used in user select. %1$s is the user's display name; #%2$s is
 #. the user ID; %3$s is the user email.
 msgid "%1$s (#%2$s – %3$s)"
@@ -991,14 +991,14 @@ msgstr ""
 msgid "Help other users on the forums"
 msgstr ""
 
-#: includes/class-wp-job-manager-ajax.php:185
+#: includes/class-wp-job-manager-ajax.php:186
 #. translators: Placeholder %d is the number of found search results.
 msgid "Search completed. Found %d matching record."
 msgid_plural "Search completed. Found %d matching records."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-wp-job-manager-ajax.php:283
+#: includes/class-wp-job-manager-ajax.php:284
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
@@ -1012,27 +1012,27 @@ msgid "Company Logo"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:52
-#: includes/class-wp-job-manager-post-types.php:1243
+#: includes/class-wp-job-manager-post-types.php:1273
 msgid "Company Name"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:53
-#: includes/class-wp-job-manager-post-types.php:1251
+#: includes/class-wp-job-manager-post-types.php:1281
 msgid "Company Website"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:54
-#: includes/class-wp-job-manager-post-types.php:1260
+#: includes/class-wp-job-manager-post-types.php:1290
 msgid "Company Tagline"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:55
-#: includes/class-wp-job-manager-post-types.php:1268
+#: includes/class-wp-job-manager-post-types.php:1298
 msgid "Company Twitter"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:56
-#: includes/class-wp-job-manager-post-types.php:1276
+#: includes/class-wp-job-manager-post-types.php:1306
 msgid "Company Video"
 msgstr ""
 
@@ -1068,52 +1068,52 @@ msgstr ""
 msgid "WordPress Update Required"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:227
+#: includes/class-wp-job-manager-email-notifications.php:259
 msgid "Job title"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:247
+#: includes/class-wp-job-manager-email-notifications.php:279
 #: includes/class-wp-job-manager-post-types.php:218
 #: includes/forms/class-wp-job-manager-form-submit-job.php:221
 msgid "Job type"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:257
+#: includes/class-wp-job-manager-email-notifications.php:289
 #: includes/class-wp-job-manager-post-types.php:154
 #: includes/forms/class-wp-job-manager-form-submit-job.php:230
 msgid "Job category"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:266
+#: includes/class-wp-job-manager-email-notifications.php:298
 #: includes/forms/class-wp-job-manager-form-submit-job.php:255
 msgid "Company name"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:274
+#: includes/class-wp-job-manager-email-notifications.php:306
 msgid "Company website"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:283
+#: includes/class-wp-job-manager-email-notifications.php:315
 msgid "Listing expires"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:441
+#: includes/class-wp-job-manager-email-notifications.php:474
 msgid "Email Notifications"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:444
+#: includes/class-wp-job-manager-email-notifications.php:477
 msgid "Select the email notifications to enable."
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:586
+#: includes/class-wp-job-manager-email-notifications.php:630
 msgid "Format"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:589
+#: includes/class-wp-job-manager-email-notifications.php:633
 msgid "Send plain text email"
 msgstr ""
 
-#: includes/class-wp-job-manager-email-notifications.php:590
+#: includes/class-wp-job-manager-email-notifications.php:634
 msgid "Send rich text email"
 msgstr ""
 
@@ -1301,78 +1301,78 @@ msgid_plural "Preview <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-wp-job-manager-post-types.php:1211
+#: includes/class-wp-job-manager-post-types.php:1241
 #: includes/forms/class-wp-job-manager-form-submit-job.php:190
 msgid "Application email/URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1212
+#: includes/class-wp-job-manager-post-types.php:1242
 #: includes/forms/class-wp-job-manager-form-submit-job.php:191
 msgid "Enter an email address or website URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1215
+#: includes/class-wp-job-manager-post-types.php:1245
 #: includes/forms/class-wp-job-manager-form-submit-job.php:180
 msgid "Application email"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1216
+#: includes/class-wp-job-manager-post-types.php:1246
 #: includes/forms/class-wp-job-manager-form-submit-job.php:181
 msgid "you@example.com"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1218
+#: includes/class-wp-job-manager-post-types.php:1248
 #: includes/forms/class-wp-job-manager-form-submit-job.php:185
 msgid "Application URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1219
+#: includes/class-wp-job-manager-post-types.php:1249
 #: includes/forms/class-wp-job-manager-form-submit-job.php:186
 msgid "https://"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1225
+#: includes/class-wp-job-manager-post-types.php:1255
 #: includes/forms/class-wp-job-manager-form-submit-job.php:217
 msgid "e.g. \"London\""
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1226
+#: includes/class-wp-job-manager-post-types.php:1256
 msgid "Leave this blank if the location is not important."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1235
+#: includes/class-wp-job-manager-post-types.php:1265
 msgid ""
 "This field is required for the \"application\" area to appear beneath the "
 "listing."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1261
+#: includes/class-wp-job-manager-post-types.php:1291
 msgid "Brief description about the company"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1277
+#: includes/class-wp-job-manager-post-types.php:1307
 msgid "URL to the company video"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1286
+#: includes/class-wp-job-manager-post-types.php:1316
 msgid "Position Filled"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1292
+#: includes/class-wp-job-manager-post-types.php:1322
 msgid "Filled listings will no longer accept applications."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1295
+#: includes/class-wp-job-manager-post-types.php:1325
 msgid "Featured Listing"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1297
+#: includes/class-wp-job-manager-post-types.php:1327
 msgid ""
 "Featured listings will be sticky during searches, and can be styled "
 "differently."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1305
+#: includes/class-wp-job-manager-post-types.php:1335
 msgid "Listing Expiry Date"
 msgstr ""
 
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "Enable Usage Tracking"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:138
+#: includes/class-wp-job-manager.php:139
 #. translators: Placeholders %1$s and %2$s are the names of the two cookies
 #. used in WP Job Manager.
 msgid ""
@@ -1461,26 +1461,26 @@ msgid ""
 "\t\t\t\thave started but have not completed: %1$s and %2$s"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:276
+#: includes/class-wp-job-manager.php:295
 msgid "Load previous listings"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:403
+#: includes/class-wp-job-manager.php:422
 msgid "Invalid file type. Accepted types:"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:420
+#: includes/class-wp-job-manager.php:439
 #: includes/forms/class-wp-job-manager-form-submit-job.php:406
 #. translators: Placeholder %d is the number of files to that users are limited
 #. to.
 msgid "You are only allowed to upload a maximum of %d files."
 msgstr ""
 
-#: includes/class-wp-job-manager.php:428
+#: includes/class-wp-job-manager.php:447
 msgid "Are you sure you want to delete this listing?"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:436
+#: includes/class-wp-job-manager.php:455
 msgid "This field is required."
 msgstr ""
 
@@ -1543,27 +1543,27 @@ msgstr ""
 msgid "days"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:108
+#: includes/forms/class-wp-job-manager-form-edit-job.php:104
 msgid "Invalid listing"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:140
+#: includes/forms/class-wp-job-manager-form-edit-job.php:136
 msgid "Save changes"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:145
+#: includes/forms/class-wp-job-manager-form-edit-job.php:141
 msgid "Submit changes for approval"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:199
+#: includes/forms/class-wp-job-manager-form-edit-job.php:195
 msgid "Your changes have been saved."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:205
+#: includes/forms/class-wp-job-manager-form-edit-job.php:201
 msgid "View &rarr;"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:207
+#: includes/forms/class-wp-job-manager-form-edit-job.php:203
 msgid ""
 "Your changes have been submitted and your listing will be visible again "
 "once approved."
@@ -1574,7 +1574,7 @@ msgid "Submit Details"
 msgstr ""
 
 #: includes/forms/class-wp-job-manager-form-submit-job.php:88
-#: includes/forms/class-wp-job-manager-form-submit-job.php:578
+#: includes/forms/class-wp-job-manager-form-submit-job.php:562
 #: templates/job-preview.php:30
 msgid "Preview"
 msgstr ""
@@ -1675,36 +1675,36 @@ msgstr ""
 msgid "Please enter a valid application email address or URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:637
+#: includes/forms/class-wp-job-manager-form-submit-job.php:621
 msgid "Please enter a username."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:641
+#: includes/forms/class-wp-job-manager-form-submit-job.php:625
 msgid "Please enter a password."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:645
+#: includes/forms/class-wp-job-manager-form-submit-job.php:629
 msgid "Please enter your email address."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:651
+#: includes/forms/class-wp-job-manager-form-submit-job.php:635
 msgid "Passwords must match."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:657
+#: includes/forms/class-wp-job-manager-form-submit-job.php:641
 #. translators: Placeholder %s is the password hint.
 msgid "Invalid Password: %s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:659
+#: includes/forms/class-wp-job-manager-form-submit-job.php:643
 msgid "Password is not valid."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:682
+#: includes/forms/class-wp-job-manager-form-submit-job.php:666
 msgid "You must be signed in to post a new listing."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:705
+#: includes/forms/class-wp-job-manager-form-submit-job.php:689
 #. translators: placeholder is the URL to the job dashboard page.
 msgid ""
 "Draft was saved. Job listing drafts can be resumed from the <a "
@@ -2293,28 +2293,20 @@ msgctxt "user selection"
 msgid "Searching&hellip;"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:123
-#: includes/forms/class-wp-job-manager-form-submit-job.php:490
-#. translators: jQuery date format, see
-#. http:api.jqueryui.com/datepicker/#utility-formatDate
-msgctxt "Date format for jQuery datepicker."
-msgid "yy-mm-dd"
-msgstr ""
-
 #: includes/admin/class-wp-job-manager-permalink-settings.php:108
-#: includes/class-wp-job-manager-post-types.php:946
+#: includes/class-wp-job-manager-post-types.php:976
 msgctxt "Job permalink - resave permalinks after changing this"
 msgid "job"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:117
-#: includes/class-wp-job-manager-post-types.php:947
+#: includes/class-wp-job-manager-post-types.php:977
 msgctxt "Job category slug - resave permalinks after changing this"
 msgid "job-category"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:126
-#: includes/class-wp-job-manager-post-types.php:948
+#: includes/class-wp-job-manager-post-types.php:978
 msgctxt "Job type slug - resave permalinks after changing this"
 msgid "job-type"
 msgstr ""
@@ -2366,7 +2358,7 @@ msgctxt "post status"
 msgid "Active"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:930
+#: includes/class-wp-job-manager-post-types.php:960
 msgctxt "Post type archive slug - resave permalinks after changing this"
 msgid "jobs"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wp-job-manager",
 	"title": "WP Job Manager",
-	"version": "1.34.0",
+	"version": "1.34.1",
 	"homepage": "http://wordpress.org/plugins/wp-job-manager/",
 	"license": "GPL-2.0+",
 	"repository": "automattic/wp-job-manager",

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,19 @@ It then creates a database based on the parameters passed to it.
 6. Job listings in admin.
 
 == Changelog ==
+
+= 1.34.1 =
+* Templates Updated: `job-submitted.php`, `job-dashboard.php`.
+* Enhancement: Email notifications are sent separately if multiple recipients are listed.
+* Enhancement: Notices at end of job submission process are now displayed as a styled notice.
+* Fix: Resuming job listing submission at a particular step is now fixed.
+* Fix: Issue with some permalink structures and WPMU would cause issues on `[jobs]` page.
+* Dev: Adds the ability to block some jobs from being edited in the frontend.
+* Dev: Adds ability to force some email notifications to be enabled. 
+* Dev: Allows email notifications to be sent immediately.
+* Dev: Adds ability for settings to reference other settings tabs.
+* Dev: Standardizes jQuery UI datepicker script IDs in frontend and backend. Plugins and themes should enqueue `wp-job-manager-datepicker` if they need jQuery UI datepicker.
+
 = 1.34.0 =
 * Templates Updated: `content-job_listing.php`, `job-submitted.php`.
 * Enhancement: Add support for pre-selecting categories in `[jobs]` using category slugs in query string (e.g. `/jobs?search_category=developer,pm,senior`).

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.34.0
+ * Version: 1.34.1-beta.1
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 4.9
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.34.0' );
+define( 'JOB_MANAGER_VERSION', '1.34.1-beta.1' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
```
= 1.34.1 =
* Templates Updated: `job-submitted.php`, `job-dashboard.php`.
* Enhancement: Email notifications are sent separately if multiple recipients are listed.
* Enhancement: Notices at end of job submission process are now displayed as a styled notice.
* Fix: Resuming job listing submission at a particular step is now fixed.
* Fix: Issue with some permalink structures and WPMU would cause issues on `[jobs]` page.
* Dev: Adds the ability to block some jobs from being edited in the frontend.
* Dev: Adds ability to force some email notifications to be enabled. 
* Dev: Allows email notifications to be sent immediately.
* Dev: Adds ability for settings to reference other settings tabs.
* Dev: Standardizes jQuery UI datepicker script IDs in frontend and backend. Plugins and themes should enqueue `wp-job-manager-datepicker` if they need jQuery UI datepicker.
```