### PR TITLE
Add job_manager_get_form_action filter fixes #2089

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -190,8 +190,20 @@ abstract class WP_Job_Manager_Form {
 	 */
 	public function get_action() {
 		$default_action = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$action = esc_url_raw( $this->action ? $this->action : $default_action );
 
-		return esc_url_raw( $this->action ? $this->action : $default_action );
+		/**
+		 * Alter form submit action URL
+		 *
+		 * Before submitting or editing a job, alter the posted values before they get stored into the database.
+		 *
+		 * @param string $action Form action value
+		 * @param WP_Job_Manager_Form $this
+		 *
+		 * @since @@version
+		 *
+		 */
+		return apply_filters( 'job_manager_get_form_action', $action, $this );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -195,13 +195,12 @@ abstract class WP_Job_Manager_Form {
 		/**
 		 * Alter form submit action URL
 		 *
-		 * Before submitting or editing a job, alter the posted values before they get stored into the database.
+		 * @since 1.35.0
 		 *
-		 * @param string $action Form action value
-		 * @param WP_Job_Manager_Form $this
+		 * @param string              $action Form action value
+		 * @param WP_Job_Manager_Form $this   Current form class object
 		 *
-		 * @since @@version
-		 *
+		 * @return string
 		 */
 		return apply_filters( 'job_manager_get_form_action', $action, $this );
 	}


### PR DESCRIPTION
Currently without overriding the entire template, there's no way to customize or change the form action URL.  This filter allows customization of the form action URL.

Fixes #2089

### Changes proposed in this Pull Request

* Adds `job_manager_get_form_action` filter

### Testing instructions

*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

```
/**
 * Alter form submit action URL
 *
 * Before submitting or editing a job, alter the posted values before they get stored into the database.
 *
 * @param string $action Form action value
 * @param WP_Job_Manager_Form $this
 *
 * @since @@version
 *
 */
return apply_filters( 'job_manager_get_form_action', $action, $this );
 ```
