### PR TITLE
Add/promoted jobs cta

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -17,6 +17,92 @@ a.wpjm-activate-licence-link:active {
 	color: orangered;
 }
 
+/** Promote Job Modal **/
+promote-job-modal {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	padding: 30px 80px 50px 80px;
+	img {
+		width: 100%;
+	}
+	h2 {
+		font-size: 36px;
+		font-weight: 300;
+		line-height: 105%;
+		margin-top: 0;
+		width: 80%;
+		margin-bottom: 0px;
+	}
+	.column-left{
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+
+		button {
+			padding: 16px 10px;
+		}
+	}
+	ul {
+		margin: 24px 0;
+	}
+	li {
+		background: url("data:image/svg+xml,<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><mask id=\"mask0_20018663_2259\" style=\"mask-type:luminance\" maskUnits=\"userSpaceOnUse\" x=\"3\" y=\"5\" width=\"18\" height=\"14\"><path d=\"M8.75685 15.9L4.57746 11.7L3.18433 13.1L8.75685 18.7L20.698 6.69999L19.3049 5.29999L8.75685 15.9Z\" fill=\"white\"/></mask><g mask=\"url%28%23mask0_20018663_2259%29\"><rect width=\"23.8823\" height=\"24\" fill=\"%232270B1\"/></g></svg>") no-repeat 0 -3px;
+		font-size: 14px;
+		list-style: none;
+		padding-left: 28px;
+	}
+	.price {
+		font-size: 12px;
+		display: flex;
+		flex-direction: column;
+		span {
+			margin-top: 10px;
+			font-size: 36px;
+			font-weight: 700;
+		}
+	}
+	.promote-buttons-group {
+		.button {
+			padding: 5px 16px;
+			margin-right: 18px;
+		}
+		.button-secondary {
+			background: #ffffff;
+		}
+	}
+}
+@media screen and ( max-width: 1000px ) {
+	.column-right {
+		display: none;
+	}
+}
+@media screen and ( max-width: 782px ) {
+	promote-job-modal {
+		padding: 0px 25px 25px;
+	}
+}
+dialog {
+	border: 0;
+	border-radius: 8px;
+	form {
+		display: flex;
+		button {
+			margin: 10px 15px auto auto;
+			content: '';
+			background: none;
+			border: 0;
+			font-size: 0;
+			&:after {
+				content: "\2715";
+				font-size: 20px;
+			}
+		}
+	}
+	&::backdrop {
+		background: rgba(0, 0, 0, 0.5);
+	}
+}
+
 .wpjm-licences {
 	margin-top: 10px;
 

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -256,6 +256,17 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 	.spinner.is-active {
 		visibility: visible;
 	}
+@media screen and (max-width: 782px) {
+
+	.job-manager-form fieldset label:not(.full-line-checkbox-field label) {
+		width: 100%;
+		float: none;
+	}
+
+	.job-manager-form fieldset div.field:not(.full-line-checkbox-field) {
+		width: 100%;
+		float: none;
+	}
 }
 
 div.job_listings {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -124,6 +124,9 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 				font-size: 0.83em;
 			}
 		}
