### PR TITLE
Download language packs for add-ons

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-language-packs.php
+++ b/includes/helper/class-wp-job-manager-helper-language-packs.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager_Helper_Language_Packs.
+ *
+ * @package wp-job-manager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WP_Job_Manager_Helper_Language_Packs
+ */
+class WP_Job_Manager_Helper_Language_Packs {
+	const TRANSLATION_UPDATES_URL  = 'https://translate.wordpress.com/api/translations-updates/wp-job-manager';
+	const REMOTE_PACKAGE_TRANSIENT = 'wp-job-manager-translations-';
+
+	/**
+	 * The plugin versions, keyed with the plugin slug.
+	 *
+	 * @var string[]
+	 */
+	private $plugin_versions;
+
+	/**
+	 * Locales to manage language packs for.
+	 *
+	 * @var string[]
+	 */
+	private $locales;
+
+	/**
+	 * Request cache of the language pack updates available.
+	 *
+	 * @var array|null
+	 */
+	private $language_pack_updates_cache;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array[]  $plugin_versions Plugin versions, keyed by plugin slug.
+	 * @param string[] $locales         Locales to manage language packs for.
+	 */
+	public function __construct( array $plugin_versions, array $locales ) {
+		$this->plugin_versions = $plugin_versions;
+		$this->locales         = $locales;
+
+		if ( empty( $plugin_versions ) || empty( $locales ) ) {
+			return;
+		}
+
+		add_filter( 'site_transient_update_plugins', [ $this, 'add_updated_translations' ] );
+	}
+
+	/**
+	 * Adds the plugin's language pack updates to the `update_plugins` transient.
+	 *
+	 * @internal
+	 *
+	 * @param \stdClass $transient Current value of `update_plugins` transient.
+	 * @return \stdClass
+	 */
+	public function add_updated_translations( $transient ) {
+		if ( empty( $transient ) ) {
+			return $transient;
+		}
+
+		$translations            = $this->get_language_pack_updates();
+		$transient->translations = array_merge( $transient->translations ?? [], $translations );
+
+		return $transient;
+	}
+
+	/**
+	 * Get translations updates from our translation pack server.
+	 *
+	 * @return array Update data {plugin_slug => data}
+	 */
+	private function get_language_pack_updates() {
+		if ( ! is_null( $this->language_pack_updates_cache ) ) {
+			return $this->language_pack_updates_cache;
+		}
+
+		if ( empty( $this->plugin_versions ) || empty( $this->locales ) ) {
+			return [];
+		}
+
+		// Check if we've cached this in the last day.
+		$transient_key = self::REMOTE_PACKAGE_TRANSIENT . md5( wp_json_encode( [ $this->plugin_versions, $this->locales ] ) );
+		$data          = get_site_transient( $transient_key );
+		if ( false !== $data && is_array( $data ) ) {
+			return $data;
+		}
+
+		// Set the timeout for the request.
+		$timeout = 5;
+		if ( wp_doing_cron() ) {
+			$timeout = 30;
+		}
+
+		$plugins = [];
+		foreach ( $this->plugin_versions as $slug => $plugin_version ) {
+			$plugins[ $slug ] = [ 'version' => $plugin_version ];
+		}
+
+		$request_body = [
+			'locales' => $this->locales,
+			'plugins' => $plugins,
+		];
+
+		$raw_response = wp_remote_post(
+			self::TRANSLATION_UPDATES_URL,
+			[
+				'body'    => wp_json_encode( $request_body ),
+				'headers' => [ 'Content-Type: application/json' ],
+				'timeout' => $timeout,
+			]
+		);
+
+		// Something unexpected happened on the translation server side.
+		$response_code = wp_remote_retrieve_response_code( $raw_response );
+		if ( 200 !== $response_code ) {
+			return [];
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $raw_response ), true );
+		// API error, api returned but something was wrong.
+		if ( array_key_exists( 'success', $response ) && false === $response['success'] ) {
+			return [];
+		}
+
+		$this->language_pack_updates_cache = $this->parse_language_pack_translations( $response['data'] );
+		set_site_transient( $transient_key, $this->language_pack_updates_cache, DAY_IN_SECONDS );
+
+		return $this->language_pack_updates_cache;
+	}
+
+	/**
+	 * Parse the language pack translations.
+	 *
+	 * @param array $update_data Update data from translate.wordpress.com.
+	 *
+	 * @return array
+	 */
+	private function parse_language_pack_translations( $update_data ) {
+		$installed_translations = wp_get_installed_translations( 'plugins' );
+		$translations           = [];
+
+		foreach ( $update_data as $plugin_name => $language_packs ) {
+			foreach ( $language_packs as $language_pack ) {
+				// Maybe we have this language pack already installed so lets check revision date.
+				if ( array_key_exists( $plugin_name, $installed_translations ) && array_key_exists( $language_pack['wp_locale'], $installed_translations[ $plugin_name ] ) ) {
+					$installed_translation_revision_time = new \DateTime( $installed_translations[ $plugin_name ][ $language_pack['wp_locale'] ]['PO-Revision-Date'] );
+					$new_translation_revision_time       = new \DateTime( $language_pack['last_modified'] );
+
+					// Skip if translation language pack is not newer than what is installed already.
+					if ( $new_translation_revision_time <= $installed_translation_revision_time ) {
+						continue;
+					}
+				}
+
+				$translations[] = [
+					'type'       => 'plugin',
+					'slug'       => $plugin_name,
+					'language'   => $language_pack['wp_locale'],
+					'version'    => $language_pack['version'],
+					'updated'    => $language_pack['last_modified'],
+					'package'    => $language_pack['package'],
+					'autoupdate' => true,
+				];
+			}
+		}
+
+		return $translations;
+	}
+}

