### PR TITLE
Fix Pending Payment

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -469,7 +469,6 @@ class WP_Job_Manager_Shortcodes {
 					];
 				}
 				break;
-			case 'pending_payment':
 			case 'pending':
 				if ( WP_Job_Manager_Post_Types::job_is_editable( $job->ID ) ) {
 					$actions['edit'] = [
@@ -478,6 +477,7 @@ class WP_Job_Manager_Shortcodes {
 					];
 				}
 				break;
+			case 'pending_payment':
 			case 'draft':
 			case 'preview':
 				$actions['continue'] = [


### PR DESCRIPTION
Fixes #https://github.com/Automattic/wpjm-addons/issues/210

This issue really affects paid listings extensions but the fix has to be here in core. There was a partial fix [here](https://github.com/Automattic/wp-job-manager-wc-paid-listings/pull/176).

### Changes proposed in this Pull Request

* Enable 'Continue Submission' when job status is `pending_payment`.

### Testing instructions

* Create a new Job Listing
* Enter job details and click on [Preview]
* Choose a package
* Do not proceed, go back to jobs dashboard.
* Check to see that the new job is listed as `pending_payment` and there's a 'Continue Submission' link on hover.

### Some Thoughts
There's a suggestion to change pending payments back to draft in [this comment](https://github.com/Automattic/WP-Job-Manager/pull/2141/files#r622625262) but I think this solution covers it.