### PR TITLE
Add link to Jobs or Job Dashboard after job submission

### DIFF
--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -35,7 +35,33 @@ switch ( $job->post_status ) :
 				esc_html__( '%s submitted successfully. Your listing will be visible once approved.', 'wp-job-manager' ),
 				esc_html( $wp_post_types['job_listing']->labels->singular_name )
 			)
-		) . '</div>';
+		);
+
+		$job_dashboard_link  = job_manager_get_permalink('job_dashboard');
+		$job_dashboard_title = get_the_title( job_manager_get_page_id( 'job_dashboard' ) );
+
+		// If job_dashboard page exists but there is no title
+		if ( $job_dashboard_link && empty( $job_dashboard_title ) ) {
+			echo wp_kses_post(
+				sprintf(
+					// translators: %1$s is the URL to view the listing; %2$s is
+					// the plural name of the job listing post type
+					__( '  <a href="%1$s"> View your %2$s</a>', 'wp-job-manager' ),
+					$job_dashboard_link,
+					esc_html( $wp_post_types['job_listing' ]->labels->name )
+				)
+			);
+		} elseif ( $job_dashboard_link && $job_dashboard_title ) { // If there is both a job_dashboard page and a title on the page
+			echo wp_kses_post(
+				sprintf(
+					__( '  <a href="%s"> %s</a>', 'wp-job-manager' ),
+					$job_dashboard_link,
+					$job_dashboard_title
+				)
+			);
+		}
+
+		echo '</div>';
 	break;
 	default :
 		do_action( 'job_manager_job_submitted_content_' . str_replace( '-', '_', sanitize_title( $job->post_status ) ), $job );


### PR DESCRIPTION
Fixes #1782

Adopted from #1854 

### Changes proposed in this Pull Request

* Adds a link to the Jobs Dashboard page after submitting the pending job.

### Testing instructions

* Make sure to require admin approval of all new listing submissions.
* Submit a job and confirm that there is a success message with a link to Job Dashboards page.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="817" alt="Screen Shot 2022-06-13 at 16 07 34" src="https://user-images.githubusercontent.com/2578542/173350156-3c398442-80a7-4493-8d5d-12715eaf82b4.png">

