### PR TITLE
Allow searching multiple job locations at once

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -592,7 +592,7 @@ class WP_Job_Manager_Post_Types {
 		if ( ! empty( $input_search_location ) ) {
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
 			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = preg_split( '/"/', $input_search_location );
+			$locations          = explode( ';', $input_search_location );
 			foreach ( $locations as $location ) {
 				$location = trim( $location );
 				if ( ! empty( $location ) ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -592,12 +592,20 @@ class WP_Job_Manager_Post_Types {
 		if ( ! empty( $input_search_location ) ) {
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
 			$location_search    = [ 'relation' => 'OR' ];
-			foreach ( $location_meta_keys as $meta_key ) {
-				$location_search[] = [
-					'key'     => $meta_key,
-					'value'   => $input_search_location,
-					'compare' => 'like',
-				];
+			$locations          = preg_split( '/"/', $args['search_location'] );
+			foreach ( $locations as $location ) {
+				$location = trim( $location );
+				if ( ! empty( $location ) ) {
+					$location_subquery = [ 'relation' => 'OR' ];
+					foreach ( $location_meta_keys as $meta_key ) {
+						$location_subquery[] = [
+							'key'     => $meta_key,
+							'value'   => $location,
+							'compare' => 'like',
+						];
+					}
+					$location_search[] = $location_subquery;
+				}
 			}
 			$query_args['meta_query'][] = $location_search;
 		}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -592,7 +592,7 @@ class WP_Job_Manager_Post_Types {
 		if ( ! empty( $input_search_location ) ) {
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
 			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = preg_split( '/"/', $args['search_location'] );
+			$locations          = preg_split( '/"/', $input_search_location );
 			foreach ( $locations as $location ) {
 				$location = trim( $location );
 				if ( ! empty( $location ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -98,7 +98,8 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		if ( ! empty( $args['search_location'] ) ) {
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
 			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = preg_split( '/"/', $args['search_location'] );
+			$locations          = explode( ';', $args['search_location'] );
+
 			foreach ( $locations as $location ) {
 				$location = trim( $location );
 				if ( ! empty( $location ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -98,18 +98,20 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		if ( ! empty( $args['search_location'] ) ) {
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
 			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = explode( ',', $args['search_location'] );
+			$locations          = preg_split( '/"/', $args['search_location'] );
 			foreach ( $locations as $location ) {
-				$location          = trim( $location );
-				$location_subquery = [ 'relation' => 'OR' ];
-				foreach ( $location_meta_keys as $meta_key ) {
-					$location_subquery[] = [
-						'key'     => $meta_key,
-						'value'   => $location,
-						'compare' => 'like',
-					];
+				$location = trim( $location );
+				if ( ! empty( $location ) ) {
+					$location_subquery = [ 'relation' => 'OR' ];
+					foreach ( $location_meta_keys as $meta_key ) {
+						$location_subquery[] = [
+							'key'     => $meta_key,
+							'value'   => $location,
+							'compare' => 'like',
+						];
+					}
+					$location_search[] = $location_subquery;
 				}
-				$location_search[] = $location_subquery;
 			}
 
 			if ( $remote_position_search ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -98,12 +98,18 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		if ( ! empty( $args['search_location'] ) ) {
 			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
 			$location_search    = [ 'relation' => 'OR' ];
-			foreach ( $location_meta_keys as $meta_key ) {
-				$location_search[] = [
-					'key'     => $meta_key,
-					'value'   => $args['search_location'],
-					'compare' => 'like',
-				];
+			$locations          = explode( ',', $args['search_location'] );
+			foreach ( $locations as $location ) {
+				$location          = trim( $location );
+				$location_subquery = [ 'relation' => 'OR' ];
+				foreach ( $location_meta_keys as $meta_key ) {
+					$location_subquery[] = [
+						'key'     => $meta_key,
+						'value'   => $location,
+						'compare' => 'like',
+					];
+				}
+				$location_search[] = $location_subquery;
 			}
 
 			if ( $remote_position_search ) {


### PR DESCRIPTION
Fixes #2373

### Changes proposed in this Pull Request

This change allows a job searcher to input multiple locations in a semi-colon-delimited list, where spaces are stripped, so "London;Denver" works, as does "London; Denver".

This change impacts any functionality that uses the `get_job_listings()` function, like the Job dashboard (frontend), Job widget, etc.

### Testing instructions

* Checkout branch
* Search for multiple job listings, single job listings, etc
* Look out for any performance issues. In my local environment, I used [`wp post generate`](https://developer.wordpress.org/cli/commands/post/generate/) to generate 1,100 job entries.

### Screenshot / Video

![Screen Recording 2023-05-26 at 01 17 37 pm](https://github.com/Automattic/WP-Job-Manager/assets/2500940/8caeaff9-91af-470f-ae7c-84895b77088f)

### Documentation changes

This change introduces new functionality in WPJM core. The following KB URL will need an update to mention this new functionality:

- [ ] https://wpjobmanager.com/document/understanding-job-and-resume-search/

The section **Search by Location** needs additional explanatory text, which I think works best as a third paragraph:

> **_Search by Location_**
>
> This field works similarly to the Keywords search but only searches the information provided in the Location field of the Job Listing post.
> 
>  This field also acts as a filter to shortlist the results from the Keyword search. For example, If you search for “iOS Developer”, and Location “New York” then the page will show all the active job listings marching iOS or Developer or iOS Developer & New York as the location.
> 
> [New paragraph]
> 
> Multiple locations can be searched at once using a semi-colon delimited list. For example, if you wanted to search for positions available in "London, UK" and "New York, USA" at the same time, you would use `London, UK; New York, USA`. 