### PR TITLE
Fix the readme stable tag information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.9  
 **Tested up to:** 5.2  
 **Requires PHP:** 5.6  
-**Stable tag:** 1.34.0  
+**Stable tag:** 1.34.1  
 **License:** GPLv3  
 **License URI:** http://www.gnu.org/licenses/gpl-3.0.html  
 


### PR DESCRIPTION
Fixes #1957

#### Changes proposed in this Pull Request:

* Just fixes the `Stable tag` on `readme`. The fix was generated running the `grunt`.
