### PR TITLE
Add job_manager_display_only_city_state option to data cleaner

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -101,6 +101,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_admin_notices',
 		'widget_widget_featured_jobs',
 		'widget_widget_recent_jobs',
+		'job_manager_display_only_city_state',
 	];
 
 	/**


### PR DESCRIPTION
Fixes #1962 

#### Changes proposed in this Pull Request:
* Add option job_manager_display_only_city_state to data cleaner

#### Testing instructions:
1. Enable the delete data on uninstall option
2. Uninstall the plugin
3. Go to the wp_options table -> the option should not be there

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Delete job_manager_display_only_city_state option on uninstall
