### PR TITLE
Return all jobs in admin

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -658,7 +658,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param WP_Query $query Query being processed.
 	 */
 	public function maybe_hide_filled_expired_job_listings_from_search( $query ) {
-		if ( ! $query->is_search() ) {
+		if ( ! $query->is_search() || is_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #2423

### Changes proposed in this Pull Request

* Adds a check if we are in admin and returns all jobs in case we are

### Testing instructions

* In WPJM have some jobs that are filled or expired
* Enable the 'Hide filled positions in job archives/search' or  'Hide expired positions in job archives/search' in settings
* Search the filled/expired jobs in admin
* Observe that the jobs are returned