### PR TITLE
Ensure job_manager_job_submitted is fired for publicly submitted jobs

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -839,7 +839,11 @@ class WP_Job_Manager_Post_Types {
 		$submitted_post_statuses = [ 'publish', 'pending' ];
 
 		// If we're coming to a published post status from a non-published post status, set the expiry.
-		if ( in_array( $new_status, $published_post_statuses, true ) && ! in_array( $old_status, $published_post_statuses, true ) ) {
+		if (
+			$old_status !== 'new'
+			&& in_array( $new_status, $published_post_statuses, true )
+			&& ! in_array( $old_status, $published_post_statuses, true )
+		) {
 			$this->set_expiry( $post );
 		}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -724,6 +724,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$this->save_job( $values['job']['job_title'], $values['job']['job_description'], $post_status, $values );
 			$this->update_job_data( $values );
 
+			// Mark this job as a public submission so the submission hook is fired.
+			update_post_meta( $this->job_id, '_public_submission', true );
+
 			if ( $this->job_id ) {
 				// Reset the `_filled` flag.
 				update_post_meta( $this->job_id, '_filled', 0 );
@@ -1082,6 +1085,15 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * Handles the job submissions before the view is called.
 	 */
 	public function done_before() {
+		delete_post_meta( $this->job_id, '_public_submission' );
+
+		/**
+		 * Trigger job submission action.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $job_id The job ID.
+		 */
 		do_action( 'job_manager_job_submitted', $this->job_id );
 	}
 


### PR DESCRIPTION
Fixes #2100

### Changes proposed in this Pull Request

* Provides backup when `\WP_Job_Manager_Form_Submit_Job::done_before` is never called, which fires `job_manager_job_submitted`. 
* Should fix issues when job submission either ends on WC checkout _or_ from WP Admin when marking order as paid.

### Testing instructions

* Ensure issue in #2100 is fixed when using WC Paid Courses.