### PR TITLE
Add workflows to provide plugin building on WP Job Manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Plugin Build
+
+on: pull_request
+
+jobs:
+    build:
+        name: Plugin Build
+        runs-on: ubuntu-18.04
+        steps:
+            - uses: actions/checkout@v2
+            - name: Get npm cache directory
+              id: npm-cache
+              run: |
+                  echo "::set-output name=dir::$(npm config get cache)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.npm-cache.outputs.dir }}
+                  key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+            - uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
+                tools: composer
+                coverage: none
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-
+            - name: Install JS dependencies
+              run: npm ci
+            - name: Install PHP dependencies
+              run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+            - name: Build Plugin
+              run: npm run build
+            - name: Decompress plugin
+              run: unzip wp-job-manager.zip -d wp-job-manager
+            - name: Store Artifact
+              uses: actions/upload-artifact@v2
+              with:
+                name: wp-job-manager-${{ github.event.pull_request.head.sha }}
+                path: ${{ github.workspace }}/wp-job-manager/
+                retention-days: 7
+                  

--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -1,0 +1,24 @@
+name: Report Plugin Build
+
+on:
+    workflow_run:
+        workflows: ["Plugin Build"]
+        types: 
+          - completed
+
+jobs:
+    report-build:
+        name: Report Plugin Build
+        runs-on: ubuntu-18.04
+        steps:
+            - uses: actions/checkout@v2
+            - name: Publish commit status with the link to download the plugin 
+              id: plugin_artifact
+              uses: fjorgemota/github-action-report-artifact@v0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  artifact-name: wp-job-manager-${{ github.event.workflow_run.head_sha }}
+                  report-on: commit_status
+                  context: Plugin Build Download
+                  message: Click on "Details" to download the plugin zip file
+                  


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add workflow similar to the ones added in sensei repository (https://github.com/Automattic/sensei/pull/4884 and https://github.com/Automattic/sensei/pull/4886), but in just one PR and changing references from Sensei core to WP Job Manager;

### Testing instructions

* Check if a "Plugin Build" check appears on this PR, click on "Details", then "Summary" and verify if the artifact "wp-job-manager-4c18a1d8b4483a846958a65806219e8b37f248b4" appears on the Artifacts list, and if it's in fact a build of this plugin.