### PR TITLE
Use github actions from Automattic org instead of from my personal profile

### DIFF
--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/checkout@v2
             - name: Publish commit status with the link to download the plugin 
               id: plugin_artifact
-              uses: fjorgemota/github-action-report-artifact@v0
+              uses: Automattic/github-action-report-artifact@v0
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   artifact-name: wp-job-manager-${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Use `github-action-report-artifact` action from the Automattic org instead of from my own personal profile;

### Testing instructions

Verify if the action still works fine (with the message `Click on "Details" to download the plugin zip file` on the Checks section below, and also with the Details link redirecting to the ZIP file of the artifact).

### Context

p1673279045277219-slack-C8QJAM52B 