### PR TITLE
Fix button "Apply for job" when the page is translated using Google Translate

### DIFF
--- a/assets/js/job-application.js
+++ b/assets/js/job-application.js
@@ -5,7 +5,7 @@ jQuery(document).ready(function($) {
 	}
 
 	$( document.body ).on( 'click', '.job_application .application_button', function() {
-		var $details = $(this).siblings('.application_details').first();
+		var $details = $(this).parents('.job_application').find('.application_details').first();
 		var $button = $(this);
 		$details.slideToggle( 400, function() {
 			if ( ! $(this).is(':visible') ) {


### PR DESCRIPTION
Fixes #1995

### Changes proposed in this Pull Request

* Changes the logic to get the application details block to one that is compatible with the Google Translate extension, which changes the HTML structure of the page, by looking first on the parent job_application and then looking out for application_details.

### Testing instructions

1. Go to a job listing
2. Translate the page to another language using [Google Translate extension on Chrome](https://chrome.google.com/webstore/detail/aapbdbdomjkkjkaonfhkkikfgjllcleb)
3. Click on the Apply button
4. Check if the application details are shown;

### Screenshot / Video

https://user-images.githubusercontent.com/529864/155597739-a342121b-9e3b-4c6b-8fde-7ffb80bb94ed.mp4
