### PR TITLE
Add release checklist workflow

### DIFF
--- a/.github/RELEASE-CHECKLIST.yml
+++ b/.github/RELEASE-CHECKLIST.yml
@@ -1,0 +1,8 @@
+paths:
+  "**":
+    - Follow the setup guide to create WPJM default pages.
+    - Check that the installed version is correct on the Plugins page.
+    - Create a new account and login with it.
+    - Go to the 'Post a Job' page and post a new job.
+    - Switch to the administrator and approve the newly posted job in admin.
+    - Visit the 'Jobs' page with the non-admin user and make sure that the job is displayed.

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -1,0 +1,25 @@
+name: Plugin Release Build
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - 'trunk'
+
+jobs:
+  checklist_job:
+    if: ${{ startsWith( github.head_ref, 'release/' ) }}
+    runs-on: ubuntu-latest
+    name: WPJM release checklist
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Checklist
+        uses: automattic/contextual-qa-checklist-action@master
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          input-file: .github/RELEASE-CHECKLIST.yml
+          comment-header: 'Please perform the following tests with the built package in a new installation before publishing:'
+          comment-footer: '' 
+          show-paths: false


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a test checklist on PRs of branches named `release/*` which are raised against trunk.
![Screenshot 2022-07-12 at 15 59 41](https://user-images.githubusercontent.com/53191348/178496017-7b1f2060-eacc-4081-bf4b-5ddb969edf37.png)

### Testing instructions

* Not sure if it is possible to test it. I tested it in a private WPJM repo.
