### PR TITLE
Add integration to Yoast SEO schema

### DIFF
--- a/includes/3rd-party/yoast.php
+++ b/includes/3rd-party/yoast.php
@@ -27,3 +27,19 @@ function wpjm_yoast_skip_filled_job_listings( $url, $type, $post ) {
 	return $url;
 }
 add_action( 'wpseo_sitemap_entry', 'wpjm_yoast_skip_filled_job_listings', 10, 3 );
+
+/**
+ * Links schema to Yoast SEO schema if Yoast SEO is loaded.
+ *
+ * @param array $data The schema data.
+ *
+ * @return array The schema data.
+ */
+function wpjm_link_schema_to_yoast_schema( $data ) {
+	if ( function_exists( 'YoastSEO' ) ) {
+		$data['mainEntityOfPage']    = [ '@id' => YoastSEO()->meta->for_current_page()->canonical ];
+		$data['identifier']['value'] = YoastSEO()->meta->for_current_page()->canonical;
+	}
+	return $data;
+}
+add_filter( 'wpjm_get_job_listing_structured_data', 'wpjm_link_schema_to_yoast_schema' );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -442,6 +442,22 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 }
 
 /**
+ * Links schema to Yoast SEO schema if Yoast SEO is loaded.
+ *
+ * @param array $data The schema data.
+ *
+ * @return array The schema data.
+ */
+function wpjm_link_schema_to_yoast_schema( $data ) {
+	if ( function_exists( 'YoastSEO' ) ) {
+		$data['mainEntityOfPage']    = [ '@id' => YoastSEO()->meta->for_current_page()->canonical ];
+		$data['identifier']['value'] = YoastSEO()->meta->for_current_page()->canonical;
+	}
+	return $data;
+}
+add_filter( 'wpjm_get_job_listing_structured_data', 'wpjm_link_schema_to_yoast_schema' );
+
+/**
  * Gets the job listing location data.
  *
  * @see http://schema.org/PostalAddress

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -442,22 +442,6 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 }
 
 /**
- * Links schema to Yoast SEO schema if Yoast SEO is loaded.
- *
- * @param array $data The schema data.
- *
- * @return array The schema data.
- */
-function wpjm_link_schema_to_yoast_schema( $data ) {
-	if ( function_exists( 'YoastSEO' ) ) {
-		$data['mainEntityOfPage']    = [ '@id' => YoastSEO()->meta->for_current_page()->canonical ];
-		$data['identifier']['value'] = YoastSEO()->meta->for_current_page()->canonical;
-	}
-	return $data;
-}
-add_filter( 'wpjm_get_job_listing_structured_data', 'wpjm_link_schema_to_yoast_schema' );
-
-/**
  * Gets the job listing location data.
  *
  * @see http://schema.org/PostalAddress


### PR DESCRIPTION
This will tie the JobPosting schema to the Yoast SEO schema.

Fixes #

### Changes proposed in this Pull Request

* This will tie the JobPosting schema to the Yoast SEO schema.

### Testing instructions

* See that the [schema validator](https://validator.schema.org/) outputs the whole Schema as one node with Yoast SEO enabled.
