### PR TITLE
Return plugin info for addon even when there's no license configured

### DIFF
--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -362,9 +362,6 @@ class WP_Job_Manager_Helper {
 			return false;
 		}
 		$args = $this->get_plugin_licence( $product_slug );
-		if ( empty( $args['licence_key'] ) || empty( $args['email'] ) ) {
-			return false;
-		}
 		$args['api_product_id'] = $product_slug;
 
 		$response = $this->api->plugin_information( $args );

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -361,7 +361,7 @@ class WP_Job_Manager_Helper {
 		if ( ! $this->is_product_installed( $product_slug ) ) {
 			return false;
 		}
-		$args = $this->get_plugin_licence( $product_slug );
+		$args                   = $this->get_plugin_licence( $product_slug );
 		$args['api_product_id'] = $product_slug;
 
 		$response = $this->api->plugin_information( $args );


### PR DESCRIPTION
Fixes #2376 

### Changes proposed in this Pull Request

- Remove the check to return early when the addon doesn't have a license, so the addon now appear on the list of plugins to be updated even when it is not licensed;

### Testing instructions

On a WordPress installation with this branch of the plugin installed, and a local version of WPJobManager.com installed and running:

1. Install a  WPJobManager addon;
2. Make sure its version is older than the one registered on your local WPJobManager.com environment, which should be running this branch too:  214-gh-Automattic/wpjobmanager.com
3. Make sure the addon isn't licensed;
4. Verify if the addon appears on the list of plugins to be updated (the `/wp-admin/update-core.php` on your installation);
5. Verify that, if you select to update the addon, it actually cannot be updated and fails with the message "An error occurred while updating WP Job Manager - YOUR ADDON: Update package not available."

Here's a snippet to use your local WPJobManager.com dev environment with a WordPress installation running WPJM:

```php

add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
	$host = parse_url( $url, PHP_URL_HOST );

	if ( 'wpjobmanager.com' === $host ) {
		$scheme  = parse_url( $url, PHP_URL_SCHEME );
		$http    = _wp_http_get_object();
		$new_url = str_replace(
			$scheme . '://' . $host,
			'http://YOUR_IP:YOUR_PORT',
			$url
		);

		error_log( 'Redirect from: ' . $url );
		error_log( 'To: ' . $new_url );

		return $http->request( $new_url, $r );
	}
	return $preempt;
}, 10, 3 );
add_filter( 'http_request_host_is_external', function($external) {
	return true;
});

add_filter( 'http_allowed_safe_ports', function($ports) {
	$ports[] = YOUR_PORT;
	return $ports;
});
```

Remember to replace `YOUR_IP` with the host/IP for your dev environment, and `YOUR_PORT` with the port used in your dev environment.

