### PR TITLE
Add validation in the post job to prevent add external images

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -379,46 +379,30 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					}
 					if ( ! empty( $check_value ) ) {
 						foreach ( $check_value as $file_url ) {
+							// Check image path.
+							$baseurl = wp_upload_dir()['baseurl'];
+							if ( ! is_numeric( $file_url ) && 0 !== strpos( $file_url, $baseurl ) ) {
+								throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );
+							}
+
+							// Check mime types.
+							if ( ! empty( $field['allowed_mime_types'] ) ) {
+								$file_url  = current( explode( '?', $file_url ) );
+								$file_info = wp_check_filetype( $file_url );
+
+								if ( ! is_numeric( $file_url ) && $file_info && ! in_array( $file_info['type'], $field['allowed_mime_types'], true ) ) {
+									// translators: Placeholder %1$s is field label; %2$s is the file mime type; %3$s is the allowed mime-types.
+									throw new Exception( sprintf( __( '"%1$s" (filetype %2$s) needs to be one of the following file types: %3$s', 'wp-job-manager' ), $field['label'], $file_info['ext'], implode( ', ', array_keys( $field['allowed_mime_types'] ) ) ) );
+								}
+							}
+
+							// Check if attachment is valid.
 							if ( is_numeric( $file_url ) ) {
 								continue;
 							}
 							$file_url = esc_url( $file_url, [ 'http', 'https' ] );
 							if ( empty( $file_url ) ) {
 								throw new Exception( __( 'Invalid attachment provided.', 'wp-job-manager' ) );
-							}
-						}
-					}
-				}
-				if ( 'file' === $field['type'] && ! empty( $field['allowed_mime_types'] ) ) {
-					if ( is_array( $values[ $group_key ][ $key ] ) ) {
-						$check_value = array_filter( $values[ $group_key ][ $key ] );
-					} else {
-						$check_value = array_filter( [ $values[ $group_key ][ $key ] ] );
-					}
-					if ( ! empty( $check_value ) ) {
-						foreach ( $check_value as $file_url ) {
-							$file_url  = current( explode( '?', $file_url ) );
-							$file_info = wp_check_filetype( $file_url );
-
-							if ( ! is_numeric( $file_url ) && $file_info && ! in_array( $file_info['type'], $field['allowed_mime_types'], true ) ) {
-								// translators: Placeholder %1$s is field label; %2$s is the file mime type; %3$s is the allowed mime-types.
-								throw new Exception( sprintf( __( '"%1$s" (filetype %2$s) needs to be one of the following file types: %3$s', 'wp-job-manager' ), $field['label'], $file_info['ext'], implode( ', ', array_keys( $field['allowed_mime_types'] ) ) ) );
-							}
-						}
-					}
-				}
-				if ( 'file' === $field['type'] ) {
-					if ( is_array( $values[ $group_key ][ $key ] ) ) {
-						$check_value = array_filter( $values[ $group_key ][ $key ] );
-					} else {
-						$check_value = array_filter( [ $values[ $group_key ][ $key ] ] );
-					}
-					if ( ! empty( $check_value ) ) {
-						foreach ( $check_value as $file_url ) {
-							$baseurl = wp_upload_dir()['baseurl'];
-
-							if ( ! is_numeric( $file_url ) && 0 !== strpos( $file_url, $baseurl ) ) {
-								throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );
 							}
 						}
 					}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -407,6 +407,22 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						}
 					}
 				}
+				if ( 'file' === $field['type'] ) {
+					if ( is_array( $values[ $group_key ][ $key ] ) ) {
+						$check_value = array_filter( $values[ $group_key ][ $key ] );
+					} else {
+						$check_value = array_filter( [ $values[ $group_key ][ $key ] ] );
+					}
+					if ( ! empty( $check_value ) ) {
+						foreach ( $check_value as $file_url ) {
+							$baseurl = wp_upload_dir()['baseurl'];
+
+							if ( ! is_numeric( $file_url ) && false === strpos( $file_url, $baseurl ) ) {
+								throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );
+							}
+						}
+					}
+				}
 				if ( empty( $field['file_limit'] ) && empty( $field['multiple'] ) ) {
 					$field['file_limit'] = 1;
 				}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -417,7 +417,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						foreach ( $check_value as $file_url ) {
 							$baseurl = wp_upload_dir()['baseurl'];
 
-							if ( ! is_numeric( $file_url ) && false === strpos( $file_url, $baseurl ) ) {
+							if ( ! is_numeric( $file_url ) && 0 !== strpos( $file_url, $baseurl ) ) {
 								throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );
 							}
 						}


### PR DESCRIPTION
Fixes #1982

#### Changes proposed in this Pull Request:

* This PR introduces a new validation when posting a job to prevent add external images.
* The issue mentions the possibility to introduce the media ID in the field. Considering the code, using the ID instead upload a new image is expected to work, so I didn't change it for now.

#### Testing instructions:

* Post a new job and approve it.
* Go to "Job Dashboard" and edit the new job.
* Inspect the code and find `<input type="hidden" class="input-text" name="current_featured_image" value="...">` and `<input type="hidden" class="input-text" name="current_company_logo" value="...">`
* Edit the value adding an external image. Trying to simulate different situations. Eg.: https://www.copaair.com/documents/20182/2614143/boeing-737max9-mobile.jpg
* Save changes and make sure that the validation doesn't allow to complete the changes.