### PR TITLE
Remove extends in SCSS

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -78,8 +78,8 @@ a.wpjm-activate-licence-link:active {
 
 			&::before {
 
-				@include jm-icon()
-					content: "\e803";
+				@include jm-icon();
+				content: "\e803";
 			}
 		}
 	}
@@ -127,8 +127,8 @@ a.wpjm-activate-licence-link:active {
 
 		span::before {
 
-			@include jm-icon()
-				position: absolute;
+			@include jm-icon();
+			position: absolute;
 			top: 0;
 			left: 0;
 			line-height: 1.5em;
@@ -265,8 +265,8 @@ a.wpjm-activate-licence-link:active {
 
 			&::before {
 
-				@include jm-icon()
-					float: left;
+				@include jm-icon();
+				float: left;
 				width: 2em !important;
 				line-height: 2em;
 			}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -79,7 +79,7 @@ a.wpjm-activate-licence-link:active {
 			&::before {
 
 				@include jm-icon()
-				content: "\e803";
+					content: "\e803";
 			}
 		}
 	}
@@ -128,7 +128,7 @@ a.wpjm-activate-licence-link:active {
 		span::before {
 
 			@include jm-icon()
-			position: absolute;
+				position: absolute;
 			top: 0;
 			left: 0;
 			line-height: 1.5em;
@@ -266,7 +266,7 @@ a.wpjm-activate-licence-link:active {
 			&::before {
 
 				@include jm-icon()
-				float: left;
+					float: left;
 				width: 2em !important;
 				line-height: 2em;
 			}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -78,7 +78,7 @@ a.wpjm-activate-licence-link:active {
 
 			&::before {
 
-				@extend .jm-icon;
+				@include jm-icon()
 				content: "\e803";
 			}
 		}
@@ -127,7 +127,7 @@ a.wpjm-activate-licence-link:active {
 
 		span::before {
 
-			@extend .jm-icon;
+			@include jm-icon()
 			position: absolute;
 			top: 0;
 			left: 0;
@@ -265,7 +265,7 @@ a.wpjm-activate-licence-link:active {
 
 			&::before {
 
-				@extend .jm-icon;
+				@include jm-icon()
 				float: left;
 				width: 2em !important;
 				line-height: 2em;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -47,7 +47,7 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 	list-style: none outside !important;
 	width: auto;
 
-	@extend .clearfix;
+	@include clearfix();
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 
 	&::before {
@@ -105,7 +105,7 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 		border: 0;
 		border-bottom: 1px solid #eee;
 
-		@extend .clearfix;
+		@include clearfix();
 
 		label {
 			display: block;
@@ -493,12 +493,12 @@ div.job_listings {
 .job_filters {
 	background: #eee;
 
-	@extend .clearfix;
+	@include clearfix();
 
 	.search_jobs {
 		padding: 1em;
 
-		@extend .clearfix;
+		@include clearfix();
 
 		div {
 			-webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
@@ -564,7 +564,7 @@ div.job_listings {
 		background: #f9f9f9;
 		border-top: 1px solid #e5e5e5;
 
-		@extend .clearfix;
+		@include clearfix();
 
 		li {
 			margin: 0;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -34,6 +34,7 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 }
 
 .display-icon {
+
 	@include display-icon();
 }
 

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -14,7 +14,7 @@ $highlightext:		desaturate(lighten($highlight, 50%), 18%);	/* Text on highlight 
 $contentbg: 		#fff; 										/* Content BG - Tabs (active state) */
 $subtext: 			#777; 										/* small, breadcrumbs etc */
 
-.display-icon {
+@mixin display-icon() {
 	display: inline-block;
 	width: 16px;
 	height: 16px;
@@ -140,7 +140,7 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 
 				&::before {
 
-					@extend .display-icon;
+					@include display-icon();
 					content: "\e808";
 				}
 			}
@@ -306,13 +306,13 @@ div.job_listings {
 
 		.website::before {
 
-			@extend .display-icon;
+			@include display-icon();
 			content: "\e809";
 		}
 
 		.company_twitter::before {
 
-			@extend .display-icon;
+			@include display-icon();
 			content: "\e80a";
 		}
 
@@ -388,20 +388,20 @@ div.job_listings {
 
 		.location::before {
 
-			@extend .display-icon;
+			@include display-icon();
 			content: "\e81d";
 		}
 
 		.date-posted::before {
 
-			@extend .display-icon;
+			@include display-icon();
 			content: "\e80f";
 		}
 
 		.position-filled::before,
 		.listing-expired::before {
 
-			@extend .display-icon;
+			@include display-icon();
 			content: "\e80e";
 		}
 	}
@@ -771,7 +771,7 @@ div.job_listings {
 
 			&::before {
 
-				@extend .display-icon;
+				@include display-icon();
 				content: "\e808";
 			}
 		}
@@ -829,7 +829,7 @@ div.job_listings {
 
 			&::before {
 
-				@extend .jm-icon;
+				@include jm-icon()
 				content: "\e803";
 			}
 		}

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -833,7 +833,7 @@ div.job_listings {
 
 			&::before {
 
-				@include jm-icon()
+				@include jm-icon();
 				content: "\e803";
 			}
 		}

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -33,6 +33,10 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 	*display: inline;
 }
 
+.display-icon {
+	@include display-icon();
+}
+
 /* =Global styles/layout
 -------------------------------------------------------------- */
 .job-manager-message,

--- a/assets/css/icons.scss
+++ b/assets/css/icons.scss
@@ -22,7 +22,7 @@
 	font-style: normal;
 }
 
-.jm-icon {
+@mixin jm-icon() {
 	font-family: job-manager !important;
 	font-style: normal;
 	font-weight: normal;

--- a/assets/css/icons.scss
+++ b/assets/css/icons.scss
@@ -40,3 +40,7 @@
 	/* fix buttons height, for twitter bootstrap */
 	line-height: 1em;
 }
+
+.jm-icon {
+	@include jm-icon();
+}

--- a/assets/css/icons.scss
+++ b/assets/css/icons.scss
@@ -42,5 +42,6 @@
 }
 
 .jm-icon {
+
 	@include jm-icon();
 }

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -7,7 +7,7 @@
 
 		.wp-menu-image::before {
 
-			@include jm-icon()
+			@include jm-icon();
 			content: "\e800";
 		}
 	}
@@ -16,7 +16,7 @@
 
 		.wp-menu-image::before {
 
-			@include jm-icon()
+			@include jm-icon();
 			content: "\e806";
 		}
 	}

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -7,7 +7,7 @@
 
 		.wp-menu-image::before {
 
-			@extend .jm-icon;
+			@include jm-icon()
 			content: "\e800";
 		}
 	}
@@ -16,7 +16,7 @@
 
 		.wp-menu-image::before {
 
-			@extend .jm-icon;
+			@include jm-icon()
 			content: "\e806";
 		}
 	}

--- a/assets/css/mixins.scss
+++ b/assets/css/mixins.scss
@@ -18,6 +18,20 @@ $temporary: #d93674;
 	}
 }
 
+@mixin clearfix() {
+	zoom: 1; /* For IE 6/7 (trigger hasLayout) */
+
+	&::before,
+	&::after {
+		content: "";
+		display: table;
+	}
+
+	&::after {
+		clear: both;
+	}
+}
+
 @mixin border_radius($radius:4px) {
 	-webkit-border-radius: $radius;
 	border-radius: $radius;

--- a/assets/css/mixins.scss
+++ b/assets/css/mixins.scss
@@ -19,6 +19,7 @@ $temporary: #d93674;
 }
 
 .clearfix {
+
 	@include clearfix();
 }
 

--- a/assets/css/mixins.scss
+++ b/assets/css/mixins.scss
@@ -4,7 +4,7 @@ $internship: #6033cc;
 $freelance: #39c;
 $temporary: #d93674;
 
-.clearfix {
+@mixin clearfix() {
 	zoom: 1; /* For IE 6/7 (trigger hasLayout) */
 
 	&::before,
@@ -18,18 +18,8 @@ $temporary: #d93674;
 	}
 }
 
-@mixin clearfix() {
-	zoom: 1; /* For IE 6/7 (trigger hasLayout) */
-
-	&::before,
-	&::after {
-		content: "";
-		display: table;
-	}
-
-	&::after {
-		clear: both;
-	}
+.clearfix {
+	@include clearfix();
 }
 
 @mixin border_radius($radius:4px) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,14 +106,27 @@
 			}
 		},
 		"@babel/helper-builder-react-jsx-experimental": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
-			"integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.11.5.tgz",
+			"integrity": "sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/types": "^7.10.5"
+				"@babel/types": "^7.11.5"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.11.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-compilation-targets": {
@@ -166,12 +179,11 @@
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
-			"integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+			"version": "7.11.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+			"integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.10.4",
 				"@babel/types": "^7.10.4"
 			}
 		},
@@ -262,15 +274,14 @@
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
-			"integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+			"version": "7.11.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+			"integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-wrap-function": "^7.10.4",
 				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
 				"@babel/types": "^7.10.4"
 			}
 		},
@@ -717,14 +728,6 @@
 				"@babel/helper-replace-supers": "^7.10.4",
 				"@babel/helper-split-export-declaration": "^7.10.4",
 				"globals": "^11.1.0"
-			},
-			"dependencies": {
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -934,12 +937,12 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx-development": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.10.4.tgz",
-			"integrity": "sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.11.5.tgz",
+			"integrity": "sha512-cImAmIlKJ84sDmpQzm4/0q/2xrXlDezQoixy3qoz1NJeZL/8PRon6xZtluvr4H4FzwlDGI5tCcFupMnXGtr+qw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+				"@babel/helper-builder-react-jsx-experimental": "^7.11.5",
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-jsx": "^7.10.4"
 			}
@@ -993,9 +996,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-			"integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+			"integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
@@ -1072,9 +1075,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-			"integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
+			"integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
 			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.11.0",
@@ -1139,18 +1142,31 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.10.4",
 				"@babel/plugin-transform-unicode-regex": "^7.10.4",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.11.0",
+				"@babel/types": "^7.11.5",
 				"browserslist": "^4.12.0",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
 				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.11.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/preset-modules": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-			"integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -1200,14 +1216,6 @@
 			"requires": {
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/template": {
@@ -1294,6 +1302,62 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			}
+		},
+		"@eslint/eslintrc": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+			"integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.12.4",
+				"debug": "^4.1.1",
+				"espree": "^7.3.0",
+				"globals": "^12.1.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^3.13.1",
+				"lodash": "^4.17.19",
+				"minimatch": "^3.0.4",
+				"strip-json-comments": "^3.1.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.4",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+					"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "12.4.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@hapi/address": {
@@ -1419,6 +1483,138 @@
 				}
 			}
 		},
