### PR TITLE
Some fixes for the Job Visibility feature

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -177,41 +177,4 @@ jQuery(document).ready(function($) {
 		$('#' + taxonomy + 'checklist li :radio, #' + taxonomy + 'checklist-pop :radio').prop('checked',false);
 		$('#in-' + taxonomy + '-' + id + ', #in-popular-' + taxonomy + '-' + id).prop( 'checked', c );
 	});
-
-	if ( $.isFunction( $.fn.select2 ) ) {
-		var job_listings_admin_select2_settings = {
-			'tags': true // Allows for free entry of custom capabilities.
-		};
-
-		if ( $( '.settings-role-select' ).length > 0 ) {
-			// This fixes a issue where backspace on role just turns it into search.
-			// @see https://github.com/select2/select2/issues/3354#issuecomment-277419278 for more info.
-			$.fn.select2.amd.require(
-				['select2/selection/search' ],
-				function ( Search ) {
-					Search.prototype.searchRemoveChoice = function (decorated, item) {
-						this.trigger(
-							'unselect',
-							{
-								data: item
-							}
-						);
-
-						this.$search.val( '' );
-						this.handleSearch();
-					};
-				},
-				null,
-				true
-			);
-		}
-
-		jQuery( '.nav-tab-wrapper a' ).on( 'click',
-			function() {
-				var $content = jQuery( jQuery( this ).attr( 'href' ) );
-				// Refresh when tab is selected.
-				$content.find( '.settings-role-select' ).select2( job_listings_admin_select2_settings );
-			}
-		);
-	}
 });

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -1044,7 +1044,7 @@ class WP_Job_Manager_Settings {
 		}
 		$result = [];
 		foreach ( $value as $item ) {
-			$item = strtolower( trim( sanitize_text_field( $item ) ) );
+			$item = trim( sanitize_text_field( $item ) );
 			if ( $item ) {
 				$result[] = $item;
 			}

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -534,16 +534,48 @@ class WP_Job_Manager_Settings {
 				return false;
 			});
 
