### PR TITLE
Release 1.38.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 1.38.0 =
+* Enhancement: Improve support for searching multiple locations (@tripflex).
+* Fix: Translation issue in onboarding wizard. (@NekoJonez)
+* Fix: Better support for jobs submissions with `0` as input.
+
 = 1.37.0 =
 * Enhancement: Job Visibility Settings
 * Enhancement: New settings for Salary fields
@@ -56,7 +61,7 @@
 * Fix: Missing variable error with cached widgets.
 * Tweak: reCAPTCHA setting has more clear language. (@tripflex)
 * Dev: Added filter `submit_job_form_create_account_role` for user role when created on job submission. (@tripflex)
-* Dev: Added filter `job_manager_should_run_shortcode_action_handler` for if a job dashboard action should run. 
+* Dev: Added filter `job_manager_should_run_shortcode_action_handler` for if a job dashboard action should run.
 * Dev: Added filter `job_manager_get_form_action` to modify the action of a frontend form. (@tripflex)
 * Template update: `job-dashboard.php` with new date functions.
 
@@ -99,7 +104,7 @@
 * Fix: Resuming job listing submission at a particular step is now fixed.
 * Fix: Issue with some permalink structures and WPMU would cause issues on `[jobs]` page.
 * Dev: Adds the ability to block some jobs from being edited in the frontend.
-* Dev: Adds ability to force some email notifications to be enabled. 
+* Dev: Adds ability to force some email notifications to be enabled.
 * Dev: Allows email notifications to be sent immediately.
 * Dev: Adds ability for settings to reference other settings tabs.
 * Dev: Standardizes jQuery UI datepicker script IDs in frontend and backend. Plugins and themes should enqueue `wp-job-manager-datepicker` if they need jQuery UI datepicker.
@@ -123,7 +128,7 @@
 * Third Party: Fix issue with Polylang where translations get overwritten on save of another language.
 * Dev: Adds the ability to completely disable the state saving functionality of `[jobs]` results.
 * Dev: Allows custom calls to `get_job_listings()` to just get `ids` and `id=>parent`. (@manzoorwanijk)
-* Dev: Switched to short-array syntax across plugin. 
+* Dev: Switched to short-array syntax across plugin.
 * Dev: Updated `jquery-fileupload` library to 10.2.0.
 * Dev: Updated `select2` library to 4.0.10.
 
@@ -136,7 +141,7 @@
 * Fix: Checking typeof undefined should be in quotes in job_submission.js.
 * Fix: Plugin activation issue that didn't set up roles correctly.
 * Fix: Escaped HTML issue in expiring jobs email notice.
-* Change: Added additional unslashing and sanitization of input variables from forms. 
+* Change: Added additional unslashing and sanitization of input variables from forms.
 * Change: Limited direct database access within the plugin and migrated to WordPress core functions when possible.
 * Removed: Transient garbage collection. WordPress 4.9 and up handle this automatically.
 
@@ -189,7 +194,7 @@
 = 1.32.0 =
 * Enhancement: Switched from Chosen to Select2 for enhanced dropdown handling and better mobile support. May require theme update.
 * Enhancement: Draft and unsubmitted job listings now appear in `[job_dashboard]`, allowing users to complete their submission.
-* Enhancement: [REVERTED IN 1.32.1] Filled and expired positions are now hidden from WordPress search. (@felipeelia) 
+* Enhancement: [REVERTED IN 1.32.1] Filled and expired positions are now hidden from WordPress search. (@felipeelia)
 * Enhancement: Adds additional support for the new block editor. Restricted to classic block for compatibility with frontend editor.
 * Enhancement: Job types can be preselected in `[jobs]` shortcode with `?search_job_type=term-slug`. (@felipeelia)
 * Enhancement: Author selection in WP admin now uses a searchable dropdown.
@@ -209,7 +214,7 @@
 * Fix: Escape the attachment URL. (Props to karimeo)
 * Fix: Custom job field priority fix when using decimals. (@tripflex)
 * Fix: Fix issue with empty mutli-select in WP admin jobs page. (@felipeelia)
-* Fix: Issue with data export when email doesn't have any job listings. 
+* Fix: Issue with data export when email doesn't have any job listings.
 * Third Party: Improved WPML support. (@vukvukovich)
 
 = 1.31.2 =
@@ -224,7 +229,7 @@
 * Fix: No longer auto-expire job listings in Draft status.
 * Fix: Issue with undefined index error in WP admin. (@albionselimaj)
 * Fix: Issue with duplicate usernames preventing submission of job listings. (@timothyjensen)
-* Dev: Widespread code formatting cleanup throughout the plugin. 
+* Dev: Widespread code formatting cleanup throughout the plugin.
 
 = 1.31.0 =
 * Change: Minimum WordPress version is now 4.7.0.
@@ -232,7 +237,7 @@
 * Enhancement: For GDPR, scrub WPJM data from database on uninstall if option is enabled.
 * Enhancement: Filter by Filled and Featured status in WP admin.
 * Enhancement: Simplify the display of application URLs.
-* Enhancement: When using WPML, prevent changes to page options when on a non-default language. (@vukvukovich) 
+* Enhancement: When using WPML, prevent changes to page options when on a non-default language. (@vukvukovich)
 * Enhancement: Include company logo in structured data. (@RajeebTheGreat)
 * Enhancement: Use more efficient jQuery selectors in scripts. (@RajeebTheGreat)
 * Enhancement: Use proper `<h2>` tag in `content-summary-job_listing.php` template for the job title. (@abdullah1908)
