### PR TITLE
Return `$redirect_url` when nothing to do with bulk edit

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -148,6 +148,8 @@ class WP_Job_Manager_CPT {
 	 * @param string $redirect_url The redirect URL.
 	 * @param string $action       The action being taken.
 	 * @param array  $post_ids     The posts to take the action on.
+	 *
+	 * @return string $redirect_url The redirect URL.
 	 */
 	public function do_bulk_actions( $redirect_url, $action, $post_ids ) {
 		$actions_handled = $this->get_bulk_actions();
@@ -166,6 +168,8 @@ class WP_Job_Manager_CPT {
 				exit;
 			}
 		}
+
+		return $redirect_url;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

* `handle_bulk_actions-edit-job_listing` can be used with other plugins to register/perform `post_type` specific actions. This PR allows returning `$redirect_url` back when the action is not supported by the plugin.

### Testing instructions

* I've tested with https://github.com/10up/classifai, bulk classification action didn't redirect me back to the correct screen due to missing `$redirect_url`. (https://github.com/10up/classifai/blob/1.7.0/includes/Classifai/Admin/BulkActions.php#L71-L80) 


