### PR TITLE
Run job_manager_job_submitted_content filter in every case

### DIFF
--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -30,7 +30,7 @@ $job = get_post( $job->ID );
 
 switch ( $job->post_status ) :
 	case 'publish' :
-		echo '<div class="job-manager-message">' . wp_kses_post(
+		$job_submitted_content = '<div class="job-manager-message">' . wp_kses_post(
 			sprintf(
 				// translators: %1$s is the job listing post type name, %2$s is the job listing URL.
 				__( '%1$s listed successfully. To view your listing <a href="%2$s">click here</a>.', 'wp-job-manager' ),
@@ -38,9 +38,10 @@ switch ( $job->post_status ) :
 				get_permalink( $job->ID )
 			)
 		) . '</div>';
-	break;
+
+		break;
 	case 'pending' :
-		echo '<div class="job-manager-message">' . wp_kses_post(
+		$job_submitted_content = '<div class="job-manager-message">' . wp_kses_post(
 			sprintf(
 				// translators: Placeholder %s is the job listing post type name.
 				esc_html__( '%s submitted successfully. Your listing will be visible once approved.', 'wp-job-manager' ),
@@ -53,7 +54,7 @@ switch ( $job->post_status ) :
 
 		// If job_dashboard page exists but there is no title
 		if ( $job_dashboard_link && empty( $job_dashboard_title ) ) {
-			echo wp_kses_post(
+			$job_submitted_content .= wp_kses_post(
 				sprintf(
 					// translators: %1$s is the URL to view the listing; %2$s is
 					// the plural name of the job listing post type
@@ -63,7 +64,7 @@ switch ( $job->post_status ) :
 				)
 			);
 		} elseif ( $job_dashboard_link && $job_dashboard_title ) { // If there is both a job_dashboard page and a title on the page
-			echo wp_kses_post(
+			$job_submitted_content .= wp_kses_post(
 				sprintf(
 					__( '  <a href="%s"> %s</a>', 'wp-job-manager' ),
 					$job_dashboard_link,
@@ -72,7 +73,7 @@ switch ( $job->post_status ) :
 			);
 		}
 
-		echo '</div>';
+		$job_submitted_content .= '</div>';
 	break;
 	default :
 		// Backwards compatibility for installations which used this action.
@@ -81,7 +82,7 @@ switch ( $job->post_status ) :
 		$content = ob_get_clean();
 
 		if ( ! empty( $content ) ) {
-			echo $content;
+			$job_submitted_content = $content;
 			break;
 		}
 
@@ -93,18 +94,19 @@ switch ( $job->post_status ) :
 			)
 		) . '</div>';
 
-		/**
-		 * Filters the job submitted contents for a post status other than pending and publish.
-		 *
-		 * @since 1.41.0
-		 *
-		 * @param string $job_submitted_content The content to filter.
-		 * @param WP_Post $job The job that was submitted.
-		 */
-		$job_submitted_content = apply_filters( 'job_manager_job_submitted_content', $job_submitted_content, $job );
-
-		echo $job_submitted_content;
 	break;
 endswitch;
+
+/**
+ * Filters the job submitted contents.
+ *
+ * @since 1.41.0
+ *
+ * @param string $job_submitted_content The content to filter.
+ * @param WP_Post $job The job that was submitted.
+ */
+$job_submitted_content = apply_filters( 'job_manager_job_submitted_content', $job_submitted_content, $job );
+
+echo $job_submitted_content;
 
 do_action( 'job_manager_job_submitted_content_after', sanitize_title( $job->post_status ), $job );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Updates the `job_manager_job_submitted_content` to be run in every case. It was a bad decision in the first place and this change is also needed for [this PR](https://github.com/Automattic/wpjm-addons/pull/84)

### Testing instructions

* Add a `job_manager_job_submitted_content` filter and make sure that it works as it should
* Alternatively test this PR](https://github.com/Automattic/wpjm-addons/pull/84)