### PR TITLE
Fix fatal error when using Sensei's learning mode

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -97,10 +97,9 @@ class WP_Job_Manager_Shortcodes {
 	public function handle_redirects() {
 		$submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
-		if ( ! is_user_logged_in() ||
-			 ! is_page( $submit_job_form_page_id ) ||
-			 ( ! empty( $_REQUEST['job_id'] ) && job_manager_user_can_edit_job( intval( $_REQUEST['job_id'] ) ) )
+		if ( ! is_user_logged_in() || ! is_page( $submit_job_form_page_id ) ||
+			 // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
+			( ! empty( $_REQUEST['job_id'] ) && job_manager_user_can_edit_job( intval( $_REQUEST['job_id'] ) ) )
 		) {
 			return;
 		}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -95,20 +95,23 @@ class WP_Job_Manager_Shortcodes {
 	 * Handle redirects
 	 */
 	public function handle_redirects() {
+		$submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
-		if ( ! get_current_user_id() || ( ! empty( $_REQUEST['job_id'] ) && job_manager_user_can_edit_job( intval( $_REQUEST['job_id'] ) ) ) ) {
+		if ( ! is_user_logged_in() ||
+			 ! is_page( $submit_job_form_page_id ) ||
+			 ( ! empty( $_REQUEST['job_id'] ) && job_manager_user_can_edit_job( intval( $_REQUEST['job_id'] ) ) )
+		) {
 			return;
 		}
 
-		$submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
-		$submission_limit        = get_option( 'job_manager_submission_limit' );
-		$job_count               = job_manager_count_user_job_listings();
+		$submission_limit = get_option( 'job_manager_submission_limit' );
+		$job_count        = job_manager_count_user_job_listings();
 
 		if (
 			$submit_job_form_page_id
 			&& $submission_limit
 			&& $job_count >= $submission_limit
-			&& is_page( $submit_job_form_page_id )
 		) {
 			$employer_dashboard_page_id = get_option( 'job_manager_job_dashboard_page_id' );
 			if ( $employer_dashboard_page_id ) {


### PR DESCRIPTION
Fixes #2322

### Changes proposed in this Pull Request

* Moves `is_page` checking earlier in the method `handle_redirects`, so we can detect whether we should call WPJM functions or not;

### Testing instructions

Verify if the functionality added on #2165 still works, and verify that Sensei's learning mode is available (or, in other words, verify if the behavior reported in #2322 doesn't happen anymore).

### Notes

I discovered the issue happens because the method `handle_redirects` loads very early in the code. So early, in fact, that sometimes the WPJM functions are not even defined yet, like when we're using Sensei's learning mode. This PR fixes the code only to call those functions when the page being accessed is, in fact, the "submit job" page defined by the user.