### PR TITLE
Remove unnecessary filter

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name:    PHP Linting
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -34,7 +34,7 @@ jobs:
         run: npm run lint:php
   test:
     name: PHP Unit Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -96,8 +96,6 @@ class WP_Job_Manager_Post_Types {
 	 * Prepare CPTs for special block editor situations.
 	 */
 	public function prepare_block_editor() {
-		add_filter( 'allowed_block_types', [ $this, 'force_classic_block' ], 10, 2 );
-
 		if ( false === job_manager_multi_job_type() ) {
 			add_filter( 'rest_prepare_taxonomy', [ $this, 'hide_job_type_block_editor_selector' ], 10, 3 );
 		}
@@ -107,11 +105,15 @@ class WP_Job_Manager_Post_Types {
 	 * Forces job listings to just have the classic block. This is necessary with the use of the classic editor on
 	 * the frontend.
 	 *
+	 * @deprecated 1.35.2
+	 *
 	 * @param array   $allowed_block_types
 	 * @param WP_Post $post
 	 * @return array
 	 */
 	public function force_classic_block( $allowed_block_types, $post ) {
+		_deprecated_function( __METHOD__, '1.35.2' );
+
 		if ( 'job_listing' === $post->post_type ) {
 			return [ 'core/freeform' ];
 		}


### PR DESCRIPTION
Fixes #2171

### Changes proposed in this Pull Request

* It fixes the WP 5.8 warning, in order to be able to update the tested up to.
* Based on [this comment](https://github.com/Automattic/WP-Job-Manager/pull/1632/files#r240592901), the removed filter was supposed to fix a "convert to blocks" issue depending on how it would evolve. Testing now, it has the same behavior with or without the filter. So probably the [template lock](https://github.com/Automattic/WP-Job-Manager/blob/78593fcb3c47894c366b25f62bcb22afe4babf9c/includes/class-wp-job-manager-post-types.php#L378-L379) is enough.
* It also updates the Ubuntu version for the GitHub actions.

### Testing instructions

* Go to the job listing editor.
* Make sure you can't introduce other blocks but the current classic editor block.
* Also, make sure the "Convert to blocks" button in the toolbar contains the same behavior as previously.
* Also, make sure you don't see any error log when opening the editor.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `WP_Job_Manager_Post_Types::force_classic_block`