### PR TITLE
Update date methods and expire jobs at the end of the day

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -469,7 +469,7 @@ class WP_Job_Manager_CPT {
 				// translators: %1$s is the singular name of the post type; %2$s is the date the post will be published; %3$s is the URL to preview the listing.
 				__( '%1$s scheduled for: <strong>%2$s</strong>. <a target="_blank" href="%3$s">Preview</a>', 'wp-job-manager' ),
 				$wp_post_types['job_listing']->labels->singular_name,
-				date_i18n( get_option( 'date_format' ) . ' @ ' . get_option( 'time_format' ), strtotime( $post->post_date ) ),
+				wp_date( get_option( 'date_format' ) . ' @ ' . get_option( 'time_format' ), get_post_timestamp() ),
 				esc_url( get_permalink( $post_ID ) )
 			),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
@@ -608,13 +608,14 @@ class WP_Job_Manager_CPT {
 				}
 				break;
 			case 'job_posted':
-				echo '<strong>' . esc_html( date_i18n( get_option( 'date_format' ), strtotime( $post->post_date ) ) ) . '</strong><span>';
+				echo '<strong>' . esc_html( wp_date( get_option( 'date_format' ), get_post_timestamp() ) ) . '</strong><span>';
 				// translators: %s placeholder is the username of the user.
 				echo ( empty( $post->post_author ) ? esc_html__( 'by a guest', 'wp-job-manager' ) : sprintf( esc_html__( 'by %s', 'wp-job-manager' ), '<a href="' . esc_url( add_query_arg( 'author', $post->post_author ) ) . '">' . esc_html( get_the_author() ) . '</a>' ) ) . '</span>';
 				break;
 			case 'job_expires':
-				if ( $post->_job_expires ) {
-					echo '<strong>' . esc_html( date_i18n( get_option( 'date_format' ), strtotime( $post->_job_expires ) ) ) . '</strong>';
+				$job_expiration = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $post );
+				if ( $job_expiration ) {
+					echo '<strong>' . esc_html( wp_date( get_option( 'date_format' ), $job_expiration->getTimestamp() ) ) . '</strong>';
 				} else {
 					echo '&ndash;';
 				}

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -308,9 +308,9 @@ final class WP_Job_Manager_Email_Notifications {
 			];
 		}
 
