### PR TITLE
Fix issue with double slash in webpack builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ const FileLoader = {
 	test: /\.(?:gif|jpg|jpeg|png|svg|woff|woff2|eot|ttf|otf)$/i,
 	loader: 'file-loader',
 	options: {
-		name: '[path]/[name]-[contenthash].[ext]',
+		name: '[path][name]-[contenthash].[ext]',
 		context: 'assets',
 		publicPath: '..',
 	},


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Minor fix for new webpack builds. The file loader output would have a double-slash between the path and filename. 
* Test break is unrelated. I'll fix it in a new PR.

### Testing instructions

* Run `npm run build` and verify assets load.