+		"@jest/core": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
+			"integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^25.5.0",
+				"@jest/reporters": "^25.5.1",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^3.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-changed-files": "^25.5.0",
+				"jest-config": "^25.5.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-resolve-dependencies": "^25.5.4",
+				"jest-runner": "^25.5.4",
+				"jest-runtime": "^25.5.4",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"jest-watcher": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^2.1.0",
+				"realpath-native": "^2.0.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"@jest/environment": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
+			"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
+			"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"lolex": "^5.0.0"
+			}
+		},
+		"@jest/globals": {
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
+			"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"expect": "^25.5.0"
+			}
+		},
 		"@jest/reporters": {
 			"version": "25.5.1",
 			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
@@ -1510,6 +1706,25 @@
 				}
 			}
 		},
+		"@jest/source-map": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
+			"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"@jest/test-result": {
 			"version": "25.5.0",
 			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
@@ -1520,6 +1735,19 @@
 				"@jest/types": "^25.5.0",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
+			"integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-runner": "^25.5.4",
+				"jest-runtime": "^25.5.4"
 			}
 		},
 		"@jest/transform": {
@@ -1868,19 +2096,6 @@
 				"@svgr/plugin-jsx": "^5.4.0",
 				"@svgr/plugin-svgo": "^5.4.0",
 				"loader-utils": "^2.0.0"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^2.1.2"
-					}
-				}
 			}
 		},
 		"@types/anymatch": {
@@ -2022,6 +2237,12 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"@types/prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+			"dev": true
+		},
 		"@types/q": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
@@ -2070,9 +2291,9 @@
 			"dev": true
 		},
 		"@types/webpack": {
-			"version": "4.41.21",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
-			"integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+			"version": "4.41.22",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+			"integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
 			"dev": true,
 			"requires": {
 				"@types/anymatch": "*",
@@ -2145,6 +2366,18 @@
 				"@typescript-eslint/typescript-estree": "2.34.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+					"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
@@ -2367,9 +2600,9 @@
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.17.0.tgz",
-			"integrity": "sha512-9SvyQIC2oYerc+zsZJtQH/P8KqKOJJJH+QrmCIrD2PQ1cw9QrF456sV/xHuNfaAoV3QGFLxP+0wVFOLKdU22DQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.18.0.tgz",
+			"integrity": "sha512-YahhYqhIFRsSGeufkBoOnfdyBASk9SlzxTWLUYmg6RTv46RruIBaOWp2w4FIMwIijMMbFJEFb8w4VMTIZ733Fg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.9.0",
@@ -2379,23 +2612,15 @@
 				"@babel/runtime": "^7.9.2",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
 				"@wordpress/browserslist-config": "^2.7.0",
-				"@wordpress/element": "^2.16.0",
-				"@wordpress/warning": "^1.2.0",
+				"@wordpress/element": "^2.17.0",
+				"@wordpress/warning": "^1.3.0",
 				"core-js": "^3.6.4"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "3.6.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-					"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-2.0.1.tgz",
-			"integrity": "sha512-nwm0OK/AkxkTkdvZTMeBxkO01RXFYP8TXdqAsx6Fn022o7YV40V89yLr7zTRoQ8MSNy6c/WmRxnLKapLdUCDUg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-2.1.0.tgz",
+			"integrity": "sha512-Ljb1xX4fYHSzvw+p8NnCF3WCNPEY6RlDrtWbJvAOeJe2LiAxiQcbgQa/WdFd21jdSgfet0Wmqk+YwwUyyeermw==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
@@ -2416,16 +2641,16 @@
 			}
 		},
 		"@wordpress/element": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.16.0.tgz",
-			"integrity": "sha512-1ijo/GR/uBfL4teCQ3oFdUTqkeV2EZ32SCvXl30iPbqYmaNSzT1ZI1dlW8GO5o5UBja9BG11hnaOwm93pE2y2A==",
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
+			"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"@wordpress/escape-html": "^1.9.0",
-				"lodash": "^4.17.15",
-				"react": "^16.9.0",
-				"react-dom": "^16.9.0"
+				"lodash": "^4.17.19",
+				"react": "^16.13.1",
+				"react-dom": "^16.13.1"
 			}
 		},
 		"@wordpress/escape-html": {
@@ -2438,16 +2663,17 @@
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-7.1.0.tgz",
-			"integrity": "sha512-FTrKkpEa8vZg7/7M6GBhd1YW24hnh5rFGzKgKX4MGyB0Jw8GGSwld9J23eRbQ5JQWGFP/tmOMeiu6W1/arxy7Q==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-7.2.0.tgz",
+			"integrity": "sha512-dp6Egzg1pm3YAnwgWb471FP0g2hedl+8TyfUxkO1gTD01ueriosqS1caAZDiaswmYEY6N6Wkzf7WI8w+dOE+uw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/prettier-config": "^0.3.0",
+				"@wordpress/prettier-config": "^0.4.0",
 				"babel-eslint": "^10.1.0",
+				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^6.10.1",
 				"eslint-plugin-jest": "^23.8.2",
-				"eslint-plugin-jsdoc": "^26.0.0",
+				"eslint-plugin-jsdoc": "^30.2.2",
 				"eslint-plugin-jsx-a11y": "^6.2.3",
 				"eslint-plugin-prettier": "^3.1.2",
 				"eslint-plugin-react": "^7.20.0",
@@ -2457,6 +2683,19 @@
 				"requireindex": "^1.2.0"
 			},
 			"dependencies": {
+				"cosmiconfig": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.2.1",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.10.0"
+					}
+				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -2465,6 +2704,12 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.0.5",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+					"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+					"dev": true
 				}
 			}
 		},
@@ -2500,12 +2745,12 @@
 			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.3.1.tgz",
-			"integrity": "sha512-BNZhZwUB0r1OQ+5J89foptarBRnjY+a8F4LtoeY2iMUbAYvT+Y6lkIyJOp5NR6oyeiV9IT1Tcih9ViqZlR+c+w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.4.0.tgz",
+			"integrity": "sha512-jg94GYU8h2UJ+5kmLdKG7FCIkgOYFKRFcmKnQKZifKTB6mRxG7u+ioIBsEipkQkt82wMKG7p2l8rtH+NWIcbDw==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^2.0.1",
+				"@wordpress/base-styles": "^2.1.0",
 				"@wordpress/postcss-themes": "^2.6.0",
 				"autoprefixer": "^9.4.5",
 				"postcss-custom-properties": "^9.1.1"
@@ -2521,25 +2766,25 @@
 			}
 		},
 		"@wordpress/prettier-config": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-0.3.0.tgz",
-			"integrity": "sha512-wL1ztV+so5Ttwz23lDmb8ZmREmND96sf+Dh/kbP2nyAw/DWt3K8uj31qbczVmjwfoetTiRoH9Z1CasgPs4bccg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-0.4.0.tgz",
+			"integrity": "sha512-7c4VeugkCwDkaHSD7ffxoP0VC5c///gCTEAT032OhI5Rik2dPxE3EkNAB2NhotGE8M4dMAg4g5Wj2OWZIn8TFw==",
 			"dev": true
 		},
 		"@wordpress/scripts": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.1.1.tgz",
-			"integrity": "sha512-PC8M9h6LkNJgzbRIVBuZrAchVNaEaWPSF47yljKRrg01xWlPtWRQwWWoYvleHuBrLozSElJYrA73W8d/vPPrtg==",
+			"version": "12.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.2.0.tgz",
+			"integrity": "sha512-82Zn6Wt/wqhpqnajgjw+F6vmvwx0GHlJ4Pk1znfznsqY1ZkHI+Jwv5PFMyRSKuq3S2gXCtuyL/693ZGyUCRilw==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
-				"@wordpress/babel-preset-default": "^4.17.0",
+				"@wordpress/babel-preset-default": "^4.18.0",
 				"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
-				"@wordpress/eslint-plugin": "^7.1.0",
-				"@wordpress/jest-preset-default": "^6.2.0",
+				"@wordpress/eslint-plugin": "^7.2.0",
+				"@wordpress/jest-preset-default": "^6.3.0",
 				"@wordpress/npm-package-json-lint-config": "^3.1.0",
-				"@wordpress/postcss-plugins-preset": "^1.3.1",
-				"@wordpress/prettier-config": "^0.3.0",
+				"@wordpress/postcss-plugins-preset": "^1.4.0",
+				"@wordpress/prettier-config": "^0.4.0",
 				"babel-jest": "^25.3.0",
 				"babel-loader": "^8.1.0",
 				"chalk": "^4.0.0",
