### PR TITLE
Move fields from Writepanels

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -60,26 +60,6 @@ class WP_Job_Manager_Writepanels {
 
 		$fields = [];
 
-		if ( ! get_option( 'job_manager_enable_salary' ) ) {
-			unset( $fields['_job_salary'] );
-		}
-		if ( $current_user->has_cap( 'manage_job_listings' ) ) {
-			$fields['_featured']    = [
-				'label'       => __( 'Featured Listing', 'wp-job-manager' ),
-				'type'        => 'checkbox',
-				'description' => __( 'Featured listings will be sticky during searches, and can be styled differently.', 'wp-job-manager' ),
-				'priority'    => 10,
-			];
-			$job_expires            = get_post_meta( $post_id, '_job_expires', true );
-			$fields['_job_expires'] = [
-				'label'       => __( 'Listing Expiry Date', 'wp-job-manager' ),
-				'priority'    => 11,
-				'classes'     => [ 'job-manager-datepicker' ],
-				'placeholder' => ! empty( $job_expires ) ? null : date_i18n( get_option( 'date_format' ), strtotime( calculate_job_expiry( $post_id ) ) ),
-				'value'       => ! empty( $job_expires ) ? gmdate( 'Y-m-d', strtotime( $job_expires ) ) : '',
-			];
-		}
-
 		if ( $current_user->has_cap( 'edit_others_job_listings' ) ) {
 			$fields['_job_author'] = [
 				'label'    => __( 'Posted by', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -58,67 +58,8 @@ class WP_Job_Manager_Writepanels {
 		$current_user = wp_get_current_user();
 		$fields_raw   = WP_Job_Manager_Post_Types::get_job_listing_fields();
 
-		$fields = [
-			'_job_location'    => [
-				'label'       => __( 'Location', 'wp-job-manager' ),
-				'placeholder' => __( 'e.g. "London"', 'wp-job-manager' ),
-				'description' => __( 'Leave this blank if the location is not important.', 'wp-job-manager' ),
-				'priority'    => 1,
-			],
-			'_remote_position' => [
-				'label'       => __( 'Remote Position', 'wp-job-manager' ),
-				'description' => __( 'Select if this is a remote position.', 'wp-job-manager' ),
-				'type'        => 'checkbox',
-				'priority'    => 2,
-			],
-			'_application'     => [
-				'label'       => __( 'Application Email or URL', 'wp-job-manager' ),
-				'placeholder' => __( 'URL or email which applicants use to apply', 'wp-job-manager' ),
-				'description' => __( 'This field is required for the "application" area to appear beneath the listing.', 'wp-job-manager' ),
-				'value'       => metadata_exists( 'post', $post_id, '_application' ) ? get_post_meta( $post_id, '_application', true ) : $current_user->user_email,
-				'priority'    => 3,
-			],
-			'_company_name'    => [
-				'label'       => __( 'Company Name', 'wp-job-manager' ),
-				'placeholder' => '',
-				'priority'    => 4,
-			],
-			'_company_website' => [
-				'label'       => __( 'Company Website', 'wp-job-manager' ),
-				'placeholder' => '',
-				'priority'    => 5,
-			],
-			'_company_tagline' => [
-				'label'       => __( 'Company Tagline', 'wp-job-manager' ),
-				'placeholder' => __( 'Brief description about the company', 'wp-job-manager' ),
-				'priority'    => 6,
-			],
-			'_company_twitter' => [
-				'label'       => __( 'Company Twitter', 'wp-job-manager' ),
-				'placeholder' => '@yourcompany',
-				'priority'    => 7,
-			],
-			'_company_video'   => [
-				'label'       => __( 'Company Video', 'wp-job-manager' ),
-				'placeholder' => __( 'URL to the company video', 'wp-job-manager' ),
-				'type'        => 'file',
-				'priority'    => 8,
-			],
-			'_filled'          => [
-				'label'       => __( 'Position Filled', 'wp-job-manager' ),
-				'type'        => 'checkbox',
-				'priority'    => 9,
-				'description' => __( 'Filled listings will no longer accept applications.', 'wp-job-manager' ),
-			],
-			'_job_salary'      => [
-				'label'       => __( 'Salary', 'wp-job-manager' ),
-				'type'        => 'text',
-				'placeholder' => 'e.g. 20000',
-				'priority'    => 10,
-				'description' => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
-				'default'     => '',
-			],
-		];
+		$fields = [];
+
 		if ( ! get_option( 'job_manager_enable_salary' ) ) {
 			unset( $fields['_job_salary'] );
 		}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1587,6 +1587,25 @@ class WP_Job_Manager_Post_Types {
 				'auth_view_callback' => [ __CLASS__, 'auth_check_can_edit_job_listings' ],
 				'sanitize_callback'  => [ __CLASS__, 'sanitize_meta_field_date' ],
 			],
+			'_remote_position' => [
+				'label'         => __( 'Remote Position', 'wp-job-manager' ),
+				'description'   => __( 'Select if this is a remote position.', 'wp-job-manager' ),
+				'type'          => 'checkbox',
+				'priority'      => 12,
+				'data_type'     => 'integer',
+				'show_in_admin' => true,
+				'show_in_rest'  => true,
+			],
+			'_job_salary'      => [
+				'label'         => __( 'Salary', 'wp-job-manager' ),
+				'type'          => 'text',
+				'placeholder'   => 'e.g. 20000',
+				'priority'      => 13,
+				'description'   => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
+				'data_type'     => 'string',
+				'show_in_admin' => true,
+				'show_in_rest'  => true,
+			],
 		];
 
 		/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1603,7 +1603,7 @@ class WP_Job_Manager_Post_Types {
 				'priority'      => 13,
 				'description'   => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
 				'data_type'     => 'string',
-				'show_in_admin' => true,
+				'show_in_admin' => (bool) get_option( 'job_manager_enable_salary' ),
 				'show_in_rest'  => true,
 			],
 		];

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -171,7 +171,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	 * Tests to make sure public meta fields are exposed to guest users and private meta fields are hidden.
 	 */
 	public function test_guest_can_read_only_public_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary' ];
 		$private_fields = [ '_job_expires' ];
 		$this->logout();
 		$post_id = $this->get_job_listing();
@@ -192,7 +192,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_same_employer_read_access_to_private_meta_fields() {
-		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires' ];
+		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires', '_remote_position', '_job_salary' ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();
 
@@ -207,7 +207,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_different_employer_read_access_to_private_meta_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured' ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary' ];
 		$private_fields = [ '_job_expires' ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();


### PR DESCRIPTION
Fixes #2286 

### Changes proposed in this Pull Request

* Empty fields array in `WP_Job_Manager_Writepanels` `job_listing_fields()` method.
* Add `_remote_position ` and `_job_salary ` to `WP_Job_Manager_Post_Types::get_job_listing_fields();`

### Testing instructions

* Test that the following snippet works and the fields don't appear on admin:
```
add_filter( 'job_manager_job_listing_data_fields', 'custom_job_manager_job_listing_data_fields' );

function custom_job_manager_job_listing_data_fields( $fields ) {

	unset($fields['_company_website']);
	unset($fields['_company_tagline']);
	unset($fields['_company_video']);
	unset($fields['_company_twitter']);
	unset($fields['_company_facebook']);

    return $fields;
}
```