### PR TITLE
Add help text for explaining time of day that job listing will expire

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1473,6 +1473,11 @@ class WP_Job_Manager_Post_Types {
 			$application_method_placeholder = __( 'https://', 'wp-job-manager' );
 		}
 
+		$job_expires_description = __( 'Job listing expires at the end of the selected day.', 'wp-job-manager' );
+		if ( ! self::instance()->jobs_expires_end_of_day() ) {
+			$job_expires_description = __( 'Job listing expires at the start of the selected day.', 'wp-job-manager' );
+		}
+
 		$fields = [
 			'_job_location'    => [
 				'label'         => __( 'Location', 'wp-job-manager' ),
@@ -1557,6 +1562,7 @@ class WP_Job_Manager_Post_Types {
 			],
 			'_job_expires'     => [
 				'label'              => __( 'Listing Expiry Date', 'wp-job-manager' ),
+				'description'        => $job_expires_description,
 				'priority'           => 11,
 				'show_in_admin'      => true,
 				'show_in_rest'       => true,

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1473,9 +1473,9 @@ class WP_Job_Manager_Post_Types {
 			$application_method_placeholder = __( 'https://', 'wp-job-manager' );
 		}
 
-		$job_expires_description = __( 'Job listing expires at the end of the selected day.', 'wp-job-manager' );
+		$job_expires_description = __( 'Job listing expires at the end of the day.', 'wp-job-manager' );
 		if ( ! self::instance()->jobs_expires_end_of_day() ) {
-			$job_expires_description = __( 'Job listing expires at the start of the selected day.', 'wp-job-manager' );
+			$job_expires_description = __( 'Job listing expires at the start of the day.', 'wp-job-manager' );
 		}
 
 		$fields = [


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Minor change to add help text for the time of day that a job listing will expire.

<img width="967" alt="Screen Shot 2021-02-08 at 6 57 01 pm" src="https://user-images.githubusercontent.com/68693/107268023-86ae8400-6a3f-11eb-8a3c-292996d02571.png">
