### PR TITLE
fix: decode html special chars for mailto link

### DIFF
--- a/templates/job-application-email.php
+++ b/templates/job-application-email.php
@@ -16,4 +16,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <?php // translators: %1$s is the email address, %2$s is the subject query args. ?>
-<p><?php printf( wp_kses_post( __( 'To apply for this job <strong>email your details to</strong> <a class="job_application_email" href="mailto:%1$s%2$s">%1$s</a>', 'wp-job-manager' ) ), esc_html( $apply->email ), '?subject=' . rawurlencode( $apply->subject ) ); ?></p>
+<p><?php printf( wp_kses_post( __( 'To apply for this job <strong>email your details to</strong> <a class="job_application_email" href="mailto:%1$s%2$s">%1$s</a>', 'wp-job-manager' ) ), esc_html( $apply->email ), '?subject=' . rawurlencode( htmlspecialchars_decode( $apply->subject ) ) ); ?></p>

--- a/templates/job-application-email.php
+++ b/templates/job-application-email.php
@@ -16,4 +16,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <?php // translators: %1$s is the email address, %2$s is the subject query args. ?>
-<p><?php printf( wp_kses_post( __( 'To apply for this job <strong>email your details to</strong> <a class="job_application_email" href="mailto:%1$s%2$s">%1$s</a>', 'wp-job-manager' ) ), esc_html( $apply->email ), '?subject=' . rawurlencode( htmlspecialchars_decode( $apply->subject ) ) ); ?></p>
+<p><?php printf( wp_kses_post( __( 'To apply for this job <strong>email your details to</strong> <a class="job_application_email" href="mailto:%1$s%2$s">%1$s</a>', 'wp-job-manager' ) ), esc_html( $apply->email ), '?subject=' . rawurlencode( wp_specialchars_decode( $apply->subject, ENT_QUOTES ) ) ); ?></p>


### PR DESCRIPTION
fixes #2194

The german translation for the email subject includes quotes around the job name.

```po
#. translators: %1$s is the job listing title; %2$s is the URL for the current
#. WordPress instance.
#: wp-job-manager-template.php:249
msgid "Application via %1$s listing on %2$s"
msgstr "Bewerbung zum Jobangebot \"%1$s\" auf %2$s"
```

In the email subject this was inserted as `&quot;` instead of `"`. This commit uses htmlspecialchars_decode to fix that.