### PR TITLE
[WIP] Add dotCom Marketplace integration and add generic filters

### DIFF
--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -13,3 +13,4 @@ require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/yoast.php';
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/all-in-one-seo-pack.php';
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/rp4wp.php';
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wp-all-import.php';
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wpcom.php';

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+/**
+ * This should be refactored to use the Docblock approach we use for the addons.
+ *
+ * Instead of having hardcoded the mapping here for each addon, we could define a new WPCOM product slug in the addon plugin docblock.
+ *
+ * This way, we won't need to update the mapping here each time we release a new addon for WPJM.
+ */
+$wpjm_product_to_wpcom_products = [
+	'wp-job-manager-applications'          => [ '', '' ],
+	'wp-job-manager-resumes'               => [ '', '' ],
+	'wp-job-manager-wc-paid-listings'      => [ '', '' ],
+	'wp-job-manager-tags'                  => [ '', '' ],
+	'wp-job-manager-alerts'                => [ '', '' ],
+	'wp-job-manager-simple-paid-listings'  => [ '', '' ],
+	'wp-job-manager-application-deadline'  => [ '', '' ],
+	'wp-job-manager-embeddable-job-widget' => [ '', '' ],
+	'wp-job-manager-bookmarks'             => [ '', '' ],
+];
+
+/**
+ * Hide the WP Job Manager activation notice for the given addon when the user purchased it from the Dotcom Marketplace.
+ *
+ * @param $hide_key_notice
+ * @param $wpjm_product_slug
+ *
+ * @return bool|mixed
+ */
+function wpcom_hide_license_key_notice( $hide_key_notice, $wpjm_product_slug ) {
+	global $wpjm_product_to_wpcom_products;
+
+	if ( ! apply_filters( 'is_wpcom_marketplace_compatible_environment' ) ) {
+		return false;
+	}
+
+	$wpcom_store_products = $wpjm_product_to_wpcom_products[ $wpjm_product_slug ];
+
+	foreach ( $wpcom_store_products as $wpcom_store_product ) {
+		if ( apply_filters( 'has_wpcom_marketplace_subscription', false, $wpcom_store_product ) ) {
+			return true;
+		}
+	}
+
+	return $hide_key_notice;
+}
+
+\add_filter( 'wpjm_hide_license_key_notice', 'wpcom_hide_license_key_notice', 10, 2 );
+
+/**
+ * When a user purchases the Addon from the Dotcom Marketplace, then we should hide the notices to activate it.
+ *
+ * @param bool $should_display_activation_link
+ * @param string $wpjm_product_slug
+ *
+ * @return false|mixed
+ */
+function wpcom_hide_the_wpjm_license_for_dotcom_marketplace_products( $should_display_activation_link, $wpjm_product_slug ) {
+	global $wpjm_product_to_wpcom_products;
+
+	$wpcom_store_products = $wpjm_product_to_wpcom_products[ $wpjm_product_slug ];
+
+	foreach ( $wpcom_store_products as $wpcom_store_product ) {
+		if ( apply_filters( 'has_wpcom_marketplace_subscription', false, $wpcom_store_product ) ) {
+			return false;
+		}
+	}
+
+	return $should_display_activation_link;
+}
+
+\add_filter( 'wpjm_display_addon_plugin_activation_link', 'wpcom_hide_the_wpjm_license_for_dotcom_marketplace_products', 10, 2 );
+\add_filter( 'wpjm_display_license_management_ui', 'wpcom_hide_the_wpjm_license_for_dotcom_marketplace_products', 10, 2 );
+
+
+/**
+ * Display notification on the addon when the product was purchased from the dotCom Marketplace.
+ *
+ * @param string $product_slug The WPJM product slug.
+ *
+ * @return void
+ */
+function wpcom_display_marketplace_license_management_information( $product_slug ) {
+	if ( ! wpcom_hide_the_wpjm_license_for_dotcom_marketplace_products( true, $product_slug ) ) {
+		return;
+	}
+
+	esc_html_e('This addon was purchased through WordPress.com Marketplace. You can manage the license from your WordPress.com account', 'wp-job-manager' );
+}
+
+add_action( 'wpjm_after_addon_licensing_management_ui_item', 'wpcom_display_marketplace_license_management_information', 10, 1 );
+
+

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -271,6 +271,11 @@ class WP_Job_Manager_Helper {
 		if ( ! $plugin || ! current_user_can( 'update_plugins' ) ) {
 			return $actions;
 		}
+
+		if ( ! apply_filters( 'wpjm_display_addon_plugin_activation_link', true, $plugin['_product_slug'] ) ) {
+			return $actions;
+		}
+
 		$product_slug = $plugin['_product_slug'];
 		$licence      = $this->get_plugin_licence( $product_slug );
 		$css_class    = '';
@@ -461,7 +466,9 @@ class WP_Job_Manager_Helper {
 		}
 		foreach ( $this->get_installed_plugins() as $product_slug => $plugin_data ) {
 			$licence = $this->get_plugin_licence( $product_slug );
-			if ( ! WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice' ) ) {
+			$hide_key_notice = apply_filters( 'wpjm_hide_license_key_notice', WP_Job_Manager_Helper_Options::get( $product_slug, 'hide_key_notice' ),  $product_slug );
+
+			if ( ! $hide_key_notice ) {
 				if ( empty( $licence['licence_key'] ) ) {
 					include 'views/html-licence-key-notice.php';
 				} elseif ( ! empty( $licence['errors'] ) ) {

--- a/includes/helper/views/html-licences.php
+++ b/includes/helper/views/html-licences.php
@@ -48,33 +48,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<form method="post">
 				<?php wp_nonce_field( 'wpjm-manage-licence' ); ?>
 				<?php
-				if ( ! empty( $licence['licence_key'] ) && ! empty( $licence['email'] ) ) {
-					?>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="deactivate"/>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
+				if ( apply_filters( 'wpjm_display_license_management_ui', true, $product_slug ) ) {
+					if ( ! empty( $licence['licence_key'] ) && ! empty( $licence['email'] ) ) {
+						?>
+						<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="deactivate"/>
+						<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
 
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
-						<input type="text" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $licence['licence_key'] ); ?>"/>
-					</label>
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
-						<input type="email" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( $licence['email'] ); ?>"/>
-					</label>
+						<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
+							<input type="text" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $licence['licence_key'] ); ?>"/>
+						</label>
+						<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
+							<input type="email" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( $licence['email'] ); ?>"/>
+						</label>
 
-					<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Deactivate License', 'wp-job-manager' ); ?>" />
-					<?php
-				} else { // licence is not active.
-					?>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="activate"/>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
-						<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
-					</label>
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
-						<input type="email" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>"/>
-					</label>
-					<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
-					<?php
-				} // end if : else licence is not active.
+						<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Deactivate License', 'wp-job-manager' ); ?>" />
+						<?php
+					} else { // licence is not active.
+						?>
+						<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="activate"/>
+						<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
+						<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
+							<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
+						</label>
+						<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
+							<input type="email" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>"/>
+						</label>
+						<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
+						<?php
+					} // end if : else licence is not active.
+				}
+				do_action( 'wpjm_after_addon_licensing_management_ui_item', $product_slug )
 				?>
 				</form>
 			</div>


### PR DESCRIPTION
Add dotCom Marketplace integration and generic filters to control the WP Job Manager's  built-in licensing notices.

Fixes https://github.com/Automattic/wp-calypso/issues/67551

### Changes proposed in this Pull Request

*

### Testing instructions

*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* wpjm_hide_license_key_notice
* wpjm_display_addon_plugin_activation_link
* wpjm_display_license_management_ui
* wpjm_after_addon_licensing_management_ui_item


<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