@@ -2577,230 +2822,30 @@
 				"webpack-livereload-plugin": "^2.3.0"
 			},
 			"dependencies": {
-				"@jest/core": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
-					"integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
+				"@wordpress/jest-console": {
+					"version": "3.8.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.8.0.tgz",
+					"integrity": "sha512-Z850aq0qk6vlWfLNb7Qnl3dt0kCncTR6abglnWXmsvWep8zI43zqUkwOx2A+fx9WLt4Lb3ECFuiLOSi2RYczuQ==",
 					"dev": true,
 					"requires": {
-						"@jest/console": "^25.5.0",
-						"@jest/reporters": "^25.5.1",
-						"@jest/test-result": "^25.5.0",
-						"@jest/transform": "^25.5.1",
-						"@jest/types": "^25.5.0",
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^3.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"jest-changed-files": "^25.5.0",
-						"jest-config": "^25.5.4",
-						"jest-haste-map": "^25.5.1",
-						"jest-message-util": "^25.5.0",
-						"jest-regex-util": "^25.2.6",
-						"jest-resolve": "^25.5.1",
-						"jest-resolve-dependencies": "^25.5.4",
-						"jest-runner": "^25.5.4",
-						"jest-runtime": "^25.5.4",
-						"jest-snapshot": "^25.5.1",
-						"jest-util": "^25.5.0",
-						"jest-validate": "^25.5.0",
-						"jest-watcher": "^25.5.0",
-						"micromatch": "^4.0.2",
-						"p-each-series": "^2.1.0",
-						"realpath-native": "^2.0.0",
-						"rimraf": "^3.0.0",
-						"slash": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
+						"@babel/runtime": "^7.9.2",
+						"jest-matcher-utils": "^25.3.0",
+						"lodash": "^4.17.19"
 					}
 				},
-				"@jest/environment": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
-					"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
+				"@wordpress/jest-preset-default": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-6.3.0.tgz",
+					"integrity": "sha512-2JIUOs1la5vPGeOa9EvuQB6zVPYopfhI4meHKhCf9U4zcUxX6U9S/syibVp7EBKHGYZvjqxvP42kBuZCvnNEKQ==",
 					"dev": true,
 					"requires": {
-						"@jest/fake-timers": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"jest-mock": "^25.5.0"
+						"@jest/reporters": "^25.3.0",
+						"@wordpress/jest-console": "^3.8.0",
+						"babel-jest": "^25.3.0",
+						"enzyme": "^3.11.0",
+						"enzyme-adapter-react-16": "^1.15.2",
+						"enzyme-to-json": "^3.4.4"
 					}
-				},
-				"@jest/fake-timers": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
-					"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"jest-message-util": "^25.5.0",
-						"jest-mock": "^25.5.0",
-						"jest-util": "^25.5.0",
-						"lolex": "^5.0.0"
-					}
-				},
-				"@jest/globals": {
-					"version": "25.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
-					"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
-					"dev": true,
-					"requires": {
-						"@jest/environment": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"expect": "^25.5.0"
-					}
-				},
-				"@jest/source-map": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
-					"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
-					"dev": true,
-					"requires": {
-						"callsites": "^3.0.0",
-						"graceful-fs": "^4.2.4",
-						"source-map": "^0.6.0"
-					}
-				},
-				"@jest/test-sequencer": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
-					"integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
-					"dev": true,
-					"requires": {
-						"@jest/test-result": "^25.5.0",
-						"graceful-fs": "^4.2.4",
-						"jest-haste-map": "^25.5.1",
-						"jest-runner": "^25.5.4",
-						"jest-runtime": "^25.5.4"
-					}
-				},
-				"@types/prettier": {
-					"version": "1.19.1",
-					"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
-					"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
-					"dev": true
-				},
-				"acorn-globals": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-					"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-					"dev": true,
-					"requires": {
-						"acorn": "^6.0.1",
-						"acorn-walk": "^6.0.1"
-					},
-					"dependencies": {
-						"acorn": {
-							"version": "6.4.1",
-							"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-							"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-							"dev": true
-						}
-					}
-				},
-				"acorn-walk": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-					"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"cacache": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
-					"integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
-					"dev": true,
-					"requires": {
-						"@npmcli/move-file": "^1.0.1",
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"glob": "^7.1.4",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^6.0.0",
-						"minipass": "^3.1.1",
-						"minipass-collect": "^1.0.2",
-						"minipass-flush": "^1.0.5",
-						"minipass-pipeline": "^1.2.2",
-						"mkdirp": "^1.0.3",
-						"p-map": "^4.0.0",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^3.0.2",
-						"ssri": "^8.0.0",
-						"tar": "^6.0.2",
-						"unique-filename": "^1.1.1"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-							"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-							"dev": true,
-							"requires": {
-								"yallist": "^4.0.0"
-							}
-						}
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"clone-deep": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-					"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-					"dev": true,
-					"requires": {
-						"is-plain-object": "^2.0.4",
-						"kind-of": "^6.0.2",
-						"shallow-clone": "^3.0.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
@@ -2813,119 +2858,13 @@
 						"which": "^1.2.9"
 					}
 				},
