### PR TITLE
search_location back to original handling + remote_listing field in filters

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -533,6 +533,41 @@ div.job_listings {
 				width: 50%;
 			}
 
+			&.search_remote_position {
+
+				width: 50%;
+				float: right;
+				padding-left: 0.5em;
+				padding-top: 0.5em;
+
+				input {
+					width: auto;
+				}
+
+				label#remote_position_label {
+					display: inline-block;
+				}
+			}
+
+			@media(max-width: 480px){
+				&.search_keywords,
+				&.filter_first {
+					width: 100%;
+					padding-right: 0;
+				}
+
+				&.search_location,
+				&.filter_last {
+					width: 100%;
+					padding-top: 0.5em;
+					padding-left: 0;
+				}
+
+				&.search_remote_position {
+					width: 100%;
+				}
+			}
+
 			&.search_categories,
 			&.filter_wide {
 				padding-top: 0.5em;

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -367,8 +367,8 @@ jQuery( document ).ready( function( $ ) {
 					location = $location.val();
 				}
 
-				if( $remote_position.length && $remote_position.is( ':checked' ) ) {
-					remote_position = 'true';
+				if( $remote_position.length ) {
+					remote_position = $remote_position.is( ':checked' ) ? 'true' : null;
 				}
 
 				data = {

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -312,6 +312,7 @@ jQuery( document ).ready( function( $ ) {
 			var order = $target.data( 'order' );
 			var featured = $target.data( 'featured' );
 			var filled = $target.data( 'filled' );
+			var remote_position = $target.data( 'remote_position' );
 			var job_types = $target.data( 'job_types' );
 			var post_status = $target.data( 'post_status' );
 			var index = $( 'div.job_listings' ).index( this );
@@ -378,6 +379,7 @@ jQuery( document ).ready( function( $ ) {
 					page: page,
 					featured: featured,
 					filled: filled,
+					remote_position: remote_position,
 					show_pagination: $target.data( 'show_pagination' ),
 					form_data: $form.serialize(),
 				};
@@ -406,6 +408,7 @@ jQuery( document ).ready( function( $ ) {
 					page: page,
 					featured: featured,
 					filled: filled,
+					remote_position: remote_position,
 					show_pagination: $target.data( 'show_pagination' ),
 				};
 			}

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -356,6 +356,7 @@ jQuery( document ).ready( function( $ ) {
 				location = '';
 				var $keywords = $form.find( ':input[name="search_keywords"]' );
 				var $location = $form.find( ':input[name="search_location"]' );
+				var $remote_position = $form.find( ':input[name="remote_position"]' );
 
 				// Workaround placeholder scripts
 				if ( $keywords.val() !== $keywords.attr( 'placeholder' ) ) {
@@ -364,6 +365,10 @@ jQuery( document ).ready( function( $ ) {
 
 				if ( $location.val() !== $location.attr( 'placeholder' ) ) {
 					location = $location.val();
+				}
+
+				if( $remote_position.length && $remote_position.is( ':checked' ) ) {
+					remote_position = 'true';
 				}
 
 				data = {
@@ -453,7 +458,7 @@ jQuery( document ).ready( function( $ ) {
 		} );
 
 	$(
-		'#search_keywords, #search_location, .job_types :input, #search_categories, .job-manager-filter'
+		'#search_keywords, #search_location, #remote_position, .job_types :input, #search_categories, .job-manager-filter'
 	)
 		.change( function() {
 			var $target = $( this ).closest( 'div.job_listings' );
@@ -487,6 +492,10 @@ jQuery( document ).ready( function( $ ) {
 				.find( ':input[name="filter_job_type[]"]' )
 				.not( ':input[type="hidden"]' )
 				.prop( 'checked', true );
+			$form
+				.find( ':input[name="remote_position"]' )
+				.not( ':input[type="hidden"]' )
+				.prop( 'checked', false );
 
 			$target.triggerHandler( 'reset' );
 			$target.triggerHandler( 'update_results', [ 1, false ] );

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -233,6 +233,15 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 						],
 						[
+							'name'       => 'job_manager_enable_remote_position',
+							'std'        => '1',
+							'label'      => __( 'Remote Position', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable Remote Position', 'wp-job-manager' ),
+							'desc'       => __( 'This lets users select if the listing is a remote position when submitting a job.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+						],
+						[
 							'name'     => 'job_manager_display_location_address',
 							'std'      => '0',
 							'label'    => __( 'Location Display', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -122,6 +122,9 @@ class WP_Job_Manager_Writepanels {
 		if ( ! get_option( 'job_manager_enable_salary' ) ) {
 			unset( $fields['_job_salary'] );
 		}
+		if ( ! get_option( 'job_manager_enable_remote_position' ) ) {
+			unset( $fields['_remote_position'] );
+		}
 		if ( $current_user->has_cap( 'manage_job_listings' ) ) {
 			$fields['_featured']    = [
 				'label'       => __( 'Featured Listing', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -58,89 +58,7 @@ class WP_Job_Manager_Writepanels {
 		$current_user = wp_get_current_user();
 		$fields_raw   = WP_Job_Manager_Post_Types::get_job_listing_fields();
 
-		$fields = [
-			'_job_location'    => [
-				'label'       => __( 'Location', 'wp-job-manager' ),
-				'placeholder' => __( 'e.g. "London"', 'wp-job-manager' ),
-				'description' => __( 'Leave this blank if the location is not important.', 'wp-job-manager' ),
-				'priority'    => 1,
-			],
-			'_remote_position' => [
-				'label'       => __( 'Remote Position', 'wp-job-manager' ),
-				'description' => __( 'Select if this is a remote position.', 'wp-job-manager' ),
-				'type'        => 'checkbox',
-				'priority'    => 2,
-			],
-			'_application'     => [
-				'label'       => __( 'Application Email or URL', 'wp-job-manager' ),
-				'placeholder' => __( 'URL or email which applicants use to apply', 'wp-job-manager' ),
-				'description' => __( 'This field is required for the "application" area to appear beneath the listing.', 'wp-job-manager' ),
-				'value'       => metadata_exists( 'post', $post_id, '_application' ) ? get_post_meta( $post_id, '_application', true ) : $current_user->user_email,
-				'priority'    => 3,
-			],
-			'_company_name'    => [
-				'label'       => __( 'Company Name', 'wp-job-manager' ),
-				'placeholder' => '',
-				'priority'    => 4,
-			],
-			'_company_website' => [
-				'label'       => __( 'Company Website', 'wp-job-manager' ),
-				'placeholder' => '',
-				'priority'    => 5,
-			],
-			'_company_tagline' => [
-				'label'       => __( 'Company Tagline', 'wp-job-manager' ),
-				'placeholder' => __( 'Brief description about the company', 'wp-job-manager' ),
-				'priority'    => 6,
-			],
-			'_company_twitter' => [
-				'label'       => __( 'Company Twitter', 'wp-job-manager' ),
-				'placeholder' => '@yourcompany',
-				'priority'    => 7,
-			],
-			'_company_video'   => [
-				'label'       => __( 'Company Video', 'wp-job-manager' ),
-				'placeholder' => __( 'URL to the company video', 'wp-job-manager' ),
-				'type'        => 'file',
-				'priority'    => 8,
-			],
-			'_filled'          => [
-				'label'       => __( 'Position Filled', 'wp-job-manager' ),
-				'type'        => 'checkbox',
-				'priority'    => 9,
-				'description' => __( 'Filled listings will no longer accept applications.', 'wp-job-manager' ),
-			],
-			'_job_salary'      => [
-				'label'       => __( 'Salary', 'wp-job-manager' ),
-				'type'        => 'text',
-				'placeholder' => 'e.g. 20000',
-				'priority'    => 10,
-				'description' => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
-				'default'     => '',
-			],
-		];
-		if ( ! get_option( 'job_manager_enable_salary' ) ) {
-			unset( $fields['_job_salary'] );
-		}
-		if ( ! get_option( 'job_manager_enable_remote_position' ) ) {
-			unset( $fields['_remote_position'] );
-		}
-		if ( $current_user->has_cap( 'manage_job_listings' ) ) {
-			$fields['_featured']    = [
-				'label'       => __( 'Featured Listing', 'wp-job-manager' ),
-				'type'        => 'checkbox',
-				'description' => __( 'Featured listings will be sticky during searches, and can be styled differently.', 'wp-job-manager' ),
-				'priority'    => 10,
-			];
-			$job_expires            = get_post_meta( $post_id, '_job_expires', true );
-			$fields['_job_expires'] = [
-				'label'       => __( 'Listing Expiry Date', 'wp-job-manager' ),
-				'priority'    => 11,
-				'classes'     => [ 'job-manager-datepicker' ],
-				'placeholder' => ! empty( $job_expires ) ? null : date_i18n( get_option( 'date_format' ), strtotime( calculate_job_expiry( $post_id ) ) ),
-				'value'       => ! empty( $job_expires ) ? gmdate( 'Y-m-d', strtotime( $job_expires ) ) : '',
-			];
-		}
+		$fields = [];
 
 		if ( $current_user->has_cap( 'edit_others_job_listings' ) ) {
 			$fields['_job_author'] = [
@@ -510,7 +428,7 @@ class WP_Job_Manager_Writepanels {
 					<span class="tips" data-tip="<?php echo esc_attr( $field['description'] ); ?>">[?]</span>
 				<?php endif; ?>
 			</label>
-			<select name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $key ); ?>">
+			<select name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $key ); ?>" autocomplete="off">
 				<?php foreach ( $field['options'] as $key => $value ) : ?>
 					<option
 						value="<?php echo esc_attr( $key ); ?>"

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -133,6 +133,7 @@ class WP_Job_Manager_Ajax {
 		$per_page           = isset( $_REQUEST['per_page'] ) ? absint( $_REQUEST['per_page'] ) : absint( get_option( 'job_manager_per_page' ) );
 		$filled             = isset( $_REQUEST['filled'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['filled'] ) ) : null;
 		$featured           = isset( $_REQUEST['featured'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured'] ) ) : null;
+		$remote_position    = isset( $_REQUEST['remote_position'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['remote_position'] ) ) : null;
 		$show_pagination    = isset( $_REQUEST['show_pagination'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['show_pagination'] ) ) : null;
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
@@ -159,6 +160,10 @@ class WP_Job_Manager_Ajax {
 
 		if ( 'true' === $filled || 'false' === $filled ) {
 			$args['filled'] = 'true' === $filled;
+		}
+
+		if ( 'true' === $remote_position || 'false' === $remote_position ) {
+			$args['remote_position'] = 'true' === $remote_position;
 		}
 
 		if ( 'true' === $featured || 'false' === $featured ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1494,7 +1494,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		$fields = [
-			'_job_location'    => [
+			'_job_location'        => [
 				'label'         => __( 'Location', 'wp-job-manager' ),
 				'placeholder'   => __( 'e.g. "London"', 'wp-job-manager' ),
 				'description'   => __( 'Leave this blank if the location is not important.', 'wp-job-manager' ),
@@ -1503,7 +1503,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
 			],
-			'_application'     => [
+			'_application'         => [
 				'label'             => $application_method_label,
 				'placeholder'       => $application_method_placeholder,
 				'description'       => __( 'This field is required for the "application" area to appear beneath the listing.', 'wp-job-manager' ),
@@ -1513,7 +1513,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_rest'      => true,
 				'sanitize_callback' => [ __CLASS__, 'sanitize_meta_field_application' ],
 			],
-			'_company_name'    => [
+			'_company_name'        => [
 				'label'         => __( 'Company Name', 'wp-job-manager' ),
 				'placeholder'   => '',
 				'priority'      => 3,
@@ -1521,7 +1521,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
 			],
-			'_company_website' => [
+			'_company_website'     => [
 				'label'             => __( 'Company Website', 'wp-job-manager' ),
 				'placeholder'       => '',
 				'priority'          => 4,
@@ -1530,7 +1530,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_rest'      => true,
 				'sanitize_callback' => [ __CLASS__, 'sanitize_meta_field_url' ],
 			],
-			'_company_tagline' => [
+			'_company_tagline'     => [
 				'label'         => __( 'Company Tagline', 'wp-job-manager' ),
 				'placeholder'   => __( 'Brief description about the company', 'wp-job-manager' ),
 				'priority'      => 5,
@@ -1538,7 +1538,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
 			],
-			'_company_twitter' => [
+			'_company_twitter'     => [
 				'label'         => __( 'Company Twitter', 'wp-job-manager' ),
 				'placeholder'   => '@yourcompany',
 				'priority'      => 6,
@@ -1546,7 +1546,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
 			],
-			'_company_video'   => [
+			'_company_video'       => [
 				'label'             => __( 'Company Video', 'wp-job-manager' ),
 				'placeholder'       => __( 'URL to the company video', 'wp-job-manager' ),
 				'type'              => 'file',
@@ -1556,7 +1556,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_rest'      => true,
 				'sanitize_callback' => [ __CLASS__, 'sanitize_meta_field_url' ],
 			],
-			'_filled'          => [
+			'_filled'              => [
 				'label'         => __( 'Position Filled', 'wp-job-manager' ),
 				'type'          => 'checkbox',
 				'priority'      => 9,
@@ -1565,7 +1565,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_rest'  => true,
 				'description'   => __( 'Filled listings will no longer accept applications.', 'wp-job-manager' ),
 			],
-			'_featured'        => [
+			'_featured'            => [
 				'label'              => __( 'Featured Listing', 'wp-job-manager' ),
 				'type'               => 'checkbox',
 				'description'        => __( 'Featured listings will be sticky during searches, and can be styled differently.', 'wp-job-manager' ),
@@ -1575,7 +1575,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_rest'       => true,
 				'auth_edit_callback' => [ __CLASS__, 'auth_check_can_manage_job_listings' ],
 			],
-			'_job_expires'     => [
+			'_job_expires'         => [
 				'label'              => __( 'Listing Expiry Date', 'wp-job-manager' ),
 				'description'        => $job_expires_description,
 				'priority'           => 11,
@@ -1586,6 +1586,47 @@ class WP_Job_Manager_Post_Types {
 				'auth_edit_callback' => [ __CLASS__, 'auth_check_can_manage_job_listings' ],
 				'auth_view_callback' => [ __CLASS__, 'auth_check_can_edit_job_listings' ],
 				'sanitize_callback'  => [ __CLASS__, 'sanitize_meta_field_date' ],
+			],
+			'_remote_position'     => [
+				'label'         => __( 'Remote Position', 'wp-job-manager' ),
+				'description'   => __( 'Select if this is a remote position.', 'wp-job-manager' ),
+				'type'          => 'checkbox',
+				'priority'      => 12,
+				'data_type'     => 'integer',
+				'show_in_admin' => (bool) get_option( 'job_manager_enable_remote_position' ),
+				'show_in_rest'  => true,
+			],
+			'_job_salary'          => [
+				'label'         => __( 'Salary', 'wp-job-manager' ),
+				'type'          => 'text',
+				'placeholder'   => 'e.g. 20000',
+				'priority'      => 13,
+				'description'   => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
+				'data_type'     => 'string',
+				'show_in_admin' => (bool) get_option( 'job_manager_enable_salary' ),
+				'show_in_rest'  => true,
+			],
+			'_job_salary_currency' => [
+				'label'         => __( 'Salary Currency', 'wp-job-manager' ),
+				'type'          => 'text',
+				'data_type'     => 'string',
+				'placeholder'   => __( 'e.g. USD', 'wp-job-manager' ),
+				'priority'      => 14,
+				'description'   => __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency.', 'wp-job-manager' ),
+				'default'       => '',
+				'show_in_admin' => get_option( 'job_manager_enable_salary' ) && get_option( 'job_manager_enable_salary_currency' ),
+				'show_in_rest'  => true,
+			],
+			'_job_salary_unit'     => [
+				'label'         => __( 'Salary Unit', 'wp-job-manager' ),
+				'type'          => 'select',
+				'data_type'     => 'string',
+				'options'       => job_manager_get_salary_unit_options(),
+				'priority'      => 15,
+				'description'   => __( 'Add a salary period unit, this field is optional. Leave it empty to use the default salary unit, if one is defined.', 'wp-job-manager' ),
+				'default'       => '',
+				'show_in_admin' => get_option( 'job_manager_enable_salary' ) && get_option( 'job_manager_enable_salary_unit' ),
+				'show_in_rest'  => true,
 			],
 		];
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -674,6 +674,7 @@ class WP_Job_Manager_Shortcodes {
 					'job_types'                 => $atts['job_types'],
 					'atts'                      => $atts,
 					'location'                  => $atts['location'],
+					'remote_position'           => $atts['remote_position'],
 					'keywords'                  => $atts['keywords'],
 					'selected_job_types'        => $atts['selected_job_types'],
 					'show_category_multiselect' => $atts['show_category_multiselect'],

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -566,6 +566,7 @@ class WP_Job_Manager_Shortcodes {
 					'post_status'               => '',
 					'featured'                  => null, // True to show only featured, false to hide featured, leave null to show both.
 					'filled'                    => null, // True to show only filled, false to hide filled, leave null to show both/use the settings.
+					'remote_position'           => null, // True to show only remote, false to hide remote, leave null to show both.
 
 					// Default values for filters.
 					'location'                  => '',
@@ -594,6 +595,10 @@ class WP_Job_Manager_Shortcodes {
 
 		if ( ! is_null( $atts['filled'] ) ) {
 			$atts['filled'] = ( is_bool( $atts['filled'] ) && $atts['filled'] ) || in_array( $atts['filled'], [ 1, '1', 'true', 'yes' ], true );
+		}
+
+		if ( ! is_null( $atts['remote_position'] ) ) {
+			$atts['remote_position'] = ( is_bool( $atts['remote_position'] ) && $atts['remote_position'] ) || in_array( $atts['remote_position'], [ 1, '1', 'true', 'yes' ], true );
 		}
 
 		// By default, use client-side state to populate form fields.
@@ -691,6 +696,7 @@ class WP_Job_Manager_Shortcodes {
 						'posts_per_page'    => $atts['per_page'],
 						'featured'          => $atts['featured'],
 						'filled'            => $atts['filled'],
+						'remote_position'   => $atts['remote_position'],
 					]
 				)
 			);
@@ -727,6 +733,9 @@ class WP_Job_Manager_Shortcodes {
 		}
 		if ( ! is_null( $atts['filled'] ) ) {
 			$data_attributes['filled'] = $atts['filled'] ? 'true' : 'false';
+		}
+		if ( ! is_null( $atts['remote_position'] ) ) {
+			$data_attributes['remote_position'] = $atts['remote_position'] ? 'true' : 'false';
 		}
 		if ( ! empty( $atts['post_status'] ) ) {
 			$data_attributes['post_status'] = implode( ',', $atts['post_status'] );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -340,6 +340,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( ! get_option( 'job_manager_enable_salary' ) ) {
 			unset( $this->fields['job']['job_salary'] );
 		}
+		if ( ! get_option( 'job_manager_enable_remote_position' ) ) {
+			unset( $this->fields['job']['remote_position'] );
+		}
 	}
 
 	/**

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -70,6 +70,10 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 			],
 		];
 
+		if ( ! get_option( 'job_manager_enable_remote_position' ) ) {
+			unset( $this->settings['remote_position'] );
+		}
+
 		parent::__construct();
 	}
 

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -91,18 +91,9 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		ob_start();
 
-		$title  = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
-		$number = absint( $instance['number'] );
-
-		$args = [
-			'search_location' => $instance['location'],
-			'search_keywords' => $instance['keyword'],
-			'posts_per_page'  => $number,
-			'orderby'         => 'date',
-			'order'           => 'DESC',
-		];
-
-		$jobs = get_job_listings(
+		$title     = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
+		$number    = absint( $instance['number'] );
+		$jobs      = get_job_listings(
 			[
 				'search_location' => $instance['location'],
 				'remote_position' => in_array( $instance['remote_position'], [ 'true', 'false' ], true ) ? 'true' === $instance['remote_position'] : null,

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -29,23 +29,33 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 		$this->widget_description = __( 'Display a list of recent listings on your site, optionally matching a keyword and location.', 'wp-job-manager' );
 		$this->widget_id          = 'widget_recent_jobs';
 		$this->settings           = [
-			'title'     => [
+			'title'           => [
 				'type'  => 'text',
 				// translators: Placeholder %s is the plural label for the job listing post type.
 				'std'   => sprintf( __( 'Recent %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name ),
 				'label' => __( 'Title', 'wp-job-manager' ),
 			],
-			'keyword'   => [
+			'keyword'         => [
 				'type'  => 'text',
 				'std'   => '',
 				'label' => __( 'Keyword', 'wp-job-manager' ),
 			],
-			'location'  => [
+			'location'        => [
 				'type'  => 'text',
 				'std'   => '',
 				'label' => __( 'Location', 'wp-job-manager' ),
 			],
-			'number'    => [
+			'remote_position' => [
+				'type'    => 'select',
+				'std'     => 0,
+				'label'   => esc_html__( 'Remote Positions', 'wp-job-manager' ),
+				'options' => [
+					'all'   => esc_html__( 'Show all', 'wp-job-manager' ),
+					'true'  => esc_html__( 'Show only remote positions', 'wp-job-manager' ),
+					'false' => esc_html__( 'Show only non-remote positions', 'wp-job-manager' ),
+				],
+			],
+			'number'          => [
 				'type'  => 'number',
 				'step'  => 1,
 				'min'   => 1,
@@ -53,7 +63,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 				'std'   => 10,
 				'label' => __( 'Number of listings to show', 'wp-job-manager' ),
 			],
-			'show_logo' => [
+			'show_logo'       => [
 				'type'  => 'checkbox',
 				'std'   => 0,
 				'label' => esc_html__( 'Show Company Logo', 'wp-job-manager' ),
@@ -81,11 +91,21 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		ob_start();
 
-		$title     = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
-		$number    = absint( $instance['number'] );
-		$jobs      = get_job_listings(
+		$title  = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
+		$number = absint( $instance['number'] );
+
+		$args = [
+			'search_location' => $instance['location'],
+			'search_keywords' => $instance['keyword'],
+			'posts_per_page'  => $number,
+			'orderby'         => 'date',
+			'order'           => 'DESC',
+		];
+
+		$jobs = get_job_listings(
 			[
 				'search_location' => $instance['location'],
+				'remote_position' => in_array( $instance['remote_position'], [ 'true', 'false' ], true ) ? 'true' === $instance['remote_position'] : null,
 				'search_keywords' => $instance['keyword'],
 				'posts_per_page'  => $number,
 				'orderby'         => 'date',

--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.33.0
+ * @version     1.37.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -35,6 +35,13 @@ do_action( 'job_manager_job_filters_before', $atts );
 			<label for="search_location"><?php esc_html_e( 'Location', 'wp-job-manager' ); ?></label>
 			<input type="text" name="search_location" id="search_location" placeholder="<?php esc_attr_e( 'Location', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( $location ); ?>" />
 		</div>
+
+		<?php if( apply_filters( 'job_manager_job_filters_show_remote_position', get_option('job_manager_enable_remote_position', true ), $atts ) ) : ?>
+			<div class="search_remote_position">
+				<input type="checkbox" class="input-checkbox" name="remote_position" id="remote_position" placeholder="<?php esc_attr_e( 'Location', 'wp-job-manager' ); ?>" value="1" <?php checked(! empty( $remote_position ) ); ?> />
+				<label for="remote_position" id="remote_position_label"><?php esc_html_e( 'Remote positions only', 'wp-job-manager' ); ?></label>
+			</div>
+		<?php endif; ?>
 
 		<div style="clear: both"></div>
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -74,50 +74,16 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		}
 
 		if ( ! empty( $args['search_location'] ) ) {
-			// translators: This one is used to determine if the user is searching for remote work type.
-			$remote_keyword     = __( 'remote', 'wp-job-manager' );
-			$search_terms       = mb_split( '[,\s]+', $args['search_location'] );
-			$search_locations   = [];
-			$location_query     = [];
-			$is_remote_location = false;
-
-			// Check if user is looking for a remote work.
-			foreach ( $search_terms as $search_term ) {
-				$levenshtein_distance = levenshtein( strtolower( $remote_keyword ), strtolower( $search_term ) );
-				if ( -1 < $levenshtein_distance && $levenshtein_distance < 3 ) {
-					$is_remote_location = true;
-				} else {
-					$search_locations[] = $search_term;
-				}
-			}
-
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
+			$location_search    = [ 'relation' => 'OR' ];
 			foreach ( $location_meta_keys as $meta_key ) {
-				foreach ( $search_locations as $search_location ) {
-					$location_query[] = [
-						'key'     => $meta_key,
-						'value'   => $search_location,
-						'compare' => 'like',
-					];
-				}
-			}
-			if ( count( $location_query ) > 0 ) {
-				$location_query['relation'] = 'OR';
-				$query_args['meta_query'][] = $location_query;
-			}
-
-			if ( $is_remote_location ) {
-				$remote_work_query = [
-					'relation' => 'AND',
-					[
-						'key'     => '_remote_position',
-						'value'   => '1',
-						'compare' => '=',
-					],
-
+				$location_search[] = [
+					'key'     => $meta_key,
+					'value'   => $args['search_location'],
+					'compare' => 'like',
 				];
-				$query_args['meta_query'][] = $remote_work_query;
 			}
+			$query_args['meta_query'][] = $location_search;
 		}
 
 		if ( ! is_null( $args['featured'] ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -32,6 +32,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 				'order'             => 'DESC',
 				'featured'          => null,
 				'filled'            => null,
+				'remote_position'   => null,
 				'fields'            => 'all',
 			]
 		);
@@ -83,7 +84,27 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 					'compare' => 'like',
 				];
 			}
+
+			if ( ! is_null( $args['remote_position'] ) ) {
+				$location_search = [
+					'relation' => 'AND',
+					[
+						'key'     => '_remote_position',
+						'value'   => '1',
+						'compare' => $args['remote_position'] ? '=' : '!=',
+					],
+					$location_search,
+				];
+			}
+
 			$query_args['meta_query'][] = $location_search;
+
+		} elseif ( ! is_null( $args['remote_position'] ) ) {
+			$query_args['meta_query'][] = [
+				'key'     => '_remote_position',
+				'value'   => '1',
+				'compare' => $args['remote_position'] ? '=' : '!=',
+			];
 		}
 
 		if ( ! is_null( $args['featured'] ) ) {


### PR DESCRIPTION
Fixes #2287 

### Changes proposed in this Pull Request

- [x] Revert `search_location` back to original handling prior to 1.36.x+
- [x] Add `remote_position` to filtering
- [x] Add shortcode support for `remote_position`
- [x] Add support for `remote_position` in `get_job_listings`
- [x] Add support for `remote_position` in `WP_Job_Manager_Ajax` `get_listings`
- [x] Add support for `remote_position` in Recent Jobs Widget
- [x] Add setting to enable/disable `remote_position`
- [x] Add mobile support (stacking) for keyword and location fields

### Remote Position Functionality
- Shortcode, Recent Jobs Widget (via select), and search method (function) support 3 values for `remote_position`:
    - `true` to show only remote, `false` to hide remote, `null` to show both (default)

- By default when `remote_position` parameter is specified in search, and search is for listings that are NOT remote positions, two meta queries will be added.  One for `!= 1` and one for `NOT EXIST` for backwards compatibility of sites prior to 1.36.x that have listings without this meta saved on them.  The `NOT EXIST` meta query can be disabled by returning false to `job_manager_get_job_listings_remote_position_check_not_exists` filter

- Remote position displaying on frontend search & filtering can be disabled via setting in admin area (disabling remote position field) or by passing false to `job_manager_job_filters_show_remote_position` filter

- Remote position field works in conjunction with the standard location search.  If a value is passed for both `search_location` and `remote_position` it will be combined as an `AND` query (ie you search `Atlanta` and `true` for `remote_position`, it will only return results that match against `Atlanta` AND have remote position checked) as listings can be both remote and have specific location values set on them.