### PR TITLE
Change addon update notices to new system.

### DIFF
--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -405,7 +405,8 @@ class WP_Job_Manager_Admin_Notices {
 		if ( ! empty( $updates ) ) {
 			$notice = self::generate_notice_from_updates( $updates );
 			if ( ! is_null( $notice ) ) {
-				$notices[ self::NOTICE_ADDON_UPDATE_AVAILABLE ] = $notice;
+				$notice_id             = self::generate_notice_id_from_updates( $updates );
+				$notices[ $notice_id ] = $notice;
 			}
 		}
 		return $notices;
@@ -570,6 +571,20 @@ class WP_Job_Manager_Admin_Notices {
 		}
 		echo '</div>';
 
+	}
+
+	/**
+	 * Generate unique notice ID based on the updates available.
+	 *
+	 * @param array $updates The updates available.
+	 * @return string The notice ID.
+	 */
+	private static function generate_notice_id_from_updates( $updates ) {
+		$notice_id = self::NOTICE_ADDON_UPDATE_AVAILABLE;
+		foreach ( $updates as $update ) {
+			$notice_id .= '-' . $update['plugin'] . '@' . $update['new_version'];
+		}
+		return md5( $notice_id );
 	}
 }
 

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -405,7 +405,7 @@ class WP_Job_Manager_Admin_Notices {
 			return $notices;
 		}
 
