### PR TITLE
Admin CSS: Improve company color accessibility

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -228,7 +228,6 @@ a.wpjm-activate-licence-link:active {
 			margin-top: 0.2em;
 			display: block;
 			padding-top: 2px;
-			color: #bbb;
 		}
 	}
 


### PR DESCRIPTION
Will fallback on default admin CSS font color for row elements (hex 555).

Fixes #

### Changes proposed in this Pull Request

Currently, the gray used for company is super light. This makes it enormously difficult to read for folks with vision issues; according to https://webaim.org/resources/contrastchecker/ the color contrast fails to meet AA standards. Using the WordPress default (#555) will easily meet AA and AAA standards.

### Testing instructions

* I didn't actually test this myself but presumably it'd be the standard build process that converts SCSS -> CSS.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* N/A

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* N/A

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Before:
![image](https://user-images.githubusercontent.com/23667022/110350820-baa6a600-7ff9-11eb-8e0a-80b6d90b4cf8.png)

After:
![image](https://user-images.githubusercontent.com/23667022/110350913-d3af5700-7ff9-11eb-9864-e5cd31e74c96.png)