### PR TITLE
Add option to allow for rectangular logos - fixes issue 1976

### DIFF
--- a/assets/css/job-listings.less
+++ b/assets/css/job-listings.less
@@ -49,6 +49,17 @@ ul.job_listings {
 				vertical-align: middle;
 				box-shadow: none;
 			}
+			img.rectangular_company_logo {
+				width: 42px;
+				height: auto;
+				max-height: 80%;
+				position: absolute;
+				left: 1em;
+				float: left;
+				margin-right: 1em;
+				vertical-align: middle;
+				box-shadow: none;
+			}
 			div.position, div.location, ul.meta {
 				-webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
 				-moz-box-sizing: border-box;    /* Firefox, other Gecko */

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -203,6 +203,15 @@ class WP_Job_Manager_Settings {
 							'type'       => 'checkbox',
 							'attributes' => [],
 						],
+						[
+							'name'       => 'job_manager_allow_rectangular_logos',
+							'std'        => '0',
+							'label'      => __( 'Rectangular logos', 'wp-job-manager' ),
+							'cb_label'   => __( 'Override the default square company logo thumbnails and display them as rectangular', 'wp-job-manager' ),
+							'desc'       => __( 'This allows users who upload rectangular logos to be shown in the job listings page without being resized into a square', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+						],
 					],
 				],
 				'job_submission' => [

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -101,6 +101,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_admin_notices',
 		'widget_widget_featured_jobs',
 		'widget_widget_recent_jobs',
+		'job_manager_allow_rectangular_logos',
 	];
 
 	/**

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -20,7 +20,11 @@ global $post;
 ?>
 <li <?php job_listing_class(); ?> data-longitude="<?php echo esc_attr( $post->geolocation_long ); ?>" data-latitude="<?php echo esc_attr( $post->geolocation_lat ); ?>">
 	<a href="<?php the_job_permalink(); ?>">
-		<?php the_company_logo(); ?>
+		<?php if ( get_option( 'job_manager_allow_rectangular_logos' ) ) : ?>
+			<img src="<?php echo esc_url( get_the_company_logo() ); ?>" class="rectangular_company_logo" alt="<?php the_company_name(); ?>" />
+		<?php else : ?>
+			<?php the_company_logo(); ?>
+		<?php endif; ?>
 		<div class="position">
 			<h3><?php wpjm_the_job_title(); ?></h3>
 			<div class="company">


### PR DESCRIPTION
Fixes #
Issues with rectangular logos being resized into a square causing a squished look: https://github.com/Automattic/WP-Job-Manager/issues/1976
### Changes proposed in this Pull Request
I added an option to in the job_listings admin page will dynamically adjust the css height property for company logos to auto so that users can display a rectangular logo. I made this an option in admin so that users have a choice of enforcing square logos still as it does create a neater look


### Testing instructions
Go into the job listing's settings page on Admin and toggle on the `Rectangular logos` option

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="1182" alt="Screen Shot 2020-05-27 at 9 09 44 pm" src="https://user-images.githubusercontent.com/18111588/83022783-9e370f80-a05e-11ea-9d4b-6fb6eea00e5a.png">
<img width="1022" alt="Screen Shot 2020-05-27 at 9 10 51 pm" src="https://user-images.githubusercontent.com/18111588/83022813-a7c07780-a05e-11ea-814c-a12526247f7b.png">