+		.full-line-checkbox-field label {
+			display: inline-block;
+		}
 
 		div.field:not(.full-line-checkbox-field) {
 			width: 70%;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -256,6 +256,35 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 	.spinner.is-active {
 		visibility: visible;
 	}
+
+	.select2-container
+	{
+		font-size: 1rem;
+
+		input.select2-search__field {
+			width: 100% !important;
+			height: unset;
+		}
+		.select2-selection--multiple .select2-selection__rendered {
+			display: block;
+			padding: 0;
+
+			li {
+				margin: 5px;
+			}
+
+			input {
+				padding: 0 5px;
+			}
+		}
+	}
+}
+
+.select2-container .select2-dropdown {
+	font-size: 1rem;
+}
+
+
 @media screen and (max-width: 782px) {
 
 	.job-manager-form fieldset label:not(.full-line-checkbox-field label) {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -44,7 +44,7 @@ $subtext: 			#777; 										/* small, breadcrumbs etc */
 .job-manager-error,
 .job-manager-info {
 	padding: 1em 2em 1em 3.5em !important;
-	margin: 0 0 2em !important;
+	margin-bottom: 2em;
 	position: relative;
 	background-color: lighten($secondary, 5%);
 	color: $secondarytext;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -178,3 +178,29 @@ jQuery(document).ready(function($) {
 		$('#in-' + taxonomy + '-' + id + ', #in-popular-' + taxonomy + '-' + id).prop( 'checked', c );
 	});
 });
+
+// Select all elements with the class "promote_job"
+const promote_job = document.querySelectorAll('.promote_job');
+const promoteDialog = document.getElementById('promoteDialog');
+
+promote_job.forEach(function (element) {
+		element.addEventListener('click', function ( event ) {
+			event.preventDefault();
+			promoteDialog.showModal();
+			let promoteID = event.target.dataset.post;
+			let promote_job_dialog = document.querySelector('.promote-buttons-group .button-primary');
+			promote_job_dialog.setAttribute('href', promoteID );
+		});
+});
+
+customElements.define('promote-job-modal',
+  class extends HTMLElement {
+    constructor() {
+      super();
+      const promoteJobs = document.getElementById('promote-job-template').content;
+      const shadowRoot = this.attachShadow({
+        mode: 'open'
+      });
+      shadowRoot.appendChild(promoteJobs.cloneNode(true));
+    }
+  });

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -457,14 +457,16 @@ jQuery( document ).ready( function( $ ) {
 			} );
 		} );
 
+	function triggerSearch() {
+		var $target = $( this ).closest( 'div.job_listings' );
+		$target.triggerHandler( 'update_results', [ 1, false ] );
+		store_state( $target );
+	}
+
 	$(
 		'#search_keywords, #search_location, #remote_position, .job_types :input, #search_categories, .job-manager-filter'
 	)
