### PR TITLE
Fix validation and sanitization of application method

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -76,7 +76,8 @@ abstract class WP_Job_Manager_Form {
 	/**
 	 * Field names of values that had a value on submission but may have been cleared during sanitization.
 	 *
-	 * This is optional and is a helper to be used when sanitation errors should be displayed over empty required fields.
+	 * This is optional and is a helper to be used when sanitation errors should be displayed over
+	 * empty required fields.
 	 *
 	 * @var array
 	 */

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -358,7 +358,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	protected function validate_fields( $values ) {
 		foreach ( $this->fields as $group_key => $group_fields ) {
 			foreach ( $group_fields as $key => $field ) {
-				if ( $field['required'] && empty( $values[ $group_key ][ $key ] ) ) {
+				if (
+					$field['required']
+					&& empty( $values[ $group_key ][ $key ] )
+				) {
 					// translators: Placeholder %s is the label for the required field.
 					return new WP_Error( 'validation-error', sprintf( __( '%s is a required field', 'wp-job-manager' ), $field['label'] ) );
 				}
@@ -451,17 +454,17 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		// Application method.
-		if ( ! $this->should_application_field_skip_email_url_validation() && isset( $values['job']['application'] ) && ! empty( $values['job']['application'] ) ) {
+		if ( ! $this->should_application_field_skip_email_url_validation() && isset( $values['job']['application'] ) ) {
 			$allowed_application_method   = get_option( 'job_manager_allowed_application_method', '' );
-			$values['job']['application'] = str_replace( ' ', '+', $values['job']['application'] );
 
 			$is_valid = true;
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce checked earlier when required.
 			$posted_value = isset( $_POST['application'] ) ? sanitize_text_field( wp_unslash( $_POST['application'] ) ) : false;
 			if ( $posted_value && empty( $values['job']['application'] ) ) {
-				$is_valid                     = false;
-				$values['job']['application'] = $posted_value;
+				$is_valid                                    = false;
+				$this->fields['job']['application']['value'] = $posted_value;
+				$values['job']['application']                = $posted_value;
 			}
 
 			switch ( $allowed_application_method ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -341,7 +341,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		/**
 		 * Force application field to skip email / URL validation.
 		 *
-		 * @since 1.x.x
+		 * @since 1.34.2
 		 *
 		 * @param bool  $is_forced Whether the application field is forced to skip email / URL validation.
 		 */

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -547,6 +547,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$job = get_post( $this->job_id );
 			foreach ( $this->fields as $group_key => $group_fields ) {
 				foreach ( $group_fields as $key => $field ) {
+					if ( isset( $this->fields[ $group_key ][ $key ]['value'] ) ) {
+						continue;
+					}
+
 					switch ( $key ) {
 						case 'job_title':
 							$this->fields[ $group_key ][ $key ]['value'] = $job->post_title;

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -361,7 +361,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				if (
 					$field['required']
 					&& empty( $values[ $group_key ][ $key ] )
-					&& ! in_array( $key, $this->values_existed, true )
+					&& ( ! isset( $field['empty'] ) || $field['empty'] )
 				) {
 					// translators: Placeholder %s is the label for the required field.
 					return new WP_Error( 'validation-error', sprintf( __( '%s is a required field', 'wp-job-manager' ), $field['label'] ) );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -465,25 +465,22 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			if ( $posted_value && empty( $values['job']['application'] ) ) {
 				$is_valid                                    = false;
 				$this->fields['job']['application']['value'] = $posted_value;
-				$values['job']['application']                = $posted_value;
 			}
 
 			switch ( $allowed_application_method ) {
 				case 'email':
-					if ( ! is_email( $values['job']['application'] ) ) {
+					if ( ! $is_valid || ! is_email( $values['job']['application'] ) ) {
 						throw new Exception( __( 'Please enter a valid application email address', 'wp-job-manager' ) );
 					}
 					break;
 				case 'url':
-					$is_valid = $is_valid && filter_var( $values['job']['application'], FILTER_VALIDATE_URL );
-					if ( ! $is_valid ) {
+					if ( ! $is_valid || ! filter_var( $values['job']['application'], FILTER_VALIDATE_URL ) ) {
 						throw new Exception( __( 'Please enter a valid application URL', 'wp-job-manager' ) );
 					}
 					break;
 				default:
 					if ( ! is_email( $values['job']['application'] ) ) {
-						$is_valid = $is_valid && filter_var( $values['job']['application'], FILTER_VALIDATE_URL );
-						if ( ! $is_valid ) {
+						if ( ! $is_valid || ! filter_var( $values['job']['application'], FILTER_VALIDATE_URL ) ) {
 							throw new Exception( __( 'Please enter a valid application email address or URL', 'wp-job-manager' ) );
 						}
 					}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -361,6 +361,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				if (
 					$field['required']
 					&& empty( $values[ $group_key ][ $key ] )
+					&& ! in_array( $key, $this->values_existed, true )
 				) {
 					// translators: Placeholder %s is the label for the required field.
 					return new WP_Error( 'validation-error', sprintf( __( '%s is a required field', 'wp-job-manager' ), $field['label'] ) );


### PR DESCRIPTION
Fixes #2067
Fixes #1814
Replaces #1829

### Changes proposed in this Pull Request

* Adds schema (http or https, depending on filter) to URL application methods when possible/necessary.
* Allows sanitization errors to show on required fields. To do this, added an extra `before_sanitize` callback property on the field. Implemented internally but optional to implement (default is based on emptiness of sanitized value) for custom fields.
* Invalid emails are cleared.
* Note: saving to drafts will allow invalid data to be saved, but not non-sanitized data. When job is properly submitted, validation will occur. 
* Eventually we should add field level error handling. Too large of task for this PR, though.

### Testing instructions

* Using all setting variations for Application Method (email, url, both), fill out the job submission form. 
* Fill out the URL/both frontend application form field with various invalid URLS (note, `filter_var` is pretty relaxed in its URL validation rules). Try just putting "google.com" and verifying it prefixes it with the schema.
* Fill out the email/both frontend application form field with various invalid emails. This is a bit more strict... for example `()@example.com` shouldn't work. 

### New/Updated Hooks

* `job_manager_form_assumed_url_scheme`: Allow setting some URLs to a `https` schema by default when no schema set.
