### PR TITLE
Add deactivate modal

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -50,6 +50,38 @@ a.wpjm-activate-licence-link:active {
 	}
 }
 
+/** Deactivate Modal **/
+.deactivate-dialog {
+	h2.deactivate-modal-heading {
+		font-size: 20px;
+		line-height: 28px;
+		margin-top: 0;
+		font-weight: 300;
+	}
+	max-width: 415px;
+	padding: 32px;
+	.deactivate-button {
+		display: block;
+		float: right;
+		button {
+			margin: 0 0 0 10px;
+		}
+	}
+	p {
+		margin: 40px 0;
+	}
+	.promote-buttons-group {
+		display: block;
+		float: right;
+		.button-secondary {
+			border: 0;
+		}
+		button:last-child {
+			margin-right: 0;
+		}
+	}
+}
+
 .wpjm-licences {
 	margin-top: 10px;
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -179,7 +179,7 @@ jQuery(document).ready(function($) {
 	});
 });
 
-function wpjmModal( selector, dialogSelector ) {
+function wpjmModal( selector, dialogSelector, action ) {
 	let item = document.querySelectorAll( selector );
 	let dialog = document.querySelector( dialogSelector );
 	let cancelButton = dialog.querySelectorAll( '.dialog-close' );
@@ -190,25 +190,38 @@ function wpjmModal( selector, dialogSelector ) {
 			dialog.close();
 		});
 	});
-	item.forEach( function( element ) {
-		element.addEventListener( 'click', function( event ) {
-			event.preventDefault();
-			dialog.showModal();
-			dialog.innerHTML = `
-			<form class="dialog" method="dialog">
-				<button class="dialog-close" type="submit">X</button>
-			</form>
-			<promote-job-template>
-				<div slot="buttons" class="promote-buttons-group">
-						<button class="promote-button button button-primary" type="submit" href="${ element.getAttribute( 'data-post') }">Promote your jobs</button>
-						<button class="promote-button button button-secondary" type="submit" href="#">Learn More</button>
-				</div>
-			<promote-job-template>`
-		});
-	});
+	populateTemplate( item, dialog, action );
 }
 
-wpjmModal( '.promote_job', '#promote-dialog' );
+function populateTemplate( item, dialog, action ) {
+	if ( typeof action !== 'undefined' )  {
+		item.forEach( function( element ) {
+			element.addEventListener( 'click', function( event ) {
+				event.preventDefault();
+				dialog.showModal();
+				if ( 'promote' === action ) {
+					dialog.innerHTML = `
+					<form class="dialog" method="dialog">
+						<button class="dialog-close" type="submit">X</button>
+					</form>
+					<promote-job-template>
+						<div slot="buttons" class="promote-buttons-group">
+								<button class="promote-button button button-primary" type="submit" href="${ this.getAttribute( 'data-post') }">Promote your jobs</button>
+								<button class="promote-button button button-secondary" type="submit" href="#">Learn More</button>
+						</div>
+					<promote-job-template>`;
+				}
+				if ( 'deactivate' === action ) {
+					let deactivateButton = document.querySelector('.deactivate-promotion');
+					deactivateButton.setAttribute( 'href', this.getAttribute( 'data-post' ) );
+				}
+			});
+		});
+	}
+}
+
+wpjmModal( '.promote_job', '#promote-dialog', 'promote' );
+wpjmModal( '.deactivate-job', '#deactivate-dialog', 'deactivate' );
 
 customElements.define('promote-job-template',
 class extends HTMLElement {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -182,7 +182,14 @@ jQuery(document).ready(function($) {
 function wpjmModal( selector, dialogSelector ) {
 	let item = document.querySelectorAll( selector );
 	let dialog = document.querySelector( dialogSelector );
+	let cancelButton = dialog.querySelectorAll( '.dialog-close' );
 
+	cancelButton.forEach( function( element ) {
+		element.addEventListener( 'click', function( event ) {
+			event.preventDefault();
+			dialog.close();
+		});
+	});
 	item.forEach( function( element ) {
 		element.addEventListener( 'click', function( event ) {
 			event.preventDefault();

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -232,6 +232,26 @@ class WP_Job_Manager_Promoted_Jobs {
 				<?php echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</template>
 			<dialog class="wpjm-dialog" id="promote-dialog"></dialog>
+
+			<dialog class="wpjm-dialog deactivate-dialog" id="deactivate-dialog">
+				<form class="dialog deactivate-button" method="dialog">
+					<button class="dialog-close" type="submit">X</button>
+				</form>
+				<h2 class="deactivate-modal-heading">
+					<?php esc_html_e( 'Are you sure you want to deactivate promotion for this job?', 'wp-job-manager' ); ?>
+				</h2>
+				<p>
+					<?php esc_html_e( 'If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.', 'wp-job-manager' ); ?>
+				</p>
+				<div class="deactivate-action promote-buttons-group">
+					<button class="dialog-close button button-secondary" type="submit">
+						<?php esc_html_e( 'Cancel', 'wp-job-manager' ); ?>
+					</button>
+					<button class="deactivate-promotion button button-primary" type="submit">
+						<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
+					</button>
+				</div>
+			</dialog>
 		<?php
 	}
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -83,7 +83,7 @@ class WP_Job_Manager_Promoted_Jobs {
 					<br />
 					<a href="#">Edit promotion</a>
 					<br />
-					<a href="#">Deactivate</a>
+					<a class="deactivate-job"href="#" data-post=' . esc_attr( $post->ID ) . '>Deactivate</a>
 				';
 			} else {
 				echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2440 (partly)
Based on the changes to the promoted jobs modal: https://github.com/Automattic/WP-Job-Manager/pull/2472
It's missing the part that actually makes the job not promoted any more - this is just the scaffolding for that.

### Changes proposed in this Pull Request

* Adds Modal for Deactivate options

### Testing instructions

* Go to Job Listings Page
* Make a job Promoted by adding the post meta to a job listing `_promoted => 1`
* Click on "Deactivate" on the Promote column for that job
* Try clicking Cancel, pressing Escape, and clicking the `X` to leave the modal

### Screenshot / Video

![deactivate-dialog](https://github.com/Automattic/WP-Job-Manager/assets/3220162/959463b7-5501-43eb-8390-7f7c88f6f221)
