### PR TITLE
Add core addon outdated notices.

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -1,0 +1,74 @@
+
+.wpjm-admin-notice {
+
+	// Layout.
+	display: flex;
+	flex-direction: column;
+
+	// Spacing.
+	gap: 10px;
+	padding: 18px 24px;
+
+	&.wpjm-admin-notice--info {
+		border-left-color: #2270B1;
+	}
+
+	&__top {
+		// Layout.
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+	}
+
+	&__message {
+		flex: 1 1 auto;
+		font-size: 14px;
+	}
+
+	&__actions {
+		// Layout.
+		display: flex;
+		gap: 10px;
+		align-self: center;
+
+		.button {
+			padding: 3px 12px;
+		}
+	}
+}
+
+.wpjm-addon-update-notice-info {
+	// Layout.
+	display: flex;
+	flex-direction: row;
+	width: 600px;
+	padding: 0 0 0 54px;
+
+	// Style.
+	color: #3C434A;
+	line-height: 20px;
+	letter-spacing: -0.24px;
+	font-size: 14px;
+
+	&__name {
+		// Layout.
+		flex: 50%;
+
+		// Style.
+		font-weight: 700;
+	}
+
+	&__version {
+		// Layout.
+		flex: 50%;
+		text-align: right;
+
+		a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -215,7 +215,7 @@ class WP_Job_Manager_Admin_Notices {
 	}
 
 	/**
-	 * Displays the setup wizard notice when WPJM is first activated.
+	 * Displays the notice that informs about WPJM addon updates available.
 	 *
 	 * Note: For internal use only. Do not call manually.
 	 */

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -260,7 +260,8 @@ class WP_Job_Manager_Admin_Notices {
 
 	/**
 	 * Given an array of updates, generate a notice.
-	 * @param $updates
+	 *
+	 * @param array $updates The contents of the addon updates transient.
 	 * @return array|null
 	 */
 	private static function generate_notice_from_updates( $updates ) {
@@ -292,7 +293,8 @@ class WP_Job_Manager_Admin_Notices {
 				$extra_info .= '<div class="wpjm-addon-update-notice-info__name">' . esc_html( $update['plugin'] ) . '</div>';
 				$extra_info .= '<div class="wpjm-addon-update-notice-info__version">';
 				$extra_info .= '<a href="https://wpjobmanager.com/release-notes/" target="_blank">';
-				$extra_info .= esc_html__( sprintf( "New Version: %s", $update['new_version'] ), 'wp-job-manager' );
+				// translators: %s is the new version number for the addon.
+				$extra_info .= sprintf( esc_html__( 'New Version: %s', 'wp-job-manager' ), $update['new_version'] );
 				$extra_info .= '</a>';
 				$extra_info .= '</div>';
 				$extra_info .= '</div>';
@@ -347,7 +349,7 @@ class WP_Job_Manager_Admin_Notices {
 			echo wp_kses( $notice['extra_info'], self::ALLOWED_HTML );
 			echo '</div>';
 		}
-		echo "</div>";
+		echo '</div>';
 	}
 }
 

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -15,8 +15,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.32.0
  */
 class WP_Job_Manager_Admin_Notices {
-	const STATE_OPTION      = 'job_manager_admin_notices';
-	const NOTICE_CORE_SETUP = 'core_setup';
+	const STATE_OPTION                  = 'job_manager_admin_notices';
+	const NOTICE_CORE_SETUP             = 'core_setup';
+	const NOTICE_ADDON_UPDATE_AVAILABLE = 'addon_update_available';
+	const ALLOWED_HTML                  = [
+		'div' => [
+			'class' => [],
+		],
+		'a'   => [
+			'target' => [],
+			'href'   => [],
+			'rel'    => [],
+		],
+	];
 
 	/**
 	 * Current notices for admin user.
@@ -98,6 +109,7 @@ class WP_Job_Manager_Admin_Notices {
 	public static function init_core_notices() {
 		// core_setup: Notice is used when first activating WP Job Manager.
 		add_action( 'job_manager_admin_notice_' . self::NOTICE_CORE_SETUP, [ __CLASS__, 'display_core_setup' ] );
+		add_action( 'job_manager_admin_notice_' . self::NOTICE_ADDON_UPDATE_AVAILABLE, [ __CLASS__, 'display_addon_update_available' ] );
 	}
 
 	/**
@@ -203,6 +215,24 @@ class WP_Job_Manager_Admin_Notices {
 	}
 
 	/**
+	 * Displays the setup wizard notice when WPJM is first activated.
+	 *
+	 * Note: For internal use only. Do not call manually.
+	 */
+	public static function display_addon_update_available() {
+		if ( ! self::is_admin_on_standard_job_manager_screen( [ 'dashboard' ] ) ) {
+			return;
+		}
+
+		$updates = get_transient( 'wpjm_addon_updates_available', [] );
+
+		if ( ! empty( $updates ) ) {
+			$notice = self::generate_notice_from_updates( $updates );
+			self::render_notice( $notice );
+		}
+	}
+
+	/**
 	 * Gets the current admin notices to be displayed.
 	 *
 	 * @return array
@@ -226,6 +256,98 @@ class WP_Job_Manager_Admin_Notices {
 		}
 
 		update_option( self::STATE_OPTION, wp_json_encode( self::get_notice_state() ), false );
+	}
+
+	/**
+	 * Given an array of updates, generate a notice.
+	 * @param $updates
+	 * @return array|null
+	 */
+	private static function generate_notice_from_updates( $updates ) {
+		if ( empty( $updates ) ) {
+			return null;
+		}
+
+		// Default: Single update available.
+		$extra_info          = null;
+		$update_action_label = __( 'Update', 'wp-job-manager' );
+		$message             = __( 'Good news, reminder to update to latest version.', 'wp-job-manager' );
+		$actions             = [
+			[
+				'url'     => 'https://wpjobmanager.com/release-notes/',
+				'label'   => __( 'View release notes', 'wp-job-manager' ),
+				'target'  => '_blank',
+				'primary' => false,
+			],
+		];
+
+		// Multiple updates: Change message, update action label, remove release notes secondary action and add extra info.
+		if ( count( $updates ) > 1 ) {
+			$message             = __( 'Good news, reminder to update these plugins to their latest versions.', 'wp-job-manager' );
+			$update_action_label = __( 'Update All', 'wp-job-manager' );
+			$extra_info          = '';
+			$actions             = []; // Remove more_info link.
+			foreach ( $updates as $update ) {
+				$extra_info .= '<div class="wpjm-addon-update-notice-info">';
+				$extra_info .= '<div class="wpjm-addon-update-notice-info__name">' . esc_html( $update['plugin'] ) . '</div>';
+				$extra_info .= '<div class="wpjm-addon-update-notice-info__version">';
+				$extra_info .= '<a href="https://wpjobmanager.com/release-notes/" target="_blank">';
+				$extra_info .= esc_html__( sprintf( "New Version: %s", $update['new_version'] ), 'wp-job-manager' );
+				$extra_info .= '</a>';
+				$extra_info .= '</div>';
+				$extra_info .= '</div>';
+			}
+		}
+
+		$actions[] = [
+			'label' => $update_action_label,
+			'url'   => admin_url( 'plugins.php' ),
+		];
+
+		return [
+			'message'    => $message,
+			'actions'    => $actions,
+			'extra_info' => $extra_info,
+		];
+	}
+
+	/**
+	 * Renders a notice.
+	 *
+	 * @param array $notice See `generate_notice_from_updates` for format.
+	 * @return void
+	 */
+	private static function render_notice( $notice ) {
+		// TODO Handle different levels of notices.
+		echo '<div class="notice wpjm-admin-notice wpjm-admin-notice--info">';
+
+		echo '<div class="wpjm-admin-notice__top">';
+		// TODO Add icon.
+		echo '<div class="wpjm-admin-notice__message">';
+		echo wp_kses( $notice['message'], self::ALLOWED_HTML );
+		echo '</div>';
+		if ( ! empty( $notice['actions'] ) ) {
+			echo '<div class="wpjm-admin-notice__actions">';
+			foreach ( $notice['actions'] as $action ) {
+				if ( ! isset( $action['label'], $action['url'] ) ) {
+					continue;
+				}
+
+				$button_class = ! isset( $action['primary'] ) || $action['primary'] ? 'button-primary' : 'button-secondary';
+				echo '<a href="' . esc_url( $action['url'] ) . '" target="' . esc_attr( $action['target'] ?? '_self' ) . '" rel="noopener noreferrer" class="button ' . esc_attr( $button_class ) . '">';
+				echo esc_html( $action['label'] );
+				echo '</a>';
+			}
+			echo '</div>';
+		}
+		echo '</div>';
+
+		if ( ! empty( $notice['extra_info'] ) ) {
+			echo '<div class="wpjm-admin-notice__extra_info">';
+			echo wp_kses( $notice['extra_info'], self::ALLOWED_HTML );
+			echo '</div>';
+		}
+		echo "</div>";
 	}
 }
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -96,6 +96,9 @@ class WP_Job_Manager_Admin {
 			WP_Job_Manager::register_style( 'job_manager_admin_css', 'css/admin.css', [] );
 			wp_enqueue_style( 'job_manager_admin_css' );
 
+			WP_Job_Manager::register_style( 'job_manager_admin_notices_css', 'css/admin-notices.css', [] );
+			wp_enqueue_style( 'job_manager_admin_notices_css' );
+
 			wp_enqueue_script( 'wp-job-manager-datepicker' );
 			wp_register_script( 'jquery-tiptip', JOB_MANAGER_PLUGIN_URL . '/assets/lib/jquery-tiptip/jquery.tipTip.min.js', [ 'jquery' ], JOB_MANAGER_VERSION, true );
 

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -213,11 +213,13 @@ class WP_Job_Manager_Helper {
 			}
 		}
 
-		// If there is an update available, add the addon update available notice.
+		// Enable or disable notices.
 		if ( ! empty($available_addon_updates) ) {
 			WP_Job_Manager_Admin_Notices::add_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
-			set_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
+		} else {
+			WP_Job_Manager_Admin_Notices::remove_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
 		}
+		set_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
 
 
 		return $check_for_updates_data;

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Handles Job Manager's Ajax endpoints.
+ * Helper functions used in WP Job Manager regarding addons and licenses.
  *
  * @package wp-job-manager
  * @since 1.29.0
@@ -198,6 +198,7 @@ class WP_Job_Manager_Helper {
 	 * @return array
 	 */
 	public function check_for_updates( $check_for_updates_data ) {
+		$available_addon_updates = [];
 		// Set version variables.
 		foreach ( $this->get_installed_plugins() as $product_slug => $plugin_data ) {
 			$response = $this->get_plugin_version( $plugin_data['_filename'] );
@@ -207,9 +208,17 @@ class WP_Job_Manager_Helper {
 				&& isset( $response['new_version'] )
 				&& version_compare( $response['new_version'], $plugin_data['Version'], '>' )
 			) {
+				$available_addon_updates[ $product_slug ] = $response;
 				$check_for_updates_data->response[ $plugin_data['_filename'] ] = (object) $response;
 			}
 		}
+
+		// If there is an update available, add the addon update available notice.
+		if ( ! empty($available_addon_updates) ) {
+			WP_Job_Manager_Admin_Notices::add_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
+			set_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
+		}
+
 
 		return $check_for_updates_data;
 	}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -208,19 +208,18 @@ class WP_Job_Manager_Helper {
 				&& isset( $response['new_version'] )
 				&& version_compare( $response['new_version'], $plugin_data['Version'], '>' )
 			) {
-				$available_addon_updates[ $product_slug ] = $response;
+				$available_addon_updates[ $product_slug ]                      = $response;
 				$check_for_updates_data->response[ $plugin_data['_filename'] ] = (object) $response;
 			}
 		}
 
 		// Enable or disable notices.
-		if ( ! empty($available_addon_updates) ) {
+		if ( ! empty( $available_addon_updates ) ) {
 			WP_Job_Manager_Admin_Notices::add_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
 		} else {
 			WP_Job_Manager_Admin_Notices::remove_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
 		}
 		set_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
-
 
 		return $check_for_updates_data;
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ const files = {
 	'js/multiselect': 'js/multiselect.js',
 	'js/term-multiselect': 'js/term-multiselect.js',
 	'css/admin': 'css/admin.scss',
+	'css/admin-notices': 'css/admin-notices.scss',
 	'css/frontend': 'css/frontend.scss',
 	'css/job-listings': 'css/job-listings.scss',
 	'css/job-submission': 'css/job-submission.scss',


### PR DESCRIPTION
Fixes #2379

### Changes proposed in this Pull Request
* Add ground for new notifications (will be completed in #2382).
* Save pending updates info in a transient for later use and save notice.
* Render correct messages depending on the amount of addons pending to update.

### Testing instructions
* Checkout to the branch.
* Purchase a paid plugin from wpjobmanager.com (you can use a promo code).
* Download **an outdated** copy of your plugin (you can use the one from the private repositories). 
* Go to `Job Listings > Add-ons > Licenses` and activate your license.
* Go to `Job Listings > All Jobs` or some other WPJM screen and you should see the notice to update.
* Repeat the steps with a different plugin and confirm the multi-plugin case.

### New/Updated Hooks
* `job_manager_admin_notice_addon_update_available`: New action that is triggered to display the notice. 

### Known bugs
- The update action brings you always to the plugins page – in the original ticket we wanted to bring you to plugins page or licensing page depending on if the plugin was licensed or unlicensed. If we want to have this behaviour **we need to decide** what to do on multiple plugins case when some are licensed and some are unlicensed. **Opinions?**
- The design is a _little bit different_ than the one reported in the original ticket, but we have a separate ticket to polish design (icons, dismissible, etc).
- The notice is not dismissible.

### Screenshot / Video
#### Single
![image](https://user-images.githubusercontent.com/799065/227608134-01c6f399-7c5c-43c5-860f-21fe40b7be29.png)

#### Multiple
![image](https://user-images.githubusercontent.com/799065/227608290-e0db218f-c9e7-49d6-90a7-a620dc6067c5.png)
