### PR TITLE
Update agreement checkbox to keep state after submit

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -441,6 +441,9 @@ abstract class WP_Job_Manager_Form {
 		$field             = [];
 		$field['required'] = true;
 
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Check only.
+		$field['checked'] = isset( $_POST['agreement-checkbox'] ) && '1' === $_POST['agreement-checkbox'];
+
 		/**
 		 * Filters the agreement checkbox label.
 		 *

--- a/templates/form-fields/full-line-checkbox-field.php
+++ b/templates/form-fields/full-line-checkbox-field.php
@@ -24,7 +24,7 @@ $allowed_label_html = [
 ?>
 <fieldset class="fieldset-<?php echo esc_attr( $key ); ?> ">
 	<div class="field full-line-checkbox-field <?php echo $field['required'] ? 'required-field' : ''; ?>">
-		<input type="checkbox" class="input-checkbox" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>" id="<?php echo esc_attr( $key ); ?>" <?php checked( ! empty( $field['value'] ), true ); ?> value="1" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
+		<input type="checkbox" class="input-checkbox" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>" id="<?php echo esc_attr( $key ); ?>" <?php checked( ! empty( $field['value'] ), true ); ?> value="1" <?php if ( isset( $field['checked'] ) && true === $field['checked'] ) echo 'checked'; ?> <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo wp_kses( $field['label'], $allowed_label_html ); ?></label>
 		<?php if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>
 	</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Keep agreement checkbox state after form submit.

### Testing instructions

* Go to the WP-admin > Job Listings > Settings > Job Submission, check the "Terms and Conditions Checkbox" option, and save it.
* Go to the Job form to post a new Job.
* Inspect the field "job_title" and remove the "required" attribute. So you'll be able to post the form without fill the required fields.
* Keep the title empty, check the agreement checkbox, and submit.
* Make sure after the submit the checkbox continues checked.