### PR TITLE
Only prefill with client state if no state already set on server

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -342,19 +342,26 @@ class WP_Job_Manager_Shortcodes {
 			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], [ 1, '1', 'true', 'yes' ], true );
 		}
 
+		// By default, use client-side state to populate form fields.
+		$disable_client_state = false;
+
 		// Get keywords, location, category and type from querystring if set.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 		if ( ! empty( $_GET['search_keywords'] ) ) {
-			$atts['keywords'] = sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) );
+			$atts['keywords']     = sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) );
+			$disable_client_state = true;
 		}
 		if ( ! empty( $_GET['search_location'] ) ) {
-			$atts['location'] = sanitize_text_field( wp_unslash( $_GET['search_location'] ) );
+			$atts['location']      = sanitize_text_field( wp_unslash( $_GET['search_location'] ) );
+			$disable_client_state  = true;
 		}
 		if ( ! empty( $_GET['search_category'] ) ) {
 			$atts['selected_category'] = sanitize_text_field( wp_unslash( $_GET['search_category'] ) );
+			$disable_client_state      = true;
 		}
 		if ( ! empty( $_GET['search_job_type'] ) ) {
 			$atts['selected_job_types'] = sanitize_text_field( wp_unslash( $_GET['search_job_type'] ) );
+			$disable_client_state       = true;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
@@ -379,14 +386,15 @@ class WP_Job_Manager_Shortcodes {
 		}
 
 		$data_attributes = [
-			'location'        => $atts['location'],
-			'keywords'        => $atts['keywords'],
-			'show_filters'    => $atts['show_filters'] ? 'true' : 'false',
-			'show_pagination' => $atts['show_pagination'] ? 'true' : 'false',
-			'per_page'        => $atts['per_page'],
-			'orderby'         => $atts['orderby'],
-			'order'           => $atts['order'],
-			'categories'      => implode( ',', $atts['categories'] ),
+			'location'                   => $atts['location'],
+			'keywords'                   => $atts['keywords'],
+			'show_filters'               => $atts['show_filters'] ? 'true' : 'false',
+			'show_pagination'            => $atts['show_pagination'] ? 'true' : 'false',
+			'per_page'                   => $atts['per_page'],
+			'orderby'                    => $atts['orderby'],
+			'order'                      => $atts['order'],
+			'categories'                 => implode( ',', $atts['categories'] ),
+			'disable-form-state-storage' => $disable_client_state,
 		];
 
 		if ( $atts['show_filters'] ) {


### PR DESCRIPTION
Fixes #1804

#### Changes proposed in this Pull Request:

When one or more URL parameters are given to pre-fill the Jobs search form, the client-side state is not used to pre-fill the form. This applies to the following URL parameters:

- `search_keywords`
- `search_location`
- `search_category`
- `search_job_type`

#### Testing instructions:

- Visit the page with the jobs search form (normally `/jobs`).
- Perform a search for Keywords, Location, Category, and/or Job Type.
- Click one of the jobs that appears.
- Navigate to the `/jobs` page and include one or more of the above URL parameters (e.g. `/jobs?search_keywords=Developer&search_location=London`).
- You should see the form pre-filled with the URL parameter values, **not** the previous search values.
- Perform the first three steps again.
- Navigate to `/jobs` without any additional URL parameters.
- You should see the form pre-filled with the previous search values.