-				"css-loader": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
-					"integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^5.3.1",
-						"cssesc": "^3.0.0",
-						"icss-utils": "^4.1.1",
-						"loader-utils": "^1.2.3",
-						"normalize-path": "^3.0.0",
-						"postcss": "^7.0.32",
-						"postcss-modules-extract-imports": "^2.0.0",
-						"postcss-modules-local-by-default": "^3.0.2",
-						"postcss-modules-scope": "^2.2.0",
-						"postcss-modules-values": "^3.0.0",
-						"postcss-value-parser": "^4.1.0",
-						"schema-utils": "^2.7.0",
-						"semver": "^6.3.0"
-					}
-				},
-				"data-urls": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-					"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.0",
-						"whatwg-mimetype": "^2.2.0",
-						"whatwg-url": "^7.0.0"
-					}
-				},
-				"domexception": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-					"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-					"dev": true,
-					"requires": {
-						"webidl-conversions": "^4.0.2"
-					}
-				},
-				"execa": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"p-finally": "^2.0.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					},
-					"dependencies": {
-						"cross-spawn": {
-							"version": "7.0.3",
-							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-							"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-							"dev": true,
-							"requires": {
-								"path-key": "^3.1.0",
-								"shebang-command": "^2.0.0",
-								"which": "^2.0.1"
-							}
-						},
-						"shebang-command": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-							"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-							"dev": true,
-							"requires": {
-								"shebang-regex": "^3.0.0"
-							}
-						},
-						"which": {
-							"version": "2.0.2",
-							"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-							"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-							"dev": true,
-							"requires": {
-								"isexe": "^2.0.0"
-							}
-						}
-					}
-				},
-				"expect": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
-					"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"ansi-styles": "^4.0.0",
-						"jest-get-type": "^25.2.6",
-						"jest-matcher-utils": "^25.5.0",
-						"jest-message-util": "^25.5.0",
-						"jest-regex-util": "^25.2.6"
-					}
-				},
-				"find-cache-dir": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^3.0.2",
-						"pkg-dir": "^4.1.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"find-up": {
@@ -2938,524 +2877,20 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"html-encoding-sniffer": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-					"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-					"dev": true,
-					"requires": {
-						"whatwg-encoding": "^1.0.1"
-					}
-				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-					"dev": true
-				},
-				"jest": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.4.tgz",
-					"integrity": "sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==",
-					"dev": true,
-					"requires": {
-						"@jest/core": "^25.5.4",
-						"import-local": "^3.0.2",
-						"jest-cli": "^25.5.4"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"jest-cli": {
-							"version": "25.5.4",
-							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
-							"integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
-							"dev": true,
-							"requires": {
-								"@jest/core": "^25.5.4",
-								"@jest/test-result": "^25.5.0",
-								"@jest/types": "^25.5.0",
-								"chalk": "^3.0.0",
-								"exit": "^0.1.2",
-								"graceful-fs": "^4.2.4",
-								"import-local": "^3.0.2",
-								"is-ci": "^2.0.0",
-								"jest-config": "^25.5.4",
-								"jest-util": "^25.5.0",
-								"jest-validate": "^25.5.0",
-								"prompts": "^2.0.1",
-								"realpath-native": "^2.0.0",
-								"yargs": "^15.3.1"
-							}
-						}
-					}
-				},
-				"jest-changed-files": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
-					"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"execa": "^3.2.0",
-						"throat": "^5.0.0"
-					}
-				},
-				"jest-config": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
-					"integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
-					"dev": true,
-					"requires": {
-						"@babel/core": "^7.1.0",
-						"@jest/test-sequencer": "^25.5.4",
-						"@jest/types": "^25.5.0",
-						"babel-jest": "^25.5.1",
-						"chalk": "^3.0.0",
-						"deepmerge": "^4.2.2",
-						"glob": "^7.1.1",
-						"graceful-fs": "^4.2.4",
-						"jest-environment-jsdom": "^25.5.0",
-						"jest-environment-node": "^25.5.0",
-						"jest-get-type": "^25.2.6",
-						"jest-jasmine2": "^25.5.4",
-						"jest-regex-util": "^25.2.6",
-						"jest-resolve": "^25.5.1",
-						"jest-util": "^25.5.0",
-						"jest-validate": "^25.5.0",
-						"micromatch": "^4.0.2",
-						"pretty-format": "^25.5.0",
-						"realpath-native": "^2.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jest-docblock": {
-					"version": "25.3.0",
-					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
-					"integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
-					"dev": true,
-					"requires": {
-						"detect-newline": "^3.0.0"
-					}
-				},
-				"jest-each": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
-					"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"chalk": "^3.0.0",
-						"jest-get-type": "^25.2.6",
-						"jest-util": "^25.5.0",
-						"pretty-format": "^25.5.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jest-environment-jsdom": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
-					"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
-					"dev": true,
-					"requires": {
-						"@jest/environment": "^25.5.0",
-						"@jest/fake-timers": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"jest-mock": "^25.5.0",
-						"jest-util": "^25.5.0",
-						"jsdom": "^15.2.1"
-					}
-				},
-				"jest-environment-node": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
-					"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
-					"dev": true,
-					"requires": {
-						"@jest/environment": "^25.5.0",
-						"@jest/fake-timers": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"jest-mock": "^25.5.0",
-						"jest-util": "^25.5.0",
-						"semver": "^6.3.0"
-					}
-				},
-				"jest-jasmine2": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
-					"integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
-					"dev": true,
-					"requires": {
-						"@babel/traverse": "^7.1.0",
-						"@jest/environment": "^25.5.0",
-						"@jest/source-map": "^25.5.0",
-						"@jest/test-result": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"chalk": "^3.0.0",
-						"co": "^4.6.0",
-						"expect": "^25.5.0",
-						"is-generator-fn": "^2.0.0",
-						"jest-each": "^25.5.0",
-						"jest-matcher-utils": "^25.5.0",
-						"jest-message-util": "^25.5.0",
-						"jest-runtime": "^25.5.4",
-						"jest-snapshot": "^25.5.1",
-						"jest-util": "^25.5.0",
-						"pretty-format": "^25.5.0",
-						"throat": "^5.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jest-leak-detector": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
-					"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
-					"dev": true,
-					"requires": {
-						"jest-get-type": "^25.2.6",
-						"pretty-format": "^25.5.0"
-					}
-				},
-				"jest-mock": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
-					"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0"
-					}
-				},
-				"jest-resolve-dependencies": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
-					"integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"jest-regex-util": "^25.2.6",
-						"jest-snapshot": "^25.5.1"
-					}
-				},
-				"jest-runner": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
-					"integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
-					"dev": true,
-					"requires": {
-						"@jest/console": "^25.5.0",
-						"@jest/environment": "^25.5.0",
-						"@jest/test-result": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"chalk": "^3.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^25.5.4",
-						"jest-docblock": "^25.3.0",
-						"jest-haste-map": "^25.5.1",
-						"jest-jasmine2": "^25.5.4",
-						"jest-leak-detector": "^25.5.0",
-						"jest-message-util": "^25.5.0",
-						"jest-resolve": "^25.5.1",
-						"jest-runtime": "^25.5.4",
-						"jest-util": "^25.5.0",
-						"jest-worker": "^25.5.0",
-						"source-map-support": "^0.5.6",
-						"throat": "^5.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jest-runtime": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
-					"integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
-					"dev": true,
-					"requires": {
-						"@jest/console": "^25.5.0",
-						"@jest/environment": "^25.5.0",
-						"@jest/globals": "^25.5.2",
-						"@jest/source-map": "^25.5.0",
-						"@jest/test-result": "^25.5.0",
-						"@jest/transform": "^25.5.1",
-						"@jest/types": "^25.5.0",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^25.5.4",
-						"jest-haste-map": "^25.5.1",
-						"jest-message-util": "^25.5.0",
-						"jest-mock": "^25.5.0",
-						"jest-regex-util": "^25.2.6",
-						"jest-resolve": "^25.5.1",
-						"jest-snapshot": "^25.5.1",
-						"jest-util": "^25.5.0",
-						"jest-validate": "^25.5.0",
-						"realpath-native": "^2.0.0",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.3.1"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jest-snapshot": {
-					"version": "25.5.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
-					"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^25.5.0",
-						"@types/prettier": "^1.19.0",
-						"chalk": "^3.0.0",
-						"expect": "^25.5.0",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^25.5.0",
-						"jest-get-type": "^25.2.6",
-						"jest-matcher-utils": "^25.5.0",
-						"jest-message-util": "^25.5.0",
-						"jest-resolve": "^25.5.1",
-						"make-dir": "^3.0.0",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^25.5.0",
-						"semver": "^6.3.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jest-validate": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
-					"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"camelcase": "^5.3.1",
-						"chalk": "^3.0.0",
-						"jest-get-type": "^25.2.6",
-						"leven": "^3.1.0",
-						"pretty-format": "^25.5.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jest-watcher": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
-					"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
-					"dev": true,
-					"requires": {
-						"@jest/test-result": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^3.0.0",
-						"jest-util": "^25.5.0",
-						"string-length": "^3.1.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"jsdom": {
-					"version": "15.2.1",
-					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-					"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
-					"dev": true,
-					"requires": {
-						"abab": "^2.0.0",
-						"acorn": "^7.1.0",
-						"acorn-globals": "^4.3.2",
-						"array-equal": "^1.0.0",
-						"cssom": "^0.4.1",
-						"cssstyle": "^2.0.0",
-						"data-urls": "^1.1.0",
-						"domexception": "^1.0.1",
-						"escodegen": "^1.11.1",
-						"html-encoding-sniffer": "^1.0.2",
-						"nwsapi": "^2.2.0",
-						"parse5": "5.1.0",
-						"pn": "^1.1.0",
-						"request": "^2.88.0",
-						"request-promise-native": "^1.0.7",
-						"saxes": "^3.1.9",
-						"symbol-tree": "^3.2.2",
-						"tough-cookie": "^3.0.1",
-						"w3c-hr-time": "^1.0.1",
-						"w3c-xmlserializer": "^1.1.2",
-						"webidl-conversions": "^4.0.2",
-						"whatwg-encoding": "^1.0.5",
-						"whatwg-mimetype": "^2.3.0",
-						"whatwg-url": "^7.0.0",
-						"ws": "^7.0.0",
-						"xml-name-validator": "^3.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"p-finally": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-					"dev": true
-				},
-				"p-limit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-					"integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
-				"parse5": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
 				"path-exists": {
@@ -3467,37 +2902,47 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"find-up": "^4.0.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-							"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-							"dev": true,
-							"requires": {
-								"locate-path": "^5.0.0",
-								"path-exists": "^4.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-							"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-							"dev": true
-						}
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.0.5",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+					"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+					"dev": true
+				},
+				"puppeteer": {
+					"version": "npm:puppeteer-core@3.0.0",
+					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+					"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+					"dev": true,
+					"requires": {
+						"@types/mime-types": "^2.1.0",
+						"debug": "^4.1.0",
+						"extract-zip": "^2.0.0",
+						"https-proxy-agent": "^4.0.0",
+						"mime": "^2.0.3",
+						"mime-types": "^2.1.25",
+						"progress": "^2.0.1",
+						"proxy-from-env": "^1.0.0",
+						"rimraf": "^3.0.2",
+						"tar-fs": "^2.0.0",
+						"unbzip2-stream": "^1.3.3",
+						"ws": "^7.2.3"
 					}
 				},
 				"read-pkg": {
@@ -3521,166 +2966,13 @@
 						"read-pkg": "^1.0.0"
 					}
 				},
-				"sass-loader": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-					"integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 					"dev": true,
 					"requires": {
-						"clone-deep": "^4.0.1",
-						"loader-utils": "^1.2.3",
-						"neo-async": "^2.6.1",
-						"schema-utils": "^2.6.1",
-						"semver": "^6.3.0"
-					}
-				},
-				"saxes": {
-					"version": "3.1.11",
-					"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-					"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
-					"dev": true,
-					"requires": {
-						"xmlchars": "^2.1.1"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"serialize-javascript": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-					"dev": true,
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
-				"shallow-clone": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-					"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.2"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.19",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-					"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				},
-				"ssri": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-					"integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"terser-webpack-plugin": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.1.0.tgz",
-					"integrity": "sha512-cjdZte66fYkZ65rQ2oJfrdCAkkhJA7YLYk5eGOcGCSGlq0ieZupRdjedSQXYknMPo2IveQL+tPdrxUkERENCFA==",
-					"dev": true,
-					"requires": {
-						"cacache": "^15.0.5",
-						"find-cache-dir": "^3.3.1",
-						"jest-worker": "^26.2.1",
-						"p-limit": "^3.0.2",
-						"schema-utils": "^2.6.6",
-						"serialize-javascript": "^4.0.0",
-						"source-map": "^0.6.1",
-						"terser": "^4.8.0",
-						"webpack-sources": "^1.4.3"
-					},
-					"dependencies": {
-						"jest-worker": {
-							"version": "26.3.0",
-							"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-							"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
-							"dev": true,
-							"requires": {
-								"@types/node": "*",
-								"merge-stream": "^2.0.0",
-								"supports-color": "^7.0.0"
-							}
-						}
-					}
-				},
-				"tr46": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-					"dev": true,
-					"requires": {
-						"punycode": "^2.1.0"
-					}
-				},
-				"w3c-xmlserializer": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-					"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
-					"dev": true,
-					"requires": {
-						"domexception": "^1.0.1",
-						"webidl-conversions": "^4.0.2",
-						"xml-name-validator": "^3.0.0"
-					}
-				},
-				"webidl-conversions": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-					"dev": true
-				},
-				"whatwg-url": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-					"dev": true,
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
+						"glob": "^7.1.3"
 					}
 				},
 				"which": {
@@ -3693,17 +2985,17 @@
 					}
 				},
 				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				}
 			}
 		},
 		"@wordpress/warning": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.2.0.tgz",
-			"integrity": "sha512-Q3WqbXHaoEuGddpFvVEmG9Xwpr5QMhi/NT+Q1td6J414fyNhafkmwGVd3roJB7/2y+ek2UDDegc32B8lkyW19A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.3.0.tgz",
+			"integrity": "sha512-xwvgwqugc3zQawSPMMA09knAgap7IGgp0PxTXpFqizGFRIohoXFWERnPBZT0VsSCovqYS0ADcH+ZZgQ+BKAzLA==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -3741,10 +3033,20 @@
 			}
 		},
 		"acorn": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
 			"dev": true
