### PR TITLE
Add Github Workflow to close issues on merge of a related PR

### DIFF
--- a/.github/workflows/close-issue-on-merge.yml
+++ b/.github/workflows/close-issue-on-merge.yml
@@ -1,0 +1,14 @@
+name: Close issues related to a merged PR
+
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+    closeIssueOnPrMergeTrigger:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Closes issues related to a merged pull request.
+              uses: docker://ghcr.io/automattic/gha-mjolnir
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sibling to https://github.com/Automattic/sensei/pull/5233

### Changes proposed in this Pull Request

* Add a workflow to close issues mentioned by PR's descriptions with prefixes like "Fix"/"Fixes" and so on (which is already on our default template) when those PRs are merged. Even if their target branch is a feature branch, for instance;


### Testing instructions

Unfortunately, I don't think there's a good way to test it. I'm using [this action](https://github.com/Automattic/gha-mjolnir) here, and the code looks pretty okay to me too.