@@ -247,8 +252,8 @@
 
 = 1.30.2 =
 * Enhancement: Show notice when user is using an older version of WordPress.
-* Enhancement: Hide unnecessary view mode in WP Admin's Job Listings page. (@RajeebTheGreat) 
-* Enhancement: Add support for the `paged` parameter in the RSS feed. (@RajeebTheGreat) 
+* Enhancement: Hide unnecessary view mode in WP Admin's Job Listings page. (@RajeebTheGreat)
+* Enhancement: Add support for the `paged` parameter in the RSS feed. (@RajeebTheGreat)
 * Fix: Minor PHP 7.2 compatibility fixes.
 * Dev: Allow `parent` attribute to be passed to `job_manager_dropdown_categories()`. (@RajeebTheGreat)
 
@@ -328,7 +333,7 @@
 * Fix: Make sure cron jobs for checking/cleaning expired listings are always in place.
 * Fix: Better handling of multiple job types. (@spencerfinnell)
 * Fix: Issue with deleting company logos from job listings submission form.
-* Fix: Warning thrown on job submission form when user not logged in. (@piersb)  
+* Fix: Warning thrown on job submission form when user not logged in. (@piersb)
 * Fix: Issue with WPML not syncing some meta fields.
 * Fix: Better handling of AJAX upload errors. (@tripflex)
 * Fix: Remove job posting cookies on logout.
@@ -336,7 +341,7 @@
 * Fix: Issue with Safari and expiration datepicker.
 
 = 1.26.2 =
-* Fix: Prevents use of Ajax file upload endpoint for visitors who aren't logged in. Themes should check with `job_manager_user_can_upload_file_via_ajax()` if using endpoint in templates.  
+* Fix: Prevents use of Ajax file upload endpoint for visitors who aren't logged in. Themes should check with `job_manager_user_can_upload_file_via_ajax()` if using endpoint in templates.
 * Fix: Escape post title in WP Admin's Job Listings page and template segments. (Props to @EhsanCod3r)
 
 = 1.26.1 =
@@ -374,30 +379,30 @@
 * Fix: Fixed taxonomy search conditions. See https://github.com/automattic/wp-job-manager/pull/859/ Props Jonas Vogel.
 
 = 1.25.2 =
-* Fix - The date format of the expiry date picker was incorrect in translations so we added a comment to clarify, and fixed translations. 
-* Fix - Changing the date of an expired job would forget the date, even though the job would become active. 
-* Fix - Site owner can allow jobs to have only one or more than one types. 
-* Fix - Show expired jobs if that setting is enabled. 
-* Fix - Simplify the search message on the jobs page to avoid translation problems. 
-* Fix - The uploader would ignore WordPress created image sizes. 
-* Fix - setup.css was loaded on all admin pages. 
-* Fix - The preview of a listing could be edited or viewed by anyone. Props @tripflex 
-* Fix - When users were deleted their jobs weren't. 
-* Fix - OrderBy Rand wasn't working. 
-* Dev - Add upload filters and update PHPDocs, props @tripflex 
-* Fix - Stop using jQuery.live, props @tripflex 
+* Fix - The date format of the expiry date picker was incorrect in translations so we added a comment to clarify, and fixed translations.
+* Fix - Changing the date of an expired job would forget the date, even though the job would become active.
+* Fix - Site owner can allow jobs to have only one or more than one types.
+* Fix - Show expired jobs if that setting is enabled.
+* Fix - Simplify the search message on the jobs page to avoid translation problems.
+* Fix - The uploader would ignore WordPress created image sizes.
+* Fix - setup.css was loaded on all admin pages.
+* Fix - The preview of a listing could be edited or viewed by anyone. Props @tripflex
+* Fix - When users were deleted their jobs weren't.
+* Fix - OrderBy Rand wasn't working.
+* Dev - Add upload filters and update PHPDocs, props @tripflex
+* Fix - Stop using jQuery.live, props @tripflex
 
 = 1.25.1 =
-* Feature - Adds a view button to the Admin UI for easy access to submitted files or URLs. Props tripflex 
+* Feature - Adds a view button to the Admin UI for easy access to submitted files or URLs. Props tripflex
 * Fix - Add hardening to file uploads to prevent accepting unexpected file times. Previously, other WP-allowed types were sometimes accepted.
-* Fix - Job post form categories are now properly cached and displayed per language when using WPML or Polylang. 
-* Fix - Refactored WPML workaround, which was causing no job listings on non-default languages. 
-* Fix - Allow employers to edit job listings when a listing is pending payment. 
-* Fix - No longer display Job Taxonomies in the WordPress tag cloud. 
-* Fix - Migrate away from jQuery.live, which is no longer supported. 
-* Tweak - Updated incorrect settings description. 
-* Dev - Adds hook to add items in a job's RSS feed item. 
-* Dev - Adds filter to disable Job Listings cache 
+* Fix - Job post form categories are now properly cached and displayed per language when using WPML or Polylang.
+* Fix - Refactored WPML workaround, which was causing no job listings on non-default languages.
+* Fix - Allow employers to edit job listings when a listing is pending payment.
+* Fix - No longer display Job Taxonomies in the WordPress tag cloud.
+* Fix - Migrate away from jQuery.live, which is no longer supported.
+* Tweak - Updated incorrect settings description.
+* Dev - Adds hook to add items in a job's RSS feed item.
+* Dev - Adds filter to disable Job Listings cache
 * Dev - Inline docs and coding standards improvements.
 
 = 1.25.0 =
