### PR TITLE
Add a filter to enable external file blocking

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -381,8 +381,20 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						foreach ( $check_value as $file_url ) {
 							// Check image path.
 							$baseurl = wp_upload_dir()['baseurl'];
-							if ( ! is_numeric( $file_url ) && 0 !== strpos( $file_url, $baseurl ) ) {
-								throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );
+
+							if ( ! is_numeric( $file_url ) ) {
+								/**
+								 * Set this flag to true to reject files from external URLs during job submission.
+								 *
+								 * @since 1.34.3
+								 *
+								 * @param bool  $reject_external_files  The flag.
+								 */
+								$reject_external_files = apply_filters( 'job_manager_submit_job_reject_external_files', false );
+
+								if ( $reject_external_files && 0 !== strpos( $file_url, $baseurl ) ) {
+									throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );
+								}
 							}
 
 							// Check mime types.

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -379,8 +379,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					}
 					if ( ! empty( $check_value ) ) {
 						foreach ( $check_value as $file_url ) {
-							// Check image path.
-							$baseurl = wp_upload_dir()['baseurl'];
 
 							if ( ! is_numeric( $file_url ) ) {
 								/**
@@ -394,6 +392,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 								 * @param array  $field                  An array containing the information for the field.
 								 */
 								$reject_external_files = apply_filters( 'job_manager_submit_job_reject_external_files', false, $key, $group_key, $field );
+
+								// Check image path.
+								$baseurl = wp_upload_dir()['baseurl'];
 
 								if ( $reject_external_files && 0 !== strpos( $file_url, $baseurl ) ) {
 									throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -388,9 +388,12 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 								 *
 								 * @since 1.34.3
 								 *
-								 * @param bool  $reject_external_files  The flag.
+								 * @param bool   $reject_external_files  The flag.
+								 * @param string $key                    The field key.
+								 * @param string $group_key              The group.
+								 * @param array  $field                  An array containing the information for the field.
 								 */
-								$reject_external_files = apply_filters( 'job_manager_submit_job_reject_external_files', false );
+								$reject_external_files = apply_filters( 'job_manager_submit_job_reject_external_files', false, $key, $group_key, $field );
 
 								if ( $reject_external_files && 0 !== strpos( $file_url, $baseurl ) ) {
 									throw new Exception( __( 'Invalid image path.', 'wp-job-manager' ) );


### PR DESCRIPTION
Fixes #2035

### Changes proposed in this Pull Request

* Hides blocking of external files behind a filter.
* The default behaviour is to not block external files as this can break sites which use CDNs.

### Testing instructions

* Follow the instructions in #1989 and check that external files are allowed.
* Add the filter:
```
add_filter(
	'job_manager_submit_job_reject_external_files',
	function( $val, $key, $group_key, $field ) {
	return true;
	},
	10,
	4
);
```
* Check that external files are now not allowed.