### PR TITLE
Actions: add a new workflow to help triaging issues

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,0 +1,36 @@
+name: Repo gardening
+
+on:
+  issues:
+    types: [opened, reopened, edited, closed]
+  issue_comment:
+    types: [created]
+
+jobs:
+  repo-gardening:
+    name: 'Perform automated triage tasks on issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v3
+
+     - name: Setup Node
+       uses: actions/setup-node@v3
+       with:
+         node-version: 16
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: 'Run gardening action'
+       uses: automattic/action-repo-gardening@trunk
+       with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         slack_token: ${{ secrets.SLACK_TOKEN }}
+         slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
+         slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
+         tasks: 'gatherSupportReferences,replyToCustomersReminder'


### PR DESCRIPTION
### Changes proposed in this Pull Request

This workflow uses the Repo Gardening action:
https://github.com/marketplace/actions/repository-gardening

This commit enables 2 tasks of that action:

- Gather support references: Adds a new comment with a list of all support references that may get posted on a GitHub issue, and posts about that issue in Slack, in the channel of your choice, if it’s gathered more than 10 tickets. This can be a good opportunity to re-prioritize issues / escalate them when we start seeing them getting more and more attention / reports.
- Reply to customers Reminder: sends a Slack message, in the channel of your choice, about High Priority issues with a certain amount of tickets added to them, when those issues get closed, to remind you to update customers about the now-fixed issue, or add that issue to your list of future bulk-replies to send when a plugin update is pushed.

Internal reference: p9JkDc-Jj-p2

### Testing instructions

This cannot really be tested before it gets merged, but you can see examples of the workflow in use in other repos, like Calypso or Jetpack. Here is an example issue:
https://github.com/Automattic/jetpack/issues/25011#issuecomment-1207704120

### New/Updated Hooks

None

### Deprecated Code

None

### Screenshot / Video

<img width="969" alt="image" src="https://user-images.githubusercontent.com/426388/184835621-8ffe6b60-bf0c-4408-b679-aad26626d998.png">

-----------

<img width="722" alt="image" src="https://user-images.githubusercontent.com/426388/184835729-cfd6eac4-5092-45f4-9ced-09cd9f62d400.png">

-----------

<img width="704" alt="image" src="https://user-images.githubusercontent.com/426388/184835847-ffe01366-cb5e-421f-bff5-9b369697af02.png">

-----------

**Note**: in the screenshots above, the DRIs getting pinged are from WordPress.com, but for WP Job Manager we'd be pinging Sattelite DRIs (`@heysatellite`).
