### PR TITLE
Fix settings using textarea getting prefixed with whitespace

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -558,9 +558,7 @@ class WP_Job_Manager_Settings {
 			echo implode( ' ', $attributes ) . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo $placeholder; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
-		>
-			<?php echo esc_textarea( $value ); ?>
-		</textarea>
+		><?php echo esc_textarea( $value ); ?></textarea>
 		<?php
 
 		if ( ! empty( $option['desc'] ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Settings using the `textarea` field were getting prefixed with some extra whitespace. 

Before:
<img width="690" alt="Screen Shot 2020-05-07 at 10 37 55 PM" src="https://user-images.githubusercontent.com/68693/81347151-797cf700-90b3-11ea-86bf-8a5c113a51d6.png">

After:
<img width="751" alt="Screen Shot 2020-05-07 at 10 38 53 PM" src="https://user-images.githubusercontent.com/68693/81347188-8a2d6d00-90b3-11ea-8e8d-78ed034026e7.png">


#### Testing instructions:

* One plugin that uses this setting field type is Alerts. Activate WP Job Manager alerts. 
* Go to WP Admin > Job Listings > Settings > Job Alerts.
* Ensure the setting isn't prefixed with spaces. If it is, try removing the spaces, saving, and then checking again.
