### PR TITLE
Add/job location address display

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -204,6 +204,14 @@ class WP_Job_Manager_Settings {
 							'type'       => 'checkbox',
 							'attributes' => [],
 						],
+						[
+							'name'     => 'job_manager_display_location_address',
+							'std'      => '0',
+							'label'    => __( 'Location Display', 'wp-job-manager' ),
+							'cb_label' => __( 'Display Location Address', 'wp-job-manager' ),
+							'desc'     => __( 'Display the full address of the job listing location if it is detected by Google Maps Geocoding API. If full address is not available then it will display whatever text the user submitted for the location.', 'wp-job-manager' ),
+							'type'     => 'checkbox',
+						],
 					],
 				],
 				'job_submission' => [


### PR DESCRIPTION
Fixes #1878 

### Changes proposed in this Pull Request

* Adds an option to display the full address of the job listings.
* Displays the full address of the job listings when option is enabled.

### Testing instructions

* Make sure you have the Google Maps API key set in the WPJM Settings and make sure the Geocoding API is enabled.
* Create a job listing and type in some address into the location field and save the job. For example `221B Baker St, London`.
* Turn on the setting for displaying the full address of the job listing in WPJM Settings.
* View the job listing and confirm the full address of the job listing is displayed.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="704" alt="Screen Shot 2022-06-17 at 17 54 06" src="https://user-images.githubusercontent.com/2578542/174312273-282c897b-1fd3-413c-aba3-91c3ce4ebf16.png">
<img width="695" alt="Screen Shot 2022-06-17 at 17 54 19" src="https://user-images.githubusercontent.com/2578542/174312283-0da47621-d496-4a17-b7da-b3ba5a6de087.png">
