### PR TITLE
Add class to generate and validate tokens for site authentication

### DIFF
--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -85,8 +85,10 @@ class WP_Job_Manager_Com_Auth_Token {
 	 */
 	private function generate_new_token() {
 		try {
-			$hash = random_bytes( 32 );
-			return bin2hex( $hash );
+			$hash = random_bytes( 48 );
+			//phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			$base64 = base64_encode( $hash );
+			return str_replace( [ '+', '/', '=' ], '', $base64 );
 		} catch ( Exception $e ) {
 			return new WP_Error( 'wpjobmanager-com-token-not-generated', __( 'Token could not be generated', 'wp-job-manager' ) );
 		}

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -16,10 +16,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since   $$next-version$$
  */
 class WP_Job_Manager_Com_Auth_Token {
+	/**
+	 * The meta key used to store the token.
+	 */
 	const META_KEY = 'wpjmcom_site_auth_token';
 
+	/**
+	 * The accepted object types to be associated with the token.
+	 */
 	const ACCEPTED_OBJECT_TYPES = [ 'post', 'user ' ];
 
+	/**
+	 * The expiration time for the token, in seconds.
+	 */
 	const EXPIRATION_TIME = MINUTE_IN_SECONDS;
 
 	/**

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -32,6 +32,30 @@ class WP_Job_Manager_Com_Auth_Token {
 	const EXPIRATION_TIME = MINUTE_IN_SECONDS;
 
 	/**
+	 * The singleton instance of the class.
+	 *
+	 * @var WP_Job_Manager_Com_Auth_Token
+	 */
+	private static $instance;
+
+	/**
+	 * WP_Job_Manager_Com_Auth_Token constructor.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Returns the singleton instance of the class.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new WP_Job_Manager_Com_Auth_Token();
+		}
+		return self::$instance;
+	}
+
+	/**
 	 * Generates the site token associated with an object type and object id
 	 *
 	 * @param string $object_type Type of the object associated with the token. Accepts 'post' or 'user'.

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -24,7 +24,7 @@ class WP_Job_Manager_Com_Auth_Token {
 	/**
 	 * The accepted object types to be associated with the token.
 	 */
-	const ACCEPTED_OBJECT_TYPES = [ 'post', 'user ' ];
+	const ACCEPTED_OBJECT_TYPES = [ 'post', 'user' ];
 
 	/**
 	 * The expiration time for the token, in seconds.

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -124,7 +124,7 @@ class WP_Job_Manager_Com_Auth_Token {
 			return false;
 		}
 		foreach ( $metadatas as $metadata ) {
-			if ( ! $this->is_valid( $metadata ) ) {
+			if ( ! $this->is_valid_format( $metadata ) ) {
 				// If the metadata structure isn't valid, just ignore it.
 				continue;
 			}
@@ -148,7 +148,7 @@ class WP_Job_Manager_Com_Auth_Token {
 	 * @param array $value The value persisted in the database.
 	 * @return bool True if the token is valid, false otherwise.
 	 */
-	private function is_valid( $value ) {
+	private function is_valid_format( $value ) {
 		return is_array( $value ) &&
 			array_key_exists( 'token', $value ) &&
 			array_key_exists( 'ts', $value ) &&

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -88,7 +88,11 @@ class WP_Job_Manager_Com_Auth_Token {
 			$hash = random_bytes( 48 );
 			//phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			$base64 = base64_encode( $hash );
-			return str_replace( [ '+', '/', '=' ], '', $base64 );
+			$result = str_replace( [ '+', '/', '=' ], '', $base64 );
+			if ( empty( $result ) ) {
+				$result = substr( bin2hex( $hash ), 0, 64 );
+			}
+			return $result;
 		} catch ( Exception $e ) {
 			return new WP_Error( 'wpjobmanager-com-token-not-generated', __( 'Token could not be generated', 'wp-job-manager' ) );
 		}

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -119,7 +119,7 @@ class WP_Job_Manager_Com_Auth_Token {
 	 * @param array $value The value persisted in the database.
 	 * @return bool True if the token is valid, false otherwise.
 	 */
-	public function is_valid( $value ) {
+	private function is_valid( $value ) {
 		return is_array( $value ) &&
 			array_key_exists( 'token', $value ) &&
 			array_key_exists( 'ts', $value ) &&

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -53,6 +53,7 @@ class WP_Job_Manager_Com_Auth_Token {
 		}
 		return $token;
 	}
+
 	/**
 	 * Generates a new random token and return it
 	 *
@@ -79,8 +80,6 @@ class WP_Job_Manager_Com_Auth_Token {
 			'ts'    => time(),
 		];
 	}
-
-
 
 	/**
 	 * Validate if a token is valid or not, and might remove it if it is valid or expired.

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager_Com_Auth_Token.
+ *
+ * @package wp-job-manager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helper functions used for creating and validating tokens used for authenticating with WPJobManager.com.
+ *
+ * @package wp-job-manager
+ * @since   $$next-version$$
+ */
+class WP_Job_Manager_Com_Auth_Token {
+	const META_KEY = 'wpjmcom_site_auth_token';
+
+	const ACCEPTED_OBJECT_TYPES = [ 'post', 'user ' ];
+
+	const EXPIRATION_TIME = MINUTE_IN_SECONDS;
+
+	/**
+	 * Generates the site token associated with an object type and object id
+	 *
+	 * @param string $object_type Type of object metadata is for. Accepts 'post' or 'user'.
+	 * @param int    $object_id The ID of the object to associate the token with.
+	 * @return string|WP_Error The token generated, or a WP_Error if the token could not be generated/persisted
+	 */
+	public function generate( $object_type, $object_id ) {
+		if ( ! in_array( $object_type, self::ACCEPTED_OBJECT_TYPES, true ) ) {
+			return new WP_Error( 'wpjobmanager-com-invalid-type', __( 'Invalid object type', 'wp-job-manager' ) );
+		}
+		$token = $this->generate_new_token();
+		if ( is_wp_error( $token ) ) {
+			return $token;
+		}
+		$encoded = $this->encode( $token );
+		$result  = add_metadata( $object_type, $object_id, self::META_KEY, $encoded );
+		if ( ! $result ) {
+			return new WP_Error( 'wpjobmanager-com-token-not-saved', __( 'Token could not be persisted', 'wp-job-manager' ) );
+		}
+		return $token;
+	}
+	/**
+	 * Generates a new random token and return it
+	 *
+	 * @return string|WP_Error The random token generated, or a WP_Error if the token could not be generated.
+	 */
+	private function generate_new_token() {
+		try {
+			$hash = random_bytes( 32 );
+			return bin2hex( $hash );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'wpjobmanager-com-token-not-generated', __( 'Token could not be generated', 'wp-job-manager' ) );
+		}
+	}
+
+	/**
+	 * Prepare the token to be persisted in the database
+	 *
+	 * @param string $token The token to encode.
+	 * @return array The value to persist in the database.
+	 */
+	private function encode( $token ) {
+		return [
+			'token' => wp_hash_password( $token ),
+			'ts'    => time(),
+		];
+	}
+
+}

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -34,7 +34,7 @@ class WP_Job_Manager_Com_Auth_Token {
 	/**
 	 * The singleton instance of the class.
 	 *
-	 * @var WP_Job_Manager_Com_Auth_Token
+	 * @var self
 	 */
 	private static $instance;
 
@@ -50,7 +50,7 @@ class WP_Job_Manager_Com_Auth_Token {
 	 */
 	public static function instance() {
 		if ( null === self::$instance ) {
-			self::$instance = new WP_Job_Manager_Com_Auth_Token();
+			self::$instance = new self();
 		}
 		return self::$instance;
 	}

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -118,6 +118,9 @@ class WP_Job_Manager_Com_Auth_Token {
 			return false;
 		}
 		$metadatas = get_metadata( $object_type, $object_id, self::META_KEY );
+		if ( false === $metadatas ) {
+			return false;
+		}
 		foreach ( $metadatas as $metadata ) {
 			if ( ! $this->is_valid( $metadata ) ) {
 				// If the metadata structure isn't valid, just ignore it.

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -74,6 +74,7 @@ class WP_Job_Manager_Helper {
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-options.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-api.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-language-packs.php';
+		include_once dirname( __FILE__ ) . '/class-wp-job-manager-com-auth-token.php';
 
 		$this->api = WP_Job_Manager_Helper_API::instance();
 

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
@@ -47,7 +47,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 
 		// Act.
-		$result = $instance->generate( 'user', "test");
+		$result = $instance->generate( 'user', 'invalid_id' );
 
 		// Assert.
 		$this->assertTrue( is_wp_error( $result ) );
@@ -60,7 +60,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$user = $this->factory->user->create_and_get();
 
 		// Act.
-		$result = $instance->generate( 'user', $user->ID);
+		$result = $instance->generate( 'user', $user->ID );
 
 		// Assert.
 		$this->assertIsString( $result );
@@ -73,7 +73,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$post = $this->factory->post->create_and_get();
 
 		// Act.
-		$result = $instance->generate( 'post', $post->ID);
+		$result = $instance->generate( 'post', $post->ID );
 
 		// Assert.
 		$this->assertIsString( $result );
@@ -118,7 +118,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$user = $this->factory->user->create_and_get();
-		$token = $instance->generate('user', $user->ID);
+		$token = $instance->generate('user', $user->ID );
 
 		// Act.
 		$result = $instance->validate( 'user', $user->ID, $token. 'a' );
@@ -131,7 +131,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$post = $this->factory->post->create_and_get();
-		$token = $instance->generate('post', $post->ID);
+		$token = $instance->generate( 'post', $post->ID );
 
 		// Act.
 		$result = $instance->validate( 'post', $post->ID, $token. 'a' );
@@ -144,7 +144,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$user = $this->factory->user->create_and_get();
-		$token = $instance->generate('user', $user->ID);
+		$token = $instance->generate( 'user', $user->ID );
 
 		// Act.
 		$instance->validate( 'user', $user->ID, $token );
@@ -158,7 +158,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$post = $this->factory->post->create_and_get();
-		$token = $instance->generate('post', $post->ID);
+		$token = $instance->generate( 'post', $post->ID );
 
 		// Act.
 		$instance->validate( 'post', $post->ID, $token );
@@ -172,7 +172,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$user = $this->factory->user->create_and_get();
-		$instance->generate('user', $user->ID);
+		$instance->generate( 'user', $user->ID );
 		$this->expire_tokens( 'user', $user->ID );
 
 		// Act.
@@ -186,7 +186,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$post = $this->factory->post->create_and_get();
-		$instance->generate('post', $post->ID);
+		$instance->generate( 'post', $post->ID );
 		$this->expire_tokens( 'post', $post->ID );
 
 		// Act.
@@ -200,7 +200,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$user = $this->factory->user->create_and_get();
-		$token = $instance->generate('user', $user->ID);
+		$token = $instance->generate( 'user', $user->ID );
 		$this->expire_tokens( 'user', $user->ID );
 
 		// Act.
@@ -224,7 +224,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$this->assertFalse( $result );
 	}
 
-	private function expire_tokens ( $object_type, $object_id ) {
+	private function expire_tokens( $object_type, $object_id ) {
 		$metadatas = get_metadata( $object_type, $object_id, WP_Job_Manager_Com_Auth_Token::META_KEY );
 		foreach ( $metadatas as $metadata ) {
 			$new_metadata = [
@@ -239,7 +239,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$user = $this->factory->user->create_and_get();
-		$token = $instance->generate('user', $user->ID);
+		$token = $instance->generate( 'user', $user->ID );
 
 		// Act.
 		$result = $instance->validate( 'user', $user->ID, $token );
@@ -252,7 +252,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();
 		$post = $this->factory->post->create_and_get();
-		$token = $instance->generate('post', $post->ID);
+		$token = $instance->generate( 'post', $post->ID );
 
 		// Act.
 		$result = $instance->validate( 'post', $post->ID, $token );

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
@@ -168,6 +168,34 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$this->assertFalse( $result );
 	}
 
+	public function testValidate_WhenCalledWithUser_ShouldDeleteExpiredTokens() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$user = $this->factory->user->create_and_get();
+		$instance->generate('user', $user->ID);
+		$this->expire_tokens( 'user', $user->ID );
+
+		// Act.
+		$instance->validate( 'user', $user->ID, 'test' );
+
+		// Assert.
+		$this->assertEmpty( get_metadata( 'user', $user->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+	}
+
+	public function testValidate_WhenCalledWithPost_ShouldDeleteExpiredTokens() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$post = $this->factory->post->create_and_get();
+		$instance->generate('post', $post->ID);
+		$this->expire_tokens( 'post', $post->ID );
+
+		// Act.
+		$instance->validate( 'post', $post->ID, 'test' );
+
+		// Assert.
+		$this->assertEmpty( get_metadata( 'user', $post->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+	}
+
 	public function testValidate_WhenPassedValidUserButTokenIsExpired_ShouldReturnFalse() {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
@@ -140,6 +140,34 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$this->assertFalse( $result );
 	}
 
+	public function testValidate_WhenPassedUserWithMetaAndValidTokenTwice_ShouldReturnFalse() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$user = $this->factory->user->create_and_get();
+		$token = $instance->generate('user', $user->ID);
+
+		// Act.
+		$instance->validate( 'user', $user->ID, $token );
+		$result = $instance->validate( 'user', $user->ID, $token );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	public function testValidate_WhenPassedPostWithMetaAndValidTokenTwice_ShouldReturnFalse() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$post = $this->factory->post->create_and_get();
+		$token = $instance->generate('post', $post->ID);
+
+		// Act.
+		$instance->validate( 'post', $post->ID, $token );
+		$result = $instance->validate( 'post', $post->ID, $token );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
 	public function testValidate_WhenPassedUserWithMetaAndValidToken_ShouldReturnTrue() {
 		// Arrange.
 		$instance = WP_Job_Manager_Com_Auth_Token::instance();

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-com-auth-token.php
@@ -1,0 +1,168 @@
+<?php
+
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-com-auth-token.php';
+
+/**
+ * @group helper
+ * @group helper-base
+ */
+class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
+
+	public function testInstance_WhenCalled_ReturnSameInstance() {
+		// Arrange.
+		$instance  = WP_Job_Manager_Com_Auth_Token::instance();
+
+		// Act.
+
+		// Assert.
+		$this->assertInstanceOf( 'WP_Job_Manager_Com_Auth_Token', $instance );
+	}
+
+	public function testInstance_WhenCalled_ReturnCorrectType() {
+		// Arrange.
+		$instance  = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance2 = WP_Job_Manager_Com_Auth_Token::instance();
+
+		// Act.
+
+		// Assert.
+		$this->assertSame( $instance2, $instance );
+	}
+
+	public function testGenerate_WhenPassedInvalidObjectType_ShouldReturnError() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+
+		// Act.
+		$result = $instance->generate( 'comment', 1);
+
+		// Assert.
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( 'wpjobmanager-com-invalid-type' , $result->get_error_code() );
+	}
+
+
+	public function testGenerate_WhenPassedInvalidObjectID_ShouldReturnError() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+
+		// Act.
+		$result = $instance->generate( 'user', "test");
+
+		// Assert.
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( 'wpjobmanager-com-token-not-saved' , $result->get_error_code() );
+	}
+
+	public function testGenerate_WhenPassedUser_ShouldPersistMeta() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$user = $this->factory->user->create_and_get();
+
+		// Act.
+		$result = $instance->generate( 'user', $user->ID);
+
+		// Assert.
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( get_user_meta( $user->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+	}
+
+	public function testGenerate_WhenPassedPost_ShouldPersistMeta() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$post = $this->factory->post->create_and_get();
+
+		// Act.
+		$result = $instance->generate( 'post', $post->ID);
+
+		// Assert.
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( get_post_meta( $post->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+	}
+
+	public function testValidate_WhenPassedInvalidObjectType_ShouldReturnFalse() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+
+		// Act.
+		$result = $instance->validate( 'comment', 1, 'test' );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	public function testValidate_WhenPassedInvalidObjectID_ShouldReturnFalse() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+
+		// Act.
+		$result = $instance->validate( 'user', 'test', 'test' );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	public function testValidate_WhenPassedUserWithoutMeta_ShouldReturnFalse() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$user = $this->factory->user->create_and_get();
+
+		// Act.
+		$result = $instance->validate( 'user', $user->ID, 'test' );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	public function testValidate_WhenPassedUserWithMetaButInvalidToken_ShouldReturnFalse() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$user = $this->factory->user->create_and_get();
+		$token = $instance->generate('user', $user->ID);
+
+		// Act.
+		$result = $instance->validate( 'user', $user->ID, $token. 'a' );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	public function testValidate_WhenPassedPostWithMetaButInvalidToken_ShouldReturnFalse() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$post = $this->factory->post->create_and_get();
+		$token = $instance->generate('post', $post->ID);
+
+		// Act.
+		$result = $instance->validate( 'post', $post->ID, $token. 'a' );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	public function testValidate_WhenPassedUserWithMetaAndValidToken_ShouldReturnTrue() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$user = $this->factory->user->create_and_get();
+		$token = $instance->generate('user', $user->ID);
+
+		// Act.
+		$result = $instance->validate( 'user', $user->ID, $token );
+
+		// Assert.
+		$this->assertTrue( $result );
+	}
+
+	public function testValidate_WhenPassedPostWithMetaAndValidToken_ShouldReturnTrue() {
+		// Arrange.
+		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$post = $this->factory->post->create_and_get();
+		$token = $instance->generate('post', $post->ID);
+
+		// Act.
+		$result = $instance->validate( 'post', $post->ID, $token );
+
+		// Assert.
+		$this->assertTrue( $result );
+	}
+}


### PR DESCRIPTION
Fixes 413-gh-Automattic/wpjobmanager.com
Sibling PR to 445-gh-Automattic/wpjobmanager.com

### Changes proposed in this Pull Request

- Add class responsible for:
    -  creating and validating tokens on WPJM, associated with a post OR user
    -  validate the tokens created 

### Testing instructions
 
Run the unit tests, and experiment creating tokens using WP-CLI Shell:

```php
$instance = WP_Job_Manager_Com_Auth_Token::instance(); // To get the instance of the class
$token = $instance->generate( 'user', 1 ); // Create a token associated with the User ID 1
// Maybe await a minute using sleep(60)?
var_dump($instance->validate( 'user', 1, $token));
// Make the same test with a valid post instead of user
```