### PR TITLE
Add/deactivation modal

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -27,9 +27,7 @@ promote-job-modal {
 	}
 	h2 {
 		font-size: 36px;
-		font-weight: 300;
 		line-height: 105%;
-		margin-top: 0;
 		width: 80%;
 		margin-bottom: 0px;
 	}
@@ -65,15 +63,6 @@ promote-job-modal {
 			font-weight: 700;
 		}
 	}
-	.promote-buttons-group {
-		.button {
-			padding: 5px 16px;
-			margin-right: 18px;
-		}
-		.button-secondary {
-			background: #ffffff;
-		}
-	}
 }
 @media screen and ( max-width: 1000px ) {
 	.promote-job-modal-column-right {
@@ -85,9 +74,15 @@ promote-job-modal {
 		padding: 0px 25px 25px;
 	}
 }
+
+/** Global Modal **/
 .promoteJobsDialog {
 	border: 0;
 	border-radius: 8px;
+	h2 {
+		margin-top: 0;
+		font-weight: 300;
+	}
 	form {
 		display: flex;
 		button {
@@ -104,6 +99,41 @@ promote-job-modal {
 	}
 	&::backdrop {
 		background: rgba(0, 0, 0, 0.5);
+	}
+	.dialog-button-group {
+		.button {
+			padding: 5px 16px;
+			margin-right: 18px;
+		}
+		.button-secondary {
+			background: #ffffff;
+		}
+	}
+}
+/** Deactivate Modal **/
+#deactivateDialog {
+	h2 {
+		font-size: 20px;
+		line-height: 28px;
+	}
+	max-width: 415px;
+	padding: 32px;
+	form {
+		display: block;
+		float: right;
+		button {
+			margin: 0 0 0 10px;
+		}
+	}
+	p {
+		margin: 40px 0;
+	}
+	.dialog-button-group {
+		display: block;
+		float: right;
+		.button-secondary {
+			border: 0;
+		}
 	}
 }
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -104,6 +104,9 @@ promote-job-modal {
 		.button {
 			padding: 5px 16px;
 			margin-right: 18px;
+			&:last-child {
+				margin-right: 0;
+			}
 		}
 		.button-secondary {
 			background: #ffffff;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -179,6 +179,27 @@ jQuery(document).ready(function($) {
 	});
 });
 
+const deactivate_job = document.querySelectorAll('.deactivateJob');
+const deactivateDialog = document.getElementById('deactivateDialog');
+const cancelPromote = document.querySelector('.cancel-promotion');
+
+cancelPromote.addEventListener('click', () => {
+	deactivateDialog.close();
+});
+
+deactivate_job.forEach(function (element) {
+		element.addEventListener('click', function ( event ) {
+			event.preventDefault();
+			deactivateDialog.showModal();
+			let deactivateID = event.target.dataset.post;
+			let deactivateJobLink = document.querySelector('.deactivate-action.dialog-button-group .button-primary');
+			console.log( deactivateJobLink);
+			deactivateJobLink.setAttribute('href', deactivateID );
+		});
+});
+
+
+
 const promoteJob = document.querySelectorAll('.promote_job');
 const promoteDialog = document.getElementById('promoteDialog');
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -193,12 +193,9 @@ deactivateJob.forEach(function (element) {
 			deactivateDialog.showModal();
 			let deactivateID = event.target.dataset.post;
 			let deactivateJobLink = document.querySelector('.deactivate-action.dialog-button-group .button-primary');
-			console.log( deactivateJobLink);
 			deactivateJobLink.setAttribute('href', deactivateID );
 		});
 });
-
-
 
 const promoteJob = document.querySelectorAll('.promote_job');
 const promoteDialog = document.getElementById('promoteDialog');

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -179,7 +179,7 @@ jQuery(document).ready(function($) {
 	});
 });
 
-const deactivate_job = document.querySelectorAll('.deactivateJob');
+const deactivateJob = document.querySelectorAll('.deactivateJob');
 const deactivateDialog = document.getElementById('deactivateDialog');
 const cancelPromote = document.querySelector('.cancel-promotion');
 
