### PR TITLE
Use wp_kses_post to process a job title instead of esc_html

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "bjornjohansen/wp-pre-commit-hook": "0.3.0",
     "squizlabs/php_codesniffer": "3.5.6",
     "wp-coding-standards/wpcs": "2.3.0",
-    "sirbrillig/phpcs-variable-analysis": "^2.6"
+    "sirbrillig/phpcs-variable-analysis": "^2.6",
+    "yoast/phpunit-polyfills": "^1.0"
   },
   "archive": {
     "exclude": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c21646ece7a33b04c827cdf035465988",
+    "content-hash": "f0d1614c50f85476e9a126fe46ec1850",
     "packages": [],
     "packages-dev": [
         {
@@ -1930,6 +1930,67 @@
                 "wordpress"
             ],
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-10-03T08:40:26+00:00"
         }
     ],
     "aliases": [],
@@ -1939,5 +2000,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -566,7 +566,7 @@ class WP_Job_Manager_CPT {
 			case 'job_position':
 				echo '<div class="job_position">';
 				// translators: %d is the post ID for the job listing.
-				echo '<a href="' . esc_url( admin_url( 'post.php?post=' . $post->ID . '&action=edit' ) ) . '" class="tips job_title" data-tip="' . sprintf( esc_html__( 'ID: %d', 'wp-job-manager' ), intval( $post->ID ) ) . '">' . esc_html( wpjm_get_the_job_title() ) . '</a>';
+				echo '<a href="' . esc_url( admin_url( 'post.php?post=' . $post->ID . '&action=edit' ) ) . '" class="tips job_title" data-tip="' . sprintf( esc_html__( 'ID: %d', 'wp-job-manager' ), intval( $post->ID ) ) . '">' . wp_kses_post( wpjm_get_the_job_title() ) . '</a>';
 
 				echo '<div class="company">';
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -162,7 +162,7 @@ class WP_Job_Manager_Shortcodes {
 
 						// Message.
 						// translators: Placeholder %s is the job listing title.
-						$this->job_dashboard_message = '<div class="job-manager-message">' . esc_html( sprintf( __( '%s has been filled', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . wp_kses_post( sprintf( __( '%s has been filled', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) ) . '</div>';
 						break;
 					case 'mark_not_filled':
 						// Check status.
@@ -175,7 +175,7 @@ class WP_Job_Manager_Shortcodes {
 
 						// Message.
 						// translators: Placeholder %s is the job listing title.
-						$this->job_dashboard_message = '<div class="job-manager-message">' . esc_html( sprintf( __( '%s has been marked as not filled', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . wp_kses_post( sprintf( __( '%s has been marked as not filled', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) ) . '</div>';
 						break;
 					case 'delete':
 						// Trash it.
@@ -183,7 +183,7 @@ class WP_Job_Manager_Shortcodes {
 
 						// Message.
 						// translators: Placeholder %s is the job listing title.
-						$this->job_dashboard_message = '<div class="job-manager-message">' . esc_html( sprintf( __( '%s has been deleted', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) ) . '</div>';
+						$this->job_dashboard_message = '<div class="job-manager-message">' . wp_kses_post( sprintf( __( '%s has been deleted', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) ) . '</div>';
 
 						break;
 					case 'duplicate':
@@ -780,7 +780,7 @@ class WP_Job_Manager_Shortcodes {
 		if ( $jobs->have_posts() ) {
 			while ( $jobs->have_posts() ) {
 				$jobs->the_post();
-				echo '<h1>' . esc_html( wpjm_get_the_job_title() ) . '</h1>';
+				echo '<h1>' . wp_kses_post( wpjm_get_the_job_title() ) . '</h1>';
 				get_job_manager_template_part( 'content-single', 'job_listing' );
 			}
 		}


### PR DESCRIPTION
Fixes #1169 & https://github.com/Automattic/wp-job-manager-applications/issues/281

There might be added some HTML to the title in filter hooks.
To be more consistent and output the title similarly, use wp_kses_post.

### Changes proposed in this Pull Request

* Use `wp_kses_post` instead of `html_esc` to process `wpjm_get_the_job_title`

### Testing instructions

* All steps must be done with the same user.
* Install WP Job Manager Applications
* Create a job.
* Apply for the job.
* Go to Jobs and check if there is no HTML on the page (`<span class="job-manager-applications-applied-notice">Applied</span>`).
* Go to Jobs Dashboard and click "Mark filled", check there is no HTML in the notification message.

### Screenshot / Video
<img width="648" alt="Screenshot 2021-10-31 at 21 17 52" src="https://user-images.githubusercontent.com/329356/139596597-9fe7ab4f-3678-4038-8aa2-8d6299d68011.png">