### PR TITLE
Add Promote button and modal

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -79,7 +79,7 @@ promote-job-modal {
 		padding: 0px 25px 25px;
 	}
 }
-.promote-jobs-dialog {
+.wpjm-dialog {
 	border: 0;
 	border-radius: 8px;
 	form.dialog {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -33,7 +33,7 @@ promote-job-modal {
 		width: 80%;
 		margin-bottom: 0px;
 	}
-	.column-left{
+	.promote-job-modal-column-left {
 		display: flex;
 		justify-content: space-between;
 		flex-direction: column;
@@ -49,12 +49,16 @@ promote-job-modal {
 		background: url("data:image/svg+xml,<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><mask id=\"mask0_20018663_2259\" style=\"mask-type:luminance\" maskUnits=\"userSpaceOnUse\" x=\"3\" y=\"5\" width=\"18\" height=\"14\"><path d=\"M8.75685 15.9L4.57746 11.7L3.18433 13.1L8.75685 18.7L20.698 6.69999L19.3049 5.29999L8.75685 15.9Z\" fill=\"white\"/></mask><g mask=\"url%28%23mask0_20018663_2259%29\"><rect width=\"23.8823\" height=\"24\" fill=\"%232270B1\"/></g></svg>") no-repeat 0 -3px;
 		font-size: 14px;
 		list-style: none;
-		padding-left: 28px;
+		padding-left: 32px;
 	}
-	.price {
-		font-size: 12px;
+	.promote-job-modal-price {
 		display: flex;
 		flex-direction: column;
+		.price-text {
+			font-size: 12px;
+			text-transform: uppercase;
+			color: #787C82;
+		}
 		span {
 			margin-top: 10px;
 			font-size: 36px;
@@ -72,7 +76,7 @@ promote-job-modal {
 	}
 }
 @media screen and ( max-width: 1000px ) {
-	.column-right {
+	.promote-job-modal-column-right {
 		display: none;
 	}
 }
@@ -81,7 +85,7 @@ promote-job-modal {
 		padding: 0px 25px 25px;
 	}
 }
-dialog {
+.promoteJobsDialog {
 	border: 0;
 	border-radius: 8px;
 	form {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -22,10 +22,10 @@ promote-job-modal {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 	padding: 30px 80px 50px 80px;
-	img {
+	img.promote-jobs-image {
 		width: 100%;
 	}
-	h2 {
+	h2.promote-jobs-heading {
 		font-size: 36px;
 		font-weight: 300;
 		line-height: 105%;
@@ -37,15 +37,8 @@ promote-job-modal {
 		display: flex;
 		justify-content: space-between;
 		flex-direction: column;
-
-		button {
-			padding: 16px 10px;
-		}
 	}
-	ul {
-		margin: 24px 0;
-	}
-	li {
+	li.promote-list-item {
 		background: url("data:image/svg+xml,<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><mask id=\"mask0_20018663_2259\" style=\"mask-type:luminance\" maskUnits=\"userSpaceOnUse\" x=\"3\" y=\"5\" width=\"18\" height=\"14\"><path d=\"M8.75685 15.9L4.57746 11.7L3.18433 13.1L8.75685 18.7L20.698 6.69999L19.3049 5.29999L8.75685 15.9Z\" fill=\"white\"/></mask><g mask=\"url%28%23mask0_20018663_2259%29\"><rect width=\"23.8823\" height=\"24\" fill=\"%232270B1\"/></g></svg>") no-repeat 0 -3px;
 		font-size: 14px;
 		list-style: none;
@@ -89,9 +82,9 @@ promote-job-modal {
 .promote-jobs-dialog {
 	border: 0;
 	border-radius: 8px;
-	form {
+	form.dialog {
 		display: flex;
-		button {
+		button.dialog-close {
 			margin: 10px 15px auto auto;
 			content: '';
 			background: none;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -86,7 +86,7 @@ promote-job-modal {
 		padding: 0px 25px 25px;
 	}
 }
-.promoteJobsDialog {
+.promote-jobs-dialog {
 	border: 0;
 	border-radius: 8px;
 	form {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -17,6 +17,92 @@ a.wpjm-activate-licence-link:active {
 	color: orangered;
 }
 
+/** Promote Job Modal **/
+promote-job-modal {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	padding: 30px 80px 50px 80px;
+	img {
+		width: 100%;
+	}
+	h2 {
+		font-size: 36px;
+		font-weight: 300;
+		line-height: 105%;
+		margin-top: 0;
+		width: 80%;
+		margin-bottom: 0px;
+	}
+	.column-left{
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+
+		button {
+			padding: 16px 10px;
+		}
+	}
+	ul {
+		margin: 24px 0;
+	}
+	li {
+		background: url("data:image/svg+xml,<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><mask id=\"mask0_20018663_2259\" style=\"mask-type:luminance\" maskUnits=\"userSpaceOnUse\" x=\"3\" y=\"5\" width=\"18\" height=\"14\"><path d=\"M8.75685 15.9L4.57746 11.7L3.18433 13.1L8.75685 18.7L20.698 6.69999L19.3049 5.29999L8.75685 15.9Z\" fill=\"white\"/></mask><g mask=\"url%28%23mask0_20018663_2259%29\"><rect width=\"23.8823\" height=\"24\" fill=\"%232270B1\"/></g></svg>") no-repeat 0 -3px;
+		font-size: 14px;
+		list-style: none;
+		padding-left: 28px;
+	}
+	.price {
+		font-size: 12px;
+		display: flex;
+		flex-direction: column;
+		span {
+			margin-top: 10px;
+			font-size: 36px;
+			font-weight: 700;
+		}
+	}
+	.promote-buttons-group {
+		.button {
+			padding: 5px 16px;
+			margin-right: 18px;
+		}
+		.button-secondary {
+			background: #ffffff;
+		}
+	}
+}
+@media screen and ( max-width: 1000px ) {
+	.column-right {
+		display: none;
+	}
+}
+@media screen and ( max-width: 782px ) {
+	promote-job-modal {
+		padding: 0px 25px 25px;
+	}
+}
+dialog {
+	border: 0;
+	border-radius: 8px;
+	form {
+		display: flex;
+		button {
+			margin: 10px 15px auto auto;
+			content: '';
+			background: none;
+			border: 0;
+			font-size: 0;
+			&:after {
+				content: "\2715";
+				font-size: 20px;
+			}
+		}
+	}
+	&::backdrop {
+		background: rgba(0, 0, 0, 0.5);
+	}
+}
+
 .wpjm-licences {
 	margin-top: 10px;
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -50,6 +50,7 @@ promote-job-modal {
 		font-size: 14px;
 		list-style: none;
 		padding-left: 32px;
+		margin: 12px 0;
 	}
 	.promote-job-modal-price {
 		display: flex;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -179,11 +179,10 @@ jQuery(document).ready(function($) {
 	});
 });
 
-// Select all elements with the class "promote_job"
-const promote_job = document.querySelectorAll('.promote_job');
+const promoteJob = document.querySelectorAll('.promote_job');
 const promoteDialog = document.getElementById('promoteDialog');
 
-promote_job.forEach(function (element) {
+promoteJob.forEach(function (element) {
 		element.addEventListener('click', function ( event ) {
 			event.preventDefault();
 			promoteDialog.showModal();
@@ -194,13 +193,13 @@ promote_job.forEach(function (element) {
 });
 
 customElements.define('promote-job-modal',
-  class extends HTMLElement {
-    constructor() {
-      super();
-      const promoteJobs = document.getElementById('promote-job-template').content;
-      const shadowRoot = this.attachShadow({
-        mode: 'open'
-      });
-      shadowRoot.appendChild(promoteJobs.cloneNode(true));
-    }
-  });
+class extends HTMLElement {
+	constructor() {
+		super();
+		const promoteJobs = document.getElementById('promote-job-template').content;
+		const shadowRoot = this.attachShadow({
+			mode: 'open'
+		});
+		shadowRoot.appendChild(promoteJobs.cloneNode(true));
+	}
+});

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -178,3 +178,29 @@ jQuery(document).ready(function($) {
 		$('#in-' + taxonomy + '-' + id + ', #in-popular-' + taxonomy + '-' + id).prop( 'checked', c );
 	});
 });
+
+// Select all elements with the class "promote_job"
+const promote_job = document.querySelectorAll('.promote_job');
+const promoteDialog = document.getElementById('promoteDialog');
+
+promote_job.forEach(function (element) {
+		element.addEventListener('click', function ( event ) {
+			event.preventDefault();
+			promoteDialog.showModal();
+			let promoteID = event.target.dataset.post;
+			let promote_job_dialog = document.querySelector('.promote-buttons-group .button-primary');
+			promote_job_dialog.setAttribute('href', promoteID );
+		});
+});
+
+customElements.define('promote-job-modal',
+  class extends HTMLElement {
+    constructor() {
+      super();
+      const promoteJobs = document.getElementById('promote-job-template').content;
+      const shadowRoot = this.attachShadow({
+        mode: 'open'
+      });
+      shadowRoot.appendChild(promoteJobs.cloneNode(true));
+    }
+  });

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -179,18 +179,19 @@ jQuery(document).ready(function($) {
 	});
 });
 
-const promoteJob = document.querySelectorAll('.promote_job');
-const promoteDialog = document.getElementById('promoteDialog');
+function wpjmModal( selector, dialogSelector ) {
+	let item = document.querySelectorAll( selector );
+	let dialog = document.querySelector( dialogSelector );
 
-promoteJob.forEach(function (element) {
-		element.addEventListener('click', function ( event ) {
+	item.forEach( function( element ) {
+		element.addEventListener( 'click', function( event ) {
 			event.preventDefault();
-			promoteDialog.showModal();
-			let promoteID = event.target.dataset.post;
-			let promote_job_dialog = document.querySelector('.promote-buttons-group .button-primary');
-			promote_job_dialog.setAttribute('href', promoteID );
+			dialog.showModal();
 		});
-});
+	});
+}
+
+wpjmModal( '.promote_job', '#promoteDialog' );
 
 customElements.define('promote-job-modal',
 class extends HTMLElement {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -191,7 +191,7 @@ function wpjmModal( selector, dialogSelector ) {
 	});
 }
 
-wpjmModal( '.promote_job', '#promoteDialog' );
+wpjmModal( '.promote_job', '#promote-dialog' );
 
 customElements.define('promote-job-modal',
 class extends HTMLElement {

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -49,6 +49,7 @@ class WP_Job_Manager_Admin {
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-cpt.php';
 		WP_Job_Manager_CPT::instance();
 
+		include_once dirname( __FILE__ ) . '/class-wp-job-manager-promoted-jobs.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-settings.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-writepanels.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-setup.php';

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -101,7 +101,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function get_promote_jobs_template() {
 		return '
-		<dialog class="promote-jobs-dialog" id="promoteDialog">
+		<dialog class="wpjm-dialog" id="promote-dialog">
 			<form class="dialog" method="dialog">
 				<button class="dialog-close" type="submit" autofocus>X</button>
 			</form>

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -42,9 +42,9 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'manage_edit-job_listing_columns', [ $this, 'columns' ] );
-		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'custom_columns' ], 2 );
-		add_action( 'admin_notices', [ $this, 'my_admin_notice' ] );
+		add_filter( 'manage_edit-job_listing_columns', [ $this, 'promoted_jobs_columns' ] );
+		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'promoted_jobs_custom_columns' ], 2 );
+		add_action( 'admin_footer', [ $this, 'promoted_jobs_admin_footer' ] );
 	}
 
 	/**
@@ -53,7 +53,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @param array $columns Columns.
 	 * @return array
 	 */
-	public function columns( $columns ) {
+	public function promoted_jobs_columns( $columns ) {
 		$columns['promoted_jobs'] = __( 'Promote', 'wp-job-manager' );
 		return $columns;
 	}
@@ -61,7 +61,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	/**
 	 * Check if a job is promoted.
 	 *
-	 * @param [string] $post_id
+	 * @param int $post_id
 	 * @return boolean
 	 */
 	public function is_promoted( $post_id ) {
@@ -74,7 +74,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 *
 	 * @param  string $column
 	 */
-	public function custom_columns( $column ) {
+	public function promoted_jobs_custom_columns( $column ) {
 		global $post;
 		if ( 'promoted_jobs' === $column ) {
 			if ( $this->is_promoted( $post->ID ) ) {
@@ -95,23 +95,24 @@ class WP_Job_Manager_Promoted_Jobs {
 	 *
 	 * TODO: we need to fetch this from wpjobmanager.com and store in cache for X amount of time
 	 * We should also have a fallback in case the API call fails.
+	 * We need to have a fallback here because we can't use a `dialog` element inside the template
 	 *
 	 * @return string
 	 */
 	public function get_promote_jobs_template() {
 		return '
-		<dialog id="promoteDialog">
+		<dialog class="promoteJobsDialog" id="promoteDialog">
 			<form method="dialog">
 				<button type="submit" autofocus>X</button>
 			</form>
 			<promote-job-modal>
-				<div slot="column-left" class="column-left">
+				<div slot="column-left" class="promote-job-modal-column-left">
 					<h2 slot="promote-heading">
-					Promote yoor job on our partner network.
+						Promote your job on our partner network.
 					</h2>
 
-					<div slot="price" class="price">
-						Starting From
+					<div slot="price" class="promote-job-modal-price">
+						<div class="price-text">Starting From</div>
 						<span>$83.00</span>
 					</div>
 
@@ -128,7 +129,7 @@ class WP_Job_Manager_Promoted_Jobs {
 						<button class="button button-secondary" type="submit">Learn More</button>
 					</div>
 				</div>
-				<div slot="column-right" class="column-right">
+				<div slot="column-right" class="promote-job-modal-column-right">
 					<img src="https://d.pr/i/4PgTqN+">
 				</div>
 			</promote-job-modal>
@@ -140,26 +141,23 @@ class WP_Job_Manager_Promoted_Jobs {
 	 *
 	 * @return void
 	 */
-	public function my_admin_notice() {
+	public function promoted_jobs_admin_footer() {
 		echo '
 			<template id="promote-job-template">
-			<style>
-
-			</style>
 				<slot name="column-left" class="column-left">
 					<slot name="promote-heading">
-					Promote Your Job on our Partner Network
+						Promote Your Job on our Partner Network
 					</slot>
 
 					<slot name="price">
-						Starting from
-						<span>$80.00</span>
+						<div class="price-text">Starting From</div>
+						<span>$--</span>
 					</slot>
 
 					<slot name="promote-list">
 						<ul>
 							<li>Your ad will get shared on our Partner Network</li>
-							<li>Featured on jobs.blog for 7 days</li>
+							<li>Promote your job on external job boards</li>
 							<li>Featured on our weekly email blast</li>
 						</ul>
 					</slot>

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -144,12 +144,12 @@ class WP_Job_Manager_Promoted_Jobs {
 	public function promoted_jobs_admin_footer() {
 		?>
 			<template id="promote-job-template">
-				<slot name="column-left" class="column-left">
+				<slot name="column-left" class="promote-job-modal-column-left">
 					<slot class="promote-jobs-heading" name="promote-heading">
 						<?php esc_html_e( 'Promote Your Job on our Partner Network', 'wp-job-manager' ); ?>
 					</slot>
 
-					<slot name="price">
+					<slot name="price" class="promote-job-modal-price">
 						<div class="price-text"><?php esc_html_e( 'Starting From', 'wp-job-manager' ); ?></div>
 						<span>$--</span>
 					</slot>
@@ -162,7 +162,7 @@ class WP_Job_Manager_Promoted_Jobs {
 						</ul>
 					</slot>
 
-					<slot name="buttons" class="button-group">
+					<slot name="buttons" class="promote-buttons-group">
 						<button class="promote-button button btn-primary" type="submit">
 							<?php esc_html_e( 'Promote your job', 'wp-job-manager' ); ?>
 						</button>
@@ -172,7 +172,7 @@ class WP_Job_Manager_Promoted_Jobs {
 					</slot>
 
 				</slot>
-			<slot name="column-right">
+			<slot name="promote-job-modal-column-right">
 				<img class="promote-jobs-image" src="#">
 			</slot>
 			</template>

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -172,9 +172,9 @@ class WP_Job_Manager_Promoted_Jobs {
 					</slot>
 
 				</slot>
-			<slot name="promote-job-modal-column-right">
-				<img class="promote-jobs-image" src="#">
-			</slot>
+				<slot name="promote-job-modal-column-right">
+					<img class="promote-jobs-image" src="#">
+				</slot>
 			</template>
 		<?php
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager_Promoted_Jobs.
+ *
+ * @package wp-job-manager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles promoted jobs functionality.
+ *
+ * @since $$next-version$$
+ */
+class WP_Job_Manager_Promoted_Jobs {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var self
+	 * @since  $$next-version$$
+	 */
+	private static $instance = null;
+
+	/**
+	 * Allows for accessing single instance of class. Class should only be constructed once per call.
+	 *
+	 * @since  $$next-version$$
+	 * @static
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'manage_edit-job_listing_columns', [ $this, 'columns' ] );
+		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'custom_columns' ], 2 );
+		add_action( 'admin_notices', [ $this, 'my_admin_notice' ] );
+	}
+
+	/**
+	 * Add a column to the job listings admin page.
+	 *
+	 * @param array $columns Columns.
+	 * @return array
+	 */
+	public function columns( $columns ) {
+		$columns['promoted_jobs'] = __( 'Promote', 'wp-job-manager' );
+		return $columns;
+	}
+
+	/**
+	 * Check if a job is promoted.
+	 *
+	 * @param [string] $post_id
+	 * @return boolean
+	 */
+	public function is_promoted( $post_id ) {
+		$promoted = get_post_meta( $post_id, '_promoted', true );
+		return $promoted ? true : false;
+	}
+
+	/**
+	 * Handle display of new column
+	 *
+	 * @param  string $column
+	 */
+	public function custom_columns( $column ) {
+		global $post;
+
+		// TODO: Need to check if the job is already promoted or not.
+
+		if ( 'promoted_jobs' == $column ) {
+			echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
+		}
+	}
+	/**
+	 * Store the promoted jobs template from wpjobmanager.com
+	 *
+	 * TODO: we need to fetch this from wpjobmanager.com and store in cache for X amount of time
+	 * We should also have a fallback in case the API call fails.
+	 *
+	 * @return string
+	 */
+	public function get_promote_jobs_template() {
+		return '
+		<dialog id="promoteDialog">
+			<form method="dialog">
+				<button type="submit" autofocus>X</button>
+			</form>
+			<promote-job-modal>
+				<div slot="column-left" class="column-left">
+					<h2 slot="promote-heading">
+					Promote yoor job on our partner network.
+					</h2>
+
+					<div slot="price" class="price">
+						Starting From
+						<span>$83.00</span>
+					</div>
+
+					<div slot="promote-list">
+						<ul>
+							<li>Your ad will get shared on our Partner Network</li>
+							<li>Featured on jobs.blog for 7 days</li>
+							<li>Featured on our weekly email blast</li>
+						</ul>
+					</div>
+
+					<div slot="buttons" class="promote-buttons-group">
+						<button class="button button-primary" type="submit">Promote your job</button>
+						<button class="button button-secondary" type="submit">Learn More</button>
+					</div>
+				</div>
+				<div slot="column-right" class="column-right">
+					<img src="https://d.pr/i/4PgTqN+">
+				</div>
+			</promote-job-modal>
+		</dialog>';
+	}
+
+	/**
+	 * Output the promote jobs template
+	 *
+	 * @return void
+	 */
+	public function my_admin_notice() {
+		echo '
+			<template id="promote-job-template">
+			<style>
+
+			</style>
+				<slot name="column-left" class="column-left">
+					<slot name="promote-heading">
+					Promote Your Job on our Partner Network
+					</slot>
+
+					<slot name="price">
+						Starting from
+						<span>$80.00</span>
+					</slot>
+
+					<slot name="promote-list">
+						<ul>
+							<li>Your ad will get shared on our Partner Network</li>
+							<li>Featured on jobs.blog for 7 days</li>
+							<li>Featured on our weekly email blast</li>
+						</ul>
+					</slot>
+
+					<slot name="buttons" class="button-group">
+						<button class="button btn-primary" type="submit">Promote your job</button>
+						<button class="button btn-secondary" type="submit">Learn More</button>
+					</slot>
+
+				</slot>
+			<slot name="column-right">
+				<img src="#">
+			</slot>
+			</template>
+		';
+		echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+}
+
+WP_Job_Manager_Promoted_Jobs::instance();

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -79,7 +79,7 @@ class WP_Job_Manager_Promoted_Jobs {
 
 		// TODO: Need to check if the job is already promoted or not.
 
-		if ( 'promoted_jobs' == $column ) {
+		if ( 'promoted_jobs' === $column ) {
 			echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
 		}
 	}

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -101,7 +101,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function get_promote_jobs_template() {
 		return '
-		<dialog class="promoteJobsDialog" id="promoteDialog">
+		<dialog class="promote-jobs-dialog" id="promoteDialog">
 			<form method="dialog">
 				<button type="submit" autofocus>X</button>
 			</form>

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -142,29 +142,33 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return void
 	 */
 	public function promoted_jobs_admin_footer() {
-		echo '
+		?>
 			<template id="promote-job-template">
 				<slot name="column-left" class="column-left">
 					<slot name="promote-heading">
-						Promote Your Job on our Partner Network
+						<?php esc_html_e( 'Promote Your Job on our Partner Network', 'wp-job-manager' ); ?>
 					</slot>
 
 					<slot name="price">
-						<div class="price-text">Starting From</div>
+						<div class="price-text"><?php esc_html_e( 'Starting From', 'wp-job-manager' ); ?></div>
 						<span>$--</span>
 					</slot>
 
 					<slot name="promote-list">
 						<ul>
-							<li>Your ad will get shared on our Partner Network</li>
-							<li>Promote your job on external job boards</li>
-							<li>Featured on our weekly email blast</li>
+							<li><?php esc_html_e( 'Your ad will get shared on our Partner Network', 'wp-job-manager' ); ?></li>
+							<li><?php esc_html_e( 'Promote your job on external job boards', 'wp-job-manager' ); ?></li>
+							<li><?php esc_html_e( 'Featured on our weekly email blast', 'wp-job-manager' ); ?></li>
 						</ul>
 					</slot>
 
 					<slot name="buttons" class="button-group">
-						<button class="button btn-primary" type="submit">Promote your job</button>
-						<button class="button btn-secondary" type="submit">Learn More</button>
+						<button class="button btn-primary" type="submit">
+							<?php esc_html_e( 'Promote your job', 'wp-job-manager' ); ?>
+						</button>
+						<button class="button btn-secondary" type="submit">
+							<?php esc_html_e( 'Learn more', 'wp-job-manager' ); ?>
+						</button>
 					</slot>
 
 				</slot>
@@ -172,7 +176,8 @@ class WP_Job_Manager_Promoted_Jobs {
 				<img src="#">
 			</slot>
 			</template>
-		';
+		<?php
+
 		echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -76,11 +76,18 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function custom_columns( $column ) {
 		global $post;
-
-		// TODO: Need to check if the job is already promoted or not.
-
 		if ( 'promoted_jobs' === $column ) {
-			echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
+			if ( $this->is_promoted( $post->ID ) ) {
+				echo '
+					Live
+					<br />
+					<a href="#">Edit promotion</a>
+					<br />
+					<a href="#">Deactivate</a>
+				';
+			} else {
+				echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
+			}
 		}
 	}
 	/**

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -129,7 +129,7 @@ class WP_Job_Manager_Promoted_Jobs {
 						<button class="promote-button button button-secondary" type="submit">Learn More</button>
 					</div>
 				</div>
-				<div slot="column-right" class="promote-job-modal-column-right">
+				<div slot="promote-job-modal-column-right" class="promote-job-modal-column-right">
 					<img class="promote-jobs-image" src="https://d.pr/i/4PgTqN+">
 				</div>
 			</promote-job-modal>
@@ -172,8 +172,8 @@ class WP_Job_Manager_Promoted_Jobs {
 					</slot>
 
 				</slot>
-				<slot name="promote-job-modal-column-right">
-					<img class="promote-jobs-image" src="#">
+				<slot name="promote-job-modal-column-right" class="promote-job-modal-column-right">
+					<img class="promote-jobs-image" src="https://wpjobmanager.com/wp-content/uploads/2023/06/Right.jpg">
 				</slot>
 			</template>
 		<?php

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -102,12 +102,12 @@ class WP_Job_Manager_Promoted_Jobs {
 	public function get_promote_jobs_template() {
 		return '
 		<dialog class="promote-jobs-dialog" id="promoteDialog">
-			<form method="dialog">
-				<button type="submit" autofocus>X</button>
+			<form class="dialog" method="dialog">
+				<button class="dialog-close" type="submit" autofocus>X</button>
 			</form>
 			<promote-job-modal>
 				<div slot="column-left" class="promote-job-modal-column-left">
-					<h2 slot="promote-heading">
+					<h2 class="promote-jobs-heading" slot="promote-heading">
 						Promote your job on our partner network.
 					</h2>
 
@@ -117,20 +117,20 @@ class WP_Job_Manager_Promoted_Jobs {
 					</div>
 
 					<div slot="promote-list">
-						<ul>
-							<li>Your ad will get shared on our Partner Network</li>
-							<li>Featured on jobs.blog for 7 days</li>
-							<li>Featured on our weekly email blast</li>
+						<ul class="promote-list">
+							<li class="promote-list-item">Your ad will get shared on our Partner Network</li>
+							<li class="promote-list-item">Featured on jobs.blog for 7 days</li>
+							<li class="promote-list-item">Featured on our weekly email blast</li>
 						</ul>
 					</div>
 
 					<div slot="buttons" class="promote-buttons-group">
-						<button class="button button-primary" type="submit">Promote your job</button>
-						<button class="button button-secondary" type="submit">Learn More</button>
+						<button class="promote-button button button-primary" type="submit">Promote your job</button>
+						<button class="promote-button button button-secondary" type="submit">Learn More</button>
 					</div>
 				</div>
 				<div slot="column-right" class="promote-job-modal-column-right">
-					<img src="https://d.pr/i/4PgTqN+">
+					<img class="promote-jobs-image" src="https://d.pr/i/4PgTqN+">
 				</div>
 			</promote-job-modal>
 		</dialog>';
@@ -145,7 +145,7 @@ class WP_Job_Manager_Promoted_Jobs {
 		?>
 			<template id="promote-job-template">
 				<slot name="column-left" class="column-left">
-					<slot name="promote-heading">
+					<slot class="promote-jobs-heading" name="promote-heading">
 						<?php esc_html_e( 'Promote Your Job on our Partner Network', 'wp-job-manager' ); ?>
 					</slot>
 
@@ -155,25 +155,25 @@ class WP_Job_Manager_Promoted_Jobs {
 					</slot>
 
 					<slot name="promote-list">
-						<ul>
-							<li><?php esc_html_e( 'Your ad will get shared on our Partner Network', 'wp-job-manager' ); ?></li>
-							<li><?php esc_html_e( 'Promote your job on external job boards', 'wp-job-manager' ); ?></li>
-							<li><?php esc_html_e( 'Featured on our weekly email blast', 'wp-job-manager' ); ?></li>
+						<ul class="promote-list">
+							<li class="promote-list-item"><?php esc_html_e( 'Your ad will get shared on our Partner Network', 'wp-job-manager' ); ?></li>
+							<li class="promote-list-item"><?php esc_html_e( 'Promote your job on external job boards', 'wp-job-manager' ); ?></li>
+							<li class="promote-list-item"><?php esc_html_e( 'Featured on our weekly email blast', 'wp-job-manager' ); ?></li>
 						</ul>
 					</slot>
 
 					<slot name="buttons" class="button-group">
-						<button class="button btn-primary" type="submit">
+						<button class="promote-button button btn-primary" type="submit">
 							<?php esc_html_e( 'Promote your job', 'wp-job-manager' ); ?>
 						</button>
-						<button class="button btn-secondary" type="submit">
+						<button class="promote-button button btn-secondary" type="submit">
 							<?php esc_html_e( 'Learn more', 'wp-job-manager' ); ?>
 						</button>
 					</slot>
 
 				</slot>
 			<slot name="column-right">
-				<img src="#">
+				<img class="promote-jobs-image" src="#">
 			</slot>
 			</template>
 		<?php


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2445 https://github.com/Automattic/WP-Job-Manager/issues/2438

### Changes proposed in this Pull Request

* In the Job Listings Admin page, it moves all the Actions from buttons to links under the job titles
* Adds a new Column called "Promote" which has a button for promoting jobs
* When you click on `Promote`, it opens a dialog box which contains a shadow-dom template that's currently populated by hand.  This is just temporary until we have a way to populate it from wpjobmanager.com
* The dialog is added as an `admin-notice` just as a way to have the HTML in the DOM, that seemed the simplest way
* There's only one dialog element, but we can use JS to dynamically change the link.  Right now, as an example, the `href` attribute is set to the POST ID - we can change this to wahtever we need.

### Next tasks
- Get the HTML fragment from wpjobmanager.com 
- Store the fragment in some kind of cache
- Add proper links to the `Promote your job` and `Learn more` buttons

### Testing instructions

* Apply this PR
* Run `npm run start` to build assets
* Go to Job Listings -> All Jobs 
* Make sure the actions work (Edit, View, Approve, Delete)
* Click on "Promote" and see the modal
* Make sure you can click the `X` to leave the dialog
* Make sure you can leave the dialog by pressing `ESC`
* Set the Post Meta of a job listing to `_promoted => 1` and make sure you see the links to Edit and Deactivate the promotion (the links don't work yet)


### Screenshot / Video
<img width="1336" alt="Screenshot 2023-06-17 at 3 44 07 PM" src="https://github.com/Automattic/WP-Job-Manager/assets/3220162/4cd90737-4e0a-4cb7-8714-a8431e5b3070">

![promote-dialog](https://github.com/Automattic/WP-Job-Manager/assets/3220162/42efec85-a8fc-418b-b66a-310edde20f27)


