### PR TITLE
Add deactivate modal

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -27,9 +27,7 @@ promote-job-modal {
 	}
 	h2.promote-jobs-heading {
 		font-size: 36px;
-		font-weight: 300;
 		line-height: 105%;
-		margin-top: 0;
 		width: 80%;
 		margin-bottom: 0px;
 	}
@@ -59,15 +57,6 @@ promote-job-modal {
 			font-weight: 700;
 		}
 	}
-	.promote-buttons-group {
-		.button {
-			padding: 5px 16px;
-			margin-right: 18px;
-		}
-		.button-secondary {
-			background: #ffffff;
-		}
-	}
 }
 @media screen and ( max-width: 1000px ) {
 	.promote-job-modal-column-right {
@@ -82,6 +71,10 @@ promote-job-modal {
 .wpjm-dialog {
 	border: 0;
 	border-radius: 8px;
+	h2.promote-jobs-heading {
+		margin-top: 0;
+		font-weight: 300;
+	}
 	form.dialog {
 		display: flex;
 		button.dialog-close {
@@ -98,6 +91,44 @@ promote-job-modal {
 	}
 	&::backdrop {
 		background: rgba(0, 0, 0, 0.5);
+	}
+	.promote-buttons-group {
+		.button {
+			padding: 5px 16px;
+			margin-right: 18px;
+		}
+		.button-secondary {
+			background: #ffffff;
+		}
+	}
+}
+/** Deactivate Modal **/
+#deactivate-dialog {
+	h2 {
+		font-size: 20px;
+		line-height: 28px;
+	}
+	max-width: 415px;
+	padding: 32px;
+	form {
+		display: block;
+		float: right;
+		button {
+			margin: 0 0 0 10px;
+		}
+	}
+	p {
+		margin: 40px 0;
+	}
+	.promote-buttons-group {
+		display: block;
+		float: right;
+		.button-secondary {
+			border: 0;
+		}
+		button:last-child {
+			margin-right: 0;
+		}
 	}
 }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -201,6 +201,8 @@ function wpjmCloseModal( selector, dialog ) {
 }
 
 wpjmModal( '.promote_job', '#promote-dialog' );
+wpjmModal( '.deactivate-job', '#deactivate-dialog' );
+wpjmCloseModal( '.cancel-promotion', '#deactivate-dialog' );
 
 customElements.define('promote-job-modal',
 class extends HTMLElement {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -190,6 +190,15 @@ function wpjmModal( selector, dialogSelector ) {
 		});
 	});
 }
+function wpjmCloseModal( selector, dialog ) {
+	let item = document.querySelectorAll( selector );
+	item.forEach( function( element ) {
+		element.addEventListener( 'click', function( event ) {
+			event.preventDefault();
+			this.closest( 'dialog' ).close();
+		});
+	});
+}
 
 wpjmModal( '.promote_job', '#promote-dialog' );
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -83,7 +83,7 @@ class WP_Job_Manager_Promoted_Jobs {
 					<br />
 					<a href="#">Edit promotion</a>
 					<br />
-					<a href="#">Deactivate</a>
+					<a class="deactivate-job"href="#" data-post=' . esc_attr( $post->ID ) . '>Deactivate</a>
 				';
 			} else {
 				echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
@@ -143,6 +143,18 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function promoted_jobs_admin_footer() {
 		?>
+			<dialog class="wpjm-dialog" id="deactivate-dialog">
+				<form class="dialog" method="dialog">
+					<button class="dialog-close" type="submit">X</button>
+				</form>
+				<h2 class="promote-jobs-heading">Are you sure you want to deactivate promotion for this job?</h2>
+				<p>If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.</p>
+				<div class="deactivate-action promote-buttons-group">
+					<button class="cancel-promotion button button-secondary" type="submit">Cancel</button>
+					<button class="button button-primary" type="submit">Deactivate</button>
+				</div>
+			</dialog>
+
 			<template id="promote-job-template">
 				<slot name="column-left" class="promote-job-modal-column-left">
 					<slot class="promote-jobs-heading" name="promote-heading">

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -147,11 +147,19 @@ class WP_Job_Manager_Promoted_Jobs {
 				<form class="dialog" method="dialog">
 					<button class="dialog-close" type="submit">X</button>
 				</form>
-				<h2 class="promote-jobs-heading">Are you sure you want to deactivate promotion for this job?</h2>
-				<p>If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.</p>
+				<h2 class="promote-jobs-heading">
+					<?php esc_html_e( 'Are you sure you want to deactivate promotion for this job?', 'wp-job-manager' ); ?>
+				</h2>
+				<p>
+					<?php esc_html_e( 'If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.', 'wp-job-manager' ); ?>
+				</p>
 				<div class="deactivate-action promote-buttons-group">
-					<button class="cancel-promotion button button-secondary" type="submit">Cancel</button>
-					<button class="button button-primary" type="submit">Deactivate</button>
+					<button class="cancel-promotion button button-secondary" type="submit">
+						<?php esc_html_e( 'Cancel', 'wp-job-manager' ); ?>
+					</button>
+					<button class="button button-primary" type="submit">
+						<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
+					</button>
 				</div>
 			</dialog>
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2462

### Changes proposed in this Pull Request

* Adds Modal for Deactivate options
* Simplifies CSS for both modals (share styles between two modals)

### Testing instructions

* Go to Job Listings Page
* Make a job Promoted by adding the post meta to a job listing `_promoted => 1`
* Click on "Deactivate" on the Promote column for that job
* Try clicking Cancel, pressing Escape, and clicking the `X` to leave the modal

### Screenshot / Video

![deactivate-dialog](https://github.com/Automattic/WP-Job-Manager/assets/3220162/959463b7-5501-43eb-8390-7f7c88f6f221)
