### PR TITLE
Fix issue where input_select didn't detect selected value properly

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -415,6 +415,10 @@ class WP_Job_Manager_Writepanels {
 		} else {
 			$name = $key;
 		}
+		$selected_value = null;
+		if ( isset( $field['value'] ) ) {
+			$selected_value = esc_attr( $field['value'] );
+		}
 		?>
 		<p class="form-field">
 			<label for="<?php echo esc_attr( $key ); ?>">
@@ -428,8 +432,8 @@ class WP_Job_Manager_Writepanels {
 					<option
 						value="<?php echo esc_attr( $key ); ?>"
 						<?php
-						if ( isset( $field['value'] ) ) {
-							selected( $field['value'], $key );
+						if ( null !== $selected_value ) {
+							selected( $selected_value, trim( $key ) );
 						}
 						?>
 					><?php echo esc_html( $value ); ?></option>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix issue where `input_select` didn't detect the selected value properly, causing the wrong value to be shown on the WP-Admin interface;

### Testing instructions

1. Install https://wordpress.org/plugins/custom-field-for-wp-job-manager/
2. Create a new Select field
3. Add a few options ( make sure some options have spaces and some do not eg "Legal", "Finance & Accounting")
4. Create a new job listing and select Legal -> publish -> all okay
5. Edit the job and select Finance & Accounting -> publish -> all okay
6. Open the same editor in a new tab, and verify if the first option from the select field is not shown as active even if you selected any other option when editing the job previously;
