### PR TITLE
Set the CC field in headers before sending email #1978

### DIFF
--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -795,6 +795,10 @@ final class WP_Job_Manager_Email_Notifications {
 				$headers[] = 'From: ' . $args['from'];
 			}
 
+			if ( ! empty( $args['cc'] ) ) {
+				$headers[] = 'CC: ' . $args['cc'];
+			}
+
 			if ( ! self::send_as_plain_text( $email_notification_key, $args ) ) {
 				$headers[] = 'Content-Type: text/html';
 			}


### PR DESCRIPTION
Fixes #1978 

#### Changes proposed in this Pull Request:

* Add a check if email `$args` contains `cc` field, add `CC` field in email headers.

#### Testing instructions:

* Use following filter and check if the Admin Notice of New Listing email contains proper CC:

```
add_filter( 'job_manager_email_admin_new_job_cc', function () {
	return 'admin@example.com';
} );
```