### PR TITLE
Do not cache parsed language pack response

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-language-packs.php
+++ b/includes/helper/class-wp-job-manager-helper-language-packs.php
@@ -102,7 +102,7 @@ class WP_Job_Manager_Helper_Language_Packs {
 		$transient_key = self::REMOTE_PACKAGE_TRANSIENT . md5( wp_json_encode( [ $this->plugin_versions, $this->locales ] ) );
 		$data          = get_site_transient( $transient_key );
 		if ( false !== $data && is_array( $data ) ) {
-			return $data;
+			return $this->parse_language_pack_translations( $data );
 		}
 
 		// Set the timeout for the request.
@@ -143,7 +143,7 @@ class WP_Job_Manager_Helper_Language_Packs {
 		}
 
 		$this->language_pack_updates_cache = $this->parse_language_pack_translations( $response['data'] );
-		set_site_transient( $transient_key, $this->language_pack_updates_cache, DAY_IN_SECONDS );
+		set_site_transient( $transient_key, $response['data'], DAY_IN_SECONDS );
 
 		return $this->language_pack_updates_cache;
 	}


### PR DESCRIPTION
I was caching the parsed version/date comparison for the language pack updates. This meant once installing the language packs, they kept being offered as available updates.

### Changes proposed in this Pull Request

* No longer cache the parsed language pack version check response.

### Testing instructions

* Make sure all site transients have been deleted if you've tested a build with the language packs already.
* From this branch, also add a first-party plugin to your site instance (Alerts, for example).
* Set the site language to a mag-16 language (Spanish). 
* Go to Dashboard > Updates
* Click Update Translations at bottom. You may need to do this a couple times before WordPress recognizes the updates from various locations.
* Ensure the translation updates are no longer being offered when visiting Dashboard > Updates.
