### PR TITLE
Fix "Hide Expired Listings Content" setting

### DIFF
--- a/templates/access-denied-single-job_listing.php
+++ b/templates/access-denied-single-job_listing.php
@@ -15,9 +15,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+?>
 
-if ( $post->post_status === 'expired' ) : ?>
-	<div class="job-manager-info"><?php _e( 'This listing has expired', 'wp-job-manager' ); ?></div>
-<?php else : ?>
-	<p class="job-manager-error"><?php _e( 'Sorry, you do not have permission to view this job listing.', 'wp-job-manager' ); ?></p>
-<?php endif; ?>
+<p class="job-manager-error"><?php _e( 'Sorry, you do not have permission to view this job listing.', 'wp-job-manager' ); ?></p>

--- a/templates/access-denied-single-job_listing.php
+++ b/templates/access-denied-single-job_listing.php
@@ -9,7 +9,7 @@
  * @package     wp-job-manager
  * @category    Template
  * @since       1.37.0
- * @version     1.37.0
+ * @version     1.39.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1661,10 +1661,6 @@ function job_manager_user_can_view_job_listing( $job_id ) {
 		}
 	}
 
-	if ( 'expired' === $job->post_status ) {
-		$can_view = false;
-	}
-
 	if ( $job->post_author > 0 && absint( $job->post_author ) === get_current_user_id() ) {
 		$can_view = true;
 	}


### PR DESCRIPTION
Fixes #2359

### Changes proposed in this Pull Request

* It fixes the "Hide Expired Listings Content" setting by allowing the template to handle expired jobs. [See more details about the issue](https://github.com/Automattic/WP-Job-Manager/issues/2359#issuecomment-1374225762).

### Testing instructions

1. Go to wp-admin > Job Listings > Settings.
2. Make sure the setting "Hide Expired Listings Content" is unchecked.
3. Add a new job.
4. Edit the job to expire in the past, so you force that the job is expired.
5. Log in with a different user (or logged out).
6. Go to the job page.
7. Check that you see the job details.