### PR TITLE
Fix test issues on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,7 @@ before_script:
     - export PLUGIN_SLUG=$(basename $(pwd) | tr '[:upper:]' '[:lower:]')
     - source ~/.nvm/nvm.sh
     - export PATH="$HOME/.composer/vendor/bin:$PATH"
-    - |
-            if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-                composer global require "phpunit/phpunit=5.7.*"
-            elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
-                composer global require "phpunit/phpunit=4.8.*"
-            fi
+    - composer global require "phpunit/phpunit=5.7.*"
     - nvm install 8
     - nvm use 8
     - ./tests/bin/prepare-wordpress.sh

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -120,6 +120,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::job_feed
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_job_feed_rss2() {
 		$this->factory->job_listing->create_many( 5 );
@@ -135,6 +136,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::job_feed
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_job_feed_rss2_2inrow() {
 		$this->factory->job_listing->create_many( 5 );
@@ -150,6 +152,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::job_feed
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_job_feed_location_search() {
 		$this->factory->job_listing->create_many(
@@ -191,6 +194,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::job_feed
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_job_feed_keyword_search() {
 		$this->factory->job_listing->create_many( 3 );


### PR DESCRIPTION
It's also being fixed here: https://github.com/Automattic/wp-job-manager-resumes/pull/321

### Changes proposed in this Pull Request

* Fix PHPUnit issues on Travis.
  * Recently our builds stopped working because a WP compatibility issue with PHPUnit. So we updated to use the `5.7.*` for all PHP versions.
  * It caused another issue with the `runInSeparateProcess`, that also was fixed with: https://phpunit.readthedocs.io/en/latest/annotations.html#preserveglobalstate