### PR TITLE
Improve access checks for Job Dashboard actions 

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -110,12 +110,17 @@ class WP_Job_Manager_Shortcodes {
 	public function job_dashboard_handler() {
 		if (
 			! empty( $_REQUEST['action'] )
+			&& ! empty( $_REQUEST['job_id'] )
 			&& ! empty( $_REQUEST['_wpnonce'] )
-			&& wp_verify_nonce( wp_unslash( $_REQUEST['_wpnonce'] ), 'job_manager_my_job_actions' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
 		) {
 
-			$action = sanitize_title( wp_unslash( $_REQUEST['action'] ) );
 			$job_id = isset( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : 0;
+			$action = sanitize_title( wp_unslash( $_REQUEST['action'] ) );
+
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+			if ( ! wp_verify_nonce( wp_unslash( $_REQUEST['_wpnonce'] ), 'job_manager_my_job_actions_' . $job_id ) ) {
+				return;
+			}
 
 			try {
 				// Get Job.

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -82,7 +82,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 											foreach ( $actions as $action => $value ) {
 												$action_url = add_query_arg( [ 'action' => $action, 'job_id' => $job->ID ] );
 												if ( $value['nonce'] ) {
-													$action_url = wp_nonce_url( $action_url, 'job_manager_my_job_actions' );
+													$action_url = wp_nonce_url( $action_url, 'job_manager_my_job_actions_' . $job->ID );
 												}
 												echo '<li><a href="' . esc_url( $action_url ) . '" class="job-dashboard-action-' . esc_attr( $action ) . '">' . esc_html( $value['label'] ) . '</a></li>';
 											}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -718,7 +718,7 @@ function job_manager_user_can_edit_job( $job_id ) {
 	} else {
 		$job = get_post( $job_id );
 
-		if ( ! $job || ( absint( $job->post_author ) !== get_current_user_id() && ! current_user_can( 'edit_post', $job_id ) ) ) {
+		if ( ! $job || 'job_listing' !== $job->post_type || ( absint( $job->post_author ) !== get_current_user_id() && ! current_user_can( 'edit_post', $job_id ) ) ) {
 			$can_edit = false;
 		}
 	}


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add job ID to nonce action
* Fix `job_manager_user_can_edit_job` to check post type

### Testing instructions

* Submit some jobs as a regular user
* Open Job Dashboard
* Actions on each job, like *Mark filled*, *Duplicate* should work
--
* Copy the Duplicate action url, and change the `job_id` parameter to reference a post that's not a job
* Duplicate action should not be performed 

