### PR TITLE
Release/1.40.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 # WP Job Manager
 
+## 1.40.1 - 2023-05-12
+* Fix: Icons not displaying properly
+
 ## 1.40.0 - 2023-05-11
 * Enhancement: Improve licensing page experience
 * Enhancement: New email notifications setting

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 1.40.0\n"
+"Project-Id-Version: WP Job Manager 1.40.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-05-05T12:47:21+00:00\n"
+"POT-Creation-Date: 2023-05-12T20:54:38+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: wp-job-manager\n"
@@ -88,24 +88,25 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:461
-msgid "Good news, reminder to update to the latest version of WP Job Manager."
+#. translators: %s is the name of the wpjm addon to be updated.
+#: includes/admin/class-wp-job-manager-admin-notices.php:463
+msgid "Good news, reminder to update to the latest version of %s."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:465
+#: includes/admin/class-wp-job-manager-admin-notices.php:467
 msgid "View release notes"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:473
+#: includes/admin/class-wp-job-manager-admin-notices.php:475
 msgid "Good news, reminder to update these plugins to their latest versions."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:474
+#: includes/admin/class-wp-job-manager-admin-notices.php:476
 msgid "Update All"
 msgstr ""
 
 #. translators: %s is the new version number for the addon.
-#: includes/admin/class-wp-job-manager-admin-notices.php:483
+#: includes/admin/class-wp-job-manager-admin-notices.php:485
 msgid "New Version: %s"
 msgstr ""
 
@@ -225,6 +226,7 @@ msgstr ""
 msgid "%1$s updated. <a href=\"%2$s\">View</a>"
 msgstr ""
 
+#. translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 #: includes/admin/class-wp-job-manager-cpt.php:460
 msgid "Custom field updated."
 msgstr ""
@@ -342,6 +344,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
+#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/admin/class-wp-job-manager-cpt.php:652
 #: includes/class-wp-job-manager-post-types.php:341
 #: includes/class-wp-job-manager-shortcodes.php:443
@@ -1203,6 +1206,7 @@ msgstr[1] ""
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
+#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/class-wp-job-manager-data-exporter.php:51
 #: includes/class-wp-job-manager-post-types.php:358
 msgid "Company Logo"
@@ -1415,6 +1419,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
+#. translators: Placeholder %s is the plural label of the job listing post type.
 #: includes/class-wp-job-manager-post-types.php:338
 msgid "Add New"
 msgstr ""
@@ -1628,6 +1633,7 @@ msgstr ""
 msgid "Missing submission page."
 msgstr ""
 
+#. translators: Placeholder %s is the plural label for the job listing post type.
 #: includes/class-wp-job-manager-shortcodes.php:394
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:36
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:52
@@ -2423,6 +2429,7 @@ msgstr ""
 msgid "%s submitted successfully. Your listing will be visible once approved."
 msgstr ""
 
+#. translators: %1$s is the URL to view the listing; %2$s is
 #: templates/job-submitted.php:49
 msgid "  <a href=\"%1$s\"> View your %2$s</a>"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: job manager, job listing, job board, job management, job lists, job list, 
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 1.40.0
+Stable tag: 1.40.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -152,6 +152,9 @@ It then creates a database based on the parameters passed to it.
 6. Job listings in admin.
 
 == Changelog ==
+
+= 1.40.1 =
+* Fix: Icons not displaying properly
 
 = 1.40.0 =
 * Enhancement: Improve licensing page experience

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.40.0
+ * Version: 1.40.1
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.0
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.40.0' );
+define( 'JOB_MANAGER_VERSION', '1.40.1' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2415

### Changes proposed in this Pull Request

* Fix icons not displaying properly

### Testing instructions

* Run `npm run build` and use the zip generated to install to a site, make sure the Job Manager Icons show up in the backend and front end.  Example:  the menu icon on `wp-admin` and the location icon on a job posting.
