### PR TITLE
Release 1.39.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 1.39.0 =
+* Enhancement: Download first-party plugin extension translations
+* Enhancement: Add integration to Yoast SEO schema (@jdevalk)
+* Fix: Make salary placeholder string translatable
+
 = 1.38.1 =
 * Enhancement: Added support for WordPress.com marketplace
 * Change: Only perform application field validation when required or not empty (@tripflex)

--- a/includes/helper/class-wp-job-manager-helper-language-packs.php
+++ b/includes/helper/class-wp-job-manager-helper-language-packs.php
@@ -102,7 +102,7 @@ class WP_Job_Manager_Helper_Language_Packs {
 		$transient_key = self::REMOTE_PACKAGE_TRANSIENT . md5( wp_json_encode( [ $this->plugin_versions, $this->locales ] ) );
 		$data          = get_site_transient( $transient_key );
 		if ( false !== $data && is_array( $data ) ) {
-			return $data;
+			return $this->parse_language_pack_translations( $data );
 		}
 
 		// Set the timeout for the request.
@@ -143,7 +143,7 @@ class WP_Job_Manager_Helper_Language_Packs {
 		}
 
 		$this->language_pack_updates_cache = $this->parse_language_pack_translations( $response['data'] );
-		set_site_transient( $transient_key, $this->language_pack_updates_cache, DAY_IN_SECONDS );
+		set_site_transient( $transient_key, $response['data'], DAY_IN_SECONDS );
 
 		return $this->language_pack_updates_cache;
 	}

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 1.38.1\n"
+"Project-Id-Version: WP Job Manager 1.39.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-10-25T15:40:11+00:00\n"
+"POT-Creation-Date: 2022-12-13T10:58:37+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.7.1\n"
+"X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: wp-job-manager\n"
 
 #. Plugin Name of the plugin
@@ -1556,6 +1556,11 @@ msgstr ""
 msgid "Select if this is a remote position."
 msgstr ""
 
+#: includes/class-wp-job-manager-post-types.php:1602
+#: includes/forms/class-wp-job-manager-form-submit-job.php:272
+msgid "e.g. 20000"
+msgstr ""
+
 #: includes/class-wp-job-manager-post-types.php:1604
 msgid "Add a salary field, this field is optional."
 msgstr ""
@@ -1917,42 +1922,42 @@ msgstr ""
 msgid "Draft was saved. Job listing drafts can be resumed from the <a href=\"%s\">job dashboard</a>."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:279
+#: includes/helper/class-wp-job-manager-helper.php:329
 msgid "Manage License (Requires Attention)"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:282
-#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:262
+#: includes/helper/class-wp-job-manager-helper.php:332
+#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:243
 msgid "Manage License"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:285
+#: includes/helper/class-wp-job-manager-helper.php:335
 #: includes/helper/views/html-licences.php:76
-#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:278
+#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:259
 msgid "Activate License"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:494
+#: includes/helper/class-wp-job-manager-helper.php:544
 msgid "Please enter a valid license key and email address in order to activate this plugin's license."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:526
+#: includes/helper/class-wp-job-manager-helper.php:576
 msgid "Connection failed to the License Key API server - possible server issue."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:535
+#: includes/helper/class-wp-job-manager-helper.php:585
 msgid "Plugin license has been activated."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:538
+#: includes/helper/class-wp-job-manager-helper.php:588
 msgid "An unknown error occurred while attempting to activate the license"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:558
+#: includes/helper/class-wp-job-manager-helper.php:608
 msgid "license is not active."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:574
+#: includes/helper/class-wp-job-manager-helper.php:624
 msgid "Plugin license has been deactivated."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: mikejolley, automattic, adamkheckler, alexsanford1, annezazu, cena, chaselivingston, csonnek, davor.altman, donnapep, donncha, drawmyface, erania-pinnera, fjorgemota, jacobshere, jakeom, jeherve, jenhooks, jgs, jonryan, kraftbj, lamdayap, lschuyler, macmanx, nancythanki, orangesareorange, rachelsquirrel, renathoc, ryancowles, richardmtl, scarstocea
 Tags: job manager, job listing, job board, job management, job lists, job list, job, jobs, company, hiring, employment, employer, employees, candidate, freelance, internship, job listings, positions, board, application, hiring, listing, manager, recruiting, recruitment, talent
 Requires at least: 5.8
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 7.2
-Stable tag: 1.38.1
+Stable tag: 1.39.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -152,6 +152,11 @@ It then creates a database based on the parameters passed to it.
 6. Job listings in admin.
 
 == Changelog ==
+
+= 1.39.0 =
+* Enhancement: Download first-party plugin extension translations
+* Enhancement: Add integration to Yoast SEO schema (@jdevalk)
+* Fix: Make salary placeholder string translatable
 
 = 1.38.1 =
 * Enhancement: Added support for WordPress.com marketplace

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.38.1
+ * Version: 1.39.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 5.8
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.38.1' );
+define( 'JOB_MANAGER_VERSION', '1.39.0' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Release PR for 1.39.0

```
= 1.39.0 =
* Enhancement: Download first-party plugin extension translations
* Enhancement: Add integration to Yoast SEO schema (@jdevalk)
* Fix: Make salary placeholder string translatable
```

[wp-job-manager.zip](https://github.com/Automattic/WP-Job-Manager/files/10218509/wp-job-manager.zip) (with fixes from #2350)