@@ -187,7 +187,7 @@ cancelPromote.addEventListener('click', () => {
 	deactivateDialog.close();
 });
 
-deactivate_job.forEach(function (element) {
+deactivateJob.forEach(function (element) {
 		element.addEventListener('click', function ( event ) {
 			event.preventDefault();
 			deactivateDialog.showModal();

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -142,17 +142,17 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function promoted_jobs_admin_footer() {
 		echo '
-		<dialog class="promoteJobsDialog" id="deactivateDialog">
-			<form method="dialog">
-				<button type="submit">X</button>
-			</form>
-			<h2>Are you sure you want to deactivate promotion for this job?</h2>
-			<p>If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.</p>
-			<div class="deactivate-action dialog-button-group">
-				<button class="cancel-promotion button button-secondary" type="submit">Cancel</button>
-				<button class="button button-primary" type="submit">Deactivate</button>
-			</div>
-		</dialog>
+			<dialog class="promoteJobsDialog" id="deactivateDialog">
+				<form method="dialog">
+					<button type="submit">X</button>
+				</form>
+				<h2>Are you sure you want to deactivate promotion for this job?</h2>
+				<p>If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.</p>
+				<div class="deactivate-action dialog-button-group">
+					<button class="cancel-promotion button button-secondary" type="submit">Cancel</button>
+					<button class="button button-primary" type="submit">Deactivate</button>
+				</div>
+			</dialog>
 
 			<template id="promote-job-template">
 				<slot name="column-left" class="column-left">

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -83,7 +83,7 @@ class WP_Job_Manager_Promoted_Jobs {
 					<br />
 					<a href="#">Edit promotion</a>
 					<br />
-					<a href="#">Deactivate</a>
+					<a class="deactivateJob"href="#" data-post=' . esc_attr( $post->ID ) . '>Deactivate</a>
 				';
 			} else {
 				echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
@@ -123,8 +123,7 @@ class WP_Job_Manager_Promoted_Jobs {
 							<li>Featured on our weekly email blast</li>
 						</ul>
 					</div>
-
-					<div slot="buttons" class="promote-buttons-group">
+					<div slot="buttons" class="dialog-button-group">
 						<button class="button button-primary" type="submit">Promote your job</button>
 						<button class="button button-secondary" type="submit">Learn More</button>
 					</div>
@@ -143,6 +142,18 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function promoted_jobs_admin_footer() {
 		echo '
+		<dialog class="promoteJobsDialog" id="deactivateDialog">
+			<form method="dialog">
+				<button type="submit">X</button>
+			</form>
+			<h2>Are you sure you want to deactivate promotion for this job?</h2>
+			<p>If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.</p>
+			<div class="deactivate-action dialog-button-group">
+				<button class="cancel-promotion button button-secondary" type="submit">Cancel</button>
+				<button class="button button-primary" type="submit">Deactivate</button>
+			</div>
+		</dialog>
+
 			<template id="promote-job-template">
 				<slot name="column-left" class="column-left">
 					<slot name="promote-heading">
@@ -162,7 +173,7 @@ class WP_Job_Manager_Promoted_Jobs {
 						</ul>
 					</slot>
 
-					<slot name="buttons" class="button-group">
+					<slot name="buttons" class="dialog-button-group">
 						<button class="button btn-primary" type="submit">Promote your job</button>
 						<button class="button btn-secondary" type="submit">Learn More</button>
 					</slot>


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2462
Based on: https://github.com/Automattic/WP-Job-Manager/pull/2460

### Changes proposed in this Pull Request

* Adds Modal for Deactivate options
* Simplifies CSS for both modals (share styles between two modals)

### Testing instructions

* Go to Job Listings Page
* Make a job Promoted by adding the post meta to a job listing `_promoted => 1`
* Click on "Deactivate" on the Promote column for that job
* Try clicking Cancel, pressing Escape, and clicking the `X` to leave the modal

### Screenshot / Video

![deactivate-dialog](https://github.com/Automattic/WP-Job-Manager/assets/3220162/959463b7-5501-43eb-8390-7f7c88f6f221)
