### PR TITLE
Add jobs pending payment to the Jobs dashboard

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -418,6 +418,10 @@ class WP_Job_Manager_Shortcodes {
 				break;
 			case 'pending_payment':
 			case 'pending':
+			$actions['continue'] = [
+				'label' => __( 'Continue Submission', 'wp-job-manager' ),
+				'nonce' => $base_nonce_action_name,
+			];
 				if ( WP_Job_Manager_Post_Types::job_is_editable( $job->ID ) ) {
 					$actions['edit'] = [
 						'label' => __( 'Edit', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -268,7 +268,7 @@ class WP_Job_Manager_Shortcodes {
 	private function get_job_dashboard_query_args( $posts_per_page = -1 ) {
 		$job_dashboard_args = [
 			'post_type'           => 'job_listing',
-			'post_status'         => [ 'publish', 'expired', 'pending', 'draft', 'preview' ],
+			'post_status'         => [ 'publish', 'expired', 'pending', 'draft', 'preview', 'pending_payment' ],
 			'ignore_sticky_posts' => 1,
 			'posts_per_page'      => $posts_per_page,
 			'orderby'             => 'date',

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -418,10 +418,10 @@ class WP_Job_Manager_Shortcodes {
 				break;
 			case 'pending_payment':
 			case 'pending':
-			$actions['continue'] = [
-				'label' => __( 'Continue Submission', 'wp-job-manager' ),
-				'nonce' => $base_nonce_action_name,
-			];
+				$actions['continue'] = [
+					'label' => __( 'Continue Submission', 'wp-job-manager' ),
+					'nonce' => $base_nonce_action_name,
+				];
 				if ( WP_Job_Manager_Post_Types::job_is_editable( $job->ID ) ) {
 					$actions['edit'] = [
 						'label' => __( 'Edit', 'wp-job-manager' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Include jobs with `pending_payment` status in the job dashboard
* Add a `Continue Submission` action to pending jobs

### Testing instructions

* Setup WC paid listing
* Start submitting a job with a new package
* Stop when reaching the WooCommerce checkout
* Open Job dashboard, and see that the job is there
* Click `Continue Submission` to try again

### Known issues

* This just takes back the user to the start of the job submission. If they select a package, but still have one in their cart, they'll have both packages in cart at checkout. 
  — should we clear the cart?
  — should this be more clever, and direct the user to the checkout if there is a related package in the cart?
  (in both cases the action should likely move to the paid listings plugins)
