### PR TITLE
Update notice string from 'c' to 's' license spelling

### DIFF
--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -932,7 +932,7 @@ class WP_Job_Manager_Helper {
 			'message'     => sprintf(
 				wp_kses_post(
 				// translators: %1$s is the URL to the licence key page, %2$s is the plugin name.
-					__( '<a href="%1$s">Please enter your licence key</a> to get updates for "%2$s".', 'wp-job-manager' )
+					__( '<a href="%1$s">Please enter your license key</a> to get updates for "%2$s".', 'wp-job-manager' )
 				),
 				esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) ),
 				esc_html( $plugin_data['Name'] )
@@ -964,7 +964,7 @@ class WP_Job_Manager_Helper {
 			'message'     => sprintf(
 				wp_kses_post(
 				// translators: %1$s is the plugin name, %2$s is the URL to the licence key page.
-					__( 'There is a problem with the licence for "%1$s". Please <a href="%2$s">manage the licence</a> to check for a solution and continue receiving updates.', 'wp-job-manager' )
+					__( 'There is a problem with the license for "%1$s". Please <a href="%2$s">manage the license</a> to check for a solution and continue receiving updates.', 'wp-job-manager' )
 				),
 				esc_html( $plugin_data['Name'] ),
 				esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) )


### PR DESCRIPTION
### Changes proposed in this Pull Request

Two 'licence' strings were missed in #2409. This corrects the spelling from `licence` to `license`.

### Testing instructions

- Checkout branch
- Check spelling
- Just make sure everything works. It should.