### PR TITLE
Fix preview and editing conflicts

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -110,6 +110,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		$this->job_id = ! empty( $_GET['job_id'] ) ? absint( $_GET['job_id'] ) : 0;
+		if ( 0 === $this->job_id ) {
+			$this->job_id = ! empty( $_POST['job_id'] ) ? absint( $_POST['job_id'] ) : 0;
+		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing,  WordPress.Security.NonceVerification.Recommended
 
 		if ( ! job_manager_user_can_edit_job( $this->job_id ) ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -109,7 +109,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$this->step = is_numeric( $_GET['step'] ) ? max( absint( $_GET['step'] ), 0 ) : array_search( sanitize_text_field( $_GET['step'] ), array_keys( $this->steps ), true );
 		}
 
-		$this->job_id = ! empty( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : 0;
+		$this->job_id = ! empty( $_GET['job_id'] ) ? absint( $_GET['job_id'] ) : 0;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing,  WordPress.Security.NonceVerification.Recommended
 
 		if ( ! job_manager_user_can_edit_job( $this->job_id ) ) {
@@ -126,6 +126,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			)
 			&& ! empty( $_COOKIE['wp-job-manager-submitting-job-id'] )
 			&& ! empty( $_COOKIE['wp-job-manager-submitting-job-key'] )
+			&& empty( $this->job_id )
 		) {
 			$job_id     = absint( $_COOKIE['wp-job-manager-submitting-job-id'] );
 			$job_status = get_post_status( $job_id );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-job-manager-wc-paid-listings/issues/138 (possibly)
**It fixes an issue from the WCPL repo.**

I reproduced the issue only twice. After that, the bug didn't happen more. I also tried to recreate the environment some times, but nothing changed.

After many tests, I reproduced a similar bug that can be related (I hope) - steps bellow.

#### What I understood as expected behavior based on code and commits:

When a user is creating a new job and goes to preview, if they leave the page and return, they can continue editing. But if they go to edit another job, they should be able to edit this one.

#### Changes proposed in this Pull Request:

* It fixes a bug that prevents the user to edit other jobs while the preview cookie is set. It can solve some related issues: https://github.com/Automattic/wp-job-manager-wc-paid-listings/issues/138 and https://github.com/Automattic/WP-Job-Manager/issues/1860. But I'm not sure because I wasn't more able to reproduce it.

#### What more we can do:

* On the WCPL we could remove the `job_id` input hidden because we use the `$_GET` or the preview cookie. I'm just not sure if it could break some other thing or it'll be dead code - If someone could confirm on code review, it would be great =)

https://github.com/Automattic/wp-job-manager-wc-paid-listings/blob/6f5f1e608fba24ab57caed8a03c7bfa8fd82c5d6/includes/class-wc-paid-listings-submit-job-form.php#L191

#### Testing instructions:

1. Active the plugins "WooCommerce" and "WP Job Manager - WooCommerce Paid Listings".
2. Create a WooCommerce product with the product type "Job Package".
3. Go to WP-admin > Job Listings > Settings > Job Submission, and set "Paid Listings Flow" to 'Choose a package before entering job details'.
4. Go to submit job page and select any package.
5. Enter job details and click Save Draft.
6. Go to submit job page again and select any package.
7. Enter details for a second job and click Preview
8. Go to job dashboard and click Continue Submission on the draft you saved on step 5.
9. Select any package. The form should appear with the draft information - the saved in the step 5.

Also can be followed the mentioned issues steps to try simulate the other bugs:
- https://github.com/Automattic/wp-job-manager-wc-paid-listings/issues/138
- https://github.com/Automattic/WP-Job-Manager/issues/1860

#### Another bug identified:

A bug on choose package while creating new job after a preview: https://github.com/Automattic/wp-job-manager-wc-paid-listings/issues/147

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixes the job editing when a new job is pending to edit as a preview