-		.change( function() {
-			var $target = $( this ).closest( 'div.job_listings' );
-			$target.triggerHandler( 'update_results', [ 1, false ] );
-			store_state( $target );
-		} )
+		.change( triggerSearch )
 		.on( 'keyup', function( e ) {
 			if ( e.which === 13 ) {
 				$( this ).trigger( 'change' );
@@ -504,6 +506,7 @@ jQuery( document ).ready( function( $ ) {
 			return false;
 		} )
 		.on( 'submit', function() {
+			triggerSearch();
 			return false;
 		} );
 

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -457,16 +457,14 @@ jQuery( document ).ready( function( $ ) {
 			} );
 		} );
 
-	function triggerSearch() {
-		var $target = $( this ).closest( 'div.job_listings' );
-		$target.triggerHandler( 'update_results', [ 1, false ] );
-		store_state( $target );
-	}
-
 	$(
 		'#search_keywords, #search_location, #remote_position, .job_types :input, #search_categories, .job-manager-filter'
 	)
-		.change( triggerSearch )
+		.change( function() {
+			var $target = $( this ).closest( 'div.job_listings' );
+			$target.triggerHandler( 'update_results', [ 1, false ] );
+			store_state( $target );
+		} )
 		.on( 'keyup', function( e ) {
 			if ( e.which === 13 ) {
 				$( this ).trigger( 'change' );
@@ -506,7 +504,6 @@ jQuery( document ).ready( function( $ ) {
 			return false;
 		} )
 		.on( 'submit', function() {
-			triggerSearch();
 			return false;
 		} );
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -49,6 +49,7 @@ class WP_Job_Manager_Admin {
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-cpt.php';
 		WP_Job_Manager_CPT::instance();
 
+		include_once dirname( __FILE__ ) . '/class-wp-job-manager-promoted-jobs.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-settings.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-writepanels.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-setup.php';

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager_Promoted_Jobs.
+ *
+ * @package wp-job-manager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles promoted jobs functionality.
+ *
+ * @since $$next-version$$
+ */
+class WP_Job_Manager_Promoted_Jobs {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var self
+	 * @since  $$next-version$$
+	 */
+	private static $instance = null;
+
+	/**
+	 * Allows for accessing single instance of class. Class should only be constructed once per call.
+	 *
+	 * @since  $$next-version$$
+	 * @static
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'manage_edit-job_listing_columns', [ $this, 'columns' ] );
+		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'custom_columns' ], 2 );
+		add_action( 'admin_notices', [ $this, 'my_admin_notice' ] );
+	}
+
+	/**
+	 * Add a column to the job listings admin page.
+	 *
+	 * @param array $columns Columns.
+	 * @return array
+	 */
+	public function columns( $columns ) {
+		$columns['promoted_jobs'] = __( 'Promote', 'wp-job-manager' );
+		return $columns;
+	}
+
+	/**
+	 * Check if a job is promoted.
+	 *
+	 * @param [string] $post_id
+	 * @return boolean
+	 */
+	public function is_promoted( $post_id ) {
+		$promoted = get_post_meta( $post_id, '_promoted', true );
+		return $promoted ? true : false;
+	}
+
+	/**
+	 * Handle display of new column
+	 *
+	 * @param  string $column
+	 */
+	public function custom_columns( $column ) {
+		global $post;
+
+		// TODO: Need to check if the job is already promoted or not.
+
+		if ( 'promoted_jobs' == $column ) {
+			echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
+		}
+	}
+	/**
+	 * Store the promoted jobs template from wpjobmanager.com
+	 *
+	 * TODO: we need to fetch this from wpjobmanager.com and store in cache for X amount of time
+	 * We should also have a fallback in case the API call fails.
+	 *
+	 * @return string
+	 */
+	public function get_promote_jobs_template() {
+		return '
+		<dialog id="promoteDialog">
+			<form method="dialog">
+				<button type="submit" autofocus>X</button>
+			</form>
+			<promote-job-modal>
+				<div slot="column-left" class="column-left">
+					<h2 slot="promote-heading">
+					Promote yoor job on our partner network.
+					</h2>
+
+					<div slot="price" class="price">
+						Starting From
+						<span>$83.00</span>
+					</div>
+
+					<div slot="promote-list">
+						<ul>
+							<li>Your ad will get shared on our Partner Network</li>
+							<li>Featured on jobs.blog for 7 days</li>
+							<li>Featured on our weekly email blast</li>
+						</ul>
+					</div>
+
+					<div slot="buttons" class="promote-buttons-group">
+						<button class="button button-primary" type="submit">Promote your job</button>
+						<button class="button button-secondary" type="submit">Learn More</button>
+					</div>
+				</div>
+				<div slot="column-right" class="column-right">
+					<img src="https://d.pr/i/4PgTqN+">
+				</div>
+			</promote-job-modal>
+		</dialog>';
+	}
+
+	/**
+	 * Output the promote jobs template
+	 *
+	 * @return void
+	 */
+	public function my_admin_notice() {
+		echo '
+			<template id="promote-job-template">
+			<style>
+
+			</style>
+				<slot name="column-left" class="column-left">
+					<slot name="promote-heading">
+					Promote Your Job on our Partner Network
+					</slot>
+
+					<slot name="price">
+						Starting from
+						<span>$80.00</span>
+					</slot>
+
+					<slot name="promote-list">
+						<ul>
+							<li>Your ad will get shared on our Partner Network</li>
+							<li>Featured on jobs.blog for 7 days</li>
+							<li>Featured on our weekly email blast</li>
+						</ul>
+					</slot>
+
+					<slot name="buttons" class="button-group">
+						<button class="button btn-primary" type="submit">Promote your job</button>
+						<button class="button btn-secondary" type="submit">Learn More</button>
+					</slot>
+
+				</slot>
+			<slot name="column-right">
+				<img src="#">
+			</slot>
+			</template>
+		';
+		echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+}
+
+WP_Job_Manager_Promoted_Jobs::instance();

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -75,7 +75,15 @@ switch ( $job->post_status ) :
 		echo '</div>';
 	break;
 	default :
-		do_action_deprecated( 'job_manager_job_submitted_content_' . str_replace( '-', '_', sanitize_title( $job->post_status ) ), $job, '1.41.0', 'job_manager_job_submitted_content' );
+		// Backwards compatibility for installations which used this action.
+		ob_start();
+		do_action( 'job_manager_job_submitted_content_' . str_replace( '-', '_', sanitize_title( $job->post_status ) ), $job );
+		$content = ob_get_clean();
+
+		if ( ! empty( $content ) ) {
+			echo $content;
+			break;
+		}
 
 		$job_submitted_content = '<div class="job-manager-message">' . wp_kses_post(
 			sprintf(

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.34.1
+ * @version     1.41.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,6 +16,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 global $wp_post_types;
+
+/**
+ * Triggers before the job-submitted template is displayed.
+ *
+ * @since 1.41.0
+ *
+ * @param WP_Post $job The job that was submitted.
+ */
+do_action( 'job_manager_job_submitted_content_before', $job );
+
+$job = get_post( $job->ID );
 
 switch ( $job->post_status ) :
 	case 'publish' :
@@ -64,7 +75,27 @@ switch ( $job->post_status ) :
 		echo '</div>';
 	break;
 	default :
-		do_action( 'job_manager_job_submitted_content_' . str_replace( '-', '_', sanitize_title( $job->post_status ) ), $job );
+		do_action_deprecated( 'job_manager_job_submitted_content_' . str_replace( '-', '_', sanitize_title( $job->post_status ) ), $job, '1.41.0', 'job_manager_job_submitted_content' );
+
+		$job_submitted_content = '<div class="job-manager-message">' . wp_kses_post(
+			sprintf(
+			// translators: %1$s is the job listing post type name.
+				__( '%1$s submitted successfully.', 'wp-job-manager' ),
+				esc_html( $wp_post_types['job_listing']->labels->singular_name )
+			)
+		) . '</div>';
+
+		/**
+		 * Filters the job submitted contents for a post status other than pending and publish.
+		 *
+		 * @since 1.41.0
+		 *
+		 * @param string $job_submitted_content The content to filter.
+		 * @param WP_Post $job The job that was submitted.
+		 */
+		$job_submitted_content = apply_filters( 'job_manager_job_submitted_content', $job_submitted_content, $job );
+
+		echo $job_submitted_content;
 	break;
 endswitch;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2445 https://github.com/Automattic/WP-Job-Manager/issues/2438

### Changes proposed in this Pull Request

* In the Job Listings Admin page, it moves all the Actions from buttons to links under the job titles
* Adds a new Column called "Promote" which has a button for promoting jobs
* When you click on `Promote`, it opens a dialog box which contains a shadow-dom template that's currently populated by hand.  This is just temporary until we have a way to populate it from wpjobmanager.com
* The dialog is added as an `admin-notice` just as a way to have the HTML in the DOM, that seemed the simplest way
* There's only one dialog element, but we can use JS to dynamically change the link.  Right now, as an example, the `href` attribute is set to the POST ID - we can change this to wahtever we need.

### Next tasks
- Deal with jobs already promoted
- Get the HTML fragment from wpjobmanager.com 
- Store the fragment in some kind of cache
- Add proper links to the `Promote your job` and `Learn more` buttons

### Testing instructions

* Apply this PR
* Run `npm run start` to build assets
* Go to Job Listings -> All Jobs 
* Make sure the actions work (Edit, View, Approve, Delete)
* Click on "Promote" and see the modal
* Make sure you can click the `X` to leave the dialog
* Make sure you can leave the dialog by pressing `ESC`


### Screenshot / Video
<img width="1336" alt="Screenshot 2023-06-17 at 3 44 07 PM" src="https://github.com/Automattic/WP-Job-Manager/assets/3220162/4cd90737-4e0a-4cb7-8714-a8431e5b3070">

![promote-dialog](https://github.com/Automattic/WP-Job-Manager/assets/3220162/42efec85-a8fc-418b-b66a-310edde20f27)


