### PR TITLE
Fix rss jobs when arguments empty

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -549,9 +549,22 @@ class WP_Job_Manager_Post_Types {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input used to filter public data in feed.
 		$input_posts_per_page  = isset( $_GET['posts_per_page'] ) ? absint( $_GET['posts_per_page'] ) : 10;
 		$input_search_location = isset( $_GET['search_location'] ) ? sanitize_text_field( wp_unslash( $_GET['search_location'] ) ) : false;
-		$input_job_types       = isset( $_GET['job_types'] ) ? explode( ',', sanitize_text_field( wp_unslash( $_GET['job_types'] ) ) ) : false;
-		$input_job_categories  = isset( $_GET['job_categories'] ) ? explode( ',', sanitize_text_field( wp_unslash( $_GET['job_categories'] ) ) ) : false;
-		$job_manager_keyword   = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
+
+		if ( isset( $_GET['job_types'] ) ) {
+			$sanitized_job_types = sanitize_text_field( wp_unslash( $_GET['job_types'] ) );
+			$input_job_types     = empty( $sanitized_job_types ) ? false : explode( ',', $sanitized_job_types );
+		} else {
+			$input_job_types = false;
+		}
+
+		if ( isset( $_GET['job_categories'] ) ) {
+			$sanitized_job_categories = sanitize_text_field( wp_unslash( $_GET['job_categories'] ) );
+			$input_job_categories     = empty( $sanitized_job_categories ) ? false : explode( ',', $sanitized_job_categories );
+		} else {
+			$input_job_categories = false;
+		}
+
+		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$query_args = [


### PR DESCRIPTION
#### Overview
There was an issue with RSS job listings. In case the RSS request included one of the 'job_types' or 'job_categories' argument with no value, no jobs would be returned. This PR fixes the above issue.

#### Changes proposed in this Pull Request:
The problem with the current implementation was that it was using `explode` function on an empty string. The function would return a single element array with an empty string as a value. With the new solution a false value is returned instead.

#### Testing instructions:
In the previous version:
* Browse a WPJM installation using the following arguments: `?feed=job_feed&job_types=full-time&search_location&job_categories&search_keywords`
* Notice that no jobs are returned.
* Remove the `job_categories` argument to observe that jobs are now returned.

In the new version:
* Observe that in both cases the correct jobs are included in the result.

#### Proposed changelog entry for your changes:
Fix: Return the correct results in RSS/Atom feeds when an empty arguments are used.