### PR TITLE
Job Visibility feature

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -177,4 +177,42 @@ jQuery(document).ready(function($) {
 		$('#' + taxonomy + 'checklist li :radio, #' + taxonomy + 'checklist-pop :radio').prop('checked',false);
 		$('#in-' + taxonomy + '-' + id + ', #in-popular-' + taxonomy + '-' + id).prop( 'checked', c );
 	});
+
+
+	if ( $.isFunction( $.fn.select2 ) ) {
+		var job_listings_admin_select2_settings = {
+			'tags': true // Allows for free entry of custom capabilities.
+		};
+
+		if ( $( '.settings-role-select' ).length > 0 ) {
+			// This fixes a issue where backspace on role just turns it into search.
+			// @see https://github.com/select2/select2/issues/3354#issuecomment-277419278 for more info.
+			$.fn.select2.amd.require(
+				['select2/selection/search' ],
+				function ( Search ) {
+					Search.prototype.searchRemoveChoice = function (decorated, item) {
+						this.trigger(
+							'unselect',
+							{
+								data: item
+							}
+						);
+
+						this.$search.val( '' );
+						this.handleSearch();
+					};
+				},
+				null,
+				true
+			);
+		}
+
+		jQuery( '.nav-tab-wrapper a' ).on( 'click',
+			function() {
+				var $content = jQuery( jQuery( this ).attr( 'href' ) );
+				// Refresh when tab is selected.
+				$content.find( '.settings-role-select' ).select2( job_listings_admin_select2_settings );
+			}
+		);
+	}
 });

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -178,7 +178,6 @@ jQuery(document).ready(function($) {
 		$('#in-' + taxonomy + '-' + id + ', #in-popular-' + taxonomy + '-' + id).prop( 'checked', c );
 	});
 
