### PR TITLE
Add salary field

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -411,7 +411,7 @@ div.job_listings {
 		}
 
 		.salary:before {
-			.display-icon;
+			@include display-icon();
 			content: '\e800';
 		}
 	}

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -409,6 +409,11 @@ div.job_listings {
 			@include display-icon();
 			content: "\e80e";
 		}
+
+		.salary:before {
+			.display-icon;
+			content: '\e800';
+		}
 	}
 
 	.job_description {

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -203,6 +203,15 @@ class WP_Job_Manager_Settings {
 							'type'       => 'checkbox',
 							'attributes' => [],
 						],
+						[
+							'name'       => 'job_manager_enable_salary',
+							'std'        => '0',
+							'label'      => __( 'Salary', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable Job Salary', 'wp-job-manager' ),
+							'desc'       => __( 'This lets users add a salary when submitting a job.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+						],
 					],
 				],
 				'job_submission' => [

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -110,7 +110,18 @@ class WP_Job_Manager_Writepanels {
 				'priority'    => 9,
 				'description' => __( 'Filled listings will no longer accept applications.', 'wp-job-manager' ),
 			],
+			'_job_salary' => [
+				'label'       => __( 'Salary', 'wp-job-manager' ),
+				'type'        => 'text',
+				'placeholder' => 'e.g. 20000',
+				'priority'    => 10,
+				'description' => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
+				'default'     => '',
+			],
 		];
+		if ( ! get_option( 'job_manager_enable_salary' ) ) {
+			unset( $fields['_job_salary'] );
+		}
 		if ( $current_user->has_cap( 'manage_job_listings' ) ) {
 			$fields['_featured']    = [
 				'label'       => __( 'Featured Listing', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -110,7 +110,7 @@ class WP_Job_Manager_Writepanels {
 				'priority'    => 9,
 				'description' => __( 'Filled listings will no longer accept applications.', 'wp-job-manager' ),
 			],
-			'_job_salary' => [
+			'_job_salary'      => [
 				'label'       => __( 'Salary', 'wp-job-manager' ),
 				'type'        => 'text',
 				'placeholder' => 'e.g. 20000',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -103,6 +103,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_admin_notices',
 		'widget_widget_featured_jobs',
 		'widget_widget_recent_jobs',
+		'job_manager_enable_salary',
 	];
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -691,7 +691,7 @@ class WP_Job_Manager_Post_Types {
 		$location  = get_the_job_location( $post_id );
 		$company   = get_the_company_name( $post_id );
 		$job_types = wpjm_get_the_job_types( $post_id );
-		$salary = get_the_job_salary( $post_id );
+		$salary    = get_the_job_salary( $post_id );
 
 		if ( $location ) {
 			echo '<job_listing:location><![CDATA[' . esc_html( $location ) . "]]></job_listing:location>\n";

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -691,6 +691,7 @@ class WP_Job_Manager_Post_Types {
 		$location  = get_the_job_location( $post_id );
 		$company   = get_the_company_name( $post_id );
 		$job_types = wpjm_get_the_job_types( $post_id );
+		$salary = get_the_job_salary( $post_id );
 
 		if ( $location ) {
 			echo '<job_listing:location><![CDATA[' . esc_html( $location ) . "]]></job_listing:location>\n";
@@ -701,6 +702,9 @@ class WP_Job_Manager_Post_Types {
 		}
 		if ( $company ) {
 			echo '<job_listing:company><![CDATA[' . esc_html( $company ) . "]]></job_listing:company>\n";
+		}
+		if ( $salary ) {
+			echo '<job_listing:salary><![CDATA[' . esc_html( $salary ) . "]]></job_listing:salary>\n";
 		}
 
 		/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -265,7 +265,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => $application_method_placeholder,
 						'priority'    => 7,
 					],
-					'job_salary'        => [
+					'job_salary'      => [
 						'label'       => __( 'Salary', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -265,6 +265,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => $application_method_placeholder,
 						'priority'    => 7,
 					],
+					'job_salary'        => [
+						'label'       => __( 'Salary', 'wp-job-manager' ),
+						'type'        => 'text',
+						'required'    => false,
+						'placeholder' => 'e.g. 20000',
+						'priority'    => 8,
+					],
 				],
 				'company' => [
 					'company_name'    => [
@@ -329,6 +336,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( 'job_listing_type' ) ) ) {
 			unset( $this->fields['job']['job_type'] );
+		}
+		if ( ! get_option( 'job_manager_enable_salary' ) ) {
+			unset( $this->fields['job']['job_salary'] );
 		}
 	}
 

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -38,7 +38,7 @@ do_action( 'single_job_listing_meta_before' ); ?>
 
 	<li class="date-posted"><?php the_job_publish_date(); ?></li>
 
-	<li class="salary"><?php the_job_salary(); ?></li>
+	<li class="salary"><?php the_job_salary(); ?> </li>
 
 	<?php if ( is_position_filled() ) : ?>
 		<li class="position-filled"><?php _e( 'This position has been filled', 'wp-job-manager' ); ?></li>

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -38,6 +38,8 @@ do_action( 'single_job_listing_meta_before' ); ?>
 
 	<li class="date-posted"><?php the_job_publish_date(); ?></li>
 
+	<li class="salary"><?php the_job_salary(); ?></li>
+
 	<?php if ( is_position_filled() ) : ?>
 		<li class="position-filled"><?php _e( 'This position has been filled', 'wp-job-manager' ); ?></li>
 	<?php elseif ( ! candidates_can_apply() && 'preview' !== $post->post_status ) : ?>

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -422,11 +422,11 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 	$currency = get_the_job_salary_currency( $post );
 	$unit     = get_the_job_salary_unit( $post );
 	if ( ! empty( $salary ) ) {
-		$data['baseSalary'] = [];
-		$data['baseSalary']['@type'] = 'MonetaryAmount';
-		$data['baseSalary']['currency'] = $currency;
-		$data['baseSalary']['value']['@type'] = 'QuantitativeValue';
-		$data['baseSalary']['value']['value'] = $salary;
+		$data['baseSalary']                      = [];
+		$data['baseSalary']['@type']             = 'MonetaryAmount';
+		$data['baseSalary']['currency']          = $currency;
+		$data['baseSalary']['value']['@type']    = 'QuantitativeValue';
+		$data['baseSalary']['value']['value']    = $salary;
 		$data['baseSalary']['value']['unitText'] = $unit;
 	}
 
@@ -1304,7 +1304,7 @@ function the_job_salary( $before = '', $after = '', $echo = true, $post = null )
 	$currency = get_the_job_salary_currency( $post );
 	$unit     = get_the_job_salary_unit( $post );
 
-	if ( strlen( $salary ) == 0 ) {
+	if ( strlen( $salary ) === 0 ) {
 		return;
 	}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -418,26 +418,16 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		}
 	}
 
-	$salary = get_the_job_salary( $post );
+	$salary   = get_the_job_salary( $post );
+	$currency = get_the_job_salary_currency( $post );
+	$unit     = get_the_job_salary_unit( $post );
 	if ( ! empty( $salary ) ) {
 		$data['baseSalary'] = [];
 		$data['baseSalary']['@type'] = 'MonetaryAmount';
-		/**
-		 * Filter for the salary currency.
-		 *
-		 * @since TBD
-		 * @param string     job salary currency.
-		 */
-		$data['baseSalary']['currency'] = apply_filters( 'wpjm_job_salary_currency', 'USD' );
+		$data['baseSalary']['currency'] = $currency;
 		$data['baseSalary']['value']['@type'] = 'QuantitativeValue';
 		$data['baseSalary']['value']['value'] = $salary;
-		/**
-		 * Filter for the salary unit.
-		 *
-		 * @since TBD
-		 * @param string     job salary unit.
-		 */
-		$data['baseSalary']['value']['unitText'] = apply_filters( 'wpjm_job_salary_unit', 'YEAR' );
+		$data['baseSalary']['value']['unitText'] = $unit;
 	}
 
 	/**
@@ -1276,7 +1266,7 @@ add_action( 'single_job_listing_start', 'job_listing_company_display', 30 );
 /**
  * Gets the job salary.
  *
- * @since T1.36.0
+ * @since 1.36.0
  * @param int|WP_Post|null $post (default: null).
  * @return string|null
  */
@@ -1310,17 +1300,67 @@ function get_the_job_salary( $post = null ) {
  * @return string|void
  */
 function the_job_salary( $before = '', $after = '', $echo = true, $post = null ) {
-	$job_salary = get_the_job_salary( $post );
+	$salary   = get_the_job_salary( $post );
+	$currency = get_the_job_salary_currency( $post );
+	$unit     = get_the_job_salary_unit( $post );
 
-	if ( strlen( $job_salary ) == 0 ) {
+	if ( strlen( $salary ) == 0 ) {
 		return;
 	}
 
-	$job_salary = $before . $job_salary . $after;
+	$job_salary = $before . $salary . ' ' . $currency . ' / ' . $unit . $after;
 
 	if ( $echo ) {
 		echo esc_html( $job_salary );
 	} else {
 		return $job_salary;
 	}
+}
+
+/**
+ * Gets the job salary currency.
+ *
+ * @since 1.36.0
+ * @param int|WP_Post|null $post (default: null).
+ * @return string|null
+ */
+function get_the_job_salary_currency( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || 'job_listing' !== $post->post_type ) {
+		return;
+	}
+
+	/**
+	 * Filter the returned job currency.
+	 *
+	 * @since 1.36.0
+	 *
+	 * @param string  $job_currency
+	 * @param WP_Post $post
+	 */
+	return apply_filters( 'wpjm_job_salary_currency', 'USD', $post );
+}
+
+/**
+ * Gets the job salary unit.
+ *
+ * @since 1.36.0
+ * @param int|WP_Post|null $post (default: null).
+ * @return string|null
+ */
+function get_the_job_salary_unit( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || 'job_listing' !== $post->post_type ) {
+		return;
+	}
+
+	/**
+	 * Filter the returned job unit (interval).
+	 *
+	 * @since 1.36.0
+	 *
+	 * @param string  $job_unit
+	 * @param WP_Post $post
+	 */
+	return apply_filters( 'wpjm_job_salary_unit', 'YEAR', $post );
 }

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -418,6 +418,28 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		}
 	}
 
+	$salary = get_the_job_salary( $post );
+	if ( ! empty( $salary ) ) {
+		$data['baseSalary'] = [];
+		$data['baseSalary']['@type'] = 'MonetaryAmount';
+		/**
+		 * Filter for the salary currency.
+		 *
+		 * @since TBD
+		 * @param string     job salary currency.
+		 */
+		$data['baseSalary']['currency'] = apply_filters( 'wpjm_job_salary_currency', 'USD' );
+		$data['baseSalary']['value']['@type'] = 'QuantitativeValue';
+		$data['baseSalary']['value']['value'] = $salary;
+		/**
+		 * Filter for the salary unit.
+		 *
+		 * @since TBD
+		 * @param string     job salary unit.
+		 */
+		$data['baseSalary']['value']['unitText'] = apply_filters( 'wpjm_job_salary_unit', 'YEAR' );
+	}
+
 	/**
 	 * Filter the structured data for a job listing.
 	 *
@@ -1250,3 +1272,55 @@ function job_listing_company_display() {
 	get_job_manager_template( 'content-single-job_listing-company.php', [] );
 }
 add_action( 'single_job_listing_start', 'job_listing_company_display', 30 );
+
+/**
+ * Gets the job salary.
+ *
+ * @since T1.36.0
+ * @param int|WP_Post|null $post (default: null).
+ * @return string|null
+ */
+function get_the_job_salary( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || 'job_listing' !== $post->post_type ) {
+		return;
+	}
+
+	$job_salary = $post->_job_salary;
+
+	/**
+	 * Filter the returned job salary.
+	 *
+	 * @since 1.36.0
+	 *
+	 * @param string  $job_salary
+	 * @param WP_Post $post
+	 */
+	return apply_filters( 'the_job_salary', $job_salary, $post );
+}
+
+/**
+ * Displays or retrieves the job salaray with optional content.
+ *
+ * @since 1.36.0
+ * @param string           $before (default: '').
+ * @param string           $after (default: '').
+ * @param bool             $echo (default: true).
+ * @param int|WP_Post|null $post (default: null).
+ * @return string|void
+ */
+function the_job_salary( $before = '', $after = '', $echo = true, $post = null ) {
+	$job_salary = get_the_job_salary( $post );
+
+	if ( strlen( $job_salary ) == 0 ) {
+		return;
+	}
+
+	$job_salary = $before . $job_salary . $after;
+
+	if ( $echo ) {
+		echo esc_html( $job_salary );
+	} else {
+		return $job_salary;
+	}
+}


### PR DESCRIPTION
Fixes #1320 
Builds upon #1510 

### Changes proposed in this Pull Request

* Adds a salary field to the frontend and admin forms.
* Adds salary information to Google's Job Search Structured Data
* Adds a setting to enable salary field. This is useful to not break sites using snippets or other plugins to add salary field.

### Testing instructions

* Create/Edit Job Listing and add salary
* View the salary on the frontend
* Copy the output HTML and paste here - [https://search.google.com/structured-data/testing-tool/u/0/](https://search.google.com/structured-data/testing-tool/u/0/)

### New/Updated Hooks

* `wpjm_job_salary_currency`: This filter provides a default currency, `USD`.
* `wpjm_job_salary_unit`: This filter provides a default unit, `YEAR`, which can be adjusted to `MONTH`, `WEEK` etc.
* `the_job_salary`: Filters the returned job salary.

### Improvements
Base on https://github.com/Automattic/WP-Job-Manager/issues/1320#issuecomment-537865339, here are a few possible enhancements:

- Setting for per job currencies with a global default. Base our function(s) off of get_woocommerce_currencies and get_woocommerce_currency_symbol.
- Interval will also need to be supported / tracked (HOUR, DAY, WEEK, MONTH, YEAR). For the default, we could probably use YEAR with a filter to adjust.
- Ideally, ranges should also be supported from the start. We could do some magic parsing of a string (20000-40000) -> 'minValue' => 20000, 'maxValue' => 40000 or two fields. Two fields would probably be best.
- UI: input currency, salary value/range (seamless way to go between a single salary and range), Interval unit (hour, day, week, month, year)
