### PR TITLE
WIP: Add Relist Feature for Expiring Listings

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -346,15 +346,6 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 						],
 						[
-							'name'       => 'job_manager_publish_relistings',
-							'std'        => '1',
-							'label'      => __( 'Publish Relisted Listings', 'wp-job-manager' ),
-							'cb_label'   => __( 'Automatically publish relisted listings', 'wp-job-manager' ),
-							'desc'       => __( 'Sets all relisted submissions to "publish." They will not need admin approval.', 'wp-job-manager' ),
-							'type'       => 'checkbox',
-							'attributes' => [],
-						],
-						[
 							'name'       => 'job_manager_expiring_soon_days',
 							'std'        => 5,
 							'label'      => __( 'Expiring Soon Days', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -346,6 +346,15 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 						],
 						[
+							'name'       => 'job_manager_publish_relistings',
+							'std'        => '1',
+							'label'      => __( 'Publish Relisted Listings', 'wp-job-manager' ),
+							'cb_label'   => __( 'Automatically publish relisted listings', 'wp-job-manager' ),
+							'desc'       => __( 'Sets all relisted submissions to "publish." They will not need admin approval.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_user_can_edit_pending_submissions',
 							'std'        => '0',
 							'label'      => __( 'Allow Pending Edits', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -355,6 +355,15 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 						],
 						[
+							'name'       => 'job_manager_expiring_soon_days',
+							'std'        => 5,
+							'label'      => __( 'Expiring Soon Days', 'wp-job-manager' ),
+							'cb_label'   => __( 'Number of days to expiry', 'wp-job-manager' ),
+							'desc'       => __( 'Sets the number of days to expiry, after which a listing can be relisted.', 'wp-job-manager' ),
+							'type'       => 'number',
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_user_can_edit_pending_submissions',
 							'std'        => '0',
 							'label'      => __( 'Allow Pending Edits', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -80,6 +80,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_use_standard_password_setup_email',
 		'job_manager_registration_role',
 		'job_manager_submission_requires_approval',
+		'job_manager_publish_relistings',
 		'job_manager_show_agreement_job_submission',
 		'job_manager_terms_and_conditions_page_id',
 		'job_manager_user_can_edit_pending_submissions',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -80,7 +80,6 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_use_standard_password_setup_email',
 		'job_manager_registration_role',
 		'job_manager_submission_requires_approval',
-		'job_manager_publish_relistings',
 		'job_manager_expiring_soon_days',
 		'job_manager_show_agreement_job_submission',
 		'job_manager_terms_and_conditions_page_id',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -81,6 +81,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_registration_role',
 		'job_manager_submission_requires_approval',
 		'job_manager_publish_relistings',
+		'job_manager_expiring_soon_days',
 		'job_manager_show_agreement_job_submission',
 		'job_manager_terms_and_conditions_page_id',
 		'job_manager_user_can_edit_pending_submissions',

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -455,6 +455,12 @@ class WP_Job_Manager_Shortcodes {
 						'nonce' => $base_nonce_action_name,
 					];
 				}
+				if ( job_manager_job_can_be_relisted( $job ) ) {
+					$actions['relist'] = [
+						'label' => __( 'Relist', 'wp-job-manager' ),
+						'nonce' => $base_nonce_action_name,
+					];
+				}
 
 				$actions['duplicate'] = [
 					'label' => __( 'Duplicate', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -253,13 +253,20 @@ class WP_Job_Manager_Shortcodes {
 
 						break;
 					case 'relist':
+					case 'extend':
 					case 'continue':
 						if ( ! job_manager_get_permalink( 'submit_job_form' ) ) {
 							throw new Exception( __( 'Missing submission page.', 'wp-job-manager' ) );
 						}
 
 						// redirect to post page.
-						wp_safe_redirect( add_query_arg( [ 'job_id' => absint( $job_id ) ], job_manager_get_permalink( 'submit_job_form' ) ) );
+						$query_args = [
+							'job_id' => absint( $job_id ),
+						];
+						if ( 'extend' === $action ) {
+							$query_args['action'] = $action;
+						}
+						wp_safe_redirect( add_query_arg( $query_args, job_manager_get_permalink( 'submit_job_form' ) ) );
 						exit;
 					default:
 						do_action( 'job_manager_job_dashboard_do_action_' . $action, $job_id );
@@ -455,9 +462,9 @@ class WP_Job_Manager_Shortcodes {
 						'nonce' => $base_nonce_action_name,
 					];
 				}
-				if ( job_manager_job_can_be_relisted( $job ) ) {
-					$actions['relist'] = [
-						'label' => __( 'Relist', 'wp-job-manager' ),
+				if ( job_manager_job_can_be_extended( $job ) ) {
+					$actions['extend'] = [
+						'label' => __( 'Extend', 'wp-job-manager' ),
 						'nonce' => $base_nonce_action_name,
 					];
 				}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1082,11 +1082,20 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					// Reset expiry.
 					delete_post_meta( $job->ID, '_job_expires' );
 				}
+				/**
+				 * Filters whether a job listing should be published when relisted.
+				 *
+				 * @since $$next_version$$
+				 *
+				 * @param bool $should_publish_relisting Whether the job listing should be published when relisted.
+				 * @param int  $job_id                   The ID of the job listing.
+				 */
+				$should_publish_relisting = $relisting && apply_filters( 'job_manager_should_publish_relisting', get_option( 'job_manager_publish_relistings' ), $job->ID );
 
 				// Update job listing.
 				$update_job                  = [];
 				$update_job['ID']            = $job->ID;
-				$update_job['post_status']   = apply_filters( 'submit_job_post_status', get_option( 'job_manager_submission_requires_approval' ) ? 'pending' : 'publish', $job );
+				$update_job['post_status']   = $should_publish_relisting ? 'publish' : apply_filters( 'submit_job_post_status', get_option( 'job_manager_submission_requires_approval' ) ? 'pending' : 'publish', $job );
 				$update_job['post_date']     = current_time( 'mysql' );
 				$update_job['post_date_gmt'] = current_time( 'mysql', 1 );
 				$update_job['post_author']   = get_current_user_id();

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -154,7 +154,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		// Load job details.
 		if ( $this->job_id ) {
 			$job_status = get_post_status( $this->job_id );
-			if ( 'expired' === $job_status ) {
+			if ( 'expired' === $job_status || job_manager_job_can_be_relisted( $this->job_id ) ) {
 				if ( ! job_manager_user_can_edit_job( $this->job_id ) ) {
 					$this->job_id = 0;
 					$this->step   = 0;

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1091,11 +1091,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				 * @param int  $job_id                   The ID of the job listing.
 				 */
 				$should_publish_relisting = $relisting && apply_filters( 'job_manager_should_publish_relisting', get_option( 'job_manager_publish_relistings' ), $job->ID );
+				$requires_approval        = get_option( 'job_manager_submission_requires_approval' );
+				$post_status              = $should_publish_relisting || ! $requires_approval ? 'publish' : 'pending';
 
 				// Update job listing.
 				$update_job                  = [];
 				$update_job['ID']            = $job->ID;
-				$update_job['post_status']   = $should_publish_relisting ? 'publish' : apply_filters( 'submit_job_post_status', get_option( 'job_manager_submission_requires_approval' ) ? 'pending' : 'publish', $job );
+				$update_job['post_status']   = apply_filters( 'submit_job_post_status', $post_status, $job, $should_publish_relisting );
 				$update_job['post_date']     = current_time( 'mysql' );
 				$update_job['post_date_gmt'] = current_time( 'mysql', 1 );
 				$update_job['post_author']   = get_current_user_id();

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -154,6 +154,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		// Load job details.
 		if ( $this->job_id ) {
 			$job_status = get_post_status( $this->job_id );
+			// Job can be edited only if expired or can be relisted.
 			if ( 'expired' === $job_status || job_manager_job_can_be_relisted( $this->job_id ) ) {
 				if ( ! job_manager_user_can_edit_job( $this->job_id ) ) {
 					$this->job_id = 0;

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -49,7 +49,7 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 								<?php if ('job_title' === $key ) : ?>
 									<?php if ( $job->post_status == 'publish' ) : ?>
 										<a href="<?php echo esc_url( get_permalink( $job->ID ) ); ?>"><?php wpjm_the_job_title( $job ); ?></a>
-										<?php if ( job_manager_job_can_be_relisted( $job ) ) : ?>
+										<?php if ( job_manager_job_can_be_extended( $job ) ) : ?>
 											<small>(<?php echo esc_html_e('Expires soon', 'wp-job-manager'); ?>)</small>
 										<?php endif; ?>
 									<?php else : ?>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -49,6 +49,9 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 								<?php if ('job_title' === $key ) : ?>
 									<?php if ( $job->post_status == 'publish' ) : ?>
 										<a href="<?php echo esc_url( get_permalink( $job->ID ) ); ?>"><?php wpjm_the_job_title( $job ); ?></a>
+										<?php if ( job_manager_job_can_be_relisted( $job ) ) : ?>
+											<small>(<?php echo __('Expires soon', 'wp-job-manager'); ?>)</small>
+										<?php endif; ?>
 									<?php else : ?>
 										<?php wpjm_the_job_title( $job ); ?> <small>(<?php the_job_status( $job ); ?>)</small>
 									<?php endif; ?>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -50,7 +50,7 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 									<?php if ( $job->post_status == 'publish' ) : ?>
 										<a href="<?php echo esc_url( get_permalink( $job->ID ) ); ?>"><?php wpjm_the_job_title( $job ); ?></a>
 										<?php if ( job_manager_job_can_be_relisted( $job ) ) : ?>
-											<small>(<?php echo __('Expires soon', 'wp-job-manager'); ?>)</small>
+											<small>(<?php echo esc_html_e('Expires soon', 'wp-job-manager'); ?>)</small>
 										<?php endif; ?>
 									<?php else : ?>
 										<?php wpjm_the_job_title( $job ); ?> <small>(<?php the_job_status( $job ); ?>)</small>

--- a/templates/job-preview.php
+++ b/templates/job-preview.php
@@ -26,7 +26,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	?>
 	<div class="job_listing_preview_title">
 		<input type="submit" name="continue" id="job_preview_submit_button" class="button job-manager-button-submit-listing" value="<?php echo esc_attr( apply_filters( 'submit_job_step_preview_submit_text', __( 'Submit Listing', 'wp-job-manager' ) ) ); ?>" />
-		<input type="submit" name="edit_job" class="button job-manager-button-edit-listing" value="<?php esc_attr_e( 'Edit listing', 'wp-job-manager' ); ?>" />
+		<?php if ( ! $form->is_extend_action() ) : ?>
+			<input type="submit" name="edit_job" class="button job-manager-button-edit-listing" value="<?php esc_attr_e( 'Edit listing', 'wp-job-manager' ); ?>" />
+		<?php endif; ?>
 		<h2><?php esc_html_e( 'Preview', 'wp-job-manager' ); ?></h2>
 	</div>
 	<div class="job_listing_preview single_job_listing">

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1461,12 +1461,14 @@ function job_manager_get_allowed_mime_types( $field = '' ) {
  *
  * @since 1.22.0
  * @since 1.35.0 Added the `$return_datetime` param.
+ * @since $$next-version$$ Added the `$from_timestamp` param.
  *
- * @param  int  $job_id          Job ID.
- * @param  bool $return_datetime Return the date time object.
+ * @param  int                    $job_id          Job ID.
+ * @param  bool                   $return_datetime Return the date time object.
+ * @param  DateTimeImmutable|null $from_timestamp The timestamp to calculate the expiry from.
  * @return string|DateTimeImmutable When `$return_datetime`, it will return either DateTimeImmutable or null.
  */
-function calculate_job_expiry( $job_id, $return_datetime = false ) {
+function calculate_job_expiry( $job_id, $return_datetime = false, $from_timestamp = null ) {
 	// Get duration from the product if set...
 	$duration = get_post_meta( $job_id, '_job_duration', true );
 
@@ -1476,7 +1478,10 @@ function calculate_job_expiry( $job_id, $return_datetime = false ) {
 	}
 
 	if ( $duration ) {
-		$new_job_expiry = current_datetime()->add( new DateInterval( 'P' . absint( $duration ) . 'D' ) );
+		if ( ! $from_timestamp ) {
+			$from_timestamp = current_datetime();
+		}
+		$new_job_expiry = $from_timestamp->add( new DateInterval( 'P' . absint( $duration ) . 'D' ) );
 
 		return $return_datetime ? WP_Job_Manager_Post_Types::instance()->prepare_job_expires_time( $new_job_expiry ) : $new_job_expiry->format( 'Y-m-d' );
 	}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1717,7 +1717,7 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
  * @return bool
  */
 function job_manager_job_can_be_relisted( $job ) {
-	$job = get_post( $job );
+	$job    = get_post( $job );
 	$status = get_post_status( $job );
 	$expiry = strtotime( get_post_meta( $job->ID, '_job_expires', true ) );
 
@@ -1735,5 +1735,5 @@ function job_manager_job_can_be_relisted( $job ) {
 	 */
 	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', 5 );
 
-	return 'publish' === $status && $expiry - current_time( 'timestamp' ) < $expiring_soon_days * DAY_IN_SECONDS;
+	return 'publish' === $status && $expiry - time() < $expiring_soon_days * DAY_IN_SECONDS;
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1703,3 +1703,32 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
 	 */
 	return apply_filters( 'job_manager_get_salary_unit_options', $options, $include_empty );
 }
+
+/**
+ * Checks if the job can be relisted. By default, this is true if the job is public and expires within 5 days.
+ *
+ * @since $$next_version$$
+ * @param int|WP_Post $job_id
+ * @return bool
+ */
+function job_manager_job_can_be_relisted( $job_id ) {
+	$job    = get_post( $job_id );
+	$status = get_post_status( $job );
+	$expiry = strtotime( get_post_meta( $job->ID, '_job_expires', true ) );
+
+	// If there is no expiry, then relisting is not necessary.
+	if ( ! $expiry ) {
+		return false;
+	}
+
+	/**
+	 * Number of days before a job expires to allow relisting it.
+	 *
+	 * @since $$next_version$$
+	 *
+	 * @param int $expiring_soon_days The default number of days.
+	 */
+	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', 5 );
+
+	return 'publish' === $status && $expiry - current_time( 'timestamp' ) < $expiring_soon_days * DAY_IN_SECONDS;
+}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1733,7 +1733,7 @@ function job_manager_job_can_be_relisted( $job ) {
 	 *
 	 * @param int $expiring_soon_days The default number of days.
 	 */
-	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', 5 );
+	$expiring_soon_days = apply_filters( 'job_manager_expiring_soon_days', get_option( 'job_manager_expiring_soon_days', 5 ) );
 
 	return 'publish' === $status && $expiry - time() < $expiring_soon_days * DAY_IN_SECONDS;
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1708,11 +1708,11 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
  * Checks if the job can be relisted. By default, this is true if the job is public and expires within 5 days.
  *
  * @since $$next_version$$
- * @param int|WP_Post $job_id
+ * @param int|WP_Post $job The job or job ID.
  * @return bool
  */
-function job_manager_job_can_be_relisted( $job_id ) {
-	$job    = get_post( $job_id );
+function job_manager_job_can_be_relisted( $job ) {
+	$job = get_post( $job );
 	$status = get_post_status( $job );
 	$expiry = strtotime( get_post_meta( $job->ID, '_job_expires', true ) );
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1716,7 +1716,7 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
  * @param int|WP_Post $job The job or job ID.
  * @return bool
  */
-function job_manager_job_can_be_relisted( $job ) {
+function job_manager_job_can_be_extended( $job ) {
 	$job    = get_post( $job );
 	$status = get_post_status( $job );
 	$expiry = strtotime( get_post_meta( $job->ID, '_job_expires', true ) );


### PR DESCRIPTION
Fixes #848

### Changes proposed in this Pull Request

* Adds the re-list link to the actions when a listing is about to expire.
* Adds 'Expires soon' label to listings that are about to expire.
* Adds an option (setting) to allow re-listed listing to be published automatically.

### Testing instructions

* Set the expiry date of a job listing to a date within 5 days from now.
* Ensure the Job Manager pages and shortcodes are set up.
* Go to the Job Dashboard page. Notice the option to Relist the job listing even though it is not expired.
* Relist the listing. The new expiry date should be calculated based on the old expiry date, not the current date.

### New/Updated Hooks

* `job_manager_expiring_soon_days`: Number of days that determine if a listing is expiring soon.
* `job_manager_should_publish_relisting`: Automatically publish relisted listings without going through approval process.


### Screenshot / Video

<img width="784" alt="Screenshot 2023-05-12 at 13 27 02" src="https://github.com/Automattic/WP-Job-Manager/assets/26160845/3832c155-b151-4ddf-a1a8-a1e2b10c35f2">


<img width="1081" alt="Screenshot 2023-05-12 at 13 28 46" src="https://github.com/Automattic/WP-Job-Manager/assets/26160845/62b0a124-3ece-44f9-9846-bed75d932ca4">


### TODO

- Make it work nicely with WC Paid Listings and Simple Paid Listings