### PR TITLE
Allow `0` as input during job submission

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -504,7 +504,7 @@ abstract class WP_Job_Manager_Form {
 							$value = trim( $value );
 						}
 
-						$this->fields[ $group_key ][ $key ]['empty'] = empty( $value );
+						$this->fields[ $group_key ][ $key ]['empty'] = $this->is_empty( $value, $key );
 					};
 				}
 
@@ -531,6 +531,35 @@ abstract class WP_Job_Manager_Form {
 		 * @param array  $fields  The form fields.
 		 */
 		return apply_filters( 'job_manager_get_posted_fields', $values, $this->fields );
+	}
+
+	/**
+	 * Checks whether a value is empty.
+	 *
+	 * @param string|numeric|array|boolean $value The value that is being checked.
+	 * @param string                       $key   The key of the field that is being checked.
+	 * @return bool True if value is empty, false otherwise.
+	 */
+	protected function is_empty( $value, $key = '' ) {
+		/**
+		 * Filter values considered as empty or falsy for required fields.
+		 * Useful for example if you want to consider zero (0) as a non-empty value.
+		 *
+		 * @see http://php.net/manual/en/function.empty.php -- standard default empty values
+		 *
+		 * @since 1.36.0
+		 *
+		 * @param array  $false_vals A list of values considered as falsy.
+		 * @param string $key        The key that this is being used for.
+		 */
+		$false_vals = apply_filters( 'submit_job_form_validate_fields_empty_values', [ '', 0, 0.0, '0', null, false, [] ], $key );
+
+		// strict true for type checking.
+		if ( in_array( $value, $false_vals, true ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -646,7 +646,7 @@ abstract class WP_Job_Manager_Form {
 			call_user_func( $field['before_sanitize'], $value );
 		}
 
-		return $value ? array_map( 'sanitize_text_field', $value ) : [];
+		return is_array( $value ) ? array_map( 'sanitize_text_field', $value ) : [];
 	}
 
 	/**
@@ -719,7 +719,7 @@ abstract class WP_Job_Manager_Form {
 			call_user_func( $field['before_sanitize'], $value );
 		}
 
-		return $value ? array_map( 'absint', $value ) : [];
+		return is_array( $value ) ? array_map( 'absint', $value ) : [];
 	}
 
 	/**
@@ -737,7 +737,7 @@ abstract class WP_Job_Manager_Form {
 			call_user_func( $field['before_sanitize'], $value );
 		}
 
-		return $value ? array_map( 'absint', $value ) : [];
+		return is_array( $value ) ? array_map( 'absint', $value ) : [];
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -628,7 +628,7 @@ abstract class WP_Job_Manager_Form {
 			call_user_func( $field['before_sanitize'], $value );
 		}
 
-		return $value ? $this->sanitize_posted_field( $value, $field['sanitizer'] ) : '';
+		return false !== $value ? $this->sanitize_posted_field( $value, $field['sanitizer'] ) : '';
 	}
 
 	/**
@@ -685,7 +685,7 @@ abstract class WP_Job_Manager_Form {
 			call_user_func( $field['before_sanitize'], $value );
 		}
 
-		return $value ? trim( wp_kses_post( $value ) ) : '';
+		return false !== $value ? trim( wp_kses_post( $value ) ) : '';
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -419,7 +419,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			foreach ( $group_fields as $key => $field ) {
 				if (
 					$field['required']
-					&& $this->is_empty( $values[ $group_key ][ $key ] )
 					&& ( ! isset( $field['empty'] ) || $field['empty'] )
 				) {
 					// translators: Placeholder %s is the label for the required field.
@@ -557,33 +556,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		 * @param array $values   Submitted input values.
 		 */
 		return apply_filters( 'submit_job_form_validate_fields', true, $this->fields, $values );
-	}
-
-	/**
-	 * Checks whether a value is empty.
-	 *
-	 * @param string|numeric|array|boolean $value
-	 * @return bool True if value is empty, false otherwise.
-	 */
-	protected function is_empty( $value ) {
-		/**
-		 * Filter values considered as empty or falsy for required fields.
-		 * Useful for example if you want to consider zero (0) as a non-empty value.
-		 *
-		 * @see http://php.net/manual/en/function.empty.php -- standard default empty values
-		 *
-		 * @since 1.36.0
-		 *
-		 * @param array  $false_vals A list of values considered as falsy.
-		 */
-		$false_vals = apply_filters( 'submit_job_form_validate_fields_empty_values', [ '', 0, 0.0, '0', null, false, [] ] );
-
-		// strict true for type checking.
-		if ( in_array( $value, $false_vals, true ) ) {
-			return true;
-		}
-
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2312

### Changes proposed in this Pull Request

* Fixes logic on `get_posted_jobs` and `get_posted_textarea_field `. We really just want to check for strict `false` from input check.
* Also added `is_array()` checks when we expect an array and are about to pass to `array_map()`.
* Moved `is_empty` method to parent class. Added `$key` param. Used this when populating `empty` for most fields (used in required checks).

### Testing instructions

* Make sure you can enter 0 for currency and it saves.
* With the snippet below, ensure you can enter `0` for a job title and it saves (this causes lots of other problems, but it is just to test the functionality for other custom fields).

### New/Updated Hooks

* `submit_job_form_validate_fields_empty_values` : Added `$key` parameter to allow people to customize what the field is.

### Snippet for Testing
```php
add_filter('submit_job_form_validate_fields_empty_values', function( $empty_vals, $key ) {
  if ($key === 'job_title') {
	return array_diff( $empty_vals, [ '0' ] );
  }
  
  return $empty_vals;
}, 10, 2);
```