### PR TITLE
Trigger search when submitting search form

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -457,14 +457,16 @@ jQuery( document ).ready( function( $ ) {
 			} );
 		} );
 
+	function triggerSearch() {
+		var $target = $( this ).closest( 'div.job_listings' );
+		$target.triggerHandler( 'update_results', [ 1, false ] );
+		store_state( $target );
+	}
+
 	$(
 		'#search_keywords, #search_location, #remote_position, .job_types :input, #search_categories, .job-manager-filter'
 	)
-		.change( function() {
-			var $target = $( this ).closest( 'div.job_listings' );
-			$target.triggerHandler( 'update_results', [ 1, false ] );
-			store_state( $target );
-		} )
+		.change( triggerSearch )
 		.on( 'keyup', function( e ) {
 			if ( e.which === 13 ) {
 				$( this ).trigger( 'change' );
@@ -504,6 +506,7 @@ jQuery( document ).ready( function( $ ) {
 			return false;
 		} )
 		.on( 'submit', function() {
+			triggerSearch();
 			return false;
 		} );
 

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -506,7 +506,16 @@ jQuery( document ).ready( function( $ ) {
 			return false;
 		} )
 		.on( 'submit', function() {
-			triggerSearch();
+			// Find the index of the closes job_listings. This will always be 0 if only one job_listings element exists
+			// on the page.
+			var $closestListings = $( this ).closest( 'div.job_listings' );
+			var index = $( 'div.job_listings' ).index( $closestListings );
+
+			// Check if there isn't an ongoing search before triggering a new search.
+			if ( xhr[ index ] && [ 0, 4 ].indexOf( xhr[ index ].readyState ) !== -1 ) {
+				triggerSearch.call( this );
+			}
+
 			return false;
 		} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2304

### Changes proposed in this Pull Request

* When using AJAX search, which submits the search whenever an input changes, also do the search when clicking the 'Search Jobs' button

### Testing instructions

* Go to the Jobs page and use the search form

### Notes

There is a bit of trade-off here. The search so far triggers on `change` events, which occurs when unfocusing an input. And that happens when the users moves to click the submit button. So in most cases the search would happen anyway. And in fact, with this change, the search request is duplicated, because both the change event and the submit event triggers it. 

The code cancels the ongoing search request when a new one is issued, but in this case it might make more sense to only trigger the search on submit when it's not already going on?