@@ -405,7 +410,7 @@
 * Fix - Support WP_EMBED in job descriptions.
 * Fix - Ensure logo is displayed on edit, before submission.
 * Fix - Attachment URLs on multisite.
-* Fix - Refactored WPML workaround, which was causing no job listings on non-default languages. 
+* Fix - Refactored WPML workaround, which was causing no job listings on non-default languages.
 * Fix - No need to decode URLs anymore https://core.trac.wordpress.org/ticket/23605.
 * Dev - submit_job_form_end/submit_job_form_start actions.
 * Dev - job-manager-datepicker class for backend date fields.

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -1,17 +1,17 @@
 # Copyright (C) 2022 Automattic
-# This file is distributed under the same license as the WP Job Manager plugin.
+# This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 1.37.0\n"
+"Project-Id-Version: WP Job Manager 1.38.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-07-18T17:12:57+00:00\n"
+"POT-Creation-Date: 2022-08-26T17:27:21+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
+"X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: wp-job-manager\n"
 
 #. Plugin Name of the plugin
@@ -251,6 +251,7 @@ msgstr ""
 #: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:46
 #: templates/job-filters.php:35
 #: templates/job-filters.php:36
+#: templates/job-filters.php:41
 msgid "Location"
 msgstr ""
 
@@ -532,367 +533,381 @@ msgid "This allows users to select more than one type when submitting a job. The
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:229
+#: includes/class-wp-job-manager-post-types.php:1591
+#: includes/forms/class-wp-job-manager-form-submit-job.php:230
+msgid "Remote Position"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-settings.php:230
+msgid "Enable Remote Position"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-settings.php:231
+msgid "This lets users select if the listing is a remote position when submitting a job."
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-settings.php:238
 #: includes/class-wp-job-manager-post-types.php:1600
 #: includes/forms/class-wp-job-manager-form-submit-job.php:269
 msgid "Salary"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:230
+#: includes/admin/class-wp-job-manager-settings.php:239
 msgid "Enable Job Salary"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:231
+#: includes/admin/class-wp-job-manager-settings.php:240
 msgid "This lets users add a salary when submitting a job."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:238
+#: includes/admin/class-wp-job-manager-settings.php:247
 #: includes/class-wp-job-manager-post-types.php:1610
 #: includes/forms/class-wp-job-manager-form-submit-job.php:276
 msgid "Salary Currency"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:239
+#: includes/admin/class-wp-job-manager-settings.php:248
 msgid "Enable Job Salary Currency Customization"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:240
-#: includes/admin/class-wp-job-manager-settings.php:259
+#: includes/admin/class-wp-job-manager-settings.php:249
+#: includes/admin/class-wp-job-manager-settings.php:268
 msgid "This lets users add a salary currency when submitting a job."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:247
+#: includes/admin/class-wp-job-manager-settings.php:256
 msgid "Default Salary Currency"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:248
+#: includes/admin/class-wp-job-manager-settings.php:257
 msgid "Default Currency used by salaries"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:249
+#: includes/admin/class-wp-job-manager-settings.php:258
 msgid "Sets the default currency used by salaries"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:251
+#: includes/admin/class-wp-job-manager-settings.php:260
 #: includes/class-wp-job-manager-post-types.php:1613
 #: includes/forms/class-wp-job-manager-form-submit-job.php:279
 msgid "e.g. USD"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:257
+#: includes/admin/class-wp-job-manager-settings.php:266
 #: includes/class-wp-job-manager-post-types.php:1621
 #: includes/forms/class-wp-job-manager-form-submit-job.php:284
 msgid "Salary Unit"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:258
+#: includes/admin/class-wp-job-manager-settings.php:267
 msgid "Enable Job Salary Unit Customization"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:266
+#: includes/admin/class-wp-job-manager-settings.php:275
 msgid "Default Salary Unit"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:267
+#: includes/admin/class-wp-job-manager-settings.php:276
 msgid "Default Unit used by salaries"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:268
+#: includes/admin/class-wp-job-manager-settings.php:277
 msgid "Sets the default period unit used by salaries"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:276
+#: includes/admin/class-wp-job-manager-settings.php:285
 msgid "Location Display"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:277
+#: includes/admin/class-wp-job-manager-settings.php:286
 msgid "Display Location Address"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:278
+#: includes/admin/class-wp-job-manager-settings.php:287
 msgid "Display the full address of the job listing location if it is detected by Google Maps Geocoding API. If full address is not available then it will display whatever text the user submitted for the location."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:284
+#: includes/admin/class-wp-job-manager-settings.php:293
 msgid "Job Submission"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:289
+#: includes/admin/class-wp-job-manager-settings.php:298
 msgid "Account Required"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:290
+#: includes/admin/class-wp-job-manager-settings.php:299
 msgid "Require an account to submit listings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:291
+#: includes/admin/class-wp-job-manager-settings.php:300
 msgid "Limits job listing submissions to registered, logged-in users."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:298
+#: includes/admin/class-wp-job-manager-settings.php:307
 msgid "Account Creation"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:299
+#: includes/admin/class-wp-job-manager-settings.php:308
 msgid "Enable account creation during submission"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:300
+#: includes/admin/class-wp-job-manager-settings.php:309
 msgid "Includes account creation on the listing submission form, to allow non-registered users to create an account and submit a job listing simultaneously."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:307
+#: includes/admin/class-wp-job-manager-settings.php:316
 msgid "Account Username"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:308