+		},
+		"acorn-globals": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			}
 		},
 		"acorn-jsx": {
 			"version": "5.2.0",
@@ -3753,9 +3055,9 @@
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
 		"agent-base": {
@@ -3853,16 +3155,19 @@
 			}
 		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 			"dev": true
 		},
 		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"anymatch": {
 			"version": "3.1.1",
@@ -4056,14 +3361,15 @@
 			}
 		},
 		"asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
 			},
 			"dependencies": {
 				"bn.js": {
@@ -4125,6 +3431,15 @@
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
+		"async": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.14"
+			}
+		},
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -4178,9 +3493,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
 			"dev": true
 		},
 		"axe-core": {
@@ -4288,6 +3603,28 @@
 				"mkdirp": "^0.5.3",
 				"pify": "^4.0.1",
 				"schema-utils": "^2.6.5"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				}
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
@@ -4508,9 +3845,9 @@
 			"dev": true
 		},
 		"bn.js": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-			"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+			"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
 			"dev": true
 		},
 		"body": {
@@ -4523,6 +3860,30 @@
 				"error": "^7.0.0",
 				"raw-body": "~1.1.0",
 				"safe-json-parse": "~1.0.1"
+			},
+			"dependencies": {
+				"bytes": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+					"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+					"dev": true
+				},
+				"raw-body": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+					"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+					"dev": true,
+					"requires": {
+						"bytes": "1",
+						"string_decoder": "0.10"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
 			}
 		},
 		"body-parser": {
@@ -4543,29 +3904,11 @@
 				"type-is": "~1.6.17"
 			},
 			"dependencies": {
-				"bytes": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-					"dev": true
-				},
 				"qs": {
 					"version": "6.7.0",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
 					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
 					"dev": true
-				},
-				"raw-body": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-					"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-					"dev": true,
-					"requires": {
-						"bytes": "3.1.0",
-						"http-errors": "1.7.2",
-						"iconv-lite": "0.4.24",
-						"unpipe": "1.0.0"
-					}
 				}
 			}
 		},
@@ -4710,14 +4053,6 @@
 			"dev": true,
 			"requires": {
 				"pako": "~1.0.5"
-			},
-			"dependencies": {
-				"pako": {
-					"version": "1.0.11",
-					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-					"dev": true
-				}
 			}
 		},
 		"browserslist": {
@@ -4777,9 +4112,9 @@
 			"dev": true
 		},
 		"bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 			"dev": true
 		},
 		"cacache": {
@@ -4803,38 +4138,6 @@
 				"ssri": "^6.0.1",
 				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
-					"requires": {
-						"yallist": "^3.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true
-				}
 			}
 		},
 		"cache-base": {
@@ -4911,9 +4214,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001112",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001112.tgz",
-			"integrity": "sha512-J05RTQlqsatidif/38aN3PGULCLrg8OYQOlJUKbeYVzC2mGZkZLIztwRlB3MtrfLmawUmjFlNJvy/uhwniIe1Q==",
+			"version": "1.0.30001124",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
+			"integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -4938,16 +4241,55 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"character-entities": {
@@ -4989,15 +4331,6 @@
 				"semver": "^5.0.3"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5007,15 +4340,6 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -5058,9 +4382,9 @@
 			}
 		},
 		"chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true
 		},
 		"chrome-trace-event": {
@@ -5138,12 +4462,6 @@
 				"wrap-ansi": "^6.2.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5166,15 +4484,6 @@
 						"is-fullwidth-code-point": "^3.0.0",
 						"strip-ansi": "^6.0.0"
 					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
 				}
 			}
 		},
@@ -5191,15 +4500,6 @@
 				"shallow-clone": "^0.1.2"
 			},
 			"dependencies": {
-				"for-own": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -5237,15 +4537,6 @@
 				"q": "^1.1.2"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5255,15 +4546,6 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -5333,9 +4615,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.5.tgz",
-			"integrity": "sha512-iH9YA35ccw94nx5244GVkpyC9eVTsL71jZz6iz5w6RIf79JLF2AsXHXq9p6Oaohyl3sx5qSMnGsWUDFIAfWL4w==",
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
+			"integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
 			"dev": true
 		},
 		"commondir": {
@@ -5395,13 +4677,10 @@
 			}
 		},
 		"console-browserify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true,
-			"requires": {
-				"date-now": "^0.1.4"
-			}
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+			"dev": true
 		},
 		"console-control-strings": {
 			"version": "1.1.0",
@@ -5469,17 +4748,6 @@
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.0"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"copy-descriptor": {
@@ -5489,9 +4757,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
 			"dev": true
 		},
 		"core-js-compat": {
@@ -5535,14 +4803,6 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.7.2"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				}
 			}
 		},
 		"create-ecdh": {
@@ -5631,6 +4891,55 @@
 				"public-encrypt": "^4.0.0",
 				"randombytes": "^2.0.0",
 				"randomfill": "^1.0.3"
+			}
+		},
+		"css-loader": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+			"integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.3.1",
+				"cssesc": "^3.0.0",
+				"icss-utils": "^4.1.1",
+				"loader-utils": "^1.2.3",
+				"normalize-path": "^3.0.0",
+				"postcss": "^7.0.32",
+				"postcss-modules-extract-imports": "^2.0.0",
+				"postcss-modules-local-by-default": "^3.0.2",
+				"postcss-modules-scope": "^2.2.0",
+				"postcss-modules-values": "^3.0.0",
+				"postcss-value-parser": "^4.1.0",
+				"schema-utils": "^2.7.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"css-select": {
@@ -5777,11 +5086,16 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"date-now": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-			"dev": true
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			}
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -5895,17 +5209,6 @@
 				"p-map": "^2.0.0",
 				"pify": "^4.0.1",
 				"rimraf": "^2.6.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"delayed-stream": {
@@ -5986,14 +5289,6 @@
 			"dev": true,
 			"requires": {
 				"path-type": "^4.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				}
 			}
 		},
 		"discontinuous-range": {
@@ -6033,6 +5328,15 @@
 			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
 			"dev": true
 		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
+		},
 		"domhandler": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
@@ -6053,9 +5357,9 @@
 			}
 		},
 		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
 		"duplexify": {
@@ -6119,9 +5423,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.524",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.524.tgz",
-			"integrity": "sha512-ZUvklIBkfXQyA6IeiEss1nfKRICcdB5afAGZAaPGaExdfrkpUu/WWVO+X7QpNnphaVMllXnAcvKnVPdyM+DCPQ==",
+			"version": "1.3.562",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz",
+			"integrity": "sha512-WhRe6liQ2q/w1MZc8mD8INkenHivuHdrr4r5EQHNomy3NJux+incP6M6lDMd0paShP3MD0WGe5R1TWmEClf+Bg==",
 			"dev": true
 		},
 		"elliptic": {
@@ -6454,12 +5758,13 @@
 			}
 		},
 		"eslint": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.6.0.tgz",
-			"integrity": "sha512-QlAManNtqr7sozWm5TF4wIH9gmUm2hE3vNRUvyoYAa4y1l5/jxD/PQStEjBMQtCqZmSep8UxrcecI60hOpe61w==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
+			"integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
+				"@eslint/eslintrc": "^0.1.3",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -6469,7 +5774,7 @@
 				"eslint-scope": "^5.1.0",
 				"eslint-utils": "^2.1.0",
 				"eslint-visitor-keys": "^1.3.0",
-				"espree": "^7.2.0",
+				"espree": "^7.3.0",
 				"esquery": "^1.2.0",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
@@ -6497,47 +5802,6 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
 				"cross-spawn": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6567,6 +5831,16 @@
 						"esutils": "^2.0.2"
 					}
 				},
+				"eslint-scope": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+					"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -6575,12 +5849,6 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -6614,24 +5882,6 @@
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 					"dev": true
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -6654,17 +5904,17 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "26.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-26.0.2.tgz",
-			"integrity": "sha512-KtZjqtM3Z8x84vQBFKGUyBbZRGXYHVWSJ2XyYSUTc8KhfFrvzQ/GXPp6f1M1/YCNzP3ImD5RuDNcr+OVvIZcBA==",
+			"version": "30.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.3.1.tgz",
+			"integrity": "sha512-185ARou6Wj/68DP0g9kLLBnvmVwgg6/E/7Z8Z7Dz7Z63WgvRNaSvOLQiXkzIOEwstQfwI9PCuFPh4qBJov907A==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "^0.7.4",
+				"comment-parser": "^0.7.6",
 				"debug": "^4.1.1",
-				"jsdoctypeparser": "^6.1.0",
-				"lodash": "^4.17.15",
+				"jsdoctypeparser": "^9.0.0",
+				"lodash": "^4.17.20",
 				"regextras": "^0.7.1",
-				"semver": "^6.3.0",
+				"semver": "^7.3.2",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
@@ -6677,6 +5927,12 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6684,9 +5940,9 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
 					"dev": true
 				}
 			}
@@ -6731,9 +5987,9 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.5.tgz",
-			"integrity": "sha512-ajbJfHuFnpVNJjhyrfq+pH1C0gLc2y94OiCbAXT5O0J0YCKaFEHDV8+3+mDOr+w8WguRX+vSs1bM2BDG0VLvCw==",
+			"version": "7.20.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz",
+			"integrity": "sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
@@ -6750,15 +6006,15 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.8.tgz",
-			"integrity": "sha512-6SSb5AiMCPd8FDJrzah+Z4F44P2CdOaK026cXFV+o/xSRzfOiV1FNFeLl2z6xm3yqWOQEZ5OfVgiec90qV2xrQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.0.tgz",
+			"integrity": "sha512-36zilUcDwDReiORXmcmTc6rRumu9JIM3WjSvV0nclHoUQ0CNrX866EwONvLR/UqaeqFutbAnVu8PEmctdo2SRQ==",
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-			"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+			"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
@@ -6781,14 +6037,22 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
-			"integrity": "sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+			"integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.3.1",
+				"acorn": "^7.4.0",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -6815,12 +6079,20 @@
 			}
 		},
 		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "^5.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
 			}
 		},
 		"estraverse": {
@@ -6929,12 +6201,53 @@
 			}
 		},
 		"expand-tilde": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
 			"dev": true,
 			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"os-homedir": "^1.0.1"
