### PR TITLE
Stop using pathinfo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "bjornjohansen/wp-pre-commit-hook": "0.3.0",
     "squizlabs/php_codesniffer": "3.5.6",
     "wp-coding-standards/wpcs": "2.3.0",
-    "sirbrillig/phpcs-variable-analysis": "^2.6"
+    "sirbrillig/phpcs-variable-analysis": "^2.6",
+    "yoast/phpunit-polyfills": "1.0.1"
   },
   "archive": {
     "exclude": [

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -47,6 +47,12 @@ class WPJM_Unit_Tests_Bootstrap {
 		// install WPJM.
 		tests_add_filter( 'setup_theme', [ $this, 'install_plugin' ] );
 
+		// Used for some libraries. Tests that require these libraries should be skipped if they don't exist.
+		$autoload_file = __DIR__ . '/../vendor/autoload.php';
+		if ( file_exists( $autoload_file ) ) {
+			require_once $autoload_file;
+		}
+
 		// load the WP testing environment.
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -895,9 +895,9 @@ function job_manager_get_resized_image( $logo, $size ) {
 
 		$upload_dir        = wp_upload_dir();
 		$logo_path         = str_replace( [ $upload_dir['baseurl'], $upload_dir['url'], WP_CONTENT_URL ], [ $upload_dir['basedir'], $upload_dir['path'], WP_CONTENT_DIR ], $logo );
-		$path_parts        = pathinfo( $logo_path );
+		$file_type         = wp_check_filetype( $logo_path );
 		$dims              = $img_width . 'x' . $img_height;
-		$resized_logo_path = str_replace( '.' . $path_parts['extension'], '-' . $dims . '.' . $path_parts['extension'], $logo_path );
+		$resized_logo_path = str_replace( '.' . $file_type['ext'], '-' . $dims . '.' . $file_type['ext'], $logo_path );
 
 		if ( strstr( $resized_logo_path, 'http:' ) || strstr( $resized_logo_path, 'https:' ) ) {
 			return $logo;
@@ -917,14 +917,14 @@ function job_manager_get_resized_image( $logo, $size ) {
 					$save = $image->save( $resized_logo_path );
 
 					if ( ! is_wp_error( $save ) ) {
-						$logo = dirname( $logo ) . '/' . basename( $resized_logo_path );
+						$logo = dirname( $logo ) . '/' . wp_basename( $resized_logo_path );
 					}
 				}
 			}
 
 			ob_get_clean();
 		} else {
-			$logo = dirname( $logo ) . '/' . basename( $resized_logo_path );
+			$logo = dirname( $logo ) . '/' . wp_basename( $resized_logo_path );
 		}
 	}
 


### PR DESCRIPTION
### Overview
It has been reported that the usage of `pathinfo` in job manager can cause issues with resized images. The problem seems to be that `pathinfo` is locale aware which means that if there is a different server configuration, the filename won't be parsed correctly causing the image url to be malformed.

### Changes proposed in this Pull Request

* Switch to using `wp_check_filetype` instead.

### Testing instructions

* The underlying issue isn't reproducible on a local environment. To test this we just need to ensure that no new bug is introduced.
* Upload an image as a company logo or as a resume photo.
* Observe the resumes page or the jobs page and ensures that the thumbnail are displayed correctly.