### PR TITLE
Reset job filter properly by using jQuery's prop instead of jQuery's attr

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -480,9 +480,10 @@ jQuery( document ).ready( function( $ ) {
 				.not( ':input[type="hidden"]' )
 				.val( '' )
 				.trigger( 'change.select2' );
-			$( ':input[name="filter_job_type[]"]', $form )
+			$form
+				.find( ':input[name="filter_job_type[]"]' )
 				.not( ':input[type="hidden"]' )
-				.attr( 'checked', 'checked' );
+				.prop( 'checked', true );
 
 			$target.triggerHandler( 'reset' );
 			$target.triggerHandler( 'update_results', [ 1, false ] );


### PR DESCRIPTION
Since jQuery 1.6, the attr method cannot be used to set "checked" to true. Instead, the prop method should be used, and this is exactly what this commit does.

Fixes #2198

### Changes proposed in this Pull Request

* Fixes the "Reset" option to also reset the Job Type checkboxes, by using jQuery's `prop` instead of jQuery's `attr` to check the fields;

### Testing instructions

* Create a job listing on WPJM;
* Go to the jobs page;
* Uncheck some "Job Types" options;
* Click on the "Reset" link/button that appears;
* Check that all the "Job Types" are checked again;

### Screenshot/Video

Here's a video of the solution working:


https://user-images.githubusercontent.com/529864/155398821-18ca9efc-d64e-4bda-9673-686523aa2aeb.mp4

