### PR TITLE
Add support for empty salary unit field

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1621,7 +1621,7 @@ class WP_Job_Manager_Post_Types {
 				'label'         => __( 'Salary Unit', 'wp-job-manager' ),
 				'type'          => 'select',
 				'data_type'     => 'string',
-				'options'       => job_manager_get_salary_unit_options( true ),
+				'options'       => job_manager_get_salary_unit_options(),
 				'priority'      => 15,
 				'description'   => __( 'Add a salary period unit, this field is optional. Leave it empty to use the default salary unit, if one is defined.', 'wp-job-manager' ),
 				'default'       => '',

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -283,7 +283,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					'job_salary_unit'     => [
 						'label'       => __( 'Salary Unit', 'wp-job-manager' ),
 						'type'        => 'select',
-						'options'     => job_manager_get_salary_unit_options( true ),
+						'options'     => job_manager_get_salary_unit_options(),
 						'description' => __( 'Add a salary period unit, this field is optional. Leave it empty to use the default salary unit, if one is defined.', 'wp-job-manager' ),
 						'required'    => false,
 						'priority'    => 10,

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1686,7 +1686,7 @@ function job_manager_user_can_view_job_listing( $job_id ) {
  * @param boolean $include_empty Defines if we should include an empty option as default.
  * @return array Where the key is the identifier used by Google Structured Data, and the value is a translated label.
  */
-function job_manager_get_salary_unit_options( $include_empty = false ) {
+function job_manager_get_salary_unit_options( $include_empty = true ) {
 	$options = [
 		''      => __( '--', 'wp-job-manager' ),
 		'YEAR'  => __( 'Year', 'wp-job-manager' ),

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1698,5 +1698,12 @@ function job_manager_get_salary_unit_options( $include_empty = false ) {
 	if ( ! $include_empty ) {
 		unset( $options[''] );
 	}
+	/**
+	 * Filter the salary unit options that should appear to the user
+	 *
+	 * @since 1.37.0
+	 * @param array $options Where the key is the identifier used by Google Structured Data, and the value is a translated label.
+	 * @param boolean $include_empty Defines if we should include an empty option as default.
+	 */
 	return apply_filters( 'job_manager_get_salary_unit_options', $options, $include_empty );
 }

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1413,7 +1413,7 @@ function get_the_job_salary_unit( $post = null ) {
 function get_the_job_salary_unit_display_text( $post = null ) {
 	$job_unit = get_the_job_salary_unit( $post );
 
-	$translated_options = job_manager_get_salary_unit_options();
+	$translated_options = job_manager_get_salary_unit_options( false );
 
 	$raw_job_unit = $job_unit;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add PHPDoc to document field related to options of the salary unit field;
* Include the empty option in all salary unity fields, so we can have the empty option as a salary unit [as requested by some users](https://github.com/Automattic/WP-Job-Manager/issues/2278#issuecomment-1167320597);

### Testing instructions

* Verify that the empty "option" (`--`) appears in every salary unit field. The default for the settings page should still be the "Year" option, by the way;
* Verify that if you choose that option (the empty one), but choose a currency and a salary, the salary unit nor the "slash" will appear on the frontend;