+			if ( jQuery.isFunction( jQuery.fn.select2 ) ) {
+
+				if ( jQuery( '.settings-role-select' ).length > 0 ) {
+					// This fixes a issue where backspace on role just turns it into search.
+					// @see https://github.com/select2/select2/issues/3354#issuecomment-277419278 for more info.
+					jQuery.fn.select2.amd.require(
+						['select2/selection/search' ],
+						function ( Search ) {
+							Search.prototype.searchRemoveChoice = function (decorated, item) {
+								this.trigger(
+									'unselect',
+									{
+										data: item
+									}
+								);
+
+								this.$search.val( '' );
+								this.handleSearch();
+							};
+						},
+						null,
+						true
+					);
+				}
+			}
+
+			var job_listings_admin_select2_settings = {
+				'tags': true // Allows for free entry of custom capabilities.
+			};
+
 			jQuery('.nav-tab-wrapper a').click(function() {
 				if ( '#' !== jQuery(this).attr( 'href' ).substr( 0, 1 ) ) {
 					return false;
 				}
 				jQuery('.settings_panel').hide();
 				jQuery('.nav-tab-active').removeClass('nav-tab-active');
-				jQuery( jQuery(this).attr('href') ).show();
+				var $content = jQuery( jQuery(this).attr('href') );
+				$content.show();
 				jQuery(this).addClass('nav-tab-active');
 				window.location.hash = jQuery(this).attr('href');
 				jQuery( 'form.job-manager-options' ).attr( 'action', 'options.php' + jQuery(this).attr( 'href' ) );
+				$content.find( '.settings-role-select' ).select2( job_listings_admin_select2_settings );
 				window.scrollTo( 0, 0 );
 				return false;
 			});

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -438,7 +438,7 @@ class WP_Job_Manager_Settings {
 					[
 						[
 							'name'              => 'job_manager_browse_job_listings_capability',
-							'std'               => '',
+							'std'               => [],
 							'label'             => __( 'Browse Job Capability', 'wp-job-manager' ),
 							'type'              => 'capabilities',
 							'sanitize_callback' => [ $this, 'sanitize_capabilities' ],
@@ -447,7 +447,7 @@ class WP_Job_Manager_Settings {
 						],
 						[
 							'name'              => 'job_manager_view_job_listing_capability',
-							'std'               => '',
+							'std'               => [],
 							'label'             => __( 'View Job Capability', 'wp-job-manager' ),
 							'type'              => 'capabilities',
 							'sanitize_callback' => [ $this, 'sanitize_capabilities' ],

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -469,7 +469,11 @@ class WP_Job_Manager_Settings {
 				if ( isset( $option['std'] ) ) {
 					add_option( $option['name'], $option['std'] );
 				}
-				register_setting( $this->settings_group, $option['name'] );
+				$args = [];
+				if ( isset( $option['sanitize_callback'] ) ) {
+					$args['sanitize_callback'] = $option['sanitize_callback'];
+				}
+				register_setting( $this->settings_group, $option['name'], $args );
 			}
 		}
 	}

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -1000,11 +1000,10 @@ class WP_Job_Manager_Settings {
 	 *
 	 * @param array    $option              Option arguments for settings input.
 	 * @param string[] $attributes          Attributes on the HTML element. Strings must already be escaped.
-	 * @param mixed    $value               Current value.
+	 * @param string[] $value               Current value.
 	 * @param string   $ignored_placeholder We set the placeholder in the method. This is ignored.
 	 */
 	protected function input_capabilities( $option, $attributes, $value, $ignored_placeholder ) {
-		$value                 = self::capabilities_string_to_array( $value );
 		$option['options']     = self::get_capabilities_and_roles( $value );
 		$option['placeholder'] = esc_html__( 'Everyone (Public)', 'wp-job-manager' );
 
@@ -1051,39 +1050,6 @@ class WP_Job_Manager_Settings {
 			}
 		}
 		return $result;
-	}
-
-	/**
-	 * Convert list of capabilities and roles into array of values.
-	 *
-	 * @param string $value Comma separated list of capabilities and roles.
-	 * @return array
-	 */
-	private static function capabilities_string_to_array( $value ) {
-		return array_filter(
-			array_map(
-				function( $value ) {
-					return trim( sanitize_text_field( $value ) );
-				},
-				explode( ',', $value )
-			)
-		);
-	}
-
-	/**
-	 * Convert array of capabilities and roles into a comma separated list.
-	 *
-	 * @param array $value Array of capabilities and roles.
-	 * @return string
-	 */
-	private static function capabilities_array_to_string( $value ) {
-		if ( ! is_array( $value ) ) {
-			return '';
-		}
-
-		$caps = array_filter( array_map( 'sanitize_text_field', $value ) );
-
-		return implode( ',', $caps );
 	}
 
 	/**

--- a/templates/access-denied-browse-job_listings.php
+++ b/templates/access-denied-browse-job_listings.php
@@ -8,7 +8,8 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.36.0
+ * @since 		1.37.0
+ * @version     1.37.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/access-denied-single-job_listing.php
+++ b/templates/access-denied-single-job_listing.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @since 		1.37.0
+ * @since       1.37.0
  * @version     1.37.0
  */
 

--- a/templates/access-denied-single-job_listing.php
+++ b/templates/access-denied-single-job_listing.php
@@ -8,7 +8,8 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.36.0
+ * @since 		1.37.0
+ * @version     1.37.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/content-single-job_listing.php
+++ b/templates/content-single-job_listing.php
@@ -9,7 +9,7 @@
  * @package     wp-job-manager
  * @category    Template
  * @since       1.0.0
- * @version     1.36.0
+ * @version     1.37.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1628,7 +1628,7 @@ function job_manager_user_can_browse_job_listings() {
 /**
  * True if an the user can view a resume.
  *
- * @since 1.36.0
+ * @since 1.37.0
  *
  * @param  int $job_id
  * @return bool

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1622,6 +1622,13 @@ function job_manager_user_can_browse_job_listings() {
 		}
 	}
 
+	/**
+	 * Filter if the current user can or cannot browse job listings
+	 *
+	 * @since 1.37.0
+	 *
+	 * @param boolean $can_browse
+	 */
 	return apply_filters( 'job_manager_user_can_browse_job_listings', $can_browse );
 }
 
@@ -1662,5 +1669,13 @@ function job_manager_user_can_view_job_listing( $job_id ) {
 		$can_view = true;
 	}
 
+	/**
+	 * Filter if the current user can or cannot view a given job
+	 *
+	 * @since 1.37.0
+	 *
+	 * @param boolean $can_view
+	 * @param int     $job_id
+	 */
 	return apply_filters( 'job_manager_user_can_view_job', $can_view, $job_id );
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1662,12 +1662,5 @@ function job_manager_user_can_view_job_listing( $job_id ) {
 		$can_view = true;
 	}
 
-	$key = get_post_meta( $job_id, 'share_link_key', true );
-
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( $key && ! empty( $_GET['key'] ) && $key === $_GET['key'] ) {
-		$can_view = true;
-	}
-
 	return apply_filters( 'job_manager_user_can_view_job', $can_view, $job_id );
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1610,7 +1610,7 @@ function job_manager_count_user_job_listings( $user_id = 0 ) {
  */
 function job_manager_user_can_browse_job_listings() {
 	$can_browse = true;
-	$caps       = array_filter( array_map( 'trim', array_map( 'strtolower', explode( ',', get_option( 'job_manager_browse_job_listings_capability' ) ) ) ) );
+	$caps       = get_option( 'job_manager_browse_job_listings_capability' );
 
 	if ( $caps ) {
 		$can_browse = false;
@@ -1642,7 +1642,7 @@ function job_manager_user_can_view_job_listing( $job_id ) {
 		return true;
 	}
 
-	$caps = array_filter( array_map( 'trim', array_map( 'strtolower', explode( ',', get_option( 'job_manager_view_job_listing_capability' ) ) ) ) );
+	$caps = get_option( 'job_manager_view_job_listing_capability' );
 
 	if ( $caps ) {
 		$can_view = false;


### PR DESCRIPTION
Some fixes to #2280, mostly based on [this review](https://github.com/Automattic/WP-Job-Manager/pull/2280#pullrequestreview-1032266561).

### Changes proposed in this Pull Request

* Update PHPDocs to refer to correct next version;
* Refactor code to not change `$_POST` on the Settings page, instead relying on sanitize callbacks;
* Move code related to Select2 from admin.js to settings.php, so we can use the same event handler to detect when the tab changed;
* Save options of capabilities as an array, avoiding conversions between strings and arrays all the time;
* Remove check for `share_link_key`, which is a post meta not used in WPJM;

### Testing instructions

Verify that the Job Visibility Feature still works, by following the testing instructions on PR #2280.

### Questions

- Right now, in the capabilities field, we show the list of capabilities that the current user has. However, we allow the user to add new "capabilities" to the list pretty freely, so, here's the question: Should we block that and allow the user to only choose what's available on the list? That should be pretty easy to do, but I'm not 100% sure it's needed. :upside_down_face: 