### PR TITLE
Add clear background to TinyMCE buttons

### DIFF
--- a/templates/form-fields/wp-editor-field.php
+++ b/templates/form-fields/wp-editor-field.php
@@ -15,25 +15,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$editor = apply_filters( 'submit_job_form_wp_editor_args', [
-	'textarea_name' => isset( $field['name'] ) ? $field['name'] : $key,
-	'media_buttons' => false,
-	'textarea_rows' => 8,
-	'quicktags'     => false,
-	'editor_css'		=> '<style> .mce-top-part button { background-color: rgba(0,0,0,0.0) !important; } </style>',
-	'tinymce'       => [
-		'plugins'                       => 'lists,paste,tabfocus,wplink,wordpress',
-		'paste_as_text'                 => true,
-		'paste_auto_cleanup_on_paste'   => true,
-		'paste_remove_spans'            => true,
-		'paste_remove_styles'           => true,
-		'paste_remove_styles_if_webkit' => true,
-		'paste_strip_class_attributes'  => true,
-		'toolbar1'                      => 'bold,italic,|,bullist,numlist,|,link,unlink,|,undo,redo',
-		'toolbar2'                      => '',
-		'toolbar3'                      => '',
-		'toolbar4'                      => ''
-	],
-] );
+$editor = apply_filters(
+	'submit_job_form_wp_editor_args',
+	[
+		'textarea_name' => isset( $field['name'] ) ? $field['name'] : $key,
+		'media_buttons' => false,
+		'textarea_rows' => 8,
+		'quicktags'     => false,
+		'editor_css'    => '<style> .mce-top-part button { background-color: rgba(0,0,0,0.0) !important; } </style>',
+		'tinymce'       => [
+			'plugins'                       => 'lists,paste,tabfocus,wplink,wordpress',
+			'paste_as_text'                 => true,
+			'paste_auto_cleanup_on_paste'   => true,
+			'paste_remove_spans'            => true,
+			'paste_remove_styles'           => true,
+			'paste_remove_styles_if_webkit' => true,
+			'paste_strip_class_attributes'  => true,
+			'toolbar1'                      => 'bold,italic,|,bullist,numlist,|,link,unlink,|,undo,redo',
+			'toolbar2'                      => '',
+			'toolbar3'                      => '',
+			'toolbar4'                      => '',
+		],
+	]
+);
 wp_editor( isset( $field['value'] ) ? wp_kses_post( $field['value'] ) : '', $key, $editor );
-if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>
+if ( ! empty( $field['description'] ) ) :
+	?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>

--- a/templates/form-fields/wp-editor-field.php
+++ b/templates/form-fields/wp-editor-field.php
@@ -20,6 +20,7 @@ $editor = apply_filters( 'submit_job_form_wp_editor_args', [
 	'media_buttons' => false,
 	'textarea_rows' => 8,
 	'quicktags'     => false,
+	'editor_css'		=> '<style> .mce-top-part button { background-color: rgba(0,0,0,0.0) !important; } </style>',
 	'tinymce'       => [
 		'plugins'                       => 'lists,paste,tabfocus,wplink,wordpress',
 		'paste_as_text'                 => true,


### PR DESCRIPTION
Fixes #1938

#### Changes proposed in this Pull Request:

* Add clear background to TinyMCE buttons


#### Testing instructions:

1. Install WPJM plugin 
2. Go to "post-a-job" page
3. TinyMCE buttons shouldn't have background color

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Add clear background to TinyMCE buttons