### PR TITLE
Revert "Release 1.34.5"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,3 @@
-= 1.34.5 =
-* Fix: Jobs list not appearing in the page load while using Firefox.
-
 = 1.34.4 =
 * Fix: Harden security of job dashboard actions. Reported by Slavco.
 * Updated template: `job-dashboard.php`.

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -1,17 +1,17 @@
 # Copyright (C) 2020 Automattic
-# This file is distributed under the GPL2+.
+# This file is distributed under the same license as the WP Job Manager plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 1.34.5\n"
+"Project-Id-Version: WP Job Manager 1.34.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-12-14T17:04:35+00:00\n"
+"POT-Creation-Date: 2020-11-24T11:31:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0-alpha-75cb7e3\n"
+"X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: wp-job-manager\n"
 
 #. Plugin Name of the plugin
@@ -183,6 +183,7 @@ msgstr ""
 msgid "%1$s updated. <a href=\"%2$s\">View</a>"
 msgstr ""
 
+#. translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 #: includes/admin/class-wp-job-manager-cpt.php:456
 msgid "Custom field updated."
 msgstr ""
@@ -299,6 +300,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
+#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/admin/class-wp-job-manager-cpt.php:647
 #: includes/class-wp-job-manager-post-types.php:335
 #: includes/class-wp-job-manager-shortcodes.php:381
@@ -983,6 +985,7 @@ msgstr[1] ""
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
+#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/class-wp-job-manager-data-exporter.php:51
 #: includes/class-wp-job-manager-post-types.php:352
 msgid "Company Logo"
@@ -1191,6 +1194,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
+#. translators: Placeholder %s is the plural label of the job listing post type.
 #: includes/class-wp-job-manager-post-types.php:332
 msgid "Add New"
 msgstr ""
@@ -1372,6 +1376,7 @@ msgstr ""
 msgid "Missing submission page."
 msgstr ""
 
+#. translators: Placeholder %s is the plural label for the job listing post type.
 #: includes/class-wp-job-manager-shortcodes.php:332
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:36
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:52

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-job-manager",
-	"version": "1.34.5",
+	"version": "1.34.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2397,12 +2397,6 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
-				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.0.5",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-					"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
-					"dev": true
 				}
 			}
 		},
@@ -2582,32 +2576,6 @@
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.0.5",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-					"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
-					"dev": true
-				},
-				"puppeteer": {
-					"version": "npm:puppeteer-core@3.0.0",
-					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-					"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-					"dev": true,
-					"requires": {
-						"@types/mime-types": "^2.1.0",
-						"debug": "^4.1.0",
-						"extract-zip": "^2.0.0",
-						"https-proxy-agent": "^4.0.0",
-						"mime": "^2.0.3",
-						"mime-types": "^2.1.25",
-						"progress": "^2.0.1",
-						"proxy-from-env": "^1.0.0",
-						"rimraf": "^3.0.2",
-						"tar-fs": "^2.0.0",
-						"unbzip2-stream": "^1.3.3",
-						"ws": "^7.2.3"
-					}
-				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -2627,15 +2595,6 @@
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
 					}
 				},
 				"which": {
@@ -11177,6 +11136,12 @@
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
+		"prettier": {
+			"version": "npm:wp-prettier@2.0.5",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+			"dev": true
+		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -11356,6 +11321,37 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"puppeteer": {
+			"version": "npm:puppeteer-core@3.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+			"dev": true,
+			"requires": {
+				"@types/mime-types": "^2.1.0",
+				"debug": "^4.1.0",
+				"extract-zip": "^2.0.0",
+				"https-proxy-agent": "^4.0.0",
+				"mime": "^2.0.3",
+				"mime-types": "^2.1.25",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
 		},
 		"q": {
 			"version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "1.34.5",
+  "version": "1.34.4",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: job manager, job listing, job board, job management, job lists, job list, 
 Requires at least: 5.2
 Tested up to: 5.6
 Requires PHP: 7.0
-Stable tag: 1.34.5
+Stable tag: 1.34.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -152,9 +152,6 @@ It then creates a database based on the parameters passed to it.
 6. Job listings in admin.
 
 == Changelog ==
-
-= 1.34.5 =
-* Fix: Jobs list not appearing in the page load while using Firefox.
 
 = 1.34.4 =
 * Fix: Harden security of job dashboard actions. Reported by Slavco.

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.34.5
+ * Version: 1.34.4
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 5.2
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.34.5' );
+define( 'JOB_MANAGER_VERSION', '1.34.4' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Reverts Automattic/WP-Job-Manager#2083

Reverting since it used the wrong source. The tagged commit was restored and the new PR will point to the correct commit.