--- a/includes/helper/class-wp-job-manager-helper-language-packs.php
+++ b/includes/helper/class-wp-job-manager-helper-language-packs.php
@@ -67,6 +67,17 @@ class WP_Job_Manager_Helper_Language_Packs {
 			return $transient;
 		}
 
+		/**
+		 * Allows for disabling language packs downloading.
+		 *
+		 * @since 1.39.0
+		 *
+		 * @param bool $disable_language_packs Whether to disable language packs. Default false.
+		 */
+		if ( apply_filters( 'wp_job_manager_helper_disable_language_packs', false ) ) {
+			return $transient;
+		}
+
 		$translations            = $this->get_language_pack_updates();
 		$transient->translations = array_merge( $transient->translations ?? [], $translations );
 

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -91,6 +91,22 @@ class WP_Job_Manager_Helper {
 	}
 
 	/**
+	 * Get the locales used in the site.
+	 *
+	 * @return string[]
+	 */
+	private function get_site_locales() {
+		$locales = array_values( get_available_languages() );
+
+		/** This action is documented in WordPress core's wp-includes/update.php */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$locales = apply_filters( 'plugins_update_check_locales', $locales );
+		$locales = array_unique( $locales );
+
+		return $locales;
+	}
+
+	/**
 	 * Handles special tasks on admin requests.
 	 */
 	private function handle_admin_request() {
@@ -182,11 +198,13 @@ class WP_Job_Manager_Helper {
 
 		$response = $this->api->plugin_update_check(
 			[
-				'plugin_name'    => $plugin_data['Name'],
-				'version'        => $plugin_data['Version'],
-				'api_product_id' => $product_slug,
-				'licence_key'    => $licence['licence_key'],
-				'email'          => $licence['email'],
+				'plugin_name'       => $plugin_data['Name'],
+				'version'           => $plugin_data['Version'],
+				'api_product_id'    => $product_slug,
+				'licence_key'       => $licence['licence_key'],
+				'email'             => $licence['email'],
+				'locale'            => get_locale(),
+				'available_locales' => implode( ',', $this->get_site_locales() ),
 			]
 		);
 

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -187,22 +187,20 @@ class WP_Job_Manager_Helper {
 	 */
 	private function get_plugin_version( $plugin_filename ) {
 		$plugin_data = $this->get_licence_managed_plugin( $plugin_filename );
-		if ( ! $plugin_data ) {
+		if ( ! $plugin_data || empty( $plugin_data['_product_slug'] ) ) {
 			return false;
 		}
+
 		$product_slug = $plugin_data['_product_slug'];
 		$licence      = $this->get_plugin_licence( $product_slug );
-		if ( ! $licence || empty( $licence['licence_key'] ) ) {
-			return false;
-		}
 
 		$response = $this->api->plugin_update_check(
 			[
 				'plugin_name'       => $plugin_data['Name'],
 				'version'           => $plugin_data['Version'],
 				'api_product_id'    => $product_slug,
-				'licence_key'       => $licence['licence_key'],
-				'email'             => $licence['email'],
+				'licence_key'       => $licence['licence_key'] ?? null,
+				'email'             => $licence['email'] ?? null,
 				'locale'            => get_locale(),
 				'available_locales' => implode( ',', $this->get_site_locales() ),
 			]
@@ -612,7 +610,7 @@ class WP_Job_Manager_Helper {
 		}
 
 		$errors         = ! empty( $response['errors'] ) ? $response['errors'] : [];
-		$allowed_errors = [ 'no_activation', 'expired_key', 'expiring_soon' ];
+		$allowed_errors = [ 'no_activation', 'expired_key', 'expiring_soon', 'update_available' ];
 		$ignored_errors = array_diff( array_keys( $errors ), $allowed_errors );
 
 		foreach ( $ignored_errors as $key ) {

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -143,15 +143,6 @@ class WP_Job_Manager_Helper {
 	}
 
 	/**
-	 * Get the language packs helper.
-	 *
-	 * @return WP_Job_Manager_Helper_Language_Packs
-	 */
-	public function get_language_pack_helper() {
-		return $this->language_pack_helper;
-	}
-
-	/**
 	 * Handles special tasks on admin requests.
 	 */
 	private function handle_admin_request() {

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -115,7 +115,7 @@ class WP_Job_Manager_Helper {
 	 *
 	 * @return string[]
 	 */
-	public function get_plugin_versions() {
+	private function get_plugin_versions() {
 		return array_filter(
 			array_map(
 				function( $plugin ) {

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -31,6 +31,13 @@ class WP_Job_Manager_Helper {
 	protected $api;
 
 	/**
+	 * Language Pack helper.
+	 *
+	 * @var WP_Job_Manager_Helper_Language_Packs
+	 */
+	private $language_pack_helper;
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var self
@@ -66,6 +73,7 @@ class WP_Job_Manager_Helper {
 	public function init() {
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-options.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-api.php';
+		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-language-packs.php';
 
 		$this->api = WP_Job_Manager_Helper_API::instance();
 
@@ -85,9 +93,37 @@ class WP_Job_Manager_Helper {
 	 * Initializes admin-only actions.
 	 */
 	public function admin_init() {
+		$this->load_language_pack_helper();
 		add_action( 'plugin_action_links', [ $this, 'plugin_links' ], 10, 2 );
 		add_action( 'admin_notices', [ $this, 'licence_error_notices' ] );
 		$this->handle_admin_request();
+	}
+
+	/**
+	 * Load the language pack helper.
+	 */
+	private function load_language_pack_helper() {
+		if ( $this->language_pack_helper ) {
+			return;
+		}
+
+		$this->language_pack_helper = new WP_Job_Manager_Helper_Language_Packs( $this->get_plugin_versions(), $this->get_site_locales() );
+	}
+
+	/**
+	 * Get the versions for the installed managed plugins, keyed with the plugin slug.
+	 *
+	 * @return string[]
+	 */
+	public function get_plugin_versions() {
+		return array_filter(
+			array_map(
+				function( $plugin ) {
+					return $plugin['Version'];
+				},
+				$this->get_installed_plugins( false )
+			)
+		);
 	}
 
 	/**
@@ -104,6 +140,15 @@ class WP_Job_Manager_Helper {
 		$locales = array_unique( $locales );
 
 		return $locales;
+	}
+
+	/**
+	 * Get the language packs helper.
+	 *
+	 * @return WP_Job_Manager_Helper_Language_Packs
+	 */
+	public function get_language_pack_helper() {
+		return $this->language_pack_helper;
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,7 +22,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.9" />
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.0-"/>
 
 	<!-- Rules -->
 	<rule ref="PHPCompatibilityWP"/>

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
@@ -119,25 +119,6 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_Helper_Base_Test {
 
 	/**
 	 * @since 1.29.0
-	 * @covers WP_Job_Manager_Helper::has_licenced_products
-	 * @covers WP_Job_Manager_Helper::get_plugin_version
-	 * @covers WP_Job_Manager_Helper::get_plugin_licence
-	 * @requires PHP 5.3.0
-	 */
-	public function test_check_for_updates_no_license() {
-		$instance = $this->getMockHelper( $this->plugin_data_with_update() );
-
-		WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
-		WP_Job_Manager_Helper_Options::delete( 'test', 'email' );
-
-		$data           = new stdClass();
-		$data->response = [];
-		$instance->check_for_updates( $data );
-		$this->assertEmpty( $data->response );
-	}
-
-	/**
-	 * @since 1.29.0
 	 * @covers WP_Job_Manager_Helper::plugin_activated
 	 * @requires PHP 5.3.0
 	 */

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-language-packs.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-language-packs.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @group helper
+ * @group helper-language-packs
+ */
+class WP_Test_WP_Job_Manager_Helper_Language_Packs extends WPJM_Helper_Base_Test {
+	public function tear_down() {
+		parent::tear_down();
+		remove_all_filters( 'pre_http_request' );
+	}
+
+	public function testAddUpdatedTranslations_NoPluginVersions_ReturnsEmpty() {
+		// Arrange.
+		$this->setUpHttpMock( [] );
+		$language_packs = new WP_Job_Manager_Helper_Language_Packs( [], [ 'es_ES' ] );
+		$transient      = new stdClass();
+		$transient->translations = null;
+
+		// Act.
+		$language_packs->add_updated_translations( $transient );
+
+		// Assert.
+		$this->assertEquals( [], $transient->translations );
+	}
+
+	public function testAddUpdatedTranslations_NoLocales_ReturnsEmpty() {
+		// Arrange.
+		$this->setUpHttpMock( [] );
+		$language_packs = new WP_Job_Manager_Helper_Language_Packs( [ 'test-plugin' => '1.0.0' ], [] );
+		$transient      = new stdClass();
+		$transient->translations = null;
+
+		// Act.
+		$language_packs->add_updated_translations( $transient );
+
+		// Assert.
+		$this->assertEquals( [], $transient->translations );
+	}
+
+	public function testAddUpdatedTranslations_HasTranslations_ReturnsTranslations() {
+		// Arrange.
+		$sample_data = $this->getSampleData();
+		$this->setUpHttpMock($sample_data);
+		$language_packs = new WP_Job_Manager_Helper_Language_Packs( [ 'test-plugin' => '1.0.0' ], [ 'es_ES' ] );
+		$transient      = new stdClass();
+		$transient->translations = null;
+
+		// Act.
+		$language_packs->add_updated_translations( $transient );
+
+		// Assert.
+		$this->assertNotEmpty( $transient->translations );
+		$this->assertArrayHasKey( 'type', $transient->translations[0] );
+		$this->assertEquals( 'plugin', $transient->translations[0]['type'] );
+
+		$this->assertArrayHasKey( 'slug', $transient->translations[0] );
+		$this->assertEquals( 'test-plugin', $transient->translations[0]['slug'] );
+
+		$this->assertArrayHasKey( 'language', $transient->translations[0] );
+		$this->assertEquals( $sample_data['data']['test-plugin'][0]['wp_locale'], $transient->translations[0]['language'] );
+
+		$this->assertArrayHasKey( 'version', $transient->translations[0] );
+		$this->assertEquals( $sample_data['data']['test-plugin'][0]['version'], $transient->translations[0]['version'] );
+
+		$this->assertArrayHasKey( 'updated', $transient->translations[0] );
+		$this->assertEquals( $sample_data['data']['test-plugin'][0]['last_modified'], $transient->translations[0]['updated'] );
+
+		$this->assertArrayHasKey( 'package', $transient->translations[0] );
+		$this->assertEquals( $sample_data['data']['test-plugin'][0]['package'], $transient->translations[0]['package'] );
+
+		$this->assertArrayHasKey( 'autoupdate', $transient->translations[0] );
+		$this->assertEquals( 1, $transient->translations[0]['autoupdate'] );
+	}
+
+	private function getSampleData() {
+		return [
+			'data' => [
+				'test-plugin' => [
+					[
+						'wp_locale' => 'es_ES',
+						'version'  => '1.0.0',
+						'last_modified'  => '2100-01-01 00:00:00',
+						'package'  => 'https://translate.wordpress.com/test-plugin/es_ES/1.0.0.zip',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Set up the HTTP mock.
+	 */
+	private function setUpHttpMock( $response, $response_code = 200, $expect_call = true ) {
+		if ( ! $expect_call ) {
+			throw new \Exception( 'No HTTP call was expected' );
+		}
+
+		add_filter(
+			'pre_http_request',
+			function() use ( $response, $response_code ) {
+				return [
+					'body'     => wp_json_encode( $response ),
+					'response' => [
+						'code' => $response_code,
+					],
+				];
+			}
+		);
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Downloads language packs from [WordPress.com's GlotPress](https://translate.wordpress.com/projects/wp-job-manager).
* Passes locales to plugin update check.

### Testing instructions

* Ensure you have at least one WP Job Manager official add-on installed (doesn't have to be activated).
* Switch site over to a language that has language packs available on GlotPress (click on project and see language pack button on far-right).
* Go to WP Admin > Dashboard > Updates.
* Refresh a few times if you don't see translation updates at the bottom.
* Install the translation updates.
* Ensure translations are loaded for that plugin/language.

Other things to check:
- Using Query Monitor, ensure these translations aren't checked unnecessarily and are cached correctly.
- Set the site to a different language first and ensure all languages are downloaded. You can also check `wp-content/languages/plugins`

### New Filters
- `wp_job_manager_helper_disable_language_packs`: Filter to true to disable this new functionality.