+			}
+		},
+		"expect": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
+			"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"ansi-styles": "^4.0.0",
+				"jest-get-type": "^25.2.6",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-regex-util": "^25.2.6"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
 			}
 		},
 		"expect-puppeteer": {
@@ -7163,6 +6476,12 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fastest-levenshtein": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+			"dev": true
+		},
 		"fastq": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
@@ -7305,64 +6624,6 @@
 			"requires": {
 				"fs-exists-sync": "^0.1.0",
 				"resolve-dir": "^0.1.0"
-			},
-			"dependencies": {
-				"expand-tilde": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-					"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.1"
-					}
-				},
-				"global-modules": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^0.1.4",
-						"is-windows": "^0.2.0"
-					}
-				},
-				"global-prefix": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.0",
-						"ini": "^1.3.4",
-						"is-windows": "^0.2.0",
-						"which": "^1.2.12"
-					}
-				},
-				"is-windows": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-					"dev": true
-				},
-				"resolve-dir": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-					"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^1.2.2",
-						"global-modules": "^0.2.3"
-					}
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
 			}
 		},
 		"find-parent-dir": {
@@ -7391,15 +6652,6 @@
 				"debug": "^2.6.8"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -7409,15 +6661,6 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -7430,6 +6673,175 @@
 			"requires": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
+			}
+		},
+		"findup-sync": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+			"dev": true,
+			"requires": {
+				"detect-file": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"micromatch": "^3.0.4",
+				"resolve-dir": "^1.0.1"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-tilde": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+					"dev": true,
+					"requires": {
+						"homedir-polyfill": "^1.0.1"
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"global-modules": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+					"dev": true,
+					"requires": {
+						"global-prefix": "^1.0.1",
+						"is-windows": "^1.0.1",
+						"resolve-dir": "^1.0.0"
+					}
+				},
+				"global-prefix": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+					"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+					"dev": true,
+					"requires": {
+						"expand-tilde": "^2.0.2",
+						"homedir-polyfill": "^1.0.1",
+						"ini": "^1.3.4",
+						"is-windows": "^1.0.1",
+						"which": "^1.2.14"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"resolve-dir": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+					"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+					"dev": true,
+					"requires": {
+						"expand-tilde": "^2.0.0",
+						"global-modules": "^1.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"flat-cache": {
@@ -7501,6 +6913,15 @@
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.1"
+			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -7658,17 +7079,6 @@
 				"inherits": "~2.0.0",
 				"mkdirp": ">=0.5 0",
 				"rimraf": "2"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"function-bind": {
@@ -7716,6 +7126,12 @@
 				"wide-align": "^1.1.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -7734,6 +7150,15 @@
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
 						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}
@@ -7819,29 +7244,41 @@
 			}
 		},
 		"global-modules": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+			"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
+				"global-prefix": "^0.1.4",
+				"is-windows": "^0.2.0"
+			},
+			"dependencies": {
+				"is-windows": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+					"dev": true
+				}
 			}
 		},
 		"global-prefix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
+				"homedir-polyfill": "^1.0.0",
 				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
+				"is-windows": "^0.2.0",
+				"which": "^1.2.12"
 			},
 			"dependencies": {
+				"is-windows": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+					"dev": true
+				},
 				"which": {
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -7852,6 +7289,12 @@
 					}
 				}
 			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
 		},
 		"globby": {
 			"version": "6.1.0",
@@ -7919,6 +7362,16 @@
 			"dev": true,
 			"optional": true
 		},
+		"gzip-size": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+			"dev": true,
+			"requires": {
+				"duplexer": "^0.1.1",
+				"pify": "^4.0.1"
+			}
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7957,6 +7410,14 @@
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
 			}
 		},
 		"has-flag": {
@@ -8097,6 +7558,15 @@
 			"dev": true,
 			"requires": {
 				"array-filter": "^1.0.0"
+			}
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"html-escaper": {
@@ -8381,6 +7851,12 @@
 				"side-channel": "^1.0.2"
 			}
 		},
+		"interpret": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+			"dev": true
+		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -8391,9 +7867,9 @@
 			}
 		},
 		"ip-regex": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+			"integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
 			"dev": true
 		},
 		"ipaddr.js": {
@@ -8600,6 +8076,12 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
 			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+			"dev": true
+		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
 			"dev": true
 		},
 		"is-number": {
@@ -8866,6 +8348,263 @@
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
+		"jest": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.4.tgz",
+			"integrity": "sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==",
+			"dev": true,
+			"requires": {
+				"@jest/core": "^25.5.4",
+				"import-local": "^3.0.2",
+				"jest-cli": "^25.5.4"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-cli": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
+					"integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^25.5.4",
+						"@jest/test-result": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"import-local": "^3.0.2",
+						"is-ci": "^2.0.0",
+						"jest-config": "^25.5.4",
+						"jest-util": "^25.5.0",
+						"jest-validate": "^25.5.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^2.0.0",
+						"yargs": "^15.3.1"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
+			"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"execa": "^3.2.0",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"p-finally": "^2.0.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+					"dev": true
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"p-finally": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				}
+			}
+		},
+		"jest-config": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
+			"integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/test-sequencer": "^25.5.4",
+				"@jest/types": "^25.5.0",
+				"babel-jest": "^25.5.1",
+				"chalk": "^3.0.0",
+				"deepmerge": "^4.2.2",
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.2.4",
+				"jest-environment-jsdom": "^25.5.0",
+				"jest-environment-node": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"jest-jasmine2": "^25.5.4",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"pretty-format": "^25.5.0",
+				"realpath-native": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"jest-dev-server": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.4.0.tgz",
@@ -8923,9 +8662,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -8997,6 +8736,116 @@
 				}
 			}
 		},
+		"jest-docblock": {
+			"version": "25.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
+			"integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
+			"dev": true,
+			"requires": {
+				"detect-newline": "^3.0.0"
+			}
+		},
+		"jest-each": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
+			"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"jest-get-type": "^25.2.6",
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
+			"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"jsdom": "^15.2.1"
+			}
+		},
+		"jest-environment-node": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
+			"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
 		"jest-environment-puppeteer": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.4.0.tgz",
@@ -9051,9 +8900,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -9086,6 +8935,93 @@
 				"sane": "^4.0.3",
 				"walker": "^1.0.7",
 				"which": "^2.0.2"
+			}
+		},
+		"jest-jasmine2": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
+			"integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"co": "^4.6.0",
+				"expect": "^25.5.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^25.5.0",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-runtime": "^25.5.4",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-leak-detector": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
+			"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
+			"dev": true,
+			"requires": {
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -9220,6 +9156,15 @@
 				}
 			}
 		},
+		"jest-mock": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
+			"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0"
+			}
+		},
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -9311,6 +9256,182 @@
 				}
 			}
 		},
+		"jest-resolve-dependencies": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
+			"integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-snapshot": "^25.5.1"
+			}
+		},
+		"jest-runner": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
+			"integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.4",
+				"jest-docblock": "^25.3.0",
+				"jest-haste-map": "^25.5.1",
+				"jest-jasmine2": "^25.5.4",
+				"jest-leak-detector": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
+				"jest-runtime": "^25.5.4",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-runtime": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
+			"integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/globals": "^25.5.2",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^3.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"realpath-native": "^2.0.0",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0",
+				"yargs": "^15.3.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"jest-serializer": {
 			"version": "25.5.0",
 			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
@@ -9318,6 +9439,87 @@
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4"
+			}
+		},
+		"jest-snapshot": {
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
+			"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^25.5.0",
+				"@types/prettier": "^1.19.0",
+				"chalk": "^3.0.0",
+				"expect": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
+				"make-dir": "^3.0.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^25.5.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-util": {
@@ -9385,6 +9587,138 @@
 				}
 			}
 		},
+		"jest-validate": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
+			"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"camelcase": "^5.3.1",
+				"chalk": "^3.0.0",
+				"jest-get-type": "^25.2.6",
+				"leven": "^3.1.0",
+				"pretty-format": "^25.5.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-watcher": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
+			"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^3.0.0",
+				"jest-util": "^25.5.0",
+				"string-length": "^3.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"jest-worker": {
 			"version": "25.5.0",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
@@ -9441,10 +9775,58 @@
 			"dev": true
 		},
 		"jsdoctypeparser": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
-			"integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+			"integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
 			"dev": true
