### PR TITLE
Fix Select2 Padding for Frontend Job Listing

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -979,3 +979,14 @@ nav.job-manager-pagination,
 		}
 	}
 }
+
+// Admin Bar Select2 overlap fixes
+#wpadminbar ~ span.select2-container, body.admin-bar > span.select2-container {
+	padding-top: 32px;
+}
+
+@media screen and ( max-width: 782px ) {
+	#wpadminbar ~ span.select2-container, body.admin-bar > span.select2-container {
+		padding-top: 46px;
+	}
+}


### PR DESCRIPTION
Fixes #https://github.com/Automattic/WP-Job-Manager/issues/2370

### Changes proposed in this Pull Request

* Add some padding for the Select2 inputs when the WP Admin Bar is present

### Testing instructions

* Apply this Patch
* Go to enter a Job from the frontend
* Make sure you are logged in and the Admin Bar is present
* Try the Job Type field, make sure the padding is correct
* Try with many different themes
* Do the same on a screen below 782 pixels wide

### Screenshot / Video
Before
![Screenshot 2023-03-23 at 2 36 56 PM](https://user-images.githubusercontent.com/3220162/227369912-8ac6524e-5eba-409f-818c-f1958eb670b2.png)

After
![Screenshot 2023-03-23 at 2 36 49 PM](https://user-images.githubusercontent.com/3220162/227369930-7f53b130-ecc2-45ed-8a96-dcf5fc5ab289.png)
