### PR TITLE
New filter to set email / url application as default field

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -167,22 +167,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Checks if it is forced application default field
-	 *
-	 * @return bool
-	 */
-	protected function is_forced_application_default_field() {
-		/**
-		 * Force application field to skip email / URL validations and sanitizer
-		 *
-		 * @since 1.x.x
-		 *
-		 * @param bool  $is_forced Whether the application field is forced to default.
-		 */
-		return apply_filters( 'job_manager_application_force_default_field', false );
-	}
-
-	/**
 	 * Initializes the fields used in the form.
 	 */
 	public function init_fields() {
@@ -207,10 +191,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				$application_method_placeholder = __( 'Enter an email address or website URL', 'wp-job-manager' );
 				$application_method_sanitizer   = 'url_or_email';
 				break;
-		}
-
-		if ( $this->is_forced_application_default_field() ) {
-			$application_method_sanitizer = null;
 		}
 
 		if ( job_manager_multi_job_type() ) {
@@ -349,6 +329,22 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
+	 * Checks if application field should use standard validation
+	 *
+	 * @return bool
+	 */
+	protected function should_application_field_use_standard_validation() {
+		/**
+		 * Force application field to use standard validation (skip email and URL validations)
+		 *
+		 * @since 1.x.x
+		 *
+		 * @param bool  $is_forced Whether the application field is forced to use standard validation.
+		 */
+		return apply_filters( 'job_manager_application_field_use_standard_validation', false );
+	}
+
+	/**
 	 * Validates the posted fields.
 	 *
 	 * @param array $values
@@ -435,7 +431,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		// Application method.
-		if ( ! $this->is_forced_application_default_field() && isset( $values['job']['application'] ) && ! empty( $values['job']['application'] ) ) {
+		if ( ! $this->should_application_field_use_standard_validation() && isset( $values['job']['application'] ) && ! empty( $values['job']['application'] ) ) {
 			$allowed_application_method   = get_option( 'job_manager_allowed_application_method', '' );
 			$values['job']['application'] = str_replace( ' ', '+', $values['job']['application'] );
 			switch ( $allowed_application_method ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -329,19 +329,19 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Checks if application field should use standard validation.
+	 * Checks if application field should use skip email / URL validation.
 	 *
 	 * @return bool
 	 */
-	protected function should_application_field_use_standard_validation() {
+	protected function should_application_field_skip_email_url_validation() {
 		/**
-		 * Force application field to use standard validation (skip email and URL validations).
+		 * Force application field to skip email / URL validation.
 		 *
 		 * @since 1.x.x
 		 *
-		 * @param bool  $is_forced Whether the application field is forced to use standard validation.
+		 * @param bool  $is_forced Whether the application field is forced to skip email / URL validation.
 		 */
-		return apply_filters( 'job_manager_application_field_use_standard_validation', false );
+		return apply_filters( 'job_manager_application_field_skip_email_url_validation', false );
 	}
 
 	/**
@@ -431,7 +431,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		// Application method.
-		if ( ! $this->should_application_field_use_standard_validation() && isset( $values['job']['application'] ) && ! empty( $values['job']['application'] ) ) {
+		if ( ! $this->should_application_field_skip_email_url_validation() && isset( $values['job']['application'] ) && ! empty( $values['job']['application'] ) ) {
 			$allowed_application_method   = get_option( 'job_manager_allowed_application_method', '' );
 			$values['job']['application'] = str_replace( ' ', '+', $values['job']['application'] );
 			switch ( $allowed_application_method ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -172,6 +172,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @return bool
 	 */
 	protected function is_forced_application_default_field() {
+		/**
+		 * Force application field to skip email / URL validations and sanitizer
+		 *
+		 * @since 1.34.1
+		 *
+		 * @param bool  $is_forced Whether the application field is forced to default.
+		 */
 		return apply_filters( 'job_manager_application_force_default_field', false );
 	}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -329,13 +329,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Checks if application field should use standard validation
+	 * Checks if application field should use standard validation.
 	 *
 	 * @return bool
 	 */
 	protected function should_application_field_use_standard_validation() {
 		/**
-		 * Force application field to use standard validation (skip email and URL validations)
+		 * Force application field to use standard validation (skip email and URL validations).
 		 *
 		 * @since 1.x.x
 		 *

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -175,7 +175,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		/**
 		 * Force application field to skip email / URL validations and sanitizer
 		 *
-		 * @since 1.34.1
+		 * @since 1.x.x
 		 *
 		 * @param bool  $is_forced Whether the application field is forced to default.
 		 */

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -435,7 +435,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		// Application method.
-		if ( isset( $values['job']['application'] ) && ! empty( $values['job']['application'] ) ) {
+		if ( ! $this->is_forced_application_default_field() && isset( $values['job']['application'] ) && ! empty( $values['job']['application'] ) ) {
 			$allowed_application_method   = get_option( 'job_manager_allowed_application_method', '' );
 			$values['job']['application'] = str_replace( ' ', '+', $values['job']['application'] );
 			switch ( $allowed_application_method ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -167,6 +167,15 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
+	 * Checks if it is forced application default field
+	 *
+	 * @return bool
+	 */
+	protected function is_forced_application_default_field() {
+		return apply_filters( 'job_manager_application_force_default_field', false );
+	}
+
+	/**
 	 * Initializes the fields used in the form.
 	 */
 	public function init_fields() {
@@ -191,6 +200,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				$application_method_placeholder = __( 'Enter an email address or website URL', 'wp-job-manager' );
 				$application_method_sanitizer   = 'url_or_email';
 				break;
+		}
+
+		if ( $this->is_forced_application_default_field() ) {
+			$application_method_sanitizer = null;
 		}
 
 		if ( job_manager_multi_job_type() ) {


### PR DESCRIPTION
Fixes #1872 

#### Changes proposed in this Pull Request:

* Add a new filter to force the application field to skip the email / url validation. The filter name is `job_manager_application_field_skip_email_url_validation`

This filter should be combined with `submit_job_form_fields` and `job_manager_job_listing_data_fields`, else the sanitizer will clear the field before the validation. Also, the user can hide the application method options from settings, using the `job_manager_settings` filter, once it doesn't make more sense if we override these options with the filters.

A full customization example with comments:

```php
/**
 * Skip application email / url validation.
 */
function application_field_skip_email_url_validation() {
	return true;
}
add_filter( 'job_manager_application_field_skip_email_url_validation', 'application_field_skip_email_url_validation' );

/**
 * Override submit job form fields.
 */
function custom_submit_job_form_fields( $fields ) {
	// Skip application sanitizer from screen
	$fields[ 'job' ][ 'application' ][ 'sanitizer' ] = null;
	// Also changes the label from frontend, if desired
	$fields[ 'job' ][ 'application' ][ 'label' ] = 'Lorem ipsum';
	return $fields;
}
add_filter( 'submit_job_form_fields', 'custom_submit_job_form_fields' );

/**
 * Override job listing data fields.
 */
function custom_job_manager_job_listing_data_fields( $fields ) {
	// Skip application sanitizer from database
	$fields[ '_application' ][ 'sanitize_callback' ] = null;
	// Also changes the label from backend, if desired
	$fields[ '_application' ][ 'label' ] = 'Lorem ipsum';
	return $fields;
}
add_filter( 'job_manager_job_listing_data_fields', 'custom_job_manager_job_listing_data_fields' );

/**
 * Hide application method options from settings.
 */
function hide_application_method_options_from_settings( $settings ) {
	foreach ( $settings[ 'job_submission' ][ 1 ] as $key => $field ) {
		if ( 'job_manager_allowed_application_method' === $settings[ 'job_submission' ][ 1 ][ $key ][ 'name' ] ) {
			unset( $settings[ 'job_submission' ][ 1 ][ $key ] );
		}
	}
	return $settings;
}
add_filter( 'job_manager_settings', 'hide_application_method_options_from_settings' );

/**
 * Set job application method to "custom".
 */
function set_job_application_method_custom() {
	$method = new stdClass();
	$method->type = 'custom';
	return $method;
}
add_filter( 'the_job_application_method', 'set_job_application_method_custom' );

/**
 * Handle display for "custom" application method.
 */
function display_custom_application_method() {
	echo '<p>';
	esc_html_e( 'To apply for this job, please visit us in the office.', 'my-text-domain' );
	echo '</p>';
}
add_action( 'job_manager_application_details_custom', 'display_custom_application_method' );
```

#### Testing instructions:

* Add the filters in the theme `functions.php` (explanations in the code comments)
* Create a page with the shortcode `[submit_job_form]`
* Go to the page created and submit a new job with the field `Application email/URL` with "Lorem ipsum" value (no email or URL format)

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Added the new filter `job_manager_application_field_skip_email_url_validation` that force the `Application email/URL` field on post job to skip the email / url validations