### PR TITLE
Update default branches for WP-Job-Manager

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,7 +3,7 @@ name: PHP Linting and Tests
 on:
   pull_request:
     branches:
-      - master
+      - trunk
       - 'feature/**'
       - 'release/**'
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you have questions about the process to contribute code or want to discuss de
 - [How to set up WP Job Manager development environment](https://github.com/Automattic/WP-Job-Manager/wiki/Setting-Up-Development-Environment)
 - [Git Flow and PR Review](https://github.com/Automattic/WP-Job-Manager/wiki/Our-Git-Flow-and-PR-Review)
 - [String localisation guidelines](https://codex.wordpress.org/I18n_for_WordPress_Developers)
-- [Running unit tests](https://github.com/Automattic/WP-Job-Manager/blob/master/tests/README.md)
+- [Running unit tests](https://github.com/Automattic/WP-Job-Manager/blob/trunk/tests/README.md)
 
 ## Coding Guidelines and Development 🛠
 

--- a/tests/bin/prepare-wordpress.sh
+++ b/tests/bin/prepare-wordpress.sh
@@ -14,7 +14,7 @@ mysql -u root -e "CREATE DATABASE wordpress_tests;"
 
 CURRENT_DIR=$(pwd)
 
-WP_SLUGS=('master' 'latest' 'previous')
+WP_SLUGS=('trunk' 'latest' 'previous')
 
 if [ ! -z "$WP_VERSION" ]; then
 	WP_SLUGS=("$WP_VERSION")
@@ -26,8 +26,8 @@ for WP_SLUG in "${WP_SLUGS[@]}"; do
 	cd $CURRENT_DIR/..
 
 	case $WP_SLUG in
-	master)
-		git clone --depth=1 --branch master https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-master
+	trunk)
+		git clone --depth=1 --branch trunk https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-trunk
 		;;
 	latest)
 		git clone --depth=1 --branch `php ./$PLUGIN_BASE_DIR/tests/bin/get-wp-version.php` https://github.com/WordPress/wordpress-develop.git /tmp/wordpress-latest

--- a/tests/bin/run-travis.sh
+++ b/tests/bin/run-travis.sh
@@ -20,7 +20,7 @@ run_phpunit_for() {
 }
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
-	WP_SLUGS=('master' 'latest' 'previous')
+	WP_SLUGS=('trunk' 'latest' 'previous')
 
 	if [ ! -z "$WP_VERSION" ]; then
 		WP_SLUGS=("$WP_VERSION")


### PR DESCRIPTION
This PR prepares the repository to use `trunk` instead of `master`.

### Changes proposed in this Pull Request

* Adjustments to support the branch migration from `master` to `trunk`.
* Also fixes a small issue where we still downloaded WordPress.org's `master` branch instead of using `trunk`, which is the most current development branch used by WordPress.org;


### Testing instructions

- Merge this PR
- Check if the is the trunk actions are running properly after the merge.

