### PR TITLE
Update the repo templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,29 +12,26 @@ Helpful tips for screenshots:
 https://en.support.wordpress.com/make-a-screenshot/
 -->
 
-#### Steps to Reproduce
-1.
-2.
-3.
+### Steps to Reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
 
-#### What I Expected
-
-
-#### What Happened Instead
+### What I Expected
 
 
-#### WordPress / WP Job Manager Version
+### What Happened Instead
 
 
-#### Browser / OS Version
+### PHP / WordPress / WP Job Manager Version
 
 
-#### Screenshot / Video
+### Browser / OS Version
 
 
-#### Context / Source
-<!-- Optional: share your unique context to help us understand your perspective.
+### Screenshot / Video
 
-If requesting a new feature, explain why you'd like to see it added.
--->
 
+### Context / Source
+<!-- Optional: share your unique context to help us understand your perspective. -->

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -3,10 +3,12 @@ name: "\U0001F41E Bug report"
 about: Report a bug if something isn't working as expected in the core WP Job Manager
   plugin.
 title: ''
-labels: ''
+labels: '[Type] Bug'
 assignees: ''
 
 ---
+
+<!-- Thanks for contributing to WP Job Manager! Pick a clear title ("Improve client-side UI validation") and proceed. -->
 
 **Describe the bug**
 A clear and concise description of what the bug is. Please be as descriptive as possible; issues lacking detail, or for any other reason than to report a bug, may be closed without action.

--- a/.github/ISSUE_TEMPLATE/Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/Enhancement.md
@@ -3,19 +3,21 @@ name: "✨ New Enhancement"
 about: If you have an idea to improve an existing feature in core or need something
   for development (such as a new hook) please let us know or submit a Pull Request!
 title: ''
-labels: ''
+labels: '[Type] Enhancement'
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+<!-- Thanks for contributing to WP Job Manager! Pick a clear title ("Improve client-side UI validation") and proceed. -->
+
+### Is your feature request related to a problem? Please describe
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -8,14 +8,16 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+<!-- Thanks for contributing to WP Job Manager! Pick a clear title ("Improve client-side UI validation") and proceed. -->
+
+### Is your feature request related to a problem? Please describe
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,3 @@ Helpful tips for screenshots:
 https://en.support.wordpress.com/make-a-screenshot/
 -->
 ### Screenshot / Video
-
-
-
-<!-- Add the following only if this is meant to be in the changelog -->
-### Proposed changelog entry for your changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,30 @@
 Fixes #
 
-#### Changes proposed in this Pull Request:
+### Changes proposed in this Pull Request
 
 *
 
-#### Testing instructions:
+### Testing instructions
 
 *
 
-<!-- Add the following only if this is meant to be in changelog -->
-#### Proposed changelog entry for your changes:
+<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
+### New/Updated Hooks
+
+*
+
+<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
+### Deprecated Code
+
+*
+
+<!--
+Helpful tips for screenshots:
+https://en.support.wordpress.com/make-a-screenshot/
+-->
+### Screenshot / Video
+
+
+
+<!-- Add the following only if this is meant to be in the changelog -->
+### Proposed changelog entry for your changes


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Standardize the repo templates based on these changes:
  * https://github.com/woocommerce/sensei-share-your-grade/pull/39
  * https://github.com/woocommerce/sensei-share-your-grade/pull/40

These templates are a bit different, so I didn't change everything because there are some specific things.