### PR TITLE
Do not enable account registration by default

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -219,7 +219,7 @@ class WP_Job_Manager_Settings {
 						],
 						[
 							'name'       => 'job_manager_enable_registration',
-							'std'        => '1',
+							'std'        => '0',
 							'label'      => __( 'Account Creation', 'wp-job-manager' ),
 							'cb_label'   => __( 'Enable account creation during submission', 'wp-job-manager' ),
 							'desc'       => __( 'Includes account creation on the listing submission form, to allow non-registered users to create an account and submit a job listing simultaneously.', 'wp-job-manager' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

Set the "Account Creation" setting to `false` by default for new installations.

### Testing instructions

#### Existing Site

* On the `master` branch, enable the Account Creation setting and Save Changes (Job Listings > Settings > Job Submission).
* Switch to this branch.
* Reload the Settings page. Ensure that the Account Creation setting remains enabled.
* In the database, manually remove the `job_manager_enable_registration` option from the `wp_options` database.
* Reload the Settings page.
* Ensure that the Account Creation setting is disabled.

#### New Site

* Create a fresh WordPress site and install the plugin from this branch.
* Ensure that the Account Creation setting is disabled by default.
