### PR TITLE
Fix company video styling when company tagline isn't present

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -321,10 +321,14 @@ div.job_listings {
 			content: "\e80a";
 		}
 
+		.company_header {
+			margin: 0 0 1em;
+			min-height: 60px;
+		}
+
 		.company_video {
 			border-top: 1px solid #eee;
 			padding: 1em 0 0;
-			margin: 1em 0 0 0;
 			position: relative;
 			padding-bottom: 56.25%;
 			padding-top: 30px;

--- a/templates/content-single-job_listing-company.php
+++ b/templates/content-single-job_listing-company.php
@@ -11,7 +11,7 @@
  * @package     wp-job-manager
  * @category    Template
  * @since       1.14.0
- * @version     1.32.0
+ * @version     1.32.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/content-single-job_listing-company.php
+++ b/templates/content-single-job_listing-company.php
@@ -25,13 +25,16 @@ if ( ! get_the_company_name() ) {
 <div class="company">
 	<?php the_company_logo(); ?>
 
-	<p class="name">
-		<?php if ( $website = get_the_company_website() ) : ?>
-			<a class="website" href="<?php echo esc_url( $website ); ?>" rel="nofollow"><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
-		<?php endif; ?>
-		<?php the_company_twitter(); ?>
-		<?php the_company_name( '<strong>', '</strong>' ); ?>
-	</p>
-	<?php the_company_tagline( '<p class="tagline">', '</p>' ); ?>
+	<div class="company_header">
+		<p class="name">
+			<?php if ( $website = get_the_company_website() ) : ?>
+				<a class="website" href="<?php echo esc_url( $website ); ?>" rel="nofollow"><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
+			<?php endif; ?>
+			<?php the_company_twitter(); ?>
+			<?php the_company_name( '<strong>', '</strong>' ); ?>
+		</p>
+		<?php the_company_tagline( '<p class="tagline">', '</p>' ); ?>
+	</div>
+
 	<?php the_company_video(); ?>
 </div>


### PR DESCRIPTION
Fixes #1954

### Changes proposed in this Pull Request

* Adds a new `company_header` div class to `content-single-job_listing-company.php`
* Styles this class to ensure company info formatting is consistent whether a company tagline is present or not

Results:

![without-tagline](https://user-images.githubusercontent.com/2500940/232435475-4f594066-be40-4853-a1f5-585934f2a1ce.png)
![with-tagline](https://user-images.githubusercontent.com/2500940/232435481-06cc6357-ae99-42d0-8aed-43908fdddf57.png)


### Testing instructions

* Check out branch
* Activate Twenty Twenty (or any other theme)
* Create a Job listing with a title, company name, tagline and video
* Check styling, then remove the tagline and check styling again