-		$job_expires = get_post_meta( $job->ID, '_job_expires', true );
+		$job_expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
 		if ( ! empty( $job_expires ) ) {
-			$job_expires_str       = date_i18n( get_option( 'date_format' ), strtotime( $job_expires ) );
+			$job_expires_str       = wp_date( get_option( 'date_format' ), $job_expires->getTimestamp() );
 			$fields['job_expires'] = [
 				'label' => __( 'Listing expires', 'wp-job-manager' ),
 				'value' => $job_expires_str,
@@ -592,8 +592,9 @@ final class WP_Job_Manager_Email_Notifications {
 	 * @param int    $days_notice
 	 */
 	private static function send_expiring_notice( $email_notification_key, $days_notice ) {
-		$notice_before_ts = current_time( 'timestamp' ) + ( DAY_IN_SECONDS * $days_notice );
-		$job_ids          = get_posts(
+		$notice_before_datetime = current_datetime()->add( new DateInterval( 'P' . $days_notice . 'D' ) );
+
+		$job_ids = get_posts(
 			[
 				'post_type'      => 'job_listing',
 				'post_status'    => 'publish',
@@ -602,7 +603,7 @@ final class WP_Job_Manager_Email_Notifications {
 				'meta_query'     => [
 					[
 						'key'   => '_job_expires',
-						'value' => date( 'Y-m-d', $notice_before_ts ),
+						'value' => $notice_before_datetime->format( 'Y-m-d' ),
 					],
 				],
 			]

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -898,7 +898,7 @@ class WP_Job_Manager_Post_Types {
 		$expiration_date = $this->get_job_expiration( $post );
 
 		// Clear the expiration field if it has expired.
-		if ( $expiration_date && $this->has_job_expired( $post ) ) {
+		if ( $this->has_job_expired( $post ) ) {
 			$this->set_job_expiration( $post, null );
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1743,7 +1743,8 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		// Checks for valid date.
-		if ( ! DateTimeImmutable::createFromFormat( 'Y-m-d', $meta_value ) ) {
+		$test_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $meta_value, wp_timezone() );
+		if ( ! $test_date || $test_date->format( 'Y-m-d' ) !== $meta_value ) {
 			return '';
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -708,6 +708,11 @@ class WP_Job_Manager_Post_Types {
 	 * Maintenance task to expire jobs.
 	 */
 	public function check_for_expired_jobs() {
+		$expired_date_comparison = current_datetime();
+		if ( ! $this->jobs_expires_end_of_day() ) {
+			$expired_date_comparison = $expired_date_comparison->add( new DateInterval( 'P1D' ) );
+		}
+
 		// Change status to expired.
 		$job_ids = get_posts(
 			[
@@ -724,7 +729,7 @@ class WP_Job_Manager_Post_Types {
 					],
 					[
 						'key'     => '_job_expires',
-						'value'   => date( 'Y-m-d', current_time( 'timestamp' ) ),
+						'value'   => $expired_date_comparison->format( 'Y-m-d' ),
 						'compare' => '<',
 					],
 				],
@@ -759,7 +764,8 @@ class WP_Job_Manager_Post_Types {
 			 */
 			$delete_expired_jobs_days = apply_filters( 'job_manager_delete_expired_jobs_days', 30 );
 
-			$job_ids = get_posts(
+			$date_cutoff = current_datetime()->sub( new DateInterval( 'P' . $delete_expired_jobs_days . 'D' ) );
+			$job_ids     = get_posts(
 				[
 					'post_type'      => 'job_listing',
 					'post_status'    => 'expired',
@@ -767,7 +773,7 @@ class WP_Job_Manager_Post_Types {
 					'date_query'     => [
 						[
 							'column' => 'post_modified',
-							'before' => date( 'Y-m-d', strtotime( '-' . $delete_expired_jobs_days . ' days', current_time( 'timestamp' ) ) ),
+							'before' => $date_cutoff->format( 'Y-m-d' ),
 						],
 					],
 					'posts_per_page' => -1,
@@ -787,7 +793,8 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function delete_old_previews() {
 		// Delete old jobs stuck in preview.
-		$job_ids = get_posts(
+		$date_cutoff = current_datetime()->sub( new DateInterval( 'P30D' ) );
+		$job_ids     = get_posts(
 			[
 				'post_type'      => 'job_listing',
 				'post_status'    => 'preview',
@@ -795,7 +802,7 @@ class WP_Job_Manager_Post_Types {
 				'date_query'     => [
 					[
 						'column' => 'post_modified',
-						'before' => date( 'Y-m-d', strtotime( '-30 days', current_time( 'timestamp' ) ) ),
+						'before' => $date_cutoff->format( 'Y-m-d' ),
 					],
 				],
 				'posts_per_page' => -1,
@@ -888,30 +895,133 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
-		// See if it is already set.
-		if ( metadata_exists( 'post', $post->ID, '_job_expires' ) ) {
-			$expires = get_post_meta( $post->ID, '_job_expires', true );
-			if ( $expires && strtotime( $expires ) < current_time( 'timestamp' ) ) {
-				update_post_meta( $post->ID, '_job_expires', '' );
-			}
+		$expiration_date = $this->get_job_expiration( $post );
+
+		// Clear the expiration field if it has expired.
+		if ( $expiration_date && $this->has_job_expired( $post ) ) {
+			$this->set_job_expiration( $post, null );
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
-		$input_job_expires = isset( $_POST['_job_expires'] ) ? sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) : null;
+		$input_job_expires          = isset( $_POST['_job_expires'] ) ? sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) : null;
+		$input_job_expires_datetime = DateTimeImmutable::createFromFormat( 'Y-m-d', $input_job_expires, wp_timezone() );
 
 		// See if the user has set the expiry manually.
-		if ( ! empty( $input_job_expires ) ) {
-			update_post_meta( $post->ID, '_job_expires', date( 'Y-m-d', strtotime( $input_job_expires ) ) );
-		} elseif ( ! isset( $expires ) ) {
+		if ( ! empty( $input_job_expires_datetime ) ) {
+			$this->set_job_expiration( $post, $input_job_expires_datetime );
+		} elseif ( ! $expiration_date ) {
 			// No manual setting? Lets generate a date if there isn't already one.
-			$expires = calculate_job_expiry( $post->ID );
-			update_post_meta( $post->ID, '_job_expires', $expires );
+			$expires = calculate_job_expiry( $post->ID, true );
+
+			$this->set_job_expiration( $post, $expires );
 
 			// In case we are saving a post, ensure post data is updated so the field is not overridden.
 			if ( null !== $input_job_expires ) {
-				$_POST['_job_expires'] = $expires;
+				$_POST['_job_expires'] = $expires ? $expires->format( 'Y-m-d' ) : '';
 			}
 		}
+	}
+
+	/**
+	 * Set the job expiration date.
+	 *
+	 * @param WP_Post|int       $job          Job post object or ID.
+	 * @param DateTimeImmutable $date_expires Date time object for the job expiration date. Null if to be cleared.
+	 *
+	 * @return false
+	 * @throws TypeError When bad argument is passed to `$date_expires`.
+	 */
+	public function set_job_expiration( $job, $date_expires ) {
+		$job = get_post( $job );
+
+		if ( 'job_listing' !== $job->post_type ) {
+			return false;
+		}
+
+		if ( null === $date_expires ) {
+			update_post_meta( $job->ID, '_job_expires', '' );
+		} elseif ( $date_expires instanceof DateTimeImmutable ) {
+			update_post_meta( $job->ID, '_job_expires', $date_expires->format( 'Y-m-d' ) );
+		} else {
+			throw new TypeError( sprintf( 'The `$date_expires` argument passed to %s must be an instance of DateTimeImmutable or null', __METHOD__ ) );
+		}
+	}
+
+	/**
+	 * Get the job expiration date object.
+	 *
+	 * @param int|WP_Post $job Job post object or ID.
+	 *
+	 * @return false|DateTimeImmutable
+	 */
+	public function get_job_expiration( $job ) {
+		$job = get_post( $job );
+
+		if ( 'job_listing' !== $job->post_type ) {
+			return false;
+		}
+
+		$job_expires = false;
+
+		if ( metadata_exists( 'post', $job->ID, '_job_expires' ) ) {
+			$expires_str = get_post_meta( $job->ID, '_job_expires', true );
+
+			$job_expires = DateTimeImmutable::createFromFormat( 'Y-m-d', $expires_str, wp_timezone() );
+		}
+
+		if ( $job_expires ) {
+			$job_expires = $this->prepare_job_expires_time( $job_expires );
+		}
+
+		return $job_expires;
+	}
+
+	/**
+	 * Prepare a job expiration date time object by normalizing the time
+	 *
+	 * @param DateTimeImmutable $job_expires Job object.
+	 *
+	 * @return DateTimeImmutable
+	 */
+	public function prepare_job_expires_time( DateTimeImmutable $job_expires ) {
+		if ( $this->jobs_expires_end_of_day() ) {
+			return $job_expires->setTime( 23, 59, 59 );
+		}
+
+		return $job_expires->setTime( 0, 0 );
+	}
+
+	/**
+	 * Check if jobs should expire at the end of the day. If not, they'll expire at the start of the day.
+	 *
+	 * @return bool
+	 */
+	private function jobs_expires_end_of_day() {
+		/**
+		 * Override if a job expires at the end of the day instead of start of the day.
+		 *
+		 * @since 1.35.0
+		 *
+		 * @param bool $end_of_day True if the job expires at the end of the day; otherwise it will end at the start of the day.
+		 */
+		return apply_filters( 'job_manager_jobs_expire_end_of_day', true );
+	}
+
+	/**
+	 * Check if a job has expired.
+	 *
+	 * @param int|WP_Post $job Job post object or ID.
+	 *
+	 * @return bool
+	 */
+	public function has_job_expired( $job ) {
+		$expiration = $this->get_job_expiration( $job );
+
+		if ( ! $expiration ) {
+			return false;
+		}
+
+		return $expiration->getTimestamp() < current_datetime()->getTimestamp();
 	}
 
 	/**
@@ -1633,7 +1743,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		// Checks for valid date.
-		if ( date( 'Y-m-d', strtotime( $meta_value ) ) !== $meta_value ) {
+		if ( wp_date( 'Y-m-d', strtotime( $meta_value ) ) !== $meta_value ) {
 			return '';
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1743,7 +1743,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		// Checks for valid date.
-		if ( wp_date( 'Y-m-d', strtotime( $meta_value ) ) !== $meta_value ) {
+		if ( ! DateTimeImmutable::createFromFormat( 'Y-m-d', $meta_value ) ) {
 			return '';
 		}
 

--- a/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
+++ b/includes/emails/class-wp-job-manager-email-employer-expiring-job.php
@@ -109,9 +109,9 @@ class WP_Job_Manager_Email_Employer_Expiring_Job extends WP_Job_Manager_Email_Te
 
 		if ( isset( $args['job'] ) ) {
 			$args['expiring_today'] = false;
-			$today                  = date( 'Y-m-d', current_time( 'timestamp' ) );
-			$expiring_date          = date( 'Y-m-d', strtotime( $args['job']->_job_expires ) );
-			if ( ! empty( $args['job']->_job_expires ) && $today === $expiring_date ) {
+			$today                  = wp_date( 'Y-m-d' );
+			$expiring_date          = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $args['job'] );
+			if ( ! empty( $args['job']->_job_expires ) && $today === $expiring_date->format( 'Y-m-d' ) ) {
 				$args['expiring_today'] = true;
 			}
 		}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,15 +45,6 @@
 	</rule>
 
 	<!-- Temporary Rule Exclusions -->
-	<rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
-		<exclude-pattern>*.php</exclude-pattern>
-	</rule>
-	<rule ref="WordPress.DateTime.CurrentTimeTimestamp.Requested">
-		<exclude-pattern>*.php</exclude-pattern>
-	</rule>
-	<!-- End of Temporary Rule Exclusions -->
-
-	<!-- Temporary Rule Exclusions -->
 	<rule ref="VariableAnalysis">
 		<exclude-pattern>includes/admin/views/</exclude-pattern>
 		<exclude-pattern>templates/</exclude-pattern>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -8,9 +8,10 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.34.4
+ * @version     1.35.0
  *
  * @since 1.34.4 Available job actions are passed in an array (`$job_actions`, keyed by job ID) and not generated in the template.
+ * @since 1.35.0 Switched to new date functions.
  *
  * @var array     $job_dashboard_columns Array of the columns to show on the job dashboard page.
  * @var int       $max_num_pages         Maximum number of pages
@@ -66,9 +67,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 										?>
 									</ul>
 								<?php elseif ('date' === $key ) : ?>
-									<?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $job->post_date ) ) ); ?>
+									<?php echo esc_html( wp_date( get_option( 'date_format' ), get_post_datetime( $job )->getTimestamp() ) ); ?>
 								<?php elseif ('expires' === $key ) : ?>
-									<?php echo esc_html( $job->_job_expires ? date_i18n( get_option( 'date_format' ), strtotime( $job->_job_expires ) ) : '&ndash;' ); ?>
+									<?php
+									$job_expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
+									echo esc_html( $job_expires ? wp_date( get_option( 'date_format' ), $job_expires->getTimestamp() ) : '&ndash;' );
+									?>
 								<?php elseif ('filled' === $key ) : ?>
 									<?php echo is_position_filled( $job ) ? '&#10004;' : '&ndash;'; ?>
 								<?php else : ?>

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -50,7 +50,7 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 
 	public function set_post_age( $post_id, $age ) {
 		global $wpdb;
-		$mod_date = date( 'Y-m-d', strtotime( $age ) );
+		$mod_date = wp_date( 'Y-m-d', strtotime( $age ) );
 		$wpdb->update(
 			$wpdb->posts,
 			[

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
@@ -10,10 +10,10 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 	}
 
 	public function data_provider_test_save_job_data_auto_expire() {
-		$expired_date = date( 'Y-m-d', strtotime( '-2 months', current_time( 'timestamp' ) ) );
-		$future_date  = date( 'Y-m-d', strtotime( '+2 months', current_time( 'timestamp' ) ) );
+		$expired_date = wp_date( 'Y-m-d', strtotime( '-2 months', current_datetime()->getTimestamp() ) );
+		$future_date  = wp_date( 'Y-m-d', strtotime( '+2 months', current_datetime()->getTimestamp() ) );
 		$duration     = absint( get_option( 'job_manager_submission_duration' ) );
-		$auto_date    = date( 'Y-m-d', strtotime( "+{$duration} days", current_time( 'timestamp' ) ) );
+		$auto_date    = wp_date( 'Y-m-d', strtotime( "+{$duration} days", current_datetime()->getTimestamp() ) );
 
 		return [
 			/**

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -252,7 +252,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 			'_company_video'   => 'https://youtube.com/example',
 			'_filled'          => 0,
 			'_featured'        => 0,
-			'_job_expires'     => date( 'Y-m-d', strtotime( '+45 days' ) ),
+			'_job_expires'     => wp_date( 'Y-m-d', strtotime( '+45 days' ) ),
 		];
 
 		$response = $this->post(

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -42,8 +42,8 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		$new_jobs['empty']         = $this->factory->job_listing->create();
 		update_post_meta( $new_jobs['empty'], '_job_expires', '' );
 		$new_jobs['invalid-none'] = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '0000-00-00' ] ] );
-		$new_jobs['today']        = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d' ) ] ] );
-		$new_jobs['tomorrow']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ] ] );
+		$new_jobs['today']        = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => wp_date( 'Y-m-d' ) ] ] );
+		$new_jobs['tomorrow']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => wp_date( 'Y-m-d', strtotime( '+1 day' ) ) ] ] );
 
 		$this->assertEquals( 0, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 		add_filter( 'job_manager_email_is_email_notification_enabled', '__return_true' );
@@ -67,8 +67,8 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		$new_jobs['empty']         = $this->factory->job_listing->create();
 		update_post_meta( $new_jobs['empty'], '_job_expires', '' );
 		$new_jobs['invalid-none'] = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '0000-00-00' ] ] );
-		$new_jobs['today']        = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d' ) ] ] );
-		$new_jobs['tomorrow']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => date( 'Y-m-d', strtotime( '+1 day' ) ) ] ] );
+		$new_jobs['today']        = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => wp_date( 'Y-m-d' ) ] ] );
+		$new_jobs['tomorrow']    = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => wp_date( 'Y-m-d', strtotime( '+1 day' ) ) ] ] );
 
 		$this->assertEquals( 0, WP_Job_Manager_Email_Notifications::get_deferred_notification_count() );
 		add_filter( 'job_manager_email_is_email_notification_enabled', '__return_true' );

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -1113,41 +1113,60 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_date
+	 * Data provider for \WP_Test_WP_Job_Manager_Post_Types::test_sanitize_meta_field_date.
+	 *
+	 * @return string[][]
 	 */
-	public function test_sanitize_meta_field_date() {
-		$strings = [
-			[
-				'expected' => '',
-				'test'     => 'http://example.com',
+	public function data_provider_sanitize_meta_field_date() {
+		return [
+			'invalid-not-date'          => [
+				'',
+				'http://example.com',
 			],
-			[
-				'expected' => '',
-				'test'     => 'January 1, 2019',
+			'invalid-bad-date-format'   => [
+				'',
+				'January 1, 2019',
 			],
-			[
-				'expected' => '',
-				'test'     => '01-01-2019',
+			'invalid-bad-date-format-2' => [
+				'',
+				'01-01-2019',
 			],
-			[
-				'expected' => '2019-01-01',
-				'test'     => '2019-01-01',
+			'valid-date-format'         => [
+				'2019-01-01',
+				'2019-01-01',
+			],
+			'valid-date-format-tz-1'    => [
+				'2019-01-01',
+				'2019-01-01',
+				'Australia/Melbourne',
+			],
+			'valid-date-format-tz-2'    => [
+				'2019-01-01',
+				'2019-01-01',
+				'America/Los_Angeles',
+			],
+			'valid-date-format-tz-3'    => [
+				'2019-01-01',
+				'2019-01-01',
+				'Pacific/Honolulu',
 			],
 		];
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Post_Types::sanitize_meta_field_date
+	 * @dataProvider data_provider_sanitize_meta_field_date
+	 */
+	public function test_sanitize_meta_field_date( $expected, $test, $tz = null ) {
+		if ( $tz ) {
+			update_option( 'timezone_string', $tz );
+		}
 
 		$this->set_up_custom_job_listing_data_feilds();
-		$results = [];
-		foreach ( $strings as $str ) {
-			$results[] = [
-				'expected' => $str['expected'],
-				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_date( $str['test'] ),
-			];
-		}
+		$result = WP_Job_Manager_Post_Types::sanitize_meta_field_date( $test );
 		$this->remove_custom_job_listing_data_feilds();
 
-		foreach ( $results as $result ) {
-			$this->assertEquals( $result['expected'], $result['result'] );
-		}
+		$this->assertEquals( $expected, $result );
 	}
 
 	private function set_up_custom_job_listing_data_feilds() {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1438,7 +1438,7 @@ function job_manager_get_allowed_mime_types( $field = '' ) {
  * @since 1.35.0 Added the `$return_datetime` param.
  *
  * @param  int  $job_id          Job ID.
- * @param bool $return_datetime Return the date time object.
+ * @param  bool $return_datetime Return the date time object.
  * @return string|DateTimeImmutable When `$return_datetime`, it will return either DateTimeImmutable or null.
  */
 function calculate_job_expiry( $job_id, $return_datetime = false ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1435,23 +1435,28 @@ function job_manager_get_allowed_mime_types( $field = '' ) {
  * Calculates and returns the job expiry date.
  *
  * @since 1.22.0
- * @param  int $job_id
- * @return string
+ * @since 1.35.0 Added the `$return_datetime` param.
+ *
+ * @param  int  $job_id          Job ID.
+ * @param bool $return_datetime Return the date time object.
+ * @return string|DateTimeImmutable When `$return_datetime`, it will return either DateTimeImmutable or null.
  */
-function calculate_job_expiry( $job_id ) {
+function calculate_job_expiry( $job_id, $return_datetime = false ) {
 	// Get duration from the product if set...
 	$duration = get_post_meta( $job_id, '_job_duration', true );
 
 	// ...otherwise use the global option.
 	if ( ! $duration ) {
-		$duration = absint( get_option( 'job_manager_submission_duration' ) );
+		$duration = get_option( 'job_manager_submission_duration' );
 	}
 
 	if ( $duration ) {
-		return date( 'Y-m-d', strtotime( "+{$duration} days", current_time( 'timestamp' ) ) );
+		$new_job_expiry = current_datetime()->add( new DateInterval( 'P' . absint( $duration ) . 'D' ) );
+
+		return $return_datetime ? WP_Job_Manager_Post_Types::instance()->prepare_job_expires_time( $new_job_expiry ) : $new_job_expiry->format( 'Y-m-d' );
 	}
 
-	return '';
+	return $return_datetime ? null : '';
 }
 
 /**

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -370,11 +370,11 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 	$data               = [];
 	$data['@context']   = 'http://schema.org/';
 	$data['@type']      = 'JobPosting';
-	$data['datePosted'] = get_post_time( 'c', false, $post );
+	$data['datePosted'] = get_post_datetime( $post )->format( 'c' );
 
-	$job_expires = get_post_meta( $post->ID, '_job_expires', true );
+	$job_expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $post );
 	if ( ! empty( $job_expires ) ) {
-		$data['validThrough'] = date( 'c', strtotime( $job_expires ) );
+		$data['validThrough'] = $job_expires->format( 'c' );
 	}
 
 	$data['title']       = wp_strip_all_tags( wpjm_get_the_job_title( $post ) );
@@ -744,13 +744,13 @@ function the_job_publish_date( $post = null ) {
 	$date_format = get_option( 'job_manager_date_format' );
 
 	if ( 'default' === $date_format ) {
-		$display_date = esc_html__( 'Posted on ', 'wp-job-manager' ) . date_i18n( get_option( 'date_format' ), get_post_time( 'U' ) );
+		$display_date = esc_html__( 'Posted on ', 'wp-job-manager' ) . wp_date( get_option( 'date_format' ), get_post_timestamp( $post ) );
 	} else {
 		// translators: Placeholder %s is the relative, human readable time since the job listing was posted.
-		$display_date = sprintf( esc_html__( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( get_post_time( 'U' ), current_time( 'timestamp' ) ) );
+		$display_date = sprintf( esc_html__( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( get_post_timestamp( $post ), time() ) );
 	}
 
-	echo '<time datetime="' . esc_attr( get_post_time( 'Y-m-d' ) ) . '">' . wp_kses_post( $display_date ) . '</time>';
+	echo '<time datetime="' . esc_attr( get_post_datetime( $post )->format( 'Y-m-d' ) ) . '">' . wp_kses_post( $display_date ) . '</time>';
 }
 
 
@@ -765,13 +765,12 @@ function get_the_job_publish_date( $post = null ) {
 	$date_format = get_option( 'job_manager_date_format' );
 
 	if ( 'default' === $date_format ) {
-		return get_post_time( get_option( 'date_format' ) );
+		return wp_date( get_option( 'date_format' ), get_post_datetime()->getTimestamp() );
 	} else {
 		// translators: Placeholder %s is the relative, human readable time since the job listing was posted.
-		return sprintf( __( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( get_post_time( 'U' ), current_time( 'timestamp' ) ) );
+		return sprintf( __( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( get_post_timestamp(), time() ) );
 	}
 }
-
 
 /**
  * Displays the location for the job listing.


### PR DESCRIPTION
Fixes #919

### Changes proposed in this Pull Request

* Update the date methods used and standardize all date rules to use the WP timezone.
* Expire jobs at the end of the day. Introduced filter `job_manager_jobs_expire_end_of_day` to revert to the original (expire at the start of the expiration day). We can easily flip this back.

We might have some changes to make in Application Deadline, but I don't _think_ anything urgent.

### Testing instructions

* Make sure dates are saved correctly when approving jobs and editing from backend. (Note: Don't forget you can't clear a job expiration if duration is set in settings)
* Dates appear correctly in metabox and on Job Dashboard page.
* In the database directly, have a job expire (`_job_expires` post meta) yesterday or today with `add_filter( 'job_manager_jobs_expire_end_of_day', '__return_false' );`. Run the `job_manager_check_for_expired_jobs` job manually and make sure they are set to a post_status=expired.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks
- `job_manager_jobs_expire_end_of_day` 