+		},
+		"jsdom": {
+			"version": "15.2.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+			"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"acorn": "^7.1.0",
+				"acorn-globals": "^4.3.2",
+				"array-equal": "^1.0.0",
+				"cssom": "^0.4.1",
+				"cssstyle": "^2.0.0",
+				"data-urls": "^1.1.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.11.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"nwsapi": "^2.2.0",
+				"parse5": "5.1.0",
+				"pn": "^1.1.0",
+				"request": "^2.88.0",
+				"request-promise-native": "^1.0.7",
+				"saxes": "^3.1.9",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^3.0.1",
+				"w3c-hr-time": "^1.0.1",
+				"w3c-xmlserializer": "^1.1.2",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.5",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^7.0.0",
+				"ws": "^7.0.0",
+				"xml-name-validator": "^3.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+					"dev": true
+				},
+				"parse5": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+					"dev": true
+				}
+			}
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -9656,25 +10038,14 @@
 			"dev": true
 		},
 		"loader-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+			"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
 			"dev": true,
 			"requires": {
 				"big.js": "^5.2.2",
 				"emojis-list": "^3.0.0",
-				"json5": "^1.0.1"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				}
+				"json5": "^2.1.2"
 			}
 		},
 		"locate-path": {
@@ -9735,58 +10106,6 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"lolex": {
@@ -9824,13 +10143,12 @@
 			}
 		},
 		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^3.0.2"
 			}
 		},
 		"make-dir": {
@@ -10137,6 +10455,23 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -10235,9 +10570,9 @@
 			}
 		},
 		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+			"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
 			"dev": true
 		},
 		"mime-db": {
@@ -10254,6 +10589,12 @@
 			"requires": {
 				"mime-db": "1.44.0"
 			}
+		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
 		},
 		"min-indent": {
 			"version": "1.0.1",
@@ -10273,6 +10614,26 @@
 				"webpack-sources": "^1.1.0"
 			},
 			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
 				"schema-utils": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -10369,9 +10730,9 @@
 			}
 		},
 		"minizlib": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
-			"integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
 			"dev": true,
 			"requires": {
 				"minipass": "^3.0.0",
@@ -10476,17 +10837,6 @@
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"ms": {
@@ -10577,31 +10927,11 @@
 				"which": "1"
 			},
 			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
 					"dev": true
-				},
-				"tar": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-					"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-					"dev": true,
-					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.12",
-						"inherits": "2"
-					}
 				},
 				"which": {
 					"version": "1.3.1",
@@ -10755,6 +11085,31 @@
 				"true-case-path": "^1.0.2"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"cross-spawn": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -10771,6 +11126,31 @@
 					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
 					"dev": true
 				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				},
 				"which": {
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -10779,6 +11159,12 @@
 					"requires": {
 						"isexe": "^2.0.0"
 					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
 				}
 			}
 		},
@@ -10856,16 +11242,6 @@
 				"strip-json-comments": "^3.1.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
 				"array-union": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -10882,31 +11258,6 @@
 						"map-obj": "^4.0.0",
 						"quick-lru": "^4.0.1"
 					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
 				},
 				"debug": {
 					"version": "4.1.1",
@@ -10930,12 +11281,6 @@
 						"merge2": "^1.3.0",
 						"slash": "^3.0.0"
 					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
 				},
 				"ignore": {
 					"version": "5.1.8",
@@ -11009,15 +11354,6 @@
 					"dev": true,
 					"requires": {
 						"min-indent": "^1.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
 					}
 				},
 				"trim-newlines": {
@@ -11246,10 +11582,19 @@
 				"wrappy": "1"
 			}
 		},
+		"onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
+			}
+		},
 		"opener": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
 			"dev": true
 		},
 		"optionator": {
@@ -11336,6 +11681,12 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
+		"pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
+		},
 		"parallel-transform": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
@@ -11383,14 +11734,13 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
 			"dev": true,
 			"requires": {
-				"asn1.js": "^4.0.0",
+				"asn1.js": "^5.2.0",
 				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
@@ -11499,23 +11849,10 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
 		},
 		"pbkdf2": {
 			"version": "3.1.1",
@@ -11649,15 +11986,6 @@
 				"mkdirp": "^0.5.5"
 			},
 			"dependencies": {
-				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
 				"debug": {
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -11692,15 +12020,6 @@
 				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -11830,6 +12149,26 @@
 				"schema-utils": "^1.0.0"
 			},
 			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
 				"schema-utils": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -11888,58 +12227,6 @@
 			"requires": {
 				"icss-utils": "^4.0.0",
 				"postcss": "^7.0.6"
-			}
-		},
-		"postcss-reporter": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
-			"integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"lodash": "^4.17.11",
-				"log-symbols": "^2.2.0",
-				"postcss": "^7.0.7"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"log-symbols": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-					"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-resolve-nested-selector": {
@@ -12029,12 +12316,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
-		},
-		"prettier": {
-			"version": "npm:wp-prettier@2.0.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -12242,49 +12523,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"puppeteer": {
-			"version": "npm:puppeteer-core@3.0.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-			"dev": true,
-			"requires": {
-				"@types/mime-types": "^2.1.0",
-				"debug": "^4.1.0",
-				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
-				"mime": "^2.0.3",
-				"mime-types": "^2.1.25",
-				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^3.0.2",
-				"tar-fs": "^2.0.0",
-				"unbzip2-stream": "^1.3.3",
-				"ws": "^7.2.3"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"mime": {
-					"version": "2.4.6",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
-		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -12292,9 +12530,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.9.4",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-			"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
 		"query-string": {
@@ -12376,21 +12614,15 @@
 			"dev": true
 		},
 		"raw-body": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-			"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
 			"dev": true,
 			"requires": {
-				"bytes": "1",
-				"string_decoder": "0.10"
-			},
-			"dependencies": {
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
 			}
 		},
 		"rc": {
@@ -12548,6 +12780,12 @@
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.14.5",
@@ -12900,12 +13138,6 @@
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
-				"qs": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
-				},
 				"tough-cookie": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -12915,12 +13147,6 @@
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
 					}
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
 				}
 			}
 		},
@@ -13002,13 +13228,13 @@
 			}
 		},
 		"resolve-dir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
 			}
 		},
 		"resolve-from": {
@@ -13036,9 +13262,9 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
@@ -13277,15 +13503,6 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"cliui": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -13381,11 +13598,81 @@
 				}
 			}
 		},
+		"sass-loader": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
+			"integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+			"dev": true,
+			"requires": {
+				"clone-deep": "^4.0.1",
+				"loader-utils": "^1.2.3",
+				"neo-async": "^2.6.1",
+				"schema-utils": "^2.6.1",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"clone-deep": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+					"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4",
+						"kind-of": "^6.0.2",
+						"shallow-clone": "^3.0.0"
+					}
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"shallow-clone": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+					"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
+		},
+		"saxes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"dev": true,
+			"requires": {
+				"xmlchars": "^2.1.1"
+			}
 		},
 		"scheduler": {
 			"version": "0.19.1",
@@ -13461,6 +13748,12 @@
 				"statuses": "~1.5.0"
 			},
 			"dependencies": {
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+					"dev": true
+				},
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -13470,9 +13763,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-			"integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
 			"dev": true,
 			"requires": {
 				"randombytes": "^2.1.0"
@@ -13593,13 +13886,35 @@
 			"optional": true
 		},
 		"side-channel": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
-			"integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
+			"integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
 			"dev": true,
 			"requires": {
-				"es-abstract": "^1.17.0-next.1",
-				"object-inspect": "^1.7.0"
+				"es-abstract": "^1.18.0-next.0",
+				"object-inspect": "^1.8.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.0",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
 			}
 		},
 		"signal-exit": {
@@ -13629,17 +13944,6 @@
 				"ansi-styles": "^3.2.0",
 				"astral-regex": "^1.0.0",
 				"is-fullwidth-code-point": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				}
 			}
 		},
 		"snapdragon": {
@@ -13780,13 +14084,24 @@
 				"loader-utils": "^1.1.0"
 			},
 			"dependencies": {
-				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.17.14"
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
 					}
 				}
 			}
@@ -13802,6 +14117,24 @@
 				"resolve-url": "^0.2.1",
 				"source-map-url": "^0.4.0",
 				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
 			}
 		},
 		"source-map-url": {
@@ -14227,12 +14560,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "^5.0.0"
 			}
 		},
 		"strip-bom": {
@@ -14283,19 +14616,21 @@
 			"dev": true
 		},
 		"stylelint": {
-			"version": "13.6.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.6.1.tgz",
-			"integrity": "sha512-XyvKyNE7eyrqkuZ85Citd/Uv3ljGiuYHC6UiztTR6sWS9rza8j3UeQv/eGcQS9NZz/imiC4GKdk1EVL3wst5vw==",
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.0.tgz",
+			"integrity": "sha512-1wStd4zVetnlHO98VjcHQbjSDmvcA39smkZQMct2cf+hom40H0xlQNdzzbswoG/jGBh61/Ue9m7Lu99PY51O6A==",
 			"dev": true,
 			"requires": {
-				"@stylelint/postcss-css-in-js": "^0.37.1",
+				"@stylelint/postcss-css-in-js": "^0.37.2",
 				"@stylelint/postcss-markdown": "^0.36.1",
-				"autoprefixer": "^9.8.0",
+				"autoprefixer": "^9.8.6",
 				"balanced-match": "^1.0.0",
 				"chalk": "^4.1.0",
-				"cosmiconfig": "^6.0.0",
+				"cosmiconfig": "^7.0.0",
 				"debug": "^4.1.1",
 				"execall": "^2.0.0",
+				"fast-glob": "^3.2.4",
+				"fastest-levenshtein": "^1.0.12",
 				"file-entry-cache": "^5.0.1",
 				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
@@ -14306,18 +14641,16 @@
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
 				"known-css-properties": "^0.19.0",
-				"leven": "^3.1.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.20",
 				"log-symbols": "^4.0.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^7.0.1",
+				"meow": "^7.1.1",
 				"micromatch": "^4.0.2",
 				"normalize-selector": "^0.2.0",
 				"postcss": "^7.0.32",
 				"postcss-html": "^0.36.0",
 				"postcss-less": "^3.1.4",
 				"postcss-media-query-parser": "^0.2.3",
-				"postcss-reporter": "^6.0.1",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^4.0.2",
 				"postcss-sass": "^0.4.4",
@@ -14333,16 +14666,22 @@
 				"style-search": "^0.1.0",
 				"sugarss": "^2.0.0",
 				"svg-tags": "^1.0.0",
-				"table": "^5.4.6",
+				"table": "^6.0.1",
 				"v8-compile-cache": "^2.1.1",
 				"write-file-atomic": "^3.0.3"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
+				"ajv": {
+					"version": "6.12.4",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+					"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
 				},
 				"ansi-styles": {
 					"version": "4.2.1",
@@ -14360,6 +14699,12 @@
 					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 					"dev": true
 				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"dev": true
+				},
 				"camelcase-keys": {
 					"version": "6.2.2",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
@@ -14369,16 +14714,6 @@
 						"camelcase": "^5.3.1",
 						"map-obj": "^4.0.0",
 						"quick-lru": "^4.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
 					}
 				},
 				"color-convert": {
@@ -14395,6 +14730,19 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.2.1",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.10.0"
+					}
 				},
 				"debug": {
 					"version": "4.1.1",
@@ -14451,12 +14799,6 @@
 						"slash": "^3.0.0"
 					}
 				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"ignore": {
 					"version": "5.1.8",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -14475,6 +14817,12 @@
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
 				"map-obj": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
@@ -14482,9 +14830,9 @@
 					"dev": true
 				},
 				"meow": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
