### PR TITLE
Fix deprecation break for `wp_no_robots()`

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -60,7 +60,7 @@ class WP_Job_Manager_Post_Types {
 
 		add_action( 'transition_post_status', [ $this, 'transition_post_status' ], 10, 3 );
 
-		add_action( 'wp_head', [ $this, 'noindex_expired_filled_job_listings' ] );
+		add_action( 'wp_head', [ $this, 'noindex_expired_filled_job_listings' ], 0 );
 		add_action( 'wp_footer', [ $this, 'output_structured_data' ] );
 		add_filter( 'wp_sitemaps_posts_query_args', [ $this, 'sitemaps_maybe_hide_filled' ], 10, 2 );
 
@@ -1379,7 +1379,11 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
-		wp_no_robots();
+		if ( function_exists( 'wp_robots_no_robots' ) ) {
+			add_filter( 'wp_robots', 'wp_robots_no_robots' );
+		} else {
+			wp_no_robots();
+		}
 	}
 
 	/**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
 		verbose="true"
-		syntaxCheck="true"
 >
 	<php>
 		<const name="PHPUNIT_WPJM_TESTSUITE" value="true"/>

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -921,14 +921,23 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		);
 		$this->assertEquals( 1, $jobs->post_count );
 		$this->assertTrue( $jobs->is_single );
-		$desired_result = $this->get_wp_no_robots();
 		while ( $jobs->have_posts() ) {
 			$jobs->the_post();
-			$post = get_post();
-			ob_start();
-			$instance->noindex_expired_filled_job_listings();
-			$result = ob_get_clean();
-			$this->assertEquals( $desired_result, $result );
+
+			if ( function_exists('wp_robots') ) {
+				$instance->noindex_expired_filled_job_listings();
+				ob_start();
+				$wp_robots = wp_robots();
+				$result = ob_get_clean();
+				$this->assertNotFalse( strpos( $result, 'noindex' ) );
+			} else {
+				$desired_result = $this->get_wp_no_robots();
+				$post = get_post();
+				ob_start();
+				$instance->noindex_expired_filled_job_listings();
+				$result = ob_get_clean();
+				$this->assertEquals( $desired_result, $result );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes tests

### Changes proposed in this Pull Request

* Uses the new filter when the function is available.

### Testing instructions

* Ensure tests are fixed.
* Go to an expired listing on WP 5.7 and ensure the `<meta name='robots' content='...'>` content includes `noindex`. 
* Go to an expired listing on WP 5.6 and ensure the `<meta name='robots' content='...'>` content includes `noindex`. 