-
 	if ( $.isFunction( $.fn.select2 ) ) {
 		var job_listings_admin_select2_settings = {
 			'tags': true // Allows for free entry of custom capabilities.

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -51,6 +51,7 @@ class WP_Job_Manager_Settings {
 	public function __construct() {
 		$this->settings_group = 'job_manager';
 		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'admin_action_update', [ $this, 'pre_process_settings_save' ] );
 	}
 
 	/**
@@ -429,6 +430,27 @@ class WP_Job_Manager_Settings {
 							'label' => __( 'Terms and Conditions Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page to link when "Terms and Conditions Checkbox" is enabled. See setting in "Job Submission" tab.', 'wp-job-manager' ),
 							'type'  => 'page',
+						],
+					],
+				],
+				'job_visibility' => [
+					__( 'Job Visibility', 'wp-job-manager' ),
+					[
+						[
+							'name'  => 'job_manager_browse_job_listings_capability',
+							'std'   => '',
+							'label' => __( 'Browse Job Capability', 'wp-job-manager' ),
+							'type'  => 'capabilities',
+							// translators: Placeholder %s is the url to the WordPress core documentation for capabilities and roles.
+							'desc'  => sprintf( __( 'Enter which <a href="%s">roles or capabilities</a> allow visitors to browse job listings. If no value is selected, everyone (including logged out guests) will be able to browse job listings.', 'wp-job-manager' ), 'http://codex.wordpress.org/Roles_and_Capabilities' ),
+						],
+						[
+							'name'  => 'job_manager_view_job_listing_capability',
+							'std'   => '',
+							'label' => __( 'View Job Capability', 'wp-job-manager' ),
+							'type'  => 'capabilities',
+							// translators: Placeholder %s is the url to the WordPress core documentation for capabilities and roles.
+							'desc'  => sprintf( __( 'Enter which <a href="%s">roles or capabilities</a> allow visitors to view a single job listing. If no value is selected, everyone (including logged out guests) will be able to view job listings.', 'wp-job-manager' ), 'http://codex.wordpress.org/Roles_and_Capabilities' ),
 						],
 					],
 				],
@@ -933,5 +955,132 @@ class WP_Job_Manager_Settings {
 	 */
 	protected function input_input( $option, $attributes, $value, $placeholder ) {
 		$this->input_text( $option, $attributes, $value, $placeholder );
+	}
+
+	/**
+	 * Outputs the capabilities or roles input field.
+	 *
+	 * @param array    $option              Option arguments for settings input.
+	 * @param string[] $attributes          Attributes on the HTML element. Strings must already be escaped.
+	 * @param mixed    $value               Current value.
+	 * @param string   $ignored_placeholder We set the placeholder in the method. This is ignored.
+	 */
+	protected function input_capabilities( $option, $attributes, $value, $ignored_placeholder ) {
+		$value                 = self::capabilities_string_to_array( $value );
+		$option['options']     = self::get_capabilities_and_roles( $value );
+		$option['placeholder'] = esc_html__( 'Everyone (Public)', 'wp-job-manager' );
+
+		?>
+		<select
+			id="setting-<?php echo esc_attr( $option['name'] ); ?>"
+			class="regular-text settings-role-select"
+			name="<?php echo esc_attr( $option['name'] ); ?>[]"
+			multiple="multiple"
+			data-placeholder="<?php echo esc_attr( $option['placeholder'] ); ?>"
+			<?php
+			echo implode( ' ', $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			?>
+		>
+			<?php
+			foreach ( $option['options'] as $key => $name ) {
+				echo '<option value="' . esc_attr( $key ) . '" ' . selected( in_array( $key, $value, true ) ? $key : null, $key, false ) . '>' . esc_html( $name ) . '</option>';
+			}
+			?>
+		</select>
+		<?php
+
+		if ( ! empty( $option['desc'] ) ) {
+			echo ' <p class="description">' . wp_kses_post( $option['desc'] ) . '</p>';
+		}
+	}
+
+	/**
+	 * Role settings should be saved as a comma-separated list.
+	 */
+	public function pre_process_settings_save() {
+		$screen = get_current_screen();
+
+		if ( ! $screen || 'options' !== $screen->id ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Settings save will handle the nonce check.
+		if ( ! isset( $_POST['option_page'] ) || 'job_manager' !== $_POST['option_page'] ) {
+			return;
+		}
+
+		$capabilities_fields = [
+			'job_manager_browse_job_listings_capability',
+			'job_manager_view_job_listing_capability',
+		];
+		foreach ( $capabilities_fields as $capabilities_field ) {
+			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Settings save will handle the nonce check.
+			if ( isset( $_POST[ $capabilities_field ] ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by `WP_Resume_Manager_Settings::capabilities_array_to_string()`
+				$input_capabilities_field_value = wp_unslash( $_POST[ $capabilities_field ] );
+				if ( is_array( $input_capabilities_field_value ) ) {
+					$_POST[ $capabilities_field ] = self::capabilities_array_to_string( $input_capabilities_field_value );
+				}
+			}
+			// phpcs:enable WordPress.Security.NonceVerification.Missing
+		}
+	}
+
+	/**
+	 * Convert list of capabilities and roles into array of values.
+	 *
+	 * @param string $value Comma separated list of capabilities and roles.
+	 * @return array
+	 */
+	private static function capabilities_string_to_array( $value ) {
+		return array_filter(
+			array_map(
+				function( $value ) {
+					return trim( sanitize_text_field( $value ) );
+				},
+				explode( ',', $value )
+			)
+		);
+	}
+
+	/**
+	 * Convert array of capabilities and roles into a comma separated list.
+	 *
+	 * @param array $value Array of capabilities and roles.
+	 * @return string
+	 */
+	private static function capabilities_array_to_string( $value ) {
+		if ( ! is_array( $value ) ) {
+			return '';
+		}
+
+		$caps = array_filter( array_map( 'sanitize_text_field', $value ) );
+
+		return implode( ',', $caps );
+	}
+
+	/**
+	 * Get the list of roles and capabilities to use in select dropdown.
+	 *
+	 * @param array $caps Selected capabilities to ensure they show up in the list.
+	 * @return array
+	 */
+	private static function get_capabilities_and_roles( $caps = [] ) {
+		$capabilities_and_roles = [];
+		$roles                  = get_editable_roles();
+
+		foreach ( $roles as $key => $role ) {
+			$capabilities_and_roles[ $key ] = $role['name'];
+		}
+
+		// Go through custom user selected capabilities and add them to the list.
+		foreach ( $caps as $value ) {
+			if ( isset( $capabilities_and_roles[ $value ] ) ) {
+				continue;
+			}
+			$capabilities_and_roles[ $value ] = $value;
+		}
+
+		return $capabilities_and_roles;
 	}
 }

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -545,6 +545,11 @@ class WP_Job_Manager_Shortcodes {
 	public function output_jobs( $atts ) {
 		ob_start();
 
+		if ( ! job_manager_user_can_browse_job_listings() ) {
+			get_job_manager_template_part( 'access-denied', 'browse-job_listings' );
+			return ob_get_clean();
+		}
+
 		$atts = shortcode_atts(
 			apply_filters(
 				'job_manager_output_jobs_defaults',

--- a/templates/access-denied-browse-job_listings.php
+++ b/templates/access-denied-browse-job_listings.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Access denied message when attempting to browse job listings.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/access-denied-browse-job_listings.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     wp-job-manager
+ * @category    Template
+ * @version     1.36.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<p class="job-manager-error"><?php _e( 'Sorry, you do not have permission to browse job listings.', 'wp-job-manager' ); ?></p>

--- a/templates/access-denied-single-job_listing.php
+++ b/templates/access-denied-single-job_listing.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Message to display when access is denied to a single job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/access-denied-single-job_listing.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     wp-job-manager
+ * @category    Template
+ * @version     1.36.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( $post->post_status === 'expired' ) : ?>
+	<div class="job-manager-info"><?php _e( 'This listing has expired', 'wp-job-manager' ); ?></div>
+<?php else : ?>
+	<p class="job-manager-error"><?php _e( 'Sorry, you do not have permission to view this job listing.', 'wp-job-manager' ); ?></p>
+<?php endif; ?>

--- a/templates/content-single-job_listing.php
+++ b/templates/content-single-job_listing.php
@@ -9,7 +9,7 @@
  * @package     wp-job-manager
  * @category    Template
  * @since       1.0.0
- * @version     1.28.0
+ * @version     1.36.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,34 +17,40 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 global $post;
-?>
-<div class="single_job_listing">
-	<?php if ( get_option( 'job_manager_hide_expired_content', 1 ) && 'expired' === $post->post_status ) : ?>
-		<div class="job-manager-info"><?php _e( 'This listing has expired.', 'wp-job-manager' ); ?></div>
-	<?php else : ?>
-		<?php
-			/**
-			 * single_job_listing_start hook
-			 *
-			 * @hooked job_listing_meta_display - 20
-			 * @hooked job_listing_company_display - 30
-			 */
-			do_action( 'single_job_listing_start' );
-		?>
 
-		<div class="job_description">
-			<?php wpjm_the_job_description(); ?>
-		</div>
+if ( job_manager_user_can_view_job_listing( $post->ID ) ) : ?>
+	<div class="single_job_listing">
+		<?php if ( get_option( 'job_manager_hide_expired_content', 1 ) && 'expired' === $post->post_status ) : ?>
+			<div class="job-manager-info"><?php _e( 'This listing has expired.', 'wp-job-manager' ); ?></div>
+		<?php else : ?>
+			<?php
+				/**
+				 * single_job_listing_start hook
+				 *
+				 * @hooked job_listing_meta_display - 20
+				 * @hooked job_listing_company_display - 30
+				 */
+				do_action( 'single_job_listing_start' );
+			?>
 
-		<?php if ( candidates_can_apply() ) : ?>
-			<?php get_job_manager_template( 'job-application.php' ); ?>
+			<div class="job_description">
+				<?php wpjm_the_job_description(); ?>
+			</div>
+
+			<?php if ( candidates_can_apply() ) : ?>
+				<?php get_job_manager_template( 'job-application.php' ); ?>
+			<?php endif; ?>
+
+			<?php
+				/**
+				 * single_job_listing_end hook
+				 */
+				do_action( 'single_job_listing_end' );
+			?>
 		<?php endif; ?>
+	</div>
+<?php else : ?>
 
-		<?php
-			/**
-			 * single_job_listing_end hook
-			 */
-			do_action( 'single_job_listing_end' );
-		?>
-	<?php endif; ?>
-</div>
+	<?php get_job_manager_template_part( 'access-denied', 'single-job_listing' ); ?>
+
+<?php endif; ?>

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1602,3 +1602,72 @@ function job_manager_count_user_job_listings( $user_id = 0 ) {
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	return $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_author = %d AND post_type = 'job_listing' AND post_status IN ( 'publish', 'pending', 'expired', 'hidden' );", $user_id ) );
 }
+
+/**
+ * True if an the user can browse resumes.
+ *
+ * @return bool
+ */
+function job_manager_user_can_browse_job_listings() {
+	$can_browse = true;
+	$caps       = array_filter( array_map( 'trim', array_map( 'strtolower', explode( ',', get_option( 'job_manager_browse_job_listings_capability' ) ) ) ) );
+
+	if ( $caps ) {
+		$can_browse = false;
+		foreach ( $caps as $cap ) {
+			if ( current_user_can( $cap ) ) {
+				$can_browse = true;
+				break;
+			}
+		}
+	}
+
+	return apply_filters( 'job_manager_user_can_browse_job_listings', $can_browse );
+}
+
+/**
+ * True if an the user can view a resume.
+ *
+ * @since 1.36.0
+ *
+ * @param  int $job_id
+ * @return bool
+ */
+function job_manager_user_can_view_job_listing( $job_id ) {
+	$can_view = true;
+	$job      = get_post( $job_id );
+
+	// Allow previews.
+	if ( 'preview' === $job->post_status ) {
+		return true;
+	}
+
+	$caps = array_filter( array_map( 'trim', array_map( 'strtolower', explode( ',', get_option( 'job_manager_view_job_listing_capability' ) ) ) ) );
+
+	if ( $caps ) {
+		$can_view = false;
+		foreach ( $caps as $cap ) {
+			if ( current_user_can( $cap ) ) {
+				$can_view = true;
+				break;
+			}
+		}
+	}
+
+	if ( 'expired' === $job->post_status ) {
+		$can_view = false;
+	}
+
+	if ( $job->post_author > 0 && absint( $job->post_author ) === get_current_user_id() ) {
+		$can_view = true;
+	}
+
+	$key = get_post_meta( $job_id, 'share_link_key', true );
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( $key && ! empty( $_GET['key'] ) && $key === $_GET['key'] ) {
+		$can_view = true;
+	}
+
+	return apply_filters( 'job_manager_user_can_view_job', $can_view, $job_id );
+}


### PR DESCRIPTION
*The feature has been reworked due to users facing various issues after updating to version 1.36.0.*

### Changes proposed in this Pull Request

Visibility settings for browsing job listings and viewing single job listing page. This works exactly as the WPJM Resumes visibility feature does.

### Testing instructions

* Go to "WP Dashboard -> Job Listings -> Settings -> Job Visibility"
* Add the roles to the settings
* Visit [job] page or single job page

### Fixes
https://github.com/Automattic/WP-Job-Manager/pull/2260 https://github.com/Automattic/WP-Job-Manager/issues/2274