### PR TITLE
#2337: Make salary value string translatable

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1599,7 +1599,7 @@ class WP_Job_Manager_Post_Types {
 			'_job_salary'          => [
 				'label'         => __( 'Salary', 'wp-job-manager' ),
 				'type'          => 'text',
-				'placeholder'   => 'e.g. 20000',
+				'placeholder'   => __( 'e.g. 20000', 'wp-job-manager' ),
 				'priority'      => 13,
 				'description'   => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
 				'data_type'     => 'string',

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -269,7 +269,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'label'       => __( 'Salary', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
-						'placeholder' => 'e.g. 20000',
+						'placeholder' => __( 'e.g. 20000', 'wp-job-manager' ),
 						'priority'    => 8,
 					],
 					'job_salary_currency' => [


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

* Makes salary value placeholder translatable. Fixes #2337 

### Testing instructions

* Use a plugin such as "Say What?" to translate try to translate the placeholder (`e.g. 20000`) on the job posting page.
* It doesn't work before this PR, but works afterwards

### Screenshot / Video

#### Before:

![Annotation on 2022-11-15 at 15-43-59](https://user-images.githubusercontent.com/45246438/202023406-85dd2c1f-3b2d-453a-b39b-7461e55b7ce5.png)

#### After:

![Annotation on 2022-11-15 at 15-44-35](https://user-images.githubusercontent.com/45246438/202023404-93f8f474-a1ee-496e-8ebb-61cb0738e9e9.png)
