### PR TITLE
Make forms responsive

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -256,6 +256,17 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 	.spinner.is-active {
 		visibility: visible;
 	}
+@media screen and (max-width: 782px) {
+
+	.job-manager-form fieldset label:not(.full-line-checkbox-field label) {
+		width: 100%;
+		float: none;
+	}
+
+	.job-manager-form fieldset div.field:not(.full-line-checkbox-field) {
+		width: 100%;
+		float: none;
+	}
 }
 
 div.job_listings {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -124,6 +124,9 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 				font-size: 0.83em;
 			}
 		}
+		.full-line-checkbox-field label {
+			display: inline-block;
+		}
 
 		div.field:not(.full-line-checkbox-field) {
 			width: 70%;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -256,6 +256,35 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 	.spinner.is-active {
 		visibility: visible;
 	}
+
+	.select2-container
+	{
+		font-size: 1rem;
+
+		input.select2-search__field {
+			width: 100% !important;
+			height: unset;
+		}
+		.select2-selection--multiple .select2-selection__rendered {
+			display: block;
+			padding: 0;
+
+			li {
+				margin: 5px;
+			}
+
+			input {
+				padding: 0 5px;
+			}
+		}
+	}
+}
+
+.select2-container .select2-dropdown {
+	font-size: 1rem;
+}
+
+
 @media screen and (max-width: 782px) {
 
 	.job-manager-form fieldset label:not(.full-line-checkbox-field label) {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -44,7 +44,7 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 .job-manager-error,
 .job-manager-info {
 	padding: 1em 2em 1em 3.5em !important;
-	margin: 0 0 2em !important;
+	margin-bottom: 2em;
 	position: relative;
 	background-color: lighten($secondary, 5%);
 	color: $secondarytext;


### PR DESCRIPTION
Fixes 84-gh-Automattic/wp-job-manager-alerts

While the original report was for the alerts plugin, the styling is provided by the core plugin, and also applies to other forms, like job submission.

### Changes proposed in this Pull Request

* Break labels and inputs into two lines on mobile
* Improve spacing for select2 dropdowns
* Fix notices on themes using auto-margins 

### Testing instructions

* Open the Post a Job form in a mobile screen size
* Check that labels and fields are in one column

### Screenshot / Video

<img width=50% src=https://github.com/Automattic/WP-Job-Manager/assets/176949/792f25e5-3b7e-44b4-8778-76b528670c7e />