### PR TITLE
Update `$company_tagline` check for PHP8+

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1090,7 +1090,7 @@ function get_the_company_website( $post = null ) {
 function the_company_tagline( $before = '', $after = '', $echo = true, $post = null ) {
 	$company_tagline = get_the_company_tagline( $post );
 
-	if ( ! $company_tagline ) {
+	if ( is_null( $company_tagline ) || 0 === strlen( $company_tagline ) ) {
 		return;
 	}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1090,7 +1090,7 @@ function get_the_company_website( $post = null ) {
 function the_company_tagline( $before = '', $after = '', $echo = true, $post = null ) {
 	$company_tagline = get_the_company_tagline( $post );
 
-	if ( 0 === strlen( $company_tagline ) ) {
+	if ( ! $company_tagline ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes # https://github.com/Automattic/WP-Job-Manager/issues/2424

### Changes proposed in this Pull Request


As of PHP8, passing `null` to `strlen()` is deprecated. The `$company_tagline` var is assigned to the output of the `get_the_company_tagline` function, which returns `null` under certain conditions.

With this change, we're checking that `$company_tagline` exists: continue if it does, but if it's `null` or doesn't exist, return early.

### Testing instructions

* Check out branch
* Create a new job listing with a company tagline
* Ensure no tagline shows if one is not present, and a tagline shows if one _is_ present
