### PR TITLE
#2238: Fix broken lost license key link

### DIFF
--- a/includes/helper/views/html-licences.php
+++ b/includes/helper/views/html-licences.php
@@ -81,7 +81,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	<?php endforeach; ?>
 		<?php // translators: Placeholder %s is the lost license key URL. ?>
-		<div class="notice notice-info inline"><p><?php printf( wp_kses_post( __( 'Lost your license key? <a href="%s">Retrieve it here</a>.', 'wp-job-manager' ) ), 'https://wpjobmanager.com/lost-licence-key/' ); ?></p></div>
+		<div class="notice notice-info inline"><p><?php printf( wp_kses_post( __( 'Lost your license key? <a href="%s">Retrieve it here</a>.', 'wp-job-manager' ) ), 'https://wpjobmanager.com/lost-license-key/' ); ?></p></div>
 	<?php else : ?>
 		<div class="notice notice-warning inline"><p><?php esc_html_e( 'No plugins are activated that have licenses managed by WP Job Manager.', 'wp-job-manager' ); ?></p></div>
 	<?php endif; ?>


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

* Fix broken link mentioned in: https://github.com/Automattic/WP-Job-Manager/issues/2238

### Testing instructions

- Activate a core add-on
- Go to the license activation screen
- Scroll down to "Lost license key?" and click "Retrieve it here"
 
Observe that link now loads the correct page.