+#: includes/admin/class-wp-job-manager-settings.php:317
 msgid "Generate usernames from email addresses"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:309
+#: includes/admin/class-wp-job-manager-settings.php:318
 msgid "Automatically generates usernames for new accounts from the registrant's email address. If this is not enabled, a \"username\" field will display instead."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:316
+#: includes/admin/class-wp-job-manager-settings.php:325
 msgid "Account Password"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:317
+#: includes/admin/class-wp-job-manager-settings.php:326
 msgid "Email new users a link to set a password"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:318
+#: includes/admin/class-wp-job-manager-settings.php:327
 msgid "Sends an email to the user with their username and a link to set their password. If this is not enabled, a \"password\" field will display instead, and their email address won't be verified."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:325
+#: includes/admin/class-wp-job-manager-settings.php:334
 msgid "Account Role"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:326
+#: includes/admin/class-wp-job-manager-settings.php:335
 msgid "Any new accounts created during submission will have this role. If you haven't enabled account creation during submission in the options above, your own method of assigning roles will apply."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:333
+#: includes/admin/class-wp-job-manager-settings.php:342
 msgid "Moderate New Listings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:334
+#: includes/admin/class-wp-job-manager-settings.php:343
 msgid "Require admin approval of all new listing submissions"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:335
+#: includes/admin/class-wp-job-manager-settings.php:344
 msgid "Sets all new submissions to \"pending.\" They will not appear on your site until an admin approves them."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:342
+#: includes/admin/class-wp-job-manager-settings.php:351
 msgid "Allow Pending Edits"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:343
+#: includes/admin/class-wp-job-manager-settings.php:352
 msgid "Allow editing of pending listings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:344
+#: includes/admin/class-wp-job-manager-settings.php:353
 msgid "Users can continue to edit pending listings until they are approved by an admin."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:351
+#: includes/admin/class-wp-job-manager-settings.php:360
 msgid "Allow Published Edits"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:352
+#: includes/admin/class-wp-job-manager-settings.php:361
 msgid "Allow editing of published listings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:353
+#: includes/admin/class-wp-job-manager-settings.php:362
 msgid "Choose whether published job listings can be edited and if edits require admin approval. When moderation is required, the original job listings will be unpublished while edits await admin approval."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:356
+#: includes/admin/class-wp-job-manager-settings.php:365
 msgid "Users cannot edit"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:357
+#: includes/admin/class-wp-job-manager-settings.php:366
 msgid "Users can edit without admin approval"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:358
+#: includes/admin/class-wp-job-manager-settings.php:367
 msgid "Users can edit, but edits require admin approval"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:365
+#: includes/admin/class-wp-job-manager-settings.php:374
 msgid "Listing Duration"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:366
+#: includes/admin/class-wp-job-manager-settings.php:375
 msgid "Listings will display for the set number of days, then expire. Leave this field blank if you don't want listings to have an expiration date."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:372
+#: includes/admin/class-wp-job-manager-settings.php:381
 msgid "Listing Limit"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:373
+#: includes/admin/class-wp-job-manager-settings.php:382
 msgid "How many listings are users allowed to post. Can be left blank to allow unlimited listings per account."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:375
+#: includes/admin/class-wp-job-manager-settings.php:384
 msgid "No limit"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:380
+#: includes/admin/class-wp-job-manager-settings.php:389
 msgid "Application Method"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:381
+#: includes/admin/class-wp-job-manager-settings.php:390
 msgid "Choose the application method job listers will need to provide. Specify URL or email address only, or allow listers to choose which they prefer."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:384
+#: includes/admin/class-wp-job-manager-settings.php:393
 msgid "Email address or website URL"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:385
+#: includes/admin/class-wp-job-manager-settings.php:394
 msgid "Email addresses only"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:386
+#: includes/admin/class-wp-job-manager-settings.php:395
 msgid "Website URLs only"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:392
+#: includes/admin/class-wp-job-manager-settings.php:401
 msgid "Terms and Conditions Checkbox"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:393
+#: includes/admin/class-wp-job-manager-settings.php:402
 msgid "Enable required Terms and Conditions checkbox on the form"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:394
+#: includes/admin/class-wp-job-manager-settings.php:403
 msgid "Require a Terms and Conditions checkbox to be marked before a job can be submitted. The linked page can be set from the <a href=\"#settings-job_pages\" class=\"nav-internal\">Pages</a> settings tab."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:401
+#: includes/admin/class-wp-job-manager-settings.php:410
 msgid "reCAPTCHA"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:405
+#: includes/admin/class-wp-job-manager-settings.php:414
 msgid "Are you human?"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:407
+#: includes/admin/class-wp-job-manager-settings.php:416
 msgid "Field Label"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:408
+#: includes/admin/class-wp-job-manager-settings.php:417
 msgid "The label used for the reCAPTCHA field on forms."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:415
+#: includes/admin/class-wp-job-manager-settings.php:424
 msgid "Site Key"
 msgstr ""
 
 #. translators: Placeholder %s is URL to set up Google reCAPTCHA API key.
-#: includes/admin/class-wp-job-manager-settings.php:417
+#: includes/admin/class-wp-job-manager-settings.php:426
 msgid "You can retrieve your reCAPTCHA v2 \"I'm not a robot\" Checkbox site key from <a href=\"%s\">Google's reCAPTCHA admin dashboard</a>."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:424
+#: includes/admin/class-wp-job-manager-settings.php:433
 msgid "Secret Key"
 msgstr ""
 
 #. translators: Placeholder %s is URL to set up Google reCAPTCHA API key.
