### PR TITLE
Remove custom config for Webpack loaders

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
-const path = require( 'path' );
+const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const path = require('path');
 
 const files = {
 	'js/admin': 'js/admin.js',
@@ -23,27 +23,14 @@ const files = {
 
 const baseDist = 'assets/dist/';
 
-Object.keys( files ).forEach( function ( key ) {
-	files[ key ] = path.resolve( './assets', files[ key ] );
-} );
-
-const FileLoader = {
-	test: /\.(?:gif|jpg|jpeg|png|svg|woff|woff2|eot|ttf|otf)$/i,
-	loader: 'file-loader',
-	options: {
-		name: '[path][name]-[contenthash].[ext]',
-		context: 'assets',
-		publicPath: '..',
-	},
-};
+Object.keys(files).forEach(function (key) {
+	files[key] = path.resolve('./assets', files[key]);
+});
 
 module.exports = {
 	...defaultConfig,
 	entry: files,
 	output: {
-		path: path.resolve( '.', baseDist ),
-	},
-	module: {
-		rules: [ FileLoader, ...defaultConfig.module.rules.slice(0, 4) ],
+		path: path.resolve('.', baseDist),
 	},
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

* @gkaragia  realized an issue while building the package for the [last release](https://github.com/Automattic/WP-Job-Manager/releases/tag/1.40.2) that it wasn't importing the fonts correctly.
  * I built it in my env (without running a new `npm install`) and it worked, we saved the package for the plugin release.
  * After running `npm install` I started seeing the same problem.
  * @gkaragia noticed that it happened after [updating the `@wordpress/scripts`](https://github.com/Automattic/WP-Job-Manager/pull/2389/files) (which was a big jump).
* So after an investigation, I fixed it by removing our custom config for Webpack loaders, which was probably fixing something for old versions.

### Testing instructions

* Build the plugin, and make sure no errors happen.
* Install it on a WordPress site.
* Make sure the fonts are working (an example is the Job Manager icon in WP Admin).
* Make sure the `gif` file is working (On the jobs page, when you filter, a spinner should be displayed).
* As a bonus, you could download the last release package, and compare to see if you see any problem with the new package.