### PR TITLE
Always show search actions

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -186,7 +186,7 @@ class WP_Job_Manager_Ajax {
 			'max_num_pages' => $jobs->max_num_pages,
 		];
 
-		if ( $jobs->post_count && ( $search_location || $search_keywords || $search_categories || $job_types_filtered ) ) {
+		if ( ( $search_location || $search_keywords || $search_categories || $job_types_filtered ) ) {
 			// translators: Placeholder %d is the number of found search results.
 			$message               = sprintf( _n( 'Search completed. Found %d matching record.', 'Search completed. Found %d matching records.', $jobs->found_posts, 'wp-job-manager' ), $jobs->found_posts );
 			$result['showing_all'] = true;


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/1749

### Changes proposed in this Pull Request

* Show the links below search even when there are no results, since they are useful in that case too.

### Testing instructions

* Search for jobs
* Check that the links for RSS and Reset are there even if there are 0 results.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![image](https://github.com/Automattic/WP-Job-Manager/assets/176949/04a0bed3-3174-4e78-98e0-463aadd39924)

