### PR TITLE
add filter for user role on submit job user creation

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -667,7 +667,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 								'username' => ( job_manager_generate_username_from_email() || empty( $input_create_account_username ) ) ? '' : $input_create_account_username,
 								'password' => ( wpjm_use_standard_password_setup_email() || empty( $input_create_account_password ) ) ? '' : $input_create_account_password,
 								'email'    => sanitize_text_field( wp_unslash( $input_create_account_email ) ),
-								'role'     => get_option( 'job_manager_registration_role' ),
+								'role'     => apply_filters( 'submit_job_form_create_account_role', get_option( 'job_manager_registration_role' ), $values, $this ),
 							]
 						);
 					}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -667,6 +667,15 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 								'username' => ( job_manager_generate_username_from_email() || empty( $input_create_account_username ) ) ? '' : $input_create_account_username,
 								'password' => ( wpjm_use_standard_password_setup_email() || empty( $input_create_account_password ) ) ? '' : $input_create_account_password,
 								'email'    => sanitize_text_field( wp_unslash( $input_create_account_email ) ),
+								/**
+								 * Allow customization of new user creation role
+								 *
+								 * @param string                         $role     New user registration role (pulled from 'job_manager_registration_role' option)
+								 * @param array                          $values   Submitted input values.
+								 * @param WP_Job_Manager_Form_Submit_Job $this     Current class object
+								 *
+								 * @since 1.35.0
+								 */
 								'role'     => apply_filters( 'submit_job_form_create_account_role', get_option( 'job_manager_registration_role' ), $values, $this ),
 							]
 						);


### PR DESCRIPTION
Fixes #1997

#### Changes proposed in this Pull Request:

* Adds `submit_job_form_create_account_role` filter

### Notes

So while this can be done via `job_manager_create_account_data` filter, I still went ahead and added it for the submit job account creation, since there are numerous addon plugins and themes that will call `wp_job_manager_create_account` so this one will be specific to user account creation from job submit area.

Added `$this` reference to be able to access fields or anything else from the filter if needed
