### PR TITLE
No longer pass locale information with plugin update checks

### DIFF
--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -232,13 +232,11 @@ class WP_Job_Manager_Helper {
 
 		$response = $this->api->plugin_update_check(
 			[
-				'plugin_name'       => $plugin_data['Name'],
-				'version'           => $plugin_data['Version'],
-				'api_product_id'    => $product_slug,
-				'licence_key'       => $licence['licence_key'] ?? null,
-				'email'             => $licence['email'] ?? null,
-				'locale'            => get_locale(),
-				'available_locales' => implode( ',', $this->get_site_locales() ),
+				'plugin_name'    => $plugin_data['Name'],
+				'version'        => $plugin_data['Version'],
+				'api_product_id' => $product_slug,
+				'licence_key'    => $licence['licence_key'] ?? null,
+				'email'          => $licence['email'] ?? null,
 			]
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* In #2342, I added site language to the plugin update request. This removes that data.

### Testing instructions

* With Query Monitor, go to Dashboard > Updates (may need to clear transients).
* Check external requests and on the wpjobmanager.com make sure `locale` and `available_locales` are not sent.

<img width="2047" alt="Screenshot 2022-12-12 at 9 38 23 PM" src="https://user-images.githubusercontent.com/68693/207160083-7b18f93a-a158-4be5-807b-c2d3b2c8a96f.png">

### Context
p4H3ND-1md-p2#comment-2915