### PR TITLE
Remove query args from paginate_links urls

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -61,6 +61,8 @@ class WP_Job_Manager_Shortcodes {
 		add_shortcode( 'job', [ $this, 'output_job' ] );
 		add_shortcode( 'job_summary', [ $this, 'output_job_summary' ] );
 		add_shortcode( 'job_apply', [ $this, 'output_job_apply' ] );
+
+		add_filter( 'paginate_links', [ $this, 'filter_paginate_links' ], 10, 1 );
 	}
 
 	/**
@@ -270,6 +272,16 @@ class WP_Job_Manager_Shortcodes {
 		);
 
 		return ob_get_clean();
+	}
+
+	/**
+	 * Filters the url from paginate_links to avoid multiple calls for same action in job dashboard
+	 *
+	 * @param string $link
+	 * @return string
+	 */
+	public function filter_paginate_links( $link ) {
+		return remove_query_arg( [ 'action', 'job_id', '_wpnonce' ], $link );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -87,9 +87,7 @@ class WP_Job_Manager_Shortcodes {
 	 * Handles actions which need to be run before the shortcode e.g. post actions.
 	 */
 	public function shortcode_action_handler() {
-		global $post;
-
-		if ( is_page() && has_shortcode( $post->post_content, 'job_dashboard' ) ) {
+		if ( $this->is_job_dashboard_page() ) {
 			$this->job_dashboard_handler();
 		}
 	}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -66,6 +66,24 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
+	* Helper function used to check if page is WPJM dashboard page.
+	*
+	* Checks if page has 'job_dashboard' shortcode.
+	*
+	* @access private
+	* @return bool True if page is dashboard page, false otherwise.
+	*/
+	private function is_job_dashboard_page() {
+		global $post;
+
+		if ( is_page() && has_shortcode( $post->post_content, 'job_dashboard' ) ) {
+			return true;
+		}
+		
+		return false;
+	}
+
+	/**
 	 * Handles actions which need to be run before the shortcode e.g. post actions.
 	 */
 	public function shortcode_action_handler() {

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -79,7 +79,7 @@ class WP_Job_Manager_Shortcodes {
 		if ( is_page() && has_shortcode( $post->post_content, 'job_dashboard' ) ) {
 			return true;
 		}
-		
+
 		return false;
 	}
 
@@ -299,7 +299,12 @@ class WP_Job_Manager_Shortcodes {
 	 * @return string
 	 */
 	public function filter_paginate_links( $link ) {
-		return remove_query_arg( [ 'action', 'job_id', '_wpnonce' ], $link );
+
+		if ( $this->is_job_dashboard_page() ) {
+			return remove_query_arg( [ 'action', 'job_id', '_wpnonce' ], $link );
+		}
+
+		return $link;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1912 

#### Changes proposed in this Pull Request:

* The paginate_links() function adds the url args (from the current url) to each pagination link. The actions (mark as filled, not filled, etc) in the job dashboard were triggered with the url (For example: url/?action=mark_as_filled). The consequences of this were that if you changed the page, the pagination link would carry the "action, job_id, and _wpnonce" parameters to the new page, causing the action to be triggered again; thus, getting the message that the job was already filled/not filled. 
* This PR removes the args from the url for the pagination links so that the actions are not triggered again when changing pages.

#### Testing instructions:

1. Make sure you have enough jobs on your jobs dashboard that they are paginated at least to a page 2.
2. On the jobs dashboard, mark a job as filled; you will get the correct "X has been filled" message.
3. Click on the "2" or the "next arrow" in the pagination at the bottom of the jobs list.
4. You should not see any messages

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Remove args from pagination_link urls
