### PR TITLE
Fix jobs preview

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -102,7 +102,7 @@ abstract class WP_Job_Manager_Form {
 			delete_post_meta( sanitize_text_field( wp_unslash( $_COOKIE['wp-job-manager-submitting-job-id'] ) ), '_submitting_key' );
 			setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
 			setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-			wp_safe_redirect( remove_query_arg( [ 'new', 'key' ] ) );
+			wp_safe_redirect( remove_query_arg( [ 'new', 'key', 'job_manager_form' ] ) );
 			exit;
 		}
 
@@ -304,7 +304,7 @@ abstract class WP_Job_Manager_Form {
 	public function clear_fields() {
 		$this->fields = [];
 	}
-	
+
 	/**
 	 * Enqueue the scripts for the form.
 	 */

--- a/includes/class-wp-job-manager-forms.php
+++ b/includes/class-wp-job-manager-forms.php
@@ -50,7 +50,7 @@ class WP_Job_Manager_Forms {
 	 */
 	public function load_posted_form() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
-		$job_manager_form = ! empty( $_POST['job_manager_form'] ) ? sanitize_title( wp_unslash( $_POST['job_manager_form'] ) ) : false;
+		$job_manager_form = ! empty( $_REQUEST['job_manager_form'] ) ? sanitize_title( wp_unslash( $_REQUEST['job_manager_form'] ) ) : false;
 
 		if ( ! empty( $job_manager_form ) ) {
 			$this->load_form_class( $job_manager_form );

--- a/templates/job-submit.php
+++ b/templates/job-submit.php
@@ -21,7 +21,7 @@ global $job_manager;
 
 	<?php
 	if ( isset( $resume_edit ) && $resume_edit ) {
-		printf( '<p><strong>' . esc_html__( "You are editing an existing job. %s", 'wp-job-manager' ) . '</strong></p>', '<a href="?new=1&key=' . esc_attr( $resume_edit ) . '">' . esc_html__( 'Create A New Job', 'wp-job-manager' ) . '</a>' );
+		printf( '<p><strong>' . esc_html__( "You are editing an existing job. %s", 'wp-job-manager' ) . '</strong></p>', '<a href="?job_manager_form=submit-job&new=1&key=' . esc_attr( $resume_edit ) . '">' . esc_html__( 'Create A New Job', 'wp-job-manager' ) . '</a>' );
 	}
 	?>
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-forms.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-forms.php
@@ -15,7 +15,7 @@ class WP_Test_WP_Job_Manager_Forms extends WPJM_BaseTest {
 	public function test_load_posted_form_too_legit_to_quit() {
 		WP_Job_manager_Form_Test::reset();
 		$this->assertFalse( WP_Job_manager_Form_Test::has_instance() );
-		$_POST['job_manager_form'] = 'Test';
+		$_REQUEST['job_manager_form'] = 'Test';
 		$instance                  = WP_Job_Manager_Forms::instance();
 		$instance->load_posted_form();
 		$this->assertTrue( WP_Job_manager_Form_Test::has_instance() );
@@ -28,7 +28,7 @@ class WP_Test_WP_Job_Manager_Forms extends WPJM_BaseTest {
 	public function test_load_posted_form_not_legit_so_quit() {
 		WP_Job_manager_Form_Test::reset();
 		$this->assertFalse( WP_Job_manager_Form_Test::has_instance() );
-		unset( $_POST['job_manager_form'] );
+		unset( $_REQUEST['job_manager_form'] );
 		$instance = WP_Job_Manager_Forms::instance();
 		$instance->load_posted_form();
 		$this->assertFalse( WP_Job_manager_Form_Test::has_instance() );


### PR DESCRIPTION
Fixes #2028

### Changes proposed in this Pull Request

* Ensure that we clean the preview job clicking on "Create A New Job"
  * It wasn't working, because of the code flow/hooks order. We updated to run the form code previously when sending the `job_manager_form` also from `GET`. Previously it only happened from the `POST`.

### Testing instructions

1. Complete job submission form ([submit_job_form])
2. Click on "Preview" page
3. Return to [job_dashboard]
4. Return to the page that the job submission form ([submit_job_form]) is on
5. Click on "You are editing an existing job. Create A New Job"
6. Enter details of new job into job submission form ([submit_job_form])
7. Click "Preview"