-		$updates = get_transient( 'wpjm_addon_updates_available', [] );
+		$updates = get_site_transient( 'wpjm_addon_updates_available', [] );
 		if ( ! empty( $updates ) ) {
 			$notice = self::generate_notice_from_updates( $updates );
 			if ( ! is_null( $notice ) ) {

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -401,6 +401,10 @@ class WP_Job_Manager_Admin_Notices {
 	 * @return mixed
 	 */
 	public static function maybe_add_addon_update_available_notice( $notices ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return $notices;
+		}
+
 		$updates = get_transient( 'wpjm_addon_updates_available', [] );
 		if ( ! empty( $updates ) ) {
 			$notice = self::generate_notice_from_updates( $updates );

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -56,6 +56,7 @@ class WP_Job_Manager_Admin_Notices {
 		add_action( 'admin_notices', [ __CLASS__, 'display_notices' ] );
 		add_action( 'wp_loaded', [ __CLASS__, 'dismiss_notices' ] );
 		add_action( 'wp_ajax_wp_job_manager_dismiss_notice', [ __CLASS__, 'handle_notice_dismiss' ] );
+		add_filter( 'wpjm_admin_notices', [ __CLASS__, 'maybe_add_addon_update_available_notice' ], 10, 1 );
 	}
 
 	/**
@@ -144,7 +145,6 @@ class WP_Job_Manager_Admin_Notices {
 	public static function init_core_notices() {
 		// core_setup: Notice is used when first activating WP Job Manager.
 		add_action( 'job_manager_admin_notice_' . self::NOTICE_CORE_SETUP, [ __CLASS__, 'display_core_setup' ] );
-		add_filter( 'wpjm_admin_notices', [ __CLASS__, 'maybe_add_addon_update_available_notice' ], 10, 1 );
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -584,11 +584,11 @@ class WP_Job_Manager_Admin_Notices {
 	 * @return string The notice ID.
 	 */
 	private static function generate_notice_id_from_updates( $updates ) {
-		$notice_id = self::NOTICE_ADDON_UPDATE_AVAILABLE;
+		$updates_info = '';
 		foreach ( $updates as $update ) {
-			$notice_id .= '-' . $update['plugin'] . '@' . $update['new_version'];
+			$updates_info .= $update['plugin'] . '@' . $update['new_version'];
 		}
-		return md5( $notice_id );
+		return self::NOTICE_ADDON_UPDATE_AVAILABLE . '-' . md5( $updates_info );
 	}
 }
 

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -213,7 +213,7 @@ class WP_Job_Manager_Helper {
 				$check_for_updates_data->response[ $plugin_data['_filename'] ] = (object) $response;
 			}
 		}
-		set_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
+		set_site_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
 
 		return $check_for_updates_data;
 	}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -504,14 +504,14 @@ class WP_Job_Manager_Helper {
 		$licenced_plugins   = $this->search_licenced_plugins( $licenced_plugins, $search_term );
 		$active_plugins     = array_filter(
 			$licenced_plugins,
-			function( $product_slug ) {
+			function ( $product_slug ) {
 				return $this->has_plugin_licence( $product_slug );
 			},
 			ARRAY_FILTER_USE_KEY
 		);
 		$inactive_plugins   = array_filter(
 			$licenced_plugins,
-			function( $product_slug ) {
+			function ( $product_slug ) {
 				return ! $this->has_plugin_licence( $product_slug );
 			},
 			ARRAY_FILTER_USE_KEY
@@ -524,7 +524,7 @@ class WP_Job_Manager_Helper {
 	 * Search for the list of licenced plugins.
 	 *
 	 * @param array  $licenced_plugins The array of licenced plugins to filter.
-	 * @param string $search_term The search term to filter by.
+	 * @param string $search_term      The search term to filter by.
 	 * @return array The filtered list of licenced plugins.
 	 */
 	private function search_licenced_plugins( $licenced_plugins, $search_term ) {
@@ -532,7 +532,7 @@ class WP_Job_Manager_Helper {
 			$search_term      = strtolower( $search_term );
 			$licenced_plugins = array_filter(
 				$licenced_plugins,
-				function( $plugin ) use ( $search_term ) {
+				function ( $plugin ) use ( $search_term ) {
 					return str_contains( strtolower( $plugin['Name'] ), $search_term )
 						|| str_contains( strtolower( $plugin['Description'] ), $search_term )
 						|| str_contains( strtolower( $plugin['Author'] ), $search_term );

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -206,6 +206,7 @@ class WP_Job_Manager_Helper {
 			if (
 				$response
 				&& isset( $response['new_version'] )
+				&& ! empty( $response['new_version'] )
 				&& version_compare( $response['new_version'], $plugin_data['Version'], '>' )
 			) {
 				$available_addon_updates[ $product_slug ]                      = $response;

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Helper functions used in WP Job Manager regarding addons and licenses.
  *
  * @package wp-job-manager
- * @since 1.29.0
+ * @since   1.29.0
  */
 class WP_Job_Manager_Helper {
 	/**
@@ -118,7 +118,7 @@ class WP_Job_Manager_Helper {
 	private function get_plugin_versions() {
 		return array_filter(
 			array_map(
-				function( $plugin ) {
+				function ( $plugin ) {
 					return $plugin['Version'];
 				},
 				$this->get_installed_plugins( false )
@@ -164,8 +164,8 @@ class WP_Job_Manager_Helper {
 	/**
 	 * Tell the add-on when to check for and display and core WPJM version notices.
 	 *
-	 * @param bool   $do_check                       True if the add-on should do a core version check.
-	 * @param string $minimum_required_core_version  Minimum version the plugin is reporting it requires.
+	 * @param bool   $do_check                      True if the add-on should do a core version check.
+	 * @param string $minimum_required_core_version Minimum version the plugin is reporting it requires.
 	 * @return bool
 	 */
 	public function addon_core_version_check( $do_check, $minimum_required_core_version = null ) {
@@ -212,13 +212,6 @@ class WP_Job_Manager_Helper {
 				$available_addon_updates[ $product_slug ]                      = $response;
 				$check_for_updates_data->response[ $plugin_data['_filename'] ] = (object) $response;
 			}
-		}
-
-		// Enable or disable notices.
-		if ( ! empty( $available_addon_updates ) ) {
-			WP_Job_Manager_Admin_Notices::add_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
-		} else {
-			WP_Job_Manager_Admin_Notices::remove_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
 		}
 		set_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
 
@@ -297,9 +290,9 @@ class WP_Job_Manager_Helper {
 	/**
 	 * Fetches the plugin information for WPJM plugins.
 	 *
-	 * @param false|object|array $response  The result object or array. Default false.
-	 * @param string             $action    The type of information being requested from the Plugin Install API.
-	 * @param object             $args      Plugin API arguments.
+	 * @param false|object|array $response The result object or array. Default false.
+	 * @param string             $action   The type of information being requested from the Plugin Install API.
+	 * @param object             $args     Plugin API arguments.
 	 *
 	 * @return false|object|array
 	 */
@@ -632,7 +625,7 @@ class WP_Job_Manager_Helper {
 	/**
 	 * Activate multiple WPJM add-on plugins with a single licence key.
 	 *
-	 * @param string   $licence_key The licence key to activate.
+	 * @param string   $licence_key   The licence key to activate.
 	 * @param string[] $product_slugs The product slugs to activate.
 	 * @return void
 	 */
@@ -679,8 +672,8 @@ class WP_Job_Manager_Helper {
 	 * Activate a licence key for a WPJM add-on plugin.
 	 *
 	 * @param string $product_slug The slug of the product to activate.
-	 * @param string $licence_key The licence key to activate.
-	 * @param string $email The e-mail associated with the license. Optional (and actually not used).
+	 * @param string $licence_key  The licence key to activate.
+	 * @param string $email        The e-mail associated with the license. Optional (and actually not used).
 	 */
 	public function activate_licence( $product_slug, $licence_key, $email = '' ) {
 		$response = $this->api->activate(
@@ -731,8 +724,8 @@ class WP_Job_Manager_Helper {
 	/**
 	 * Handle errors from the API.
 	 *
-	 * @param  string $product_slug
-	 * @param  array  $response
+	 * @param string $product_slug
+	 * @param array  $response
 	 */
 	private function handle_api_errors( $product_slug, $response ) {
 		$plugin_products = $this->get_installed_plugins();
@@ -759,7 +752,7 @@ class WP_Job_Manager_Helper {
 	 * Add an error message.
 	 *
 	 * @param string $product_slug The plugin slug.
-	 * @param string $message Your error message.
+	 * @param string $message      Your error message.
 	 */
 	private function add_error( $product_slug, $message ) {
 		$this->add_message( 'error', $product_slug, $message );
@@ -769,7 +762,7 @@ class WP_Job_Manager_Helper {
 	 * Add a success message.
 	 *
 	 * @param string $product_slug The plugin slug.
-	 * @param string $message Your error message.
+	 * @param string $message      Your error message.
 	 */
 	private function add_success( $product_slug, $message ) {
 		$this->add_message( 'success', $product_slug, $message );
@@ -778,9 +771,9 @@ class WP_Job_Manager_Helper {
 	/**
 	 * Add a message.
 	 *
-	 * @param string $type Message type.
+	 * @param string $type         Message type.
 	 * @param string $product_slug The plugin slug.
-	 * @param string $message Your error message.
+	 * @param string $message      Your error message.
 	 */
 	private function add_message( $type, $product_slug, $message ) {
 		if ( ! isset( $this->licence_messages[ $product_slug ] ) ) {
@@ -823,9 +816,9 @@ class WP_Job_Manager_Helper {
 	/**
 	 * Handle the response of the product activation API on WPJobManager.com.
 	 *
-	 * @param array|boolean $response The response to handle.
-	 * @param string        $product_slug The slug of the product.
-	 * @param string        $licence_key The licence key being activated.
+	 * @param array|boolean $response             The response to handle.
+	 * @param string        $product_slug         The slug of the product.
+	 * @param string        $licence_key          The licence key being activated.
 	 * @param boolean       $show_success_message Whether to show a success message or not.
 	 * @return void
 	 */


### PR DESCRIPTION
Fixes #2406 

### Changes proposed in this Pull Request
* Move addon update notices to new `wpjm_admin_notices` filter.

### Testing instructions
* Either install an outdated addon or go to `includes/helper/class-wp-job-manager-helper.php` and reverse the `version_compare` condition.
* Clean transients.
* Confirm the outdated addons notice appears in dashboard and the wpjm default screens.
* If you see wrong addon names in the notice you might need to checkout to this branch (229-gh-Automattic/wpjobmanager.com) in your local wpjobmanager.com environment.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1715" alt="image" src="https://user-images.githubusercontent.com/799065/233070367-cc71aa15-ae36-4d1b-9c45-9e1f779b2ef5.png">