### PR TITLE
Fix: Undefined type PHP Notice

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -763,7 +763,7 @@ class WP_Job_Manager_Writepanels {
 			}
 
 			// Checkboxes that aren't sent are unchecked.
-			if ( 'checkbox' === $field['type'] ) {
+			if ( isset( $field['type'] ) && 'checkbox' === $field['type'] ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 				if ( ! empty( $_POST[ $key ] ) ) {
 					$_POST[ $key ] = 1;


### PR DESCRIPTION
### Testing instructions

* Go to WP Dashboard -> Job Listing
* Select a listing and simply update it

This will generate the PHP notice `PHP Notice:  Undefined index: type in /wp-content/plugins/wp-job-manager/includes/admin/class-wp-job-manager-writepanels.php on line 766`.

(Debug and Xdebug is enabled)