### PR TITLE
Add schema for promoted-jobs (including Swagger setup).

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - trunk
-      - add/* # Temporary addition for testing.
+      - workflow_dispatch
 
 jobs:
   deploy:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,26 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - trunk
+      - add/* # Temporary addition for testing.
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+      - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: swagger-ui
+          spec-file: ./docs/api/internal.json
+          version: "^4.18.0"
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: swagger-ui
+          destination_dir: api/internal

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,9 @@
+API docs
+========
+This folder contains documentation for our publicly exposed APIs.
+
+## Internal APIs
+We consider that an API is _internal_ when it is not expected to be used by any third-party. We will not provide any
+support for these APIs, and they are subject to change **without any previous warning**.
+- [OpenAPI spec](internal.json)
+- [Swagger UI](https://automattic.github.io/wp-job-manager/api/internal/)

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -91,6 +91,10 @@
                               "temporary",
                               "other"
                             ]
+                          },
+                          "salary":  {
+                            "type": "string",
+                            "example": "$50,000 - $100,000"
                           }
                         }
                       }

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -1,0 +1,108 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "WP Job Manager APIs (internal)",
+    "version": "1.0",
+    "description": "Internal WP Job Manager endpoints. These endpoints are not subject to any backwards compatibility guarantees. They may change at any time without warning since are considered as internal APIs.",
+    "contact": {
+      "name": "WPJobManager",
+      "url": "https://wpjobmanager.com/"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://wpjm.local"
+    }
+  ],
+  "tags": [
+    {
+      "name": "promoted-jobs"
+    }
+  ],
+  "paths": {
+    "/wp-json/wpjm-internal/v1/promoted-jobs": {
+      "get": {
+        "summary": "Promoted Jobs - Get list of promoted jobs",
+        "description": "Get promoted jobs list",
+        "operationId": "get-promotedjobs-list",
+        "tags": [
+          "promoted-jobs"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "description": "application/json"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jobs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "example": "9788656",
+                            "description": "The unique identifier for the job in the site (post ID)."
+                          },
+                          "title": {
+                            "type": "string",
+                            "example": "Senior Software Engineer"
+                          },
+                          "description": {
+                            "type": "string",
+                            "example": "We are looking for a Senior Software Engineer to join our team."
+                          },
+                          "permalink": {
+                            "type": "string",
+                            "example": "https://wpjm.local/job/senior-software-engineer/"
+                          },
+                          "location": {
+                            "type": "string",
+                            "example": "New York, NY, USA"
+                          },
+                          "company_name": {
+                            "type": "string",
+                            "example": "ACME Inc."
+                          },
+                          "is_remote":  {
+                            "type": "boolean",
+                            "example": false
+                          },
+                          "job_type":  {
+                            "type": "string",
+                            "enum": [
+                              "freelance",
+                              "full-time",
+                              "internship",
+                              "part-time",
+                              "temporary",
+                              "other"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": []
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2436 

### Changes proposed in this Pull Request
* Added GH Workflow to generate Swagger UI and publish under Github Pages.
* Added swagger file for internal API including the `/wp-json/wpjm-internal/v1/promoted-jobs` endpoint.
* Added README to `docs/api/`.

### Testing instructions
* Check the Github Pages: https://automattic.github.io/WP-Job-Manager/api/internal/
* Alternatively, download the OpenAPI specification and check it on https://editor.swagger.io/ (for example)
