### PR TITLE
Add job_manager_select2_filters_args for search_categories filtering field, and fix job_manager_select2_args pollution

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -507,12 +507,8 @@ jQuery( document ).ready( function( $ ) {
 		return false;
 	} );
 
-	if ( $.isFunction( $.fn.select2 ) && typeof job_manager_select2_args !== 'undefined' ) {
-		var select2_args = job_manager_select2_args;
-		select2_args[ 'allowClear' ] = true;
-		select2_args[ 'minimumResultsForSearch' ] = 10;
-
-		$( 'select[name^="search_categories"]:visible' ).select2( select2_args );
+	if ( $.isFunction( $.fn.select2 ) && typeof job_manager_select2_filters_args !== 'undefined' ) {
+		$( 'select[name^="search_categories"]:visible' ).select2( job_manager_select2_filters_args );
 	}
 
 	// Initial job and $form population

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -432,10 +432,14 @@ class WP_Job_Manager {
 		wp_localize_script( 'wp-job-manager-ajax-filters', 'job_manager_ajax_filters', $ajax_data );
 
 		if ( isset( $select2_args ) ) {
-			$select2_filters_args = array_merge( $select2_args, [ 'allowClear'              => true,
-			                                                      'minimumResultsForSearch' => 10,
-			                                                      'placeholder'             => __( 'Any Category', 'wp-job-manager' )
-			] );
+			$select2_filters_args = array_merge(
+				$select2_args,
+				[
+					'allowClear'              => true,
+					'minimumResultsForSearch' => 10,
+					'placeholder'             => __( 'Any Category', 'wp-job-manager' ),
+				]
+			);
 
 			wp_localize_script(
 				'select2',

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -437,12 +437,10 @@ class WP_Job_Manager {
 			                                                      'placeholder'             => __( 'Any Category', 'wp-job-manager' )
 			] );
 
-			$select2_filters_args = apply_filters( 'job_manager_select2_filters_args', $select2_filters_args );
-
 			wp_localize_script(
 				'select2',
 				'job_manager_select2_filters_args',
-				$select2_filters_args
+				apply_filters( 'job_manager_select2_filters_args', $select2_filters_args )
 			);
 		}
 

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -431,6 +431,21 @@ class WP_Job_Manager {
 		wp_register_script( 'wp-job-manager-job-submission', JOB_MANAGER_PLUGIN_URL . '/assets/js/job-submission.min.js', [ 'jquery' ], JOB_MANAGER_VERSION, true );
 		wp_localize_script( 'wp-job-manager-ajax-filters', 'job_manager_ajax_filters', $ajax_data );
 
+		if ( isset( $select2_args ) ) {
+			$select2_filters_args = array_merge( $select2_args, [ 'allowClear'              => true,
+			                                                      'minimumResultsForSearch' => 10,
+			                                                      'placeholder'             => __( 'Any Category', 'wp-job-manager' )
+			] );
+
+			$select2_filters_args = apply_filters( 'job_manager_select2_filters_args', $select2_filters_args );
+
+			wp_localize_script(
+				'select2',
+				'job_manager_select2_filters_args',
+				$select2_filters_args
+			);
+		}
+
 		wp_localize_script(
 			'wp-job-manager-job-submission',
 			'job_manager_job_submission',


### PR DESCRIPTION
Fixes #2058

### Changes proposed in this Pull Request

* Add `job_manager_select2_filters_args` for select2 initialization on search categories field

### Testing instructions

* Load up job lists page, and check `job_manager_select2_filters_args` in console