-#: includes/admin/class-wp-job-manager-settings.php:426
+#: includes/admin/class-wp-job-manager-settings.php:435
 msgid "You can retrieve your reCAPTCHA v2 \"I'm not a robot\" Checkbox secret key from <a href=\"%s\">Google's reCAPTCHA admin dashboard</a>."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:432
+#: includes/admin/class-wp-job-manager-settings.php:441
 msgid "Job Submission Form"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:433
+#: includes/admin/class-wp-job-manager-settings.php:442
 msgid "Display a reCAPTCHA field on job submission form."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:434
+#: includes/admin/class-wp-job-manager-settings.php:443
 msgid "This will help prevent bots from submitting job listings. You must have entered a valid site key and secret key above."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:441
+#: includes/admin/class-wp-job-manager-settings.php:450
 msgid "Pages"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:446
+#: includes/admin/class-wp-job-manager-settings.php:455
 msgid "Submit Job Form Page"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:447
+#: includes/admin/class-wp-job-manager-settings.php:456
 msgid "Select the page where you've used the [submit_job_form] shortcode. This lets the plugin know the location of the form."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:453
+#: includes/admin/class-wp-job-manager-settings.php:462
 msgid "Job Dashboard Page"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:454
+#: includes/admin/class-wp-job-manager-settings.php:463
 msgid "Select the page where you've used the [job_dashboard] shortcode. This lets the plugin know the location of the dashboard."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:460
+#: includes/admin/class-wp-job-manager-settings.php:469
 msgid "Job Listings Page"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:461
+#: includes/admin/class-wp-job-manager-settings.php:470
 msgid "Select the page where you've used the [jobs] shortcode. This lets the plugin know the location of the job listings page."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:467
+#: includes/admin/class-wp-job-manager-settings.php:476
 msgid "Terms and Conditions Page"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:468
+#: includes/admin/class-wp-job-manager-settings.php:477
 msgid "Select the page to link when \"Terms and Conditions Checkbox\" is enabled. See setting in \"Job Submission\" tab."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:474
+#: includes/admin/class-wp-job-manager-settings.php:483
 msgid "Job Visibility"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:479
+#: includes/admin/class-wp-job-manager-settings.php:488
 msgid "Browse Job Capability"
 msgstr ""
 
 #. translators: Placeholder %s is the url to the WordPress core documentation for capabilities and roles.
-#: includes/admin/class-wp-job-manager-settings.php:483
+#: includes/admin/class-wp-job-manager-settings.php:492
 msgid "Enter which <a href=\"%s\">roles or capabilities</a> allow visitors to browse job listings. If no value is selected, everyone (including logged out guests) will be able to browse job listings."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:488
+#: includes/admin/class-wp-job-manager-settings.php:497
 msgid "View Job Capability"
 msgstr ""
 
 #. translators: Placeholder %s is the url to the WordPress core documentation for capabilities and roles.
-#: includes/admin/class-wp-job-manager-settings.php:492
+#: includes/admin/class-wp-job-manager-settings.php:501
 msgid "Enter which <a href=\"%s\">roles or capabilities</a> allow visitors to view a single job listing. If no value is selected, everyone (including logged out guests) will be able to view job listings."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:543
+#: includes/admin/class-wp-job-manager-settings.php:552
 msgid "Settings successfully saved"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:568
+#: includes/admin/class-wp-job-manager-settings.php:577
 msgid "Save Changes"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:807
+#: includes/admin/class-wp-job-manager-settings.php:816
 msgid "--no page--"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:813
+#: includes/admin/class-wp-job-manager-settings.php:822
 msgid "Select a page&hellip;"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:1053
+#: includes/admin/class-wp-job-manager-settings.php:1062
 msgid "Everyone (Public)"
 msgstr ""
 
@@ -937,7 +952,7 @@ msgstr ""
 
 #. translators: Used in user select. %1$s is the user's display name; #%2$s is the user ID; %3$s is the user email.
 #: includes/admin/class-wp-job-manager-writepanels.php:532
-#: includes/class-wp-job-manager-ajax.php:419
+#: includes/class-wp-job-manager-ajax.php:424
 msgid "%1$s (#%2$s – %3$s)"
 msgstr ""
 
@@ -1074,6 +1089,10 @@ msgstr ""
 msgid "Creates a page where visitors can browse, search, and filter job listings."
 msgstr ""
 
+#: includes/admin/views/html-admin-setup-step-2.php:71
+msgid "Create selected pages"
+msgstr ""
+
 #: includes/admin/views/html-admin-setup-step-2.php:72
 msgid "Skip this step"
 msgstr ""
@@ -1151,13 +1170,13 @@ msgid "Help other users on the forums"
 msgstr ""
 
 #. translators: Placeholder %d is the number of found search results.
-#: includes/class-wp-job-manager-ajax.php:186
+#: includes/class-wp-job-manager-ajax.php:191
 msgid "Search completed. Found %d matching record."
 msgid_plural "Search completed. Found %d matching records."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-wp-job-manager-ajax.php:284
+#: includes/class-wp-job-manager-ajax.php:289
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
@@ -1528,11 +1547,6 @@ msgstr ""
 msgid "Listing Expiry Date"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1591
-#: includes/forms/class-wp-job-manager-form-submit-job.php:230
-msgid "Remote Position"
-msgstr ""
-
 #: includes/class-wp-job-manager-post-types.php:1592
 #: includes/forms/class-wp-job-manager-form-submit-job.php:231
 msgid "Select if this is a remote position."
