### PR TITLE
Fix crash when installing WPJM via WP-CLI

### DIFF
--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -213,11 +213,13 @@ class WP_Job_Manager_Helper {
 			}
 		}
 
-		// Enable or disable notices.
-		if ( ! empty( $available_addon_updates ) ) {
-			WP_Job_Manager_Admin_Notices::add_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
-		} else {
-			WP_Job_Manager_Admin_Notices::remove_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
+		if ( class_exists( 'WP_Job_Manager_Admin_Notices' ) ) {
+			// Enable or disable notices.
+			if ( ! empty( $available_addon_updates ) ) {
+				WP_Job_Manager_Admin_Notices::add_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
+			} else {
+				WP_Job_Manager_Admin_Notices::remove_notice( WP_Job_Manager_Admin_Notices::NOTICE_ADDON_UPDATE_AVAILABLE );
+			}
 		}
 		set_transient( 'wpjm_addon_updates_available', $available_addon_updates ); // No expiration set.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Only changes notices when checking for updates if the WPJM Admin Notices class is available;

### Testing instructions

This is a hard one to reproduce properly, but, basically, this PR fixes this error that happens sometimes when installing WPJM with another set of plugins via WP-CLI:

```
[19-Apr-2023 22:39:20 UTC] PHP Fatal error:  Uncaught Error: Class 'WP_Job_Manager_Admin_Notices' not found in /var/www/html/wp-content/plugins/WP-Job-Manager/includes/helper/class-wp-job-manager-helper.php:220
Stack trace:
#0 /var/www/html/wp-includes/class-wp-hook.php(309): WP_Job_Manager_Helper->check_for_updates(Object(stdClass))
#1 /var/www/html/wp-includes/plugin.php(191): WP_Hook->apply_filters(Object(stdClass), Array)
#2 /var/www/html/wp-includes/option.php(1992): apply_filters('pre_set_site_tr...', Object(stdClass), 'update_plugins')
#3 /var/www/html/wp-includes/update.php(354): set_site_transient('update_plugins', Object(stdClass))
#4 /var/www/html/wp-includes/class-wp-hook.php(305): wp_update_plugins()
#5 /var/www/html/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters(NULL, Array)
#6 /var/www/html/wp-includes/plugin.php(476): WP_Hook->do_action(Array)
#7 /var/www/html/wp-admin/includes/class-wp-upgrader.php(858): do_action('upgrader_proces...', Object(Plugin_Upgrader), Array)
#8 /var/www/html/wp-admin/includes/class-plugin-upgrader.p in /var/www/html/wp-content/plugins/WP-Job-Manager/includes/helper/class-wp-job-manager-helper.php on line 220
```

From what I saw, my guess is that `WP_Job_Manager_Admin_Notices` not being loaded. I thought about just loading it, but I worry about possible issues that it might cause (given that this class adds a bunch of hooks pretty much related to wp-admin..).
