### PR TITLE
Add check for job listing limit being 0

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -108,9 +108,8 @@ class WP_Job_Manager_Shortcodes {
 		$job_count        = job_manager_count_user_job_listings();
 
 		if (
-			$submit_job_form_page_id
-			&& $submission_limit
-			&& $job_count >= $submission_limit
+			$submit_job_form_page_id &&
+			! \job_manager_user_can_submit_job_listing()
 		) {
 			$employer_dashboard_page_id = get_option( 'job_manager_job_dashboard_page_id' );
 			if ( $employer_dashboard_page_id ) {

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -87,7 +87,7 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 				<?php endforeach; ?>
 			<?php endif; ?>
 		</tbody>
-		<?php if ( $submit_job_form_page_id && ( job_manager_count_user_job_listings() < $submission_limit || 'false' === $submission_limit ) ) : ?>
+		<?php if ( job_manager_user_can_submit_job_listing() ) : ?>
 			<tfoot>
 				<tr>
 					<td colspan="<?php echo count( $job_dashboard_columns ); ?>">

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -87,7 +87,7 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 				<?php endforeach; ?>
 			<?php endif; ?>
 		</tbody>
-		<?php if ( $submit_job_form_page_id && ( job_manager_count_user_job_listings() < $submission_limit || ! $submission_limit ) ) : ?>
+		<?php if ( $submit_job_form_page_id && ( job_manager_count_user_job_listings() < $submission_limit || ! $submission_limit ) && '0' !== $submission_limit ) : ?>
 			<tfoot>
 				<tr>
 					<td colspan="<?php echo count( $job_dashboard_columns ); ?>">

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -87,14 +87,7 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 				<?php endforeach; ?>
 			<?php endif; ?>
 		</tbody>
-		<?php
-
-var_dump($submit_job_form_page_id );
-var_dump(  job_manager_count_user_job_listings() < $submission_limit );
-var_dump( $submission_limit );
-
-		?>
-		<?php if ( $submit_job_form_page_id && job_manager_count_user_job_listings() < $submission_limit && false !== $submission_limit ) : ?>
+		<?php if ( $submit_job_form_page_id && ( job_manager_count_user_job_listings() < $submission_limit || 'false' === $submission_limit ) ) : ?>
 			<tfoot>
 				<tr>
 					<td colspan="<?php echo count( $job_dashboard_columns ); ?>">

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$submission_limit			= get_option( 'job_manager_submission_limit' );
+$submission_limit			= ! empty( get_option( 'job_manager_submission_limit' ) ) ? absint( get_option( 'job_manager_submission_limit' ) ) : false;
 $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 ?>
 <div id="job-manager-job-dashboard">
@@ -87,7 +87,14 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 				<?php endforeach; ?>
 			<?php endif; ?>
 		</tbody>
-		<?php if ( $submit_job_form_page_id && ( job_manager_count_user_job_listings() < $submission_limit || ! $submission_limit ) && '0' !== $submission_limit ) : ?>
+		<?php
+
+var_dump($submit_job_form_page_id );
+var_dump(  job_manager_count_user_job_listings() < $submission_limit );
+var_dump( $submission_limit );
+
+		?>
+		<?php if ( $submit_job_form_page_id && job_manager_count_user_job_listings() < $submission_limit && false !== $submission_limit ) : ?>
 			<tfoot>
 				<tr>
 					<td colspan="<?php echo count( $job_dashboard_columns ); ?>">

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1707,3 +1707,29 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
 	 */
 	return apply_filters( 'job_manager_get_salary_unit_options', $options, $include_empty );
 }
+
+/**
+ * Check if user can submit job listings.
+ *
+ * @return bool
+ * @since $$next-version$$
+ */
+function job_manager_user_can_submit_job_listing() {
+	$can_submit       = true;
+	$submission_limit = get_option( 'job_manager_submission_limit', '' );
+	$job_count        = job_manager_count_user_job_listings();
+
+	if ( '' !== $submission_limit &&
+		$job_count >= $submission_limit
+	) {
+		$can_submit = false;
+	}
+	/**
+	 * Filter if the current user can or cannot submit job listings
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param boolean $can_submit
+	 */
+	return apply_filters( 'job_manager_user_can_submit_job_listing', $can_submit );
+}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1715,15 +1715,9 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
  * @since $$next-version$$
  */
 function job_manager_user_can_submit_job_listing() {
-	$can_submit       = true;
 	$submission_limit = get_option( 'job_manager_submission_limit', '' );
 	$job_count        = job_manager_count_user_job_listings();
-
-	if ( '' !== $submission_limit &&
-		$job_count >= $submission_limit
-	) {
-		$can_submit = false;
-	}
+	$can_submit       = '' === $submission_limit || $submission_limit >= $job_count;
 	/**
 	 * Filter if the current user can or cannot submit job listings
 	 *


### PR DESCRIPTION
Fixes #2333

### Changes proposed in this Pull Request

* Add a check for job listing limit being `0`.  Currently if it's set to `0` it works the same as it being unlimited, which I don't think is intended.

### Testing instructions

* Create a few job listings
* Set the limit to 0
* Verify that you can't add more job listings
