### PR TITLE
Fix jobs list not appearing in the page load while using Firefox

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -515,43 +515,6 @@ jQuery( document ).ready( function( $ ) {
 		$( 'select[name^="search_categories"]:visible' ).select2( select2_args );
 	}
 
-	// Initial job and $form population
-	$( window ).on( 'load', function() {
-		$( 'div.job_listings' ).each( function() {
-			var $target = $( this );
-			var $form = $target.find( '.job_filters' );
-			var results_loaded = false;
-			var state = get_state( $target );
-
-			if ( state ) {
-				// Restore the results from cache.
-				if ( state.results ) {
-					results_loaded = handle_result( $target, state.results );
-
-					// We don't want this to continue to persist unless we click on another link.
-					persist_results( $target, false );
-					clear_form( $target );
-				}
-
-				// Restore the form state.
-				if ( typeof state.form === 'string' && '' !== state.form ) {
-					// When deserializing a form, we need to first uncheck the checkboxes that are by default checked.
-					$form.find('input[type=checkbox]').prop('checked', false);
-					$form.deserialize(state.form);
-					$form
-						.find(':input[name^="search_categories"]')
-						.not(':input[type="hidden"]')
-						.trigger('change.select2');
-				}
-			}
-
-			if ( ! results_loaded && $form.length > 0 ) {
-				// If we didn't load results from cache, load page 1.
-				$target.triggerHandler( 'update_results', [ 1, false ] );
-			}
-		} );
-	} );
-
 	$( window ).on( 'unload', function() {
 		$( 'div.job_listings' ).each( function() {
 			var state = get_state( $( this ) );
@@ -561,5 +524,40 @@ jQuery( document ).ready( function( $ ) {
 		} );
 
 		return true;
+	} );
+
+	// Initial job and $form population
+	$( 'div.job_listings' ).each( function() {
+		var $target = $( this );
+		var $form = $target.find( '.job_filters' );
+		var results_loaded = false;
+		var state = get_state( $target );
+
+		if ( state ) {
+			// Restore the results from cache.
+			if ( state.results ) {
+				results_loaded = handle_result( $target, state.results );
+
+				// We don't want this to continue to persist unless we click on another link.
+				persist_results( $target, false );
+				clear_form( $target );
+			}
+
+			// Restore the form state.
+			if ( typeof state.form === 'string' && '' !== state.form ) {
+				// When deserializing a form, we need to first uncheck the checkboxes that are by default checked.
+				$form.find('input[type=checkbox]').prop('checked', false);
+				$form.deserialize(state.form);
+				$form
+					.find(':input[name^="search_categories"]')
+					.not(':input[type="hidden"]')
+					.trigger('change.select2');
+			}
+		}
+
+		if ( ! results_loaded && $form.length > 0 ) {
+			// If we didn't load results from cache, load page 1.
+			$target.triggerHandler( 'update_results', [ 1, false ] );
+		}
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This fixes an issue with the jobs list not appearing in the page load while using Firefox.

### Testing instructions

* Create some jobs using WP 5.6.
* In Firefox, open the jobs page.
* Make sure you see the jobs list after the page load.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="641" alt="Screen Shot 2020-12-11 at 14 53 56" src="https://user-images.githubusercontent.com/876340/101937584-d0562c00-3bc0-11eb-9492-e613aaf3a538.png">
