### PR TITLE
Added clear_fields() method to Form class

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -299,6 +299,13 @@ abstract class WP_Job_Manager_Form {
 	}
 
 	/**
+	 * Clears form fields (resets to empty array)
+	 */
+	public function clear_fields() {
+		$this->fields = [];
+	}
+	
+	/**
 	 * Enqueue the scripts for the form.
 	 */
 	public function enqueue_scripts() {


### PR DESCRIPTION
There's no way currently to zero out `$this->fields` through any extending classes at all, this adds a public method to clear the fields array so it can be used for force fields to run through filter again when `$this->init_fields()` is called

I need this for Conditional Logic support in Field Editor plugin to allow me to force the fields to be reinit through the filter.

Basically when a listing is being edited and saved, I have custom logic that runs through a user's conditional logic and removes any fields from the array of fields, to prevent saving a field to the listing meta -- which it is not needed (and is hidden by conditional logic).

The problem is that I have no way to force the fields to be reinitialized before the `job-submit.php` template is output (for editing a listing), even though `$this->init_fields()` is called again.

What ends up happening is the form shows missing all those "conditional logic" fields .. so if a user changes something on the listing the other fields will not exist since they were "removed" from the array to prevent excessive database inserts for meta that is not necessary.