### PR TITLE
Fix warnings

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -1088,12 +1088,16 @@ class WP_Job_Manager_Settings {
 			$value = explode( ',', $value );
 		}
 		$result = [];
-		foreach ( $value as $item ) {
-			$item = trim( sanitize_text_field( $item ) );
-			if ( $item ) {
-				$result[] = $item;
+
+		if ( ! empty( $value ) ) {
+			foreach ( $value as $item ) {
+				$item = trim( sanitize_text_field( $item ) );
+				if ( $item ) {
+					$result[] = $item;
+				}
 			}
 		}
+
 		return $result;
 	}
 

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -51,7 +51,6 @@ class WP_Job_Manager_Settings {
 	public function __construct() {
 		$this->settings_group = 'job_manager';
 		add_action( 'admin_init', [ $this, 'register_settings' ] );
-		add_action( 'admin_action_update', [ $this, 'pre_process_settings_save' ] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes some warnings when testing the 1.37.0 package.

### Changes proposed in this Pull Request

* Remove unused hook.
* Check for empty value before looping.

### Testing instructions

* Go to the Settings page for WPJM, and on the Job Listings tab, change the settings for the Salary field.
* Check the PHP error log and ensure there are no new messages.

Previously there were the messages:

```
[12-Jul-2022 17:18:57 UTC] PHP Warning:  call_user_func_array() expects parameter 1 to be a valid callback, class 'WP_Job_Manager_Settings' does not have a method 'pre_process_settings_save' in /.../wp-includes/class-wp-hook.php on line 307

...

[12-Jul-2022 17:18:57 UTC] PHP Warning:  Invalid argument supplied for foreach() in /.../plugins/wp-job-manager/includes/admin/class-wp-job-manager-settings.php on line 1092
```