### PR TITLE
Add support for multiple location search.

### DIFF
--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -77,11 +77,14 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
 			$location_search    = [ 'relation' => 'OR' ];
 			foreach ( $location_meta_keys as $meta_key ) {
-				$location_search[] = [
-					'key'     => $meta_key,
-					'value'   => $args['search_location'],
-					'compare' => 'like',
-				];
+				$search_locations = mb_split( '[,\s]+', $args['search_location'] );
+				foreach ( $search_locations as $search_location ) {
+					$location_search[] = [
+						'key'     => $meta_key,
+						'value'   => $search_location,
+						'compare' => 'like',
+					];
+				}
 			}
 			$query_args['meta_query'][] = $location_search;
 		}


### PR DESCRIPTION
Fixes #1217 

### Changes proposed in this Pull Request

* Adds support for multiple location search. We simply take the `search_location` argument and split it with `[,\s]+` regex. This allows to insert location names with one or more comma and/or space between them.

### Testing instructions

* Make sure you have job posts with different location names.
* Enter a single location name and search. Confirm the results are correct.
* Enter two or more location names separating them with one or more commas and/or spaces and search. Confirm the results are correct.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/2578542/173345120-e088940c-c3a9-4a17-bc56-c15c9238c669.mp4

