### PR TITLE
Add methods to hide filled and expired posts

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -722,11 +722,10 @@ class WP_Job_Manager_Post_Types {
 	 * @return void
 	 */
 	public function maybe_hide_filled_expired_job_listings_from_search( WP_Query $query ): void {
-		if ( ! get_option( 'job_manager_hide_filled_positions' ) ) {
-			return;
-		}
+		$hide_filled_positions = get_option( 'job_manager_hide_filled_positions' );
+		$hide_expired          = get_option( 'job_manager_hide_expired' );
 
-		if ( ! get_option( 'job_manager_hide_expired' ) ) {
+		if ( ! $hide_filled_positions && ! $hide_expired ) {
 			return;
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -723,32 +723,6 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Hide expired listings from the search results.
-	 *
-	 * @param array $listings
-	 *
-	 * @return array
-	 */
-	public function hide_expired( $listings ) {
-
-		// Get all expired listings.
-		$expired_listings = get_posts(
-			[
-				'post_type'   => 'job_listing',
-				'post_status' => 'expired',
-			]
-		);
-
-		// Remove expired listings from the search results.
-		foreach ( $expired_listings as $listing ) {
-			unset( $listings[ $listing->ID ] );
-		}
-
-		return $listings;
-
-	}
-
-	/**
 	 * Adds query arguments in order to make sure that the feed properly queries the 'job_listing' type.
 	 *
 	 * @param WP_Query $wp

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -401,9 +401,9 @@ class WP_Job_Manager_Post_Types {
 		 * This will also address historical issues stemming from addressing the issue raised here
 		 * https://github.com/Automattic/WP-Job-Manager/issues/1884.
 		 */
-		$is_site_search        = ( isset( $_GET['s'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_expired_searchable = (bool) get_option( 'job_manager_hide_expired' );
-		$is_expired_public     = ! $is_site_search || ! $is_expired_searchable;
+		$is_site_search    = ( isset( $_GET['s'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_expired_hidden = (bool) get_option( 'job_manager_hide_expired' );
+		$is_expired_public = ! $is_site_search || ! $is_expired_hidden;
 
 		/**
 		 * Post status

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -674,6 +674,7 @@ class WP_Job_Manager_Post_Types {
 		if ( false === $filled_jobs_transient ) {
 			$filled_jobs_transient = get_posts(
 				[
+					'post_status'    => 'publish',
 					'post_type'      => 'job_listing',
 					'fields'         => 'ids',
 					'posts_per_page' => -1,

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -729,7 +729,14 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
-		if ( ! is_admin() && $query->is_search() ) {
+		if (
+			! is_admin()
+			&& $query->is_main_query()
+			&& 'job_listing' === $query->get( 'post_type' )
+			&& $query->is_search()
+			|| $query->is_archive()
+		) {
+
 			$jobs_to_exclude = array_merge( $this->get_filled_job_listings(), $this->get_expired_job_listings() );
 			if ( ! empty( $jobs_to_exclude ) ) {
 				$query->set( 'post__not_in', $jobs_to_exclude );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -81,6 +81,7 @@ class WP_Job_Manager_Post_Types {
 		add_filter( 'wp_insert_post_data', [ $this, 'fix_post_name' ], 10, 2 );
 		add_action( 'add_post_meta', [ $this, 'maybe_add_geolocation_data' ], 10, 3 );
 		add_action( 'update_post_meta', [ $this, 'update_post_meta' ], 10, 4 );
+		add_action( 'updated_post_meta', [ $this, 'delete_filled_job_listing_transient' ], 10, 4 );
 		add_action( 'wp_insert_post', [ $this, 'maybe_add_default_meta_data' ], 10, 2 );
 		add_filter( 'post_types_to_delete_with_user', [ $this, 'delete_user_add_job_listings_post_type' ] );
 
@@ -1958,4 +1959,22 @@ class WP_Job_Manager_Post_Types {
 		return $types;
 	}
 
+	/**
+	 * Delete the 'job_manager_hide_filled_jobs' transient when meta is updated.
+	 *
+	 * @param int    $meta_id    ID of updated metadata entry.
+	 * @param int    $object_id  ID of the object metadata is for.
+	 * @param string $meta_key   Metadata key.
+	 * @param mixed  $_meta_value Metadata value. This will be a PHP-serialized string representation of the value if the value is an array, an object, or itself a PHP-serialized string.
+	 *
+	 * @return void
+	 */
+	public function delete_filled_job_listing_transient( $meta_id, $object_id, $meta_key, $_meta_value ) {
+
+		if ( '_edit_lock' !== $meta_key || 'job_listing' !== get_post_type( $object_id ) ) {
+			return;
+		}
+
+		delete_transient( 'hide_filled_jobs_transient' );
+	}
 }

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -705,6 +705,18 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
+		/**
+		 * We want to ensure this only runs when: (1) not in admin and (2) the query is the main query and (3) the query
+		 * is either a search query or an archive query. This is to address complications stemming from the following
+		 * feature request: https://github.com/Automattic/WP-Job-Manager/issues/1884
+		 *
+		 * See also:
+		 *
+		 * https://github.com/Automattic/WP-Job-Manager/pull/1570
+		 * https://github.com/Automattic/WP-Job-Manager/pull/2367
+		 * https://github.com/Automattic/WP-Job-Manager/issues/2423
+		 */
+
 		if (
 			! is_admin()
 			&& $query->is_main_query()
@@ -728,6 +740,11 @@ class WP_Job_Manager_Post_Types {
 		if ( ! $hide_expired ) {
 			return;
 		}
+
+		/**
+		 * We want to ensure this only runs when: (1) not in admin and (2) the query is the main query and (3) the query.
+		 * See the comment in the maybe_hide_filled_job_listings() method for more information.
+		 */
 
 		if (
 			! is_admin()

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -681,9 +681,6 @@ class WP_Job_Manager_Post_Types {
 	 * @return array Array of filled job listing post IDs.
 	 */
 	public function get_filled_job_listings(): array {
-		if ( ! get_option( 'job_manager_hide_filled_positions' ) ) {
-			return [];
-		}
 
 		$filled_jobs_transient = get_transient( 'hide_filled_jobs_transient' );
 		if ( false === $filled_jobs_transient ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -87,7 +87,7 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'transition_post_status', [ $this, 'track_job_submission' ], 10, 3 );
 
 		add_action( 'parse_query', [ $this, 'add_feed_query_args' ] );
-		add_action( 'pre_get_posts', [ $this, 'maybe_hide_filled_expired_job_listings_from_search' ] );
+		add_action( 'pre_get_posts', [ $this, 'maybe_hide_filled_job_listings_from_search' ] );
 
 		// Single job content.
 		$this->job_content_filter( true );
@@ -391,13 +391,28 @@ class WP_Job_Manager_Post_Types {
 		add_feed( self::get_job_feed_name(), [ $this, 'job_feed' ] );
 
 		/**
+		 * This code checks if (1) we're on a search or (2) the option to hide expired job listings is enabled.
+		 * If either condition is false, we're going to set the register_post_status() 'public' arg to false,
+		 * otherwise it will be true.
+		 *
+		 * This will prevent single expired job listings from showing a '404', instead of an
+		 * 'Expired' notice, when viewing the single job listing and not logged in.
+		 *
+		 * This will also address historical issues stemming from addressing the issue raised here
+		 * https://github.com/Automattic/wpjobmanager.com/issues/420.
+		 */
+		$is_site_search        = ( isset( $_GET['s'] ) );
+		$is_expired_searchable = (bool) get_option( 'job_manager_hide_expired' );
+		$is_expired_public     = ! $is_site_search || ! $is_expired_searchable;
+
+		/**
 		 * Post status
 		 */
 		register_post_status(
 			'expired',
 			[
 				'label'                     => _x( 'Expired', 'post status', 'wp-job-manager' ),
-				'public'                    => true,
+				'public'                    => $is_expired_public,
 				'protected'                 => true,
 				'exclude_from_search'       => true,
 				'show_in_admin_all_list'    => true,
@@ -699,28 +714,20 @@ class WP_Job_Manager_Post_Types {
 	 *
 	 * @return void
 	 */
-	public function maybe_hide_filled_expired_job_listings_from_search( WP_Query $query ): void {
+	public function maybe_hide_filled_job_listings_from_search( WP_Query $query ): void {
 		$hide_filled_positions = get_option( 'job_manager_hide_filled_positions' );
-		$hide_expired          = get_option( 'job_manager_hide_expired' );
 
-		if ( ! $hide_filled_positions && ! $hide_expired ) {
+		if ( ! $hide_filled_positions ) {
 			return;
 		}
 
 		if (
 			! is_admin()
 			&& $query->is_main_query()
-			&& $query->is_search()
-			|| $query->is_archive() && 'job_listing' === $query->get( 'post_type' )
+			&& ( $query->is_search() || $query->is_archive() )
 		) {
 
-			if ( $hide_expired ) {
-				$query->set( 'post_status', 'publish' );
-			}
-
-			if ( $hide_filled_positions ) {
-				$query->set( 'post__not_in', $this->get_filled_job_listings() );
-			}
+			$query->set( 'post__not_in', $this->get_filled_job_listings() );
 		}
 	}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -695,7 +695,7 @@ class WP_Job_Manager_Post_Types {
 	 *
 	 * @return array
 	 */
-	public function get_expired_jobs_listings(): array {
+	public function get_expired_job_listings(): array {
 		if ( ! get_option( 'job_manager_hide_expired' ) ) {
 			return [];
 		}
@@ -731,7 +731,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		if ( ! is_admin() && $query->is_search() ) {
-			$jobs_to_exclude = array_merge( $this->get_filled_job_listings(), $this->get_expired_jobs_listings() );
+			$jobs_to_exclude = array_merge( $this->get_filled_job_listings(), $this->get_expired_job_listings() );
 			if ( ! empty( $jobs_to_exclude ) ) {
 				$query->set( 'post__not_in', $jobs_to_exclude );
 			}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -399,7 +399,7 @@ class WP_Job_Manager_Post_Types {
 		 * 'Expired' notice, when viewing the single job listing and not logged in.
 		 *
 		 * This will also address historical issues stemming from addressing the issue raised here
-		 * https://github.com/Automattic/wpjobmanager.com/issues/420.
+		 * https://github.com/Automattic/WP-Job-Manager/issues/1884.
 		 */
 		$is_site_search        = ( isset( $_GET['s'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$is_expired_searchable = (bool) get_option( 'job_manager_hide_expired' );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -732,7 +732,6 @@ class WP_Job_Manager_Post_Types {
 		if (
 			! is_admin()
 			&& $query->is_main_query()
-			&& 'job_listing' === $query->get( 'post_type' )
 			&& $query->is_search()
 			|| $query->is_archive()
 		) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -676,9 +676,9 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
-	 * Get filled jobs.
+	 * Retrieve and return the post IDs of any job listings marked as filled.
 	 *
-	 * @return array
+	 * @return array Array of filled job listing post IDs.
 	 */
 	public function get_filled_job_listings(): array {
 		if ( ! get_option( 'job_manager_hide_filled_positions' ) ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -401,7 +401,7 @@ class WP_Job_Manager_Post_Types {
 		 * This will also address historical issues stemming from addressing the issue raised here
 		 * https://github.com/Automattic/wpjobmanager.com/issues/420.
 		 */
-		$is_site_search        = ( isset( $_GET['s'] ) );
+		$is_site_search        = ( isset( $_GET['s'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$is_expired_searchable = (bool) get_option( 'job_manager_hide_expired' );
 		$is_expired_public     = ! $is_site_search || ! $is_expired_searchable;
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1719,7 +1719,7 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
  * @param int     $post_id  The ID of the post being saved.
  * @param WP_Post $post The post object being saved.
  */
-function delete_job_listings_transients_on_save( int $post_id, WP_Post $post ): void {
+function delete_filled_job_listing_transient_on_post_meta_update( int $post_id, WP_Post $post ): void {
 
 	if ( 'job_listing' === $post->post_type ) {
 
@@ -1729,4 +1729,4 @@ function delete_job_listings_transients_on_save( int $post_id, WP_Post $post ): 
 	}
 
 }
-add_action( 'save_post', 'delete_job_listings_transients_on_save', 10, 2 );
+add_action( 'update_post_meta', 'delete_filled_job_listing_transient_on_post_meta_update', 10, 2 );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1727,7 +1727,7 @@ function delete_job_listings_transients_on_save( int $post_id, WP_Post $post ): 
 			delete_transient( 'hide_filled_jobs_transient' );
 		}
 
-		$post_status = [ 'publish', 'expired' ];
+		$post_status = [ 'publish', 'expired', 'trash' ];
 		if ( in_array( $post->post_status, $post_status, true ) ) {
 			delete_transient( 'hide_expired_jobs_transient' );
 		}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1712,21 +1712,3 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
 	 */
 	return apply_filters( 'job_manager_get_salary_unit_options', $options, $include_empty );
 }
-
-/**
- * Delete filled_jobs_transient and expired_jobs_transient transients when a job listing is saved or updated.
- *
- * @param int     $post_id  The ID of the post being saved.
- * @param WP_Post $post The post object being saved.
- */
-function delete_filled_job_listing_transient_on_post_meta_update( int $post_id, WP_Post $post ): void {
-
-	if ( 'job_listing' === $post->post_type ) {
-
-		if ( '1' === get_post_meta( $post_id, '_filled', true ) ) {
-			delete_transient( 'hide_filled_jobs_transient' );
-		}
-	}
-
-}
-add_action( 'save_post', 'delete_filled_job_listing_transient_on_post_meta_update', 10, 2 );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1726,11 +1726,6 @@ function delete_job_listings_transients_on_save( int $post_id, WP_Post $post ): 
 		if ( '1' === get_post_meta( $post_id, '_filled', true ) ) {
 			delete_transient( 'hide_filled_jobs_transient' );
 		}
-
-		$post_status = [ 'publish', 'expired', 'trash' ];
-		if ( in_array( $post->post_status, $post_status, true ) ) {
-			delete_transient( 'hide_expired_jobs_transient' );
-		}
 	}
 
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1712,3 +1712,26 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
 	 */
 	return apply_filters( 'job_manager_get_salary_unit_options', $options, $include_empty );
 }
+
+/**
+ * Delete filled_jobs_transient and expired_jobs_transient transients when a job listing is saved or updated.
+ *
+ * @param int     $post_id  The ID of the post being saved.
+ * @param WP_Post $post The post object being saved.
+ */
+function delete_job_listings_transients_on_save( int $post_id, WP_Post $post ): void {
+
+	if ( 'job_listing' === $post->post_type ) {
+
+		if ( '1' === get_post_meta( $post_id, '_filled', true ) ) {
+			delete_transient( 'hide_filled_jobs_transient' );
+		}
+
+		$post_status = [ 'publish', 'expired' ];
+		if ( in_array( $post->post_status, $post_status, true ) ) {
+			delete_transient( 'hide_expired_jobs_transient' );
+		}
+	}
+
+}
+add_action( 'save_post', 'delete_job_listings_transients_on_save', 10, 2 );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1729,4 +1729,4 @@ function delete_filled_job_listing_transient_on_post_meta_update( int $post_id, 
 	}
 
 }
-add_action( 'update_post_meta', 'delete_filled_job_listing_transient_on_post_meta_update', 10, 2 );
+add_action( 'save_post', 'delete_filled_job_listing_transient_on_post_meta_update', 10, 2 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/1884

### Changes proposed in this Pull Request

* Adds three new methods: (1) `get_filled_job_listings()`, (2), `get_expired_job_listings` and (3) `maybe_hide_filled_expired_job_listings_from_search`
* The first two methods only run if the "Hide Filled Jobs" or "Hide Expired Jobs" options are enabled. If they aren't, an empty array is returned.
* The third method returns early if the "Hide Filled Jobs" and "Hide Expired Jobs" options are disabled. If they aren't, a `post__not_in` parameter is applied to `$query->set` when **not** in WP Admin, and when on a WP search results page.

Unlike the previous implementation, this one relies on `get_posts()` and `meta_query` but without the expensive `OR` relation.

Because `expired` jobs already have their post status updated to `expired` if a post's expiry date is set in the past or elapses, we don't need to `meta_query` for expired posts but can instead look for `job_listings` with an `expired` post status.

We don't have the same luxury with `filled` posts, but we can do a singular `meta_query` without any relations to retrieve these.

My understanding is that these changes should be far less expensive than the previous implementation.

To further help with performance, the results of `get_filled_job_listings` and `get_expired_job_listings` are stored in a transient that is expired every 24 hours, which lines up with the various [job expiration methods](https://github.com/Automattic/WP-Job-Manager/blob/acb96b9e0ff499338f144732519f6d51b1a4dbca/includes/class-wp-job-manager-post-types.php#L1018).

Either transient is then cleared on post update if: (1) we're looking at a job listing, (2) the '_filled' post meta has been updated, or (3) the post status has changed from `publish` to `expired`, `trash` or vice-versa.

### Testing instructions

* Check out branch
* Create a few job posts, setting one or some to `Expired` with an expiry date in the past, or `Filled` by checking the `Filled` checkbox.
* Check transients to ensure `hide_filled_jobs_transient` and `hide_expired_jobs_transient` is not set. With WP CLI these can be checked with `wp transient get hide_filled_jobs_transient` and `wp transient get hide_expired_jobs_transient`
* Navigate to **Job Listings --> Settings --> Job Listings** and enable (as desired), the **Hide Filled Positions** and **Hide expired listings in your job archives/search** options
* Check your transient again, which should now be populated with the post IDs of the posts you marked as `expired` or `filled`
* Check WP Search results to make sure these posts, and only these posts, are excluded

If you would like to test on a large dataset, WP CLI can be used to bulk create posts:

**Bulk create `Expired` posts**

```
wp post generate --count=1000 --post_type=job_listing --post_status=expired
```

**Bulk generate `Filled` posts**

`Filled` posts are a little more troublesome because we're working with meta values, and `wp post generate`, as well as `wp post create`, do not touch these values.

So, you could do something like:

```
# generate our posts
wp post generate --count=1000 --post_type=job_listing --post_status=publish

# grab the IDs of some arbitrary number of posts, say, 100, and update the post meta
for post_id in $(wp post list --post_type=job_listing --post_status=publish --numberposts=100 --fields=ID); do
    wp post meta update \
        $post_id \
        _filled \
        1 \
       && echo "Post ID $post_id changed"
done
```

The above can be added to a file on your environment, like `create-filled-posts.sh`. Make sure to `chmod +x $file` and then `./$file.sh` to execute the `for` loop and create your posts.

**Note** that when creating posts programmatically you may need to manually clear the transients.