### PR TITLE
Fix missing variable with widget caching

### DIFF
--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -102,6 +102,12 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	 * @param string $content
 	 */
 	public function cache_widget( $args, $content ) {
+		$cache = wp_cache_get( $this->widget_id, 'widget' );
+
+		if ( ! is_array( $cache ) ) {
+			$cache = [];
+		}
+
 		$cache[ $args['widget_id'] ] = $content;
 
 		wp_cache_set( $this->widget_id, $cache, 'widget' );


### PR DESCRIPTION
Fixes #2009

### Changes proposed in this Pull Request

* Before updating the cached instances of a widget, it retrieves the current value and builds off of that. It is a bit confusing, but `$this->widget_id` is the general widget ID (`widget_featured_jobs`) where `$args['widget_id']` is the unique instance ID of the widget (`widget_featured_jobs-5`). 

### Testing instructions

* Level 1: Just add a WPJM widget to a widget area and make sure it renders as expected.
* Level 2: With object caching set up, make sure a widget's rendering is cached between page loads. You could test this by changing a displayed post title in the database (not with WordPress).