### PR TITLE
Fix padding on "Apply for job" button

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -448,7 +448,7 @@ div.job_listings {
 			line-height: 1em;
 			display: inline-block;
 			margin: 0 0.5em 0 0;
-			padding: 1/1.1em 2em;
+			padding: 1em 2em;
 			outline: 0;
 		}
 


### PR DESCRIPTION
Fixes #2125.

### Changes proposed in this Pull Request

Fix the padding on the _Apply for job_ button.

### Testing instructions

* `npm run build`
* Activate the Applications plugin.
* View an active job on the site and ensure the _Apply for job_ button has padding.

### Screenshot / Video

_Before_

![before](https://user-images.githubusercontent.com/1190420/120697947-5bcbbe00-c47c-11eb-9d14-75a98a2d7af8.jpg)

_After_

![after](https://user-images.githubusercontent.com/1190420/120697928-566e7380-c47c-11eb-9231-5c58d2e0d30b.jpg)