### PR TITLE
Add heading support for notices. Rename `extra_info` to `extra_details`.

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -42,6 +42,11 @@ $notice-success: #43af99;
 		margin-right: 10px;
 	}
 
+	&__heading {
+		margin: 5px 0;
+		font-weight: bold;
+	}
+
 	&__message {
 		flex: 1 1 auto;
 		font-size: 14px;

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -456,7 +456,7 @@ class WP_Job_Manager_Admin_Notices {
 		}
 
 		// Default: Single update available.
-		$extra_info          = null;
+		$extra_details       = null;
 		$update_action_label = __( 'Update', 'wp-job-manager' );
 		$message             = __( 'Good news, reminder to update to the latest version of WP Job Manager.', 'wp-job-manager' );
 		$actions             = [
@@ -472,18 +472,18 @@ class WP_Job_Manager_Admin_Notices {
 		if ( count( $updates ) > 1 ) {
 			$message             = __( 'Good news, reminder to update these plugins to their latest versions.', 'wp-job-manager' );
 			$update_action_label = __( 'Update All', 'wp-job-manager' );
-			$extra_info          = '';
+			$extra_details       = '';
 			$actions             = []; // Remove more_info link.
 			foreach ( $updates as $update ) {
-				$extra_info .= '<div class="wpjm-addon-update-notice-info">';
-				$extra_info .= '<div class="wpjm-addon-update-notice-info__name">' . esc_html( $update['plugin'] ) . '</div>';
-				$extra_info .= '<div class="wpjm-addon-update-notice-info__version">';
-				$extra_info .= '<a href="https://wpjobmanager.com/release-notes/" target="_blank">';
+				$extra_details .= '<div class="wpjm-addon-update-notice-info">';
+				$extra_details .= '<div class="wpjm-addon-update-notice-info__name">' . esc_html( $update['plugin'] ) . '</div>';
+				$extra_details .= '<div class="wpjm-addon-update-notice-info__version">';
+				$extra_details .= '<a href="https://wpjobmanager.com/release-notes/" target="_blank">';
 				// translators: %s is the new version number for the addon.
-				$extra_info .= sprintf( esc_html__( 'New Version: %s', 'wp-job-manager' ), $update['new_version'] );
-				$extra_info .= '</a>';
-				$extra_info .= '</div>';
-				$extra_info .= '</div>';
+				$extra_details .= sprintf( esc_html__( 'New Version: %s', 'wp-job-manager' ), $update['new_version'] );
+				$extra_details .= '</a>';
+				$extra_details .= '</div>';
+				$extra_details .= '</div>';
 			}
 		}
 
@@ -493,9 +493,9 @@ class WP_Job_Manager_Admin_Notices {
 		];
 
 		return [
-			'message'    => $message,
-			'actions'    => $actions,
-			'extra_info' => $extra_info,
+			'message'       => $message,
+			'actions'       => $actions,
+			'extra_details' => $extra_details,
 		];
 	}
 
@@ -537,8 +537,12 @@ class WP_Job_Manager_Admin_Notices {
 		if ( ! empty( $notice['icon'] ) ) {
 			echo '<img src="' . esc_url( self::get_icon( $notice['icon'] ) ) . '" class="wpjm-admin-notice__icon" alt="WP Job Manager Icon" />';
 		}
-
 		echo '<div class="wpjm-admin-notice__message">';
+		if ( ! empty( $notice['heading'] ) ) {
+			echo '<div class="wpjm-admin-notice__heading">';
+			echo wp_kses( $notice['heading'], self::ALLOWED_HTML );
+			echo '</div>';
+		}
 		echo wp_kses( $notice['message'], self::ALLOWED_HTML );
 		echo '</div>';
 		if ( ! empty( $notice['actions'] ) ) {
@@ -557,9 +561,9 @@ class WP_Job_Manager_Admin_Notices {
 		}
 		echo '</div>';
 
-		if ( ! empty( $notice['extra_info'] ) ) {
-			echo '<div class="wpjm-admin-notice__extra_info">';
-			echo wp_kses( $notice['extra_info'], self::ALLOWED_HTML );
+		if ( ! empty( $notice['extra_details'] ) ) {
+			echo '<div class="wpjm-admin-notice__extra_details">';
+			echo wp_kses( $notice['extra_details'], self::ALLOWED_HTML );
 			echo '</div>';
 		}
 		echo '</div>';


### PR DESCRIPTION
Fixes #2404

### Changes proposed in this Pull Request
* Adding support for `heading` field to notices.
* Renamed `extra_info` to `extra_details`. Didn't integrate into `message` because design alignment becomes very difficult to achieve.

### Testing instructions
* You can use the following snippet:
```
add_filter( 'pre_http_request', function($preempt, $r, $url) {
	$parsed = parse_url( $url );

	if ( 'wpjobmanager.com' === $parsed['host'] ) {
		if ( '/wp-json/wpjmcom-notices/1.0/notices' === $parsed['path']) {						
			return array(
            'headers'     => array(),
            'cookies'     => array(),
            'filename'    => null,
            'response'    => [ 'code' => 200 ],
            'status_code' => 200,
            'success'     => 1,
            'body'        => <<<EOQ
{
	"notices": {
		"test-notice-2404": {
			"type": "site-wide",
			"icon": "wpjm",
			"heading": "The header for the notice",
			"message": "This is a test notice message with header and message.",
			"actions": [
				{
					"label": "Read more",
					"url": "https:\/\/wpjobmanager.com",
					"primary": true,
					"target": "_blank"
				},
				{
					"label": "Other",
					"url": "https:\/\/wpjobmanager.com",
					"primary": false,
					"target": "_blank"
				}
			],
			"conditions": [
				{
					"type": "screens",
					"screens": [
						"wpjm*"
					]
				}
			]
		}
	}
}
EOQ,
        );
		}
	}
	return $preempt;
}, 9, 3 );
```
### Screenshot / Video

<img width="1723" alt="image" src="https://user-images.githubusercontent.com/799065/233051445-97e0444f-86a5-4389-9838-0fbec99591a1.png">
