### PR TITLE
Add feature to prevent assets cache while debugging

### DIFF
--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -100,6 +100,10 @@ class WP_Job_Manager {
 
 		// Defaults for WPJM core actions.
 		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );
+
+		// Prevent assets cache.
+		add_filter( 'script_loader_src', [ $this, 'prevent_debug_assets_cache' ] );
+		add_filter( 'style_loader_src', [ $this, 'prevent_debug_assets_cache' ] );
 	}
 
 	/**
@@ -485,5 +489,27 @@ class WP_Job_Manager {
 		} else {
 			wp_register_style( 'wp-job-manager-job-listings', JOB_MANAGER_PLUGIN_URL . '/assets/css/job-listings.css', [], JOB_MANAGER_VERSION );
 		}
+	}
+
+	/**
+	 * Prevent assets cache while debugging.
+	 * Hooked into `script_loader_src` and `style_loader_src`.
+	 *
+	 * @access private
+	 * @since  1.34.2
+	 *
+	 * @param string $src File src to filter.
+	 *
+	 * @return string $src File src filtered.
+	 */
+	public function prevent_debug_assets_cache( $src ) {
+		if ( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) {
+			return $src;
+		}
+
+		$debug_param = 'debug=' . uniqid();
+		$concat_char = false === strpos( $src, '?' ) ? '?' : '&';
+
+		return $src . $concat_char . $debug_param;
 	}
 }

--- a/tests/php/tests/test_class.wp-job-manager.php
+++ b/tests/php/tests/test_class.wp-job-manager.php
@@ -65,4 +65,63 @@ class WP_Test_WP_Job_Manager extends WPJM_BaseTest {
 		$this->assertTrue( defined( 'JOB_MANAGER_PLUGIN_DIR' ) );
 		$this->assertTrue( defined( 'JOB_MANAGER_PLUGIN_URL' ) );
 	}
+
+	/**
+	 * Tests prevent assets cache while debugging.
+	 *
+	 * @since 1.34.2
+	 *
+	 * @covers WP_Job_Manager::prevent_debug_assets_cache
+	 */
+	public function test_prevent_debug_assets_cache() {
+		$src = 'file.js';
+
+		$this->assertNotEquals(
+			WP_Job_Manager::instance()->prevent_debug_assets_cache( $src ),
+			WP_Job_Manager::instance()->prevent_debug_assets_cache( $src ),
+			'Should return different URL to prevent cache'
+		);
+	}
+
+	/**
+	 * Tests prevent assets cache while debugging with URL not containing query string.
+	 *
+	 * @since 1.34.2
+	 *
+	 * @covers WP_Job_Manager::prevent_debug_assets_cache
+	 */
+	public function test_prevent_debug_assets_cache_without_query_string() {
+		$src = 'file.js';
+
+		$has_new_query_string = false !== strpos(
+			WP_Job_Manager::instance()->prevent_debug_assets_cache( $src ),
+			'?debug='
+		);
+
+		$this->assertTrue(
+			$has_new_query_string,
+			'Should return URL with new query string'
+		);
+	}
+
+	/**
+	 * Tests prevent assets cache while debugging with URL containing query string.
+	 *
+	 * @since 1.34.2
+	 *
+	 * @covers WP_Job_Manager::prevent_debug_assets_cache
+	 */
+	public function test_prevent_debug_assets_cache_with_query_string() {
+		$src = 'file.js?q=123';
+
+		$has_new_query_string = false !== strpos(
+			WP_Job_Manager::instance()->prevent_debug_assets_cache( $src ),
+			'&debug='
+		);
+
+		$this->assertTrue(
+			$has_new_query_string,
+			'Should return URL adding other query string'
+		);
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* The assets URL only changes when changing the version. So while we are changing the assets, the assets can keep cached. This PR introduces a feature to add a different debug query string to the asset files while debugging in each reload.

I prefer to add it to the code, so it solves for all developers that use the project in the same manner. But another alternative (if we don't want to introduce it to the plugin code), would be to add the filters in our development environment.

#### Testing instructions:

* Define the `SCRIPT_DEBUG` as `true` in your env (it can be done in the `wp-config.php`).
* Change any JS or CSS file and access the page that loads it.
* Check if there is a unique id in the `debug` query string in the script import.
* Define the `SCRIPT_DEBUG` as `false` in your env.
* Access the page again.
* Check if the `debug` query string was not included.