### PR TITLE
Add support for WP.com Marketplace Addon purchase flow

### DIFF
--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -13,3 +13,4 @@ require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/yoast.php';
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/all-in-one-seo-pack.php';
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/rp4wp.php';
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wp-all-import.php';
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/wpcom.php';

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -63,7 +63,7 @@ foreach ( WPJM_WPCOM_PRODUCTS as $wpjm_wpcom_product ) {
  * @return false|mixed
  */
 function wpjm_hide_addon_license_form_for_purchases_on_wpcom( $status, $product_slug ) {
-	$subscriptions = get_option( 'wpcom_active_subscriptions', array() );
+	$subscriptions = get_option( 'wpcom_active_subscriptions', [] );
 	if ( isset( $subscriptions[ $product_slug ] ) ) {
 		return false;
 	}
@@ -81,12 +81,12 @@ add_filter( 'wpjm_display_license_form_for_addon', 'wpjm_hide_addon_license_form
  * @return false|void
  */
 function wpjm_display_managed_by_wpcom_notice_for_addon( $product_slug ) {
-	$subscriptions = get_option( 'wpcom_active_subscriptions', array() );
+	$subscriptions = get_option( 'wpcom_active_subscriptions', [] );
 	if ( ! isset( $subscriptions[ $product_slug ] ) ) {
 		return false;
 	}
 
-	esc_html_e( 'The license for this product is automatically managed by WordPress.com.', 'wpjm' );
+	esc_html_e( 'The license for this product is automatically managed by WordPress.com.', 'wp-job-manager' );
 }
 
 add_action( 'wpjm_manage_license_page_after_license_form', 'wpjm_display_managed_by_wpcom_notice_for_addon' );

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -8,9 +8,9 @@
 /**
  * Configure license configuration for WP Job Manager when purchased from WP.com Marketplace.
  *
- * @param bool|WP_Error $result The result of the licensing configuration.
- * @param array $payload        The payload receivced from WPJobManager.com back-end API.
- * @param string $event_type    The event type that triggers this filter.
+ * @param bool|WP_Error $result     The result of the licensing configuration.
+ * @param array         $payload    The payload receivced from WPJobManager.com back-end API.
+ * @param string        $event_type The event type that triggers this filter.
  *
  * @return bool
  */

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -86,7 +86,7 @@ function wpjm_display_managed_by_wpcom_notice_for_addon( $product_slug ) {
 		return;
 	}
 
-	esc_html_e( 'The license for this product is automatically managed by WordPress.com.', 'wp-job-manager' );
+	esc_html_e( 'The license for this add-on is automatically managed by WordPress.com.', 'wp-job-manager' );
 }
 
 add_action( 'wpjm_manage_license_page_after_license_form', 'wpjm_display_managed_by_wpcom_notice_for_addon' );

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -53,3 +53,40 @@ const WPJM_WPCOM_PRODUCTS = [
 foreach ( WPJM_WPCOM_PRODUCTS as $wpjm_wpcom_product ) {
 	add_filter( 'wpcom_marketplace_webhook_response_' . $wpjm_wpcom_product, 'wpjm_dotcom_marketplace_configure_license_for_wp_job_manager_addon', 10, 3 );
 }
+
+/**
+ * Hide the license form on the licenses page for addons that are purchased from WP.com.
+ *
+ * @param $status
+ * @param $product_slug
+ *
+ * @return false|mixed
+ */
+function wpjm_hide_addon_license_form_for_purchases_on_wpcom( $status, $product_slug ) {
+	$subscriptions = get_option( 'wpcom_active_subscriptions', array() );
+	if ( isset( $subscriptions[ $product_slug ] ) ) {
+		return false;
+	}
+
+	return $status;
+}
+
+add_filter( 'wpjm_display_license_form_for_addon', 'wpjm_hide_addon_license_form_for_purchases_on_wpcom', 10, 2 );
+
+/**
+ * Display a notice after the license form for each addon.
+ *
+ * @param $product_slug
+ *
+ * @return false|void
+ */
+function wpjm_display_managed_by_wpcom_notice_for_addon( $product_slug ) {
+	$subscriptions = get_option( 'wpcom_active_subscriptions', array() );
+	if ( ! isset( $subscriptions[ $product_slug ] ) ) {
+		return false;
+	}
+
+	esc_html_e( 'The license for this product is automatically managed by WordPress.com.', 'wpjm' );
+}
+
+add_action( 'wpjm_manage_license_page_after_license_form', 'wpjm_display_managed_by_wpcom_notice_for_addon' );

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -1,15 +1,20 @@
 <?php
+/**
+ * WP.com Marketplace licensing integration for premium core addons.
+ *
+ * @package wp-job-manager
+ */
 
 /**
  * Configure license configuration for WP Job Manager when purchased from WP.com Marketplace.
  *
- * @param $result
- * @param $payload
- * @param string $event_type
+ * @param bool|WP_Error $result The result of the licensing configuration.
+ * @param array $payload        The payload receivced from WPJobManager.com back-end API.
+ * @param string $event_type    The event type that triggers this filter.
  *
  * @return bool
  */
-function dotcom_marketplace_configure_license_for_wp_job_manager_addon( $result, $payload, string $event_type ) {
+function dotcom_marketplace_configure_license_for_wp_job_manager_addon( $result, $payload, $event_type ) {
 	if ( 'provision_license' !== $event_type ) {
 		return $result;
 	}
@@ -19,9 +24,12 @@ function dotcom_marketplace_configure_license_for_wp_job_manager_addon( $result,
 
 	$messages = $helper->get_messages( $payload['wpjm_product_slug'] );
 
-	$errors = array_filter( $messages, function ( $message ) {
-		return 'error' === $message['type'];
-	} );
+	$errors = array_filter(
+		$messages,
+		function ( $message ) {
+			return 'error' === $message['type'];
+		}
+	);
 
 	if ( ! empty( $errors ) ) {
 		return new \WP_Error( 'error', 'An error has occurred while installing ' . $payload['wpjm_product_slug'], $errors );

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Configure license configuration for WP Job Manager when purchased from WP.com Marketplace.
+ *
+ * @param $result
+ * @param $payload
+ * @param string $event_type
+ *
+ * @return bool
+ */
+function dotcom_marketplace_configure_license_for_wp_job_manager_addon( $result, $payload, string $event_type ) {
+	if ( 'provision_license' !== $event_type ) {
+		return $result;
+	}
+
+	$helper = WP_Job_Manager_Helper::instance();
+	$helper->activate_licence( $payload['wpjm_product_slug'], $payload['license_code'], $payload['email_address'] );
+
+	$messages = $helper->get_messages( $payload['wpjm_product_slug'] );
+
+	$errors = array_filter( $messages, function ( $message ) {
+		return 'error' === $message['type'];
+	} );
+
+	if ( ! empty( $errors ) ) {
+		return new \WP_Error( 'error', 'An error has occurred while installing ' . $payload['wpjm_product_slug'], $errors );
+	}
+
+	return $result;
+}
+
+const WPJM_WPCOM_PRODUCTS = [
+	'wp-job-manager-applications',
+	'wp-job-manager-resumes',
+	'wp-job-manager-simple-paid-listings',
+	'wp-job-manager-wc-paid-listings',
+	'wp-job-manager-tags',
+	'wp-job-manager-bookmarks',
+	'wp-job-manager-alerts',
+	'wp-job-manager-application-deadline',
+	'wp-job-manager-embeddable-job-widget',
+];
+
+foreach ( WPJM_WPCOM_PRODUCTS as $wpjm_wpcom_product ) {
+	add_filter( 'wpcom_marketplace_webhook_response_' . $wpjm_wpcom_product, 'dotcom_marketplace_configure_license_for_wp_job_manager_addon', 10, 3 );
+}

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -83,7 +83,7 @@ add_filter( 'wpjm_display_license_form_for_addon', 'wpjm_hide_addon_license_form
 function wpjm_display_managed_by_wpcom_notice_for_addon( $product_slug ) {
 	$subscriptions = get_option( 'wpcom_active_subscriptions', [] );
 	if ( ! isset( $subscriptions[ $product_slug ] ) ) {
-		return false;
+		return;
 	}
 
 	esc_html_e( 'The license for this product is automatically managed by WordPress.com.', 'wp-job-manager' );

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -57,8 +57,8 @@ foreach ( WPJM_WPCOM_PRODUCTS as $wpjm_wpcom_product ) {
 /**
  * Hide the license form on the licenses page for addons that are purchased from WP.com.
  *
- * @param $status
- * @param $product_slug
+ * @param bool   $status
+ * @param string $product_slug
  *
  * @return false|mixed
  */
@@ -76,7 +76,7 @@ add_filter( 'wpjm_display_license_form_for_addon', 'wpjm_hide_addon_license_form
 /**
  * Display a notice after the license form for each addon.
  *
- * @param $product_slug
+ * @param string $product_slug
  *
  * @return false|void
  */

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -14,7 +14,7 @@
  *
  * @return bool
  */
-function dotcom_marketplace_configure_license_for_wp_job_manager_addon( $result, $payload, $event_type ) {
+function wpjm_dotcom_marketplace_configure_license_for_wp_job_manager_addon( $result, $payload, $event_type ) {
 	if ( 'provision_license' !== $event_type ) {
 		return $result;
 	}
@@ -51,5 +51,5 @@ const WPJM_WPCOM_PRODUCTS = [
 ];
 
 foreach ( WPJM_WPCOM_PRODUCTS as $wpjm_wpcom_product ) {
-	add_filter( 'wpcom_marketplace_webhook_response_' . $wpjm_wpcom_product, 'dotcom_marketplace_configure_license_for_wp_job_manager_addon', 10, 3 );
+	add_filter( 'wpcom_marketplace_webhook_response_' . $wpjm_wpcom_product, 'wpjm_dotcom_marketplace_configure_license_for_wp_job_manager_addon', 10, 3 );
 }

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -511,7 +511,7 @@ class WP_Job_Manager_Helper {
 	 * @param string $licence_key
 	 * @param string $email
 	 */
-	private function activate_licence( $product_slug, $licence_key, $email ) {
+	public function activate_licence( $product_slug, $licence_key, $email ) {
 		$response = $this->api->activate(
 			[
 				'api_product_id' => $product_slug,

--- a/includes/helper/views/html-licences.php
+++ b/includes/helper/views/html-licences.php
@@ -78,7 +78,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						} // end if : else licence is not active.
 						?>
 					</form>
-				<?php
+					<?php
 				}
 				do_action( 'wpjm_manage_license_page_after_license_form', $product_slug );
 				?>

--- a/includes/helper/views/html-licences.php
+++ b/includes/helper/views/html-licences.php
@@ -44,39 +44,44 @@ if ( ! defined( 'ABSPATH' ) ) {
 				foreach ( $notices as $message ) {
 					echo '<div class="notice inline notice-' . esc_attr( $message['type'] ) . '"><p>' . wp_kses_post( $message['message'] ) . '</p></div>';
 				}
-				?>
-				<form method="post">
-				<?php wp_nonce_field( 'wpjm-manage-licence' ); ?>
+				if ( apply_filters( 'wpjm_display_license_form_for_addon', true, $product_slug ) ) {
+					?>
+					<form method="post">
+						<?php wp_nonce_field( 'wpjm-manage-licence' ); ?>
+						<?php
+						if ( ! empty( $licence['licence_key'] ) && ! empty( $licence['email'] ) ) {
+							?>
+							<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="deactivate"/>
+							<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
+
+							<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
+								<input type="text" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $licence['licence_key'] ); ?>"/>
+							</label>
+							<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
+								<input type="email" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( $licence['email'] ); ?>"/>
+							</label>
+
+							<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Deactivate License', 'wp-job-manager' ); ?>" />
+							<?php
+						} else { // licence is not active.
+							?>
+							<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="activate"/>
+							<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
+							<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
+								<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
+							</label>
+							<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
+								<input type="email" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>"/>
+							</label>
+							<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
+							<?php
+						} // end if : else licence is not active.
+						?>
+					</form>
 				<?php
-				if ( ! empty( $licence['licence_key'] ) && ! empty( $licence['email'] ) ) {
-					?>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="deactivate"/>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
-
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
-						<input type="text" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $licence['licence_key'] ); ?>"/>
-					</label>
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
-						<input type="email" disabled="disabled" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( $licence['email'] ); ?>"/>
-					</label>
-
-					<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Deactivate License', 'wp-job-manager' ); ?>" />
-					<?php
-				} else { // licence is not active.
-					?>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="activate"/>
-					<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key"><?php esc_html_e( 'License', 'wp-job-manager' ); ?>:
-						<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
-					</label>
-					<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email"><?php esc_html_e( 'Email', 'wp-job-manager' ); ?>:
-						<input type="email" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_email" name="email" placeholder="<?php esc_attr_e( 'Email address', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>"/>
-					</label>
-					<input type="submit" class="button" name="submit" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
-					<?php
-				} // end if : else licence is not active.
+				}
+				do_action( 'wpjm_manage_license_page_after_license_form', $product_slug );
 				?>
-				</form>
 			</div>
 		</div>
 	<?php endforeach; ?>

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -21,8 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.38.0-dev' );
-define( 'JOB_MANAGER_DEV_API_BASE_URL', 'https://2018.wpjobmanager.com/wp-json/wpcom-marketplace/v1/webhooks' );
+define( 'JOB_MANAGER_VERSION', '1.38.0' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -21,7 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.38.0' );
+define( 'JOB_MANAGER_VERSION', '1.38.0-dev' );
+define( 'JOB_MANAGER_DEV_API_BASE_URL', 'https://2018.wpjobmanager.com/wp-json/wpcom-marketplace/v1/webhooks' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
When an addon is purchased through the WP.com Marketplace, the new integration would automatically configure the addon with the licensing information.

This is done by using a WordPress.com specific filter that's executed after the provision_license event is triggered. This filter contains the licensing information needed by the plugin to connect to WPJobManager.com back-end API.

Fixes https://github.com/Automattic/wp-calypso/issues/67551

### Changes proposed in this Pull Request

* Add an integration for WP.com Marketplace that automatically configures the licensing on a target site

### Testing instructions

* Checkout this branch locally and upload the plugin on one of your test sites
* If you have WP CLI installed, execute `wp shell` and execute the following snippet
```
$payload = [ 'license_code' => 'invalid-license-key', 'email_address' => 'example@example.com', 'wpjm_product_slug' => 'wp-job-manager-applications' ];
$result = apply_filters( 'wpcom_marketplace_webhook_response_wp-job-manager-applications', true, $payload, 'provision_license' );
```
- This should return an error.
- To execute it with a valid license with an associated valid email address, please contact me.