@@ -1620,8 +1634,8 @@ msgstr ""
 msgid "Continue Submission"
 msgstr ""
 
-#: includes/class-wp-job-manager-shortcodes.php:682
-#: includes/class-wp-job-manager-shortcodes.php:720
+#: includes/class-wp-job-manager-shortcodes.php:688
+#: includes/class-wp-job-manager-shortcodes.php:727
 msgid "Load more listings"
 msgstr ""
 
@@ -1666,7 +1680,7 @@ msgstr ""
 
 #. translators: Placeholder %d is the number of files to that users are limited to.
 #: includes/class-wp-job-manager.php:523
-#: includes/forms/class-wp-job-manager-form-submit-job.php:502
+#: includes/forms/class-wp-job-manager-form-submit-job.php:504
 msgid "You are only allowed to upload a maximum of %d files."
 msgstr ""
 
@@ -1762,7 +1776,7 @@ msgid "Submit Details"
 msgstr ""
 
 #: includes/forms/class-wp-job-manager-form-submit-job.php:93
-#: includes/forms/class-wp-job-manager-form-submit-job.php:692
+#: includes/forms/class-wp-job-manager-form-submit-job.php:667
 #: templates/job-preview.php:30
 msgid "Preview"
 msgstr ""
@@ -1829,73 +1843,73 @@ msgid "Logo"
 msgstr ""
 
 #. translators: Placeholder %s is the label for the required field.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:423
+#: includes/forms/class-wp-job-manager-form-submit-job.php:425
 msgid "%s is a required field"
 msgstr ""
 
 #. translators: Placeholder %s is the field label that is did not validate.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:434
+#: includes/forms/class-wp-job-manager-form-submit-job.php:436
 msgid "%s is invalid"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:464
+#: includes/forms/class-wp-job-manager-form-submit-job.php:466
 msgid "Invalid image path."
 msgstr ""
 
 #. translators: Placeholder %1$s is field label; %2$s is the file mime type; %3$s is the allowed mime-types.
 #. translators: %1$s is the file field label; %2$s is the file type; %3$s is the list of allowed file types.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:475
+#: includes/forms/class-wp-job-manager-form-submit-job.php:477
 #: wp-job-manager-functions.php:1393
 msgid "\"%1$s\" (filetype %2$s) needs to be one of the following file types: %3$s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:485
+#: includes/forms/class-wp-job-manager-form-submit-job.php:487
 msgid "Invalid attachment provided."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:529
+#: includes/forms/class-wp-job-manager-form-submit-job.php:531
 msgid "Please enter a valid application email address"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:534
+#: includes/forms/class-wp-job-manager-form-submit-job.php:536
 msgid "Please enter a valid application URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:540
+#: includes/forms/class-wp-job-manager-form-submit-job.php:542
 msgid "Please enter a valid application email address or URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:751
+#: includes/forms/class-wp-job-manager-form-submit-job.php:726
 msgid "Please enter a username."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:755
+#: includes/forms/class-wp-job-manager-form-submit-job.php:730
 msgid "Please enter a password."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:759
+#: includes/forms/class-wp-job-manager-form-submit-job.php:734
 msgid "Please enter your email address."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:765
+#: includes/forms/class-wp-job-manager-form-submit-job.php:740
 msgid "Passwords must match."
 msgstr ""
 
 #. translators: Placeholder %s is the password hint.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:771
+#: includes/forms/class-wp-job-manager-form-submit-job.php:746
 msgid "Invalid Password: %s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:773
+#: includes/forms/class-wp-job-manager-form-submit-job.php:748
 msgid "Password is not valid."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:805
+#: includes/forms/class-wp-job-manager-form-submit-job.php:780
 msgid "You must be signed in to post a new listing."
 msgstr ""
 
 #. translators: placeholder is the URL to the job dashboard page.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:831
+#: includes/forms/class-wp-job-manager-form-submit-job.php:806
 msgid "Draft was saved. Job listing drafts can be resumed from the <a href=\"%s\">job dashboard</a>."
 msgstr ""
 
@@ -1992,7 +2006,7 @@ msgid "Display a list of featured listings on your site."
 msgstr ""
 
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:44
-#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:54
+#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:64
 msgid "Number of listings to show"
 msgstr ""
 
@@ -2025,7 +2039,7 @@ msgid "Descending"
 msgstr ""
 
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:69
-#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:59
+#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:69
 msgid "Show Company Logo"
 msgstr ""
 
@@ -2041,6 +2055,22 @@ msgstr ""
 
 #: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:41
 msgid "Keyword"
+msgstr ""
+
+#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:51
+msgid "Remote Positions"
+msgstr ""
+
+#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:53
+msgid "Show all"
+msgstr ""
+
+#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:54
+msgid "Show only remote positions"
+msgstr ""
+
+#: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:55
+msgid "Show only non-remote positions"
 msgstr ""
 
 #: templates/access-denied-browse-job_listings.php:19
@@ -2278,19 +2308,23 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: templates/job-filters.php:47
+#: templates/job-filters.php:42
+msgid "Remote positions only"
+msgstr ""
+
+#: templates/job-filters.php:54
 msgid "Category"
 msgstr ""
 
-#: templates/job-filters.php:51
+#: templates/job-filters.php:58
 msgid "Any category"
 msgstr ""
 
-#: templates/job-filters.php:68
+#: templates/job-filters.php:75
 msgid "Search Jobs"
 msgstr ""
 
