### PR TITLE
Fix 404 errors when jQuery migrate plugin is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
 
 # Clones WordPress and configures our testing environment.
 before_script:
+    - composer self-update --1
     - phpenv config-rm xdebug.ini
     - export PLUGIN_BASE_DIR=$(basename $(pwd))
     - export PLUGIN_SLUG=$(basename $(pwd) | tr '[:upper:]' '[:lower:]')

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -251,6 +251,7 @@ class WP_Job_Manager {
 		global $wp_scripts;
 
 		$jquery_version = isset( $wp_scripts->registered['jquery-ui-core']->ver ) ? $wp_scripts->registered['jquery-ui-core']->ver : '1.9.2';
+		$jquery_version = preg_replace( '/-wp/', '', $jquery_version );
 		wp_register_style( 'jquery-ui', '//code.jquery.com/ui/' . $jquery_version . '/themes/smoothness/jquery-ui.min.css', [], $jquery_version );
 
 		// Register datepicker JS. It will be enqueued if needed when a date field is used.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This fixes an issue where CSS assets where not loaded when jQuery migrate plugin is installed.
<img width="531" alt="slack-imgs com" src="https://user-images.githubusercontent.com/53191348/102892295-564b6000-4468-11eb-9757-b2898338b31d.png">

### Testing instructions

* Install `Enable jQuery Migrate Helper` plugin on a WPJM site.
* On the plugin settings, set the version as `Legacy 1.12.4-wp`
* Observe that there are no 404s on the console when trying accessing WPJM pages.

