### PR TITLE
check for job cat select2 search before handle validation fixes #2139

### DIFF
--- a/assets/js/job-submission.js
+++ b/assets/js/job-submission.js
@@ -92,8 +92,10 @@ jQuery(document).ready(function($) {
 			$(this).find( 'input[type=submit]' ).blur();
 
 			var jobCategoryInput = $( '.fieldset-job_category .select2-search__field' )[0];
-			jobCategoryInput.setCustomValidity( job_manager_job_submission.i18n_required_field );
-			jobCategoryInput.reportValidity();
+			if ( jobCategoryInput && jobCategoryInput.length ) {
+				jobCategoryInput.setCustomValidity( job_manager_job_submission.i18n_required_field );
+				jobCategoryInput.reportValidity();
+			}
 
 			return true;
 		}
@@ -147,8 +149,10 @@ jQuery(document).ready(function($) {
 	// Listen for changes to the category field to clear validity
 	$( '#job_category' ).on( 'select2:select', function() {
 		var jobCategoryInput = $( '.fieldset-job_category .select2-search__field' )[0];
-		jobCategoryInput.setCustomValidity( '' );
-		jobCategoryInput.reportValidity();
+		if ( jobCategoryInput && jobCategoryInput.length ) {
+			jobCategoryInput.setCustomValidity( '' );
+			jobCategoryInput.reportValidity();
+		}
 	});
 
 	// Listen for changes to the description field to clear validity

--- a/assets/js/job-submission.js
+++ b/assets/js/job-submission.js
@@ -91,10 +91,10 @@ jQuery(document).ready(function($) {
 		if ( jobCategoryFieldIsInvalid() ) {
 			$(this).find( 'input[type=submit]' ).blur();
 
-			var jobCategoryInput = $( '.fieldset-job_category .select2-search__field' )[0];
+			var jobCategoryInput = $( '.fieldset-job_category .select2-search__field' );
 			if ( jobCategoryInput && jobCategoryInput.length ) {
-				jobCategoryInput.setCustomValidity( job_manager_job_submission.i18n_required_field );
-				jobCategoryInput.reportValidity();
+				jobCategoryInput[0].setCustomValidity( job_manager_job_submission.i18n_required_field );
+				jobCategoryInput[0].reportValidity();
 			}
 
 			return true;
@@ -148,10 +148,10 @@ jQuery(document).ready(function($) {
 
 	// Listen for changes to the category field to clear validity
 	$( '#job_category' ).on( 'select2:select', function() {
-		var jobCategoryInput = $( '.fieldset-job_category .select2-search__field' )[0];
+		var jobCategoryInput = $( '.fieldset-job_category .select2-search__field' );
 		if ( jobCategoryInput && jobCategoryInput.length ) {
-			jobCategoryInput.setCustomValidity( '' );
-			jobCategoryInput.reportValidity();
+			jobCategoryInput[0].setCustomValidity( '' );
+			jobCategoryInput[0].reportValidity();
 		}
 	});
 


### PR DESCRIPTION
Fixes #2139 

### Changes proposed in this Pull Request

* Adds check around Select2 input for `job_category` before triggering validation handling

### Testing instructions

* Goto submit listing page, and don't fill out `job_category` field, confirm it throws validation error
