### PR TITLE
Fix/license notice

### DIFF
--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -506,7 +506,10 @@ class WP_Job_Manager_Helper {
 	 */
 	public function licence_error_notices() {
 		$screen = get_current_screen();
-		if ( null === $screen || in_array( $screen->id, [ 'job_listing_page_job-manager-addons' ], true ) ) {
+		if (
+			null === $screen ||
+			in_array( $screen->id, [ 'job_listing_page_job-manager-addons' ], true ) ||
+			! current_user_can( 'update_plugins' ) ) {
 			return;
 		}
 		foreach ( $this->get_installed_plugins() as $product_slug => $plugin_data ) {

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -509,7 +509,8 @@ class WP_Job_Manager_Helper {
 		if (
 			null === $screen ||
 			in_array( $screen->id, [ 'job_listing_page_job-manager-addons' ], true ) ||
-			! current_user_can( 'update_plugins' ) ) {
+			! current_user_can( 'update_plugins' )
+		) {
 			return;
 		}
 		foreach ( $this->get_installed_plugins() as $product_slug => $plugin_data ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2315

### Changes proposed in this Pull Request

* Adds a check for the `update_plugins` capability so we only display the "Please enter your license key" prompt to users who can view the license screen and manage plugins.

### Testing instructions

* Add a paid addon
* Log in as Admin - see notice
* Log in as Editor - notice is no longer displayed

### Screenshot / Video
![Y7045w.png](https://user-images.githubusercontent.com/3220162/227646438-cc16aa64-1cf8-43b7-bfeb-32359b31ad84.png)