### PR TITLE
Fixes #2068

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -771,8 +771,10 @@ function is_wpjm_page() {
 		 * @param int[] $wpjm_page_ids
 		 */
 		$wpjm_page_ids = array_unique( apply_filters( 'job_manager_page_ids', $wpjm_page_ids ) );
-
-		$is_wpjm_page = is_page( $wpjm_page_ids );
+		
+		if ( ! empty ( $wpjm_page_ids ) ) {
+			$is_wpjm_page = is_page( $wpjm_page_ids );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Added a check to `$wpjm_page_ids` before calling `is_page`. This is because according to the notes here: https://developer.wordpress.org/reference/functions/is_page/#notes `is_page` will return `true` if an empty value is passed.

Fixes #2068

### Changes proposed in this Pull Request

Added a check to `$wpjm_page_ids` before calling `is_page`. This is because according to the notes here: https://developer.wordpress.org/reference/functions/is_page/#notes `is_page` will return `true` if an empty value is passed.