-#: templates/job-filters.php:80
+#: templates/job-filters.php:87
 msgid "Your browser does not support JavaScript, or it is disabled. JavaScript must be enabled in order to view listings."
 msgstr ""
 
@@ -2335,11 +2369,6 @@ msgstr ""
 
 #: templates/job-submitted.php:57
 msgid "  <a href=\"%s\"> %s</a>"
-msgstr ""
-
-#. translators: This one is used to determine if the user is searching for remote work type.
-#: wp-job-manager-functions.php:78
-msgid "remote"
 msgstr ""
 
 #: wp-job-manager-functions.php:359

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === WP Job Manager ===
 Contributors: mikejolley, automattic, adamkheckler, alexsanford1, annezazu, cena, chaselivingston, csonnek, davor.altman, donnapep, donncha, drawmyface, erania-pinnera, fjorgemota, jacobshere, jakeom, jeherve, jenhooks, jgs, jonryan, kraftbj, lamdayap, lschuyler, macmanx, nancythanki, orangesareorange, rachelsquirrel, renathoc, ryancowles, richardmtl, scarstocea
 Tags: job manager, job listing, job board, job management, job lists, job list, job, jobs, company, hiring, employment, employer, employees, candidate, freelance, internship, job listings, positions, board, application, hiring, listing, manager, recruiting, recruitment, talent
-Requires at least: 5.7
+Requires at least: 5.8
 Tested up to: 6.0
-Requires PHP: 7.0
-Stable tag: 1.37.0
+Requires PHP: 7.2
+Stable tag: 1.38.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -139,7 +139,7 @@ Developers who would like to run the existing tests or add their tests to the te
 2. Run the install script(you will need to have `wget` installed) - `bash tests/bin/install-wp-tests.sh <db-name> <db-user> <db-pass> <db-host> <wp-version>`.
 3. Run the plugin tests - `phpunit`
 
-The install script installs a copy of WordPress in the `/tmp` directory along with the WordPress unit testing tools. 
+The install script installs a copy of WordPress in the `/tmp` directory along with the WordPress unit testing tools.
 It then creates a database based on the parameters passed to it.
 
 == Screenshots ==
@@ -152,6 +152,11 @@ It then creates a database based on the parameters passed to it.
 6. Job listings in admin.
 
 == Changelog ==
+
+= 1.38.0 =
+* Enhancement: Improve support for searching multiple locations (@tripflex).
+* Fix: Translation issue in onboarding wizard. (@NekoJonez)
+* Fix: Better support for jobs submissions with `0` as input.
 
 = 1.37.0 =
 * Enhancement: Job Visibility Settings
@@ -211,7 +216,7 @@ It then creates a database based on the parameters passed to it.
 * Fix: Missing variable error with cached widgets.
 * Tweak: reCAPTCHA setting has more clear language. (@tripflex)
 * Dev: Added filter `submit_job_form_create_account_role` for user role when created on job submission. (@tripflex)
-* Dev: Added filter `job_manager_should_run_shortcode_action_handler` for if a job dashboard action should run. 
+* Dev: Added filter `job_manager_should_run_shortcode_action_handler` for if a job dashboard action should run.
 * Dev: Added filter `job_manager_get_form_action` to modify the action of a frontend form. (@tripflex)
 
 = 1.34.5 =
@@ -253,7 +258,7 @@ It then creates a database based on the parameters passed to it.
 * Fix: Resuming job listing submission at a particular step is now fixed.
 * Fix: Issue with some permalink structures and WPMU would cause issues on `[jobs]` page.
 * Dev: Adds the ability to block some jobs from being edited in the frontend.
-* Dev: Adds ability to force some email notifications to be enabled. 
+* Dev: Adds ability to force some email notifications to be enabled.
 * Dev: Allows email notifications to be sent immediately.
 * Dev: Adds ability for settings to reference other settings tabs.
 * Dev: Standardizes jQuery UI datepicker script IDs in frontend and backend. Plugins and themes should enqueue `wp-job-manager-datepicker` if they need jQuery UI datepicker.
@@ -277,7 +282,7 @@ It then creates a database based on the parameters passed to it.
 * Third Party: Fix issue with Polylang where translations get overwritten on save of another language.
 * Dev: Adds the ability to completely disable the state saving functionality of `[jobs]` results.
 * Dev: Allows custom calls to `get_job_listings()` to just get `ids` and `id=>parent`. (@manzoorwanijk)
-* Dev: Switched to short-array syntax across plugin. 
+* Dev: Switched to short-array syntax across plugin.
 * Dev: Updated `jquery-fileupload` library to 10.2.0.
 * Dev: Updated `select2` library to 4.0.10.
 
@@ -290,7 +295,7 @@ It then creates a database based on the parameters passed to it.
 * Fix: Checking typeof undefined should be in quotes in job_submission.js.
 * Fix: Plugin activation issue that didn't set up roles correctly.
 * Fix: Escaped HTML issue in expiring jobs email notice.
-* Change: Added additional unslashing and sanitization of input variables from forms. 
+* Change: Added additional unslashing and sanitization of input variables from forms.
 * Change: Limited direct database access within the plugin and migrated to WordPress core functions when possible.
 * Removed: Transient garbage collection. WordPress 4.9 and up handle this automatically.
 
@@ -346,7 +351,7 @@ It then creates a database based on the parameters passed to it.
 = 1.32.0 =
 * Enhancement: Switched from Chosen to Select2 for enhanced dropdown handling and better mobile support. May require theme update.
 * Enhancement: Draft and unsubmitted job listings now appear in `[job_dashboard]`, allowing users to complete their submission.
