### PR TITLE
Do not use job listing template if job is password protected.

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -527,7 +527,12 @@ class WP_Job_Manager_Post_Types {
 	public function job_content( $content ) {
 		global $post;
 
-		if ( ! is_singular( 'job_listing' ) || ! in_the_loop() || 'job_listing' !== $post->post_type ) {
+		if (
+			! is_singular( 'job_listing' ) ||
+			! in_the_loop() ||
+			'job_listing' !== $post->post_type ||
+			post_password_required()
+		) {
 			return $content;
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -531,7 +531,7 @@ class WP_Job_Manager_Post_Types {
 			! is_singular( 'job_listing' ) ||
 			! in_the_loop() ||
 			'job_listing' !== $post->post_type ||
-			post_password_required()
+			( post_password_required() && ! is_super_admin() )
 		) {
 			return $content;
 		}


### PR DESCRIPTION
Fixes #1672 

### Changes proposed in this Pull Request

* Avoids using job listing template if the job post is password protected.

### Testing instructions

* Create a job post
* Set Visibility to **Password Protected**. Choose some password.
* Visit the Job post page.
* Confirm that you cannot see the job post content if you're not logged in as an admin.
* Confirm that you can submit the password and see the job post content.
