### PR TITLE
Remove add-ons screen messages

### DIFF
--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -80,35 +80,6 @@ class WP_Job_Manager_Addons {
 	}
 
 	/**
-	 * Get messages for the add-ons screen
-	 *
-	 * @since  1.30.0
-	 *
-	 * @return array of objects.
-	 */
-	private function get_messages() {
-		$add_on_messages = get_transient( 'jm_wpjmcom_add_on_messages' );
-		if ( false === ( $add_on_messages ) ) {
-			$raw_messages = wp_safe_remote_get(
-				add_query_arg(
-					[
-						'version' => JOB_MANAGER_VERSION,
-						'lang'    => get_locale(),
-					],
-					self::WPJM_COM_PRODUCTS_API_BASE_URL . '/messages'
-				)
-			);
-			if ( ! is_wp_error( $raw_messages ) ) {
-				$add_on_messages = json_decode( wp_remote_retrieve_body( $raw_messages ) );
-				if ( $add_on_messages ) {
-					set_transient( 'jm_wpjmcom_add_on_messages', $add_on_messages, WEEK_IN_SECONDS );
-				}
-			}
-		}
-		return apply_filters( 'job_manager_add_on_messages', $add_on_messages );
-	}
-
-	/**
 	 * Handles output of the reports page in admin.
 	 */
 	public function output() {
@@ -140,7 +111,6 @@ class WP_Job_Manager_Addons {
 			} else {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 				$category   = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : null;
-				$messages   = $this->get_messages();
 				$categories = $this->get_categories();
 				$add_ons    = $this->get_add_ons( $category );
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -10,27 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 echo '<h1 class="screen-reader-text">' . esc_html__( 'WP Job Manager Add-ons', 'wp-job-manager' ) . '</h1>';
-if ( ! empty( $messages ) ) {
-	foreach ( $messages as $message ) {
-		if ( empty( $message->message ) ) {
-			continue;
-		}
-		$message_type = 'info';
-		if ( isset( $message->type )
-		&& in_array( $message->type, [ 'info', 'success', 'warning', 'error' ], true ) ) {
-			$message_type = $message->type;
-		}
-		$action_label  = isset( $message->action_label ) ? esc_attr( $message->action_label ) : __( 'More Information &rarr;', 'wp-job-manager' );
-		$action_url    = isset( $message->action_url ) ? esc_url( $message->action_url, [ 'http', 'https' ] ) : false;
-		$action_target = isset( $message->action_target ) && 'self' === $message->action_target ? '_self' : '_blank';
-		$action_str    = '';
-		if ( $action_url ) {
-			$action_str = ' <a href="' . esc_url( $action_url ) . '" target="' . esc_attr( $action_target ) . '" class="button">' . esc_html( $action_label ) . '</a>';
-		}
-
-		echo '<div class="notice notice-' . esc_attr( $message_type ) . ' below-h2"><p><strong>' . esc_html( $message->message ) . '</strong>' . wp_kses_post( $action_str ) . '</p></div>';
-	}
-}
 if ( ! empty( $categories ) ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 	$current_category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '_all';

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -69,7 +69,6 @@ class WP_Job_Manager_Install {
 		}
 
 		delete_transient( 'wp_job_manager_addons_html' );
-		delete_transient( 'jm_wpjmcom_add_on_messages' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );
 	}
 


### PR DESCRIPTION
Part of #2399

This functionality will be replaced by the Notices API.

### Changes proposed in this Pull Request

* Removes the `/messages` call on the Add-ons page.

### Testing instructions

* Go to WP Job Manager > Add-ons.
* Ensure no messages show up.
* Check Query Monitor and ensure no calls to the `/messages` endpoint on WPJobManager.com happen.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* All methods were private.