-* Enhancement: [REVERTED IN 1.32.1] Filled and expired positions are now hidden from WordPress search. (@felipeelia) 
+* Enhancement: [REVERTED IN 1.32.1] Filled and expired positions are now hidden from WordPress search. (@felipeelia)
 * Enhancement: Adds additional support for the new block editor. Restricted to classic block for compatibility with frontend editor.
 * Enhancement: Job types can be preselected in `[jobs]` shortcode with `?search_job_type=term-slug`. (@felipeelia)
 * Enhancement: Author selection in WP admin now uses a searchable dropdown.
@@ -366,7 +371,7 @@ It then creates a database based on the parameters passed to it.
 * Fix: Escape the attachment URL. (Props to karimeo)
 * Fix: Custom job field priority fix when using decimals. (@tripflex)
 * Fix: Fix issue with empty mutli-select in WP admin jobs page. (@felipeelia)
-* Fix: Issue with data export when email doesn't have any job listings. 
+* Fix: Issue with data export when email doesn't have any job listings.
 * Third Party: Improved WPML support. (@vukvukovich)
 
 = 1.31.2 =
@@ -381,7 +386,7 @@ It then creates a database based on the parameters passed to it.
 * Fix: No longer auto-expire job listings in Draft status.
 * Fix: Issue with undefined index error in WP admin. (@albionselimaj)
 * Fix: Issue with duplicate usernames preventing submission of job listings. (@timothyjensen)
-* Dev: Widespread code formatting cleanup throughout the plugin. 
+* Dev: Widespread code formatting cleanup throughout the plugin.
 
 = 1.31.0 =
 * Change: Minimum WordPress version is now 4.7.0.
@@ -389,7 +394,7 @@ It then creates a database based on the parameters passed to it.
 * Enhancement: For GDPR, scrub WPJM data from database on uninstall if option is enabled.
 * Enhancement: Filter by Filled and Featured status in WP admin.
 * Enhancement: Simplify the display of application URLs.
-* Enhancement: When using WPML, prevent changes to page options when on a non-default language. (@vukvukovich) 
+* Enhancement: When using WPML, prevent changes to page options when on a non-default language. (@vukvukovich)
 * Enhancement: Include company logo in structured data. (@RajeebTheGreat)
 * Enhancement: Use more efficient jQuery selectors in scripts. (@RajeebTheGreat)
 * Enhancement: Use proper `<h2>` tag in `content-summary-job_listing.php` template for the job title. (@abdullah1908)
@@ -404,7 +409,7 @@ It then creates a database based on the parameters passed to it.
 
 = 1.30.2 =
 * Enhancement: Show notice when user is using an older version of WordPress.
-* Enhancement: Hide unnecessary view mode in WP Admin's Job Listings page. (@RajeebTheGreat) 
+* Enhancement: Hide unnecessary view mode in WP Admin's Job Listings page. (@RajeebTheGreat)
 * Enhancement: Add support for the `paged` parameter in the RSS feed. (@RajeebTheGreat)
 * Fix: Minor PHP 7.2 compatibility fixes.
 * Dev: Allow `parent` attribute to be passed to `job_manager_dropdown_categories()`. (@RajeebTheGreat)
@@ -485,7 +490,7 @@ It then creates a database based on the parameters passed to it.
 * Fix: Make sure cron jobs for checking/cleaning expired listings are always in place.
 * Fix: Better handling of multiple job types. (@spencerfinnell)
 * Fix: Issue with deleting company logos from job listings submission form.
-* Fix: Warning thrown on job submission form when user not logged in. (@piersb)  
+* Fix: Warning thrown on job submission form when user not logged in. (@piersb)
 * Fix: Issue with WPML not syncing some meta fields.
 * Fix: Better handling of AJAX upload errors. (@tripflex)
 * Fix: Remove job posting cookies on logout.
@@ -493,7 +498,7 @@ It then creates a database based on the parameters passed to it.
 * Fix: Issue with Safari and expiration datepicker.
 
 = 1.26.2 =
-* Fix: Prevents use of Ajax file upload endpoint for visitors who aren't logged in. Themes should check with `job_manager_user_can_upload_file_via_ajax()` if using endpoint in templates.  
+* Fix: Prevents use of Ajax file upload endpoint for visitors who aren't logged in. Themes should check with `job_manager_user_can_upload_file_via_ajax()` if using endpoint in templates.
 * Fix: Escape post title in WP Admin's Job Listings page and template segments. (Props to @EhsanCod3r)
 
 = 1.26.1 =

--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.37.1
+ * @version     1.38.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,12 +3,12 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.37.0
+ * Version: 1.38.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
- * Requires at least: 5.7
+ * Requires at least: 5.8
  * Tested up to: 6.0
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  * Text Domain: wp-job-manager
  * Domain Path: /languages/
  * License: GPL2+
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.37.0' );
+define( 'JOB_MANAGER_VERSION', '1.38.0' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
### Changes proposed
- Preps release for 1.38.0
- Matches PHP and WP requirements based on our support rules.

```
= 1.38.0 =
* Enhancement: Improve support for searching multiple locations (@tripflex).
* Fix: Translation issue in onboarding wizard. (@NekoJonez)
* Fix: Better support for jobs submissions with `0` as input.
```

Build: [wp-job-manager.zip](https://github.com/Automattic/WP-Job-Manager/files/9435156/wp-job-manager.zip)
 