-					"integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+					"integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
 					"dev": true,
 					"requires": {
 						"@types/minimist": "^1.2.0",
@@ -14516,6 +14864,17 @@
 						"strip-indent": "^3.0.0"
 					}
 				},
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				},
 				"string-width": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -14527,15 +14886,6 @@
 						"strip-ansi": "^6.0.0"
 					}
 				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
 				"strip-indent": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -14545,13 +14895,16 @@
 						"min-indent": "^1.0.0"
 					}
 				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+				"table": {
+					"version": "6.0.3",
+					"resolved": "https://registry.npmjs.org/table/-/table-6.0.3.tgz",
+					"integrity": "sha512-8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^4.0.0"
+						"ajv": "^6.12.4",
+						"lodash": "^4.17.20",
+						"slice-ansi": "^4.0.0",
+						"string-width": "^4.2.0"
 					}
 				},
 				"trim-newlines": {
@@ -14626,10 +14979,13 @@
 			}
 		},
 		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
 		},
 		"supports-hyperlinks": {
 			"version": "2.1.0",
@@ -14691,15 +15047,6 @@
 				"util.promisify": "~1.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -14738,15 +15085,6 @@
 						"dom-serializer": "0",
 						"domelementtype": "1"
 					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -14775,31 +15113,14 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
-			"integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
 			"dev": true,
 			"requires": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.0",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
+				"block-stream": "*",
+				"fstream": "^1.0.12",
+				"inherits": "2"
 			}
 		},
 		"tar-fs": {
@@ -14861,57 +15182,178 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.19",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-					"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
 				}
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-			"integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.1.0.tgz",
+			"integrity": "sha512-cjdZte66fYkZ65rQ2oJfrdCAkkhJA7YLYk5eGOcGCSGlq0ieZupRdjedSQXYknMPo2IveQL+tPdrxUkERENCFA==",
 			"dev": true,
 			"requires": {
-				"cacache": "^12.0.2",
-				"find-cache-dir": "^2.1.0",
-				"is-wsl": "^1.1.0",
-				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^3.1.0",
+				"cacache": "^15.0.5",
+				"find-cache-dir": "^3.3.1",
+				"jest-worker": "^26.2.1",
+				"p-limit": "^3.0.2",
+				"schema-utils": "^2.6.6",
+				"serialize-javascript": "^4.0.0",
 				"source-map": "^0.6.1",
-				"terser": "^4.1.2",
-				"webpack-sources": "^1.4.0",
-				"worker-farm": "^1.7.0"
+				"terser": "^4.8.0",
+				"webpack-sources": "^1.4.3"
 			},
 			"dependencies": {
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-					"dev": true
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+				"cacache": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+					"integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
+						"@npmcli/move-file": "^1.0.1",
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"glob": "^7.1.4",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^6.0.0",
+						"minipass": "^3.1.1",
+						"minipass-collect": "^1.0.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.2",
+						"mkdirp": "^1.0.3",
+						"p-map": "^4.0.0",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^3.0.2",
+						"ssri": "^8.0.0",
+						"tar": "^6.0.2",
+						"unique-filename": "^1.1.1"
+					}
+				},
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
+				"find-cache-dir": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.2",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-worker": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+					"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
+				"p-limit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+					"integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"ssri": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+					"integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"tar": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+					"integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+					"dev": true,
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -14942,6 +15384,28 @@
 				"loader-runner": "^2.3.1",
 				"loader-utils": "^1.1.0",
 				"neo-async": "^2.6.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				}
 			}
 		},
 		"throat": {
@@ -15050,6 +15514,12 @@
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
 			"dev": true
 		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -15106,6 +15576,23 @@
 				"ip-regex": "^2.1.0",
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
+			},
+			"dependencies": {
+				"ip-regex": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+					"dev": true
+				}
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
 			}
 		},
 		"tree-kill": {
@@ -15510,11 +15997,25 @@
 				"schema-utils": "^2.5.0"
 			},
 			"dependencies": {
-				"mime": {
-					"version": "2.4.6",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-					"dev": true
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
 				}
 			}
 		},
@@ -15526,14 +16027,6 @@
 			"requires": {
 				"ip-regex": "^4.1.0",
 				"tlds": "^1.203.0"
-			},
-			"dependencies": {
-				"ip-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-					"integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
-					"dev": true
-				}
 			}
 		},
 		"use": {
@@ -15581,6 +16074,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
+		},
+		"uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"v8-compile-cache": {
@@ -15677,6 +16176,17 @@
 				"browser-process-hrtime": "^1.0.0"
 			}
 		},
+		"w3c-xmlserializer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"dev": true,
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
 		"wait-on": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
@@ -15688,6 +16198,14 @@
 				"minimist": "^1.2.0",
 				"request": "^2.88.0",
 				"rx": "^4.1.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+					"dev": true
+				}
 			}
 		},
 		"wait-port": {
@@ -15701,15 +16219,6 @@
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -15741,15 +16250,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -16030,6 +16530,12 @@
 				}
 			}
 		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
+		},
 		"webpack": {
 			"version": "4.44.1",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
@@ -16061,12 +16567,6 @@
 				"webpack-sources": "^1.4.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-					"dev": true
-				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
@@ -16094,16 +16594,6 @@
 								"is-extendable": "^0.1.0"
 							}
 						}
-					}
-				},
-				"eslint-scope": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
 					}
 				},
 				"fill-range": {
@@ -16149,6 +16639,32 @@
 						}
 					}
 				},
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -16179,6 +16695,29 @@
 						"ajv": "^6.1.0",
 						"ajv-errors": "^1.0.0",
 						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"terser-webpack-plugin": {
+					"version": "1.4.5",
+					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+					"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+					"dev": true,
+					"requires": {
+						"cacache": "^12.0.2",
+						"find-cache-dir": "^2.1.0",
+						"is-wsl": "^1.1.0",
+						"schema-utils": "^1.0.0",
+						"serialize-javascript": "^4.0.0",
+						"source-map": "^0.6.1",
+						"terser": "^4.1.2",
+						"webpack-sources": "^1.4.0",
+						"worker-farm": "^1.7.0"
 					}
 				},
 				"to-regex-range": {
@@ -16214,14 +16753,17 @@
 				"ws": "^6.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
+				"acorn": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+					"dev": true
+				},
+				"acorn-walk": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+					"dev": true
 				},
 				"chalk": {
 					"version": "2.4.2",
@@ -16232,25 +16774,6 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
-					}
-				},
-				"gzip-size": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-					"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
-					"dev": true,
-					"requires": {
-						"duplexer": "^0.1.1",
-						"pify": "^4.0.1"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				},
 				"ws": {
@@ -16289,44 +16812,6 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -16360,29 +16845,6 @@
 						"wrap-ansi": "^5.1.0"
 					}
 				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -16390,18 +16852,6 @@
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
-					}
-				},
-				"findup-sync": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-					"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-					"dev": true,
-					"requires": {
-						"detect-file": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"micromatch": "^3.0.4",
-						"resolve-dir": "^1.0.1"
 					}
 				},
 				"global-modules": {
@@ -16434,30 +16884,24 @@
 						"resolve-cwd": "^2.0.0"
 					}
 				},
-				"interpret": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-					"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-					"dev": true
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
 					}
 				},
 				"locate-path": {
@@ -16468,27 +16912,6 @@
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
-					}
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
 					}
 				},
 				"p-locate": {
@@ -16537,16 +16960,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"dev": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
 					}
 				},
 				"which": {
@@ -16660,6 +17073,17 @@
 			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
 			"dev": true
 		},
+		"whatwg-url": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -16737,12 +17161,6 @@
 				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
 				"ansi-styles": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -16789,15 +17207,6 @@
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
 						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -16866,9 +17275,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true
 		},
 		"yaml": {
@@ -16896,12 +17305,6 @@
 				"yargs-parser": "^18.1.2"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -16923,15 +17326,6 @@
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
 						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@wordpress/jest-preset-default": "6.2.0",
-    "@wordpress/scripts": "12.1.1",
+    "@wordpress/scripts": "12.2.0",
     "file-loader": "6.0.0"
   },
   "scripts": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* From @renatho's review in the Resume build PR, I learned that SASS `@extends` behaves differently between the LESS equivalent and adds new inherited classes instead of just putting the styles from that class. To get it to generate CSS more similar to the previous LESS version, I've moved them over to mixins. For backwards compatibility, I kept the `.jm-icon`, `.clearfix`, and `.display-icon` classes.

### Testing instructions

* Confirm no visual regressions.
