### PR TITLE
Fix deprecated error in case $post=null in the function the_company_twitter()

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1134,7 +1134,7 @@ function get_the_company_tagline( $post = null ) {
 function the_company_twitter( $before = '', $after = '', $echo = true, $post = null ) {
 	$company_twitter = get_the_company_twitter( $post );
 
-	if ( 0 === strlen( $company_twitter ) ) {
+	if ( ! $company_twitter || 0 === strlen( $company_twitter ) ) {
 		return null;
 	}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1134,7 +1134,7 @@ function get_the_company_tagline( $post = null ) {
 function the_company_twitter( $before = '', $after = '', $echo = true, $post = null ) {
 	$company_twitter = get_the_company_twitter( $post );
 
-	if ( ! $company_twitter || 0 === strlen( $company_twitter ) ) {
+	if ( empty( $company_twitter ) ) {
 		return null;
 	}
 
@@ -1162,7 +1162,7 @@ function get_the_company_twitter( $post = null ) {
 
 	$company_twitter = $post->_company_twitter;
 
-	if ( 0 === strlen( $company_twitter ) ) {
+	if ( empty( $company_twitter ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fix deprecated error in case $post=null in the function the_company_twitter()

This way, if $post=null, it will not run the second test with strlen().

Error for reference: Deprecated: strlen():
Passing null to parameter #1 ($string) of type string is deprecated in /wp-job-manager/wp-job-manager-template.php on line 1137

Tested on PHP 8.1, not sure if that makes a difference.