### PR TITLE
Change "Site Authentication" feature to "Site Trust", and make small changes to the constants

### DIFF
--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -17,9 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WP_Job_Manager_Com_Auth_Token {
 	/**
-	 * The meta key used to store the token.
+	 * The meta key used to store the tokens.
 	 */
-	const META_KEY = 'wpjmcom_site_auth_token';
+	const META_KEY = '_wpjm_site_trust_tokens';
 
 	/**
 	 * The accepted object types to be associated with the token.

--- a/includes/helper/class-wp-job-manager-com-auth-token.php
+++ b/includes/helper/class-wp-job-manager-com-auth-token.php
@@ -64,7 +64,7 @@ class WP_Job_Manager_Com_Auth_Token {
 	 */
 	public function generate( $object_type, $object_id ) {
 		if ( ! in_array( $object_type, self::ACCEPTED_OBJECT_TYPES, true ) ) {
-			return new WP_Error( 'wpjobmanager-com-invalid-type', __( 'Invalid object type', 'wp-job-manager' ) );
+			return new WP_Error( 'wpjobmanager-site-trust-invalid-object-type', __( 'Invalid object type to associate with token', 'wp-job-manager' ) );
 		}
 		$token = $this->generate_new_token();
 		if ( is_wp_error( $token ) ) {
@@ -73,7 +73,7 @@ class WP_Job_Manager_Com_Auth_Token {
 		$encoded = $this->encode( $token );
 		$result  = add_metadata( $object_type, $object_id, self::META_KEY, $encoded );
 		if ( ! $result ) {
-			return new WP_Error( 'wpjobmanager-com-token-not-saved', __( 'Token could not be persisted', 'wp-job-manager' ) );
+			return new WP_Error( 'wpjobmanager-site-trust-token-not-saved', __( 'Token could not be persisted', 'wp-job-manager' ) );
 		}
 		return $token;
 	}
@@ -94,7 +94,7 @@ class WP_Job_Manager_Com_Auth_Token {
 			}
 			return $result;
 		} catch ( Exception $e ) {
-			return new WP_Error( 'wpjobmanager-com-token-not-generated', __( 'Token could not be generated', 'wp-job-manager' ) );
+			return new WP_Error( 'wpjobmanager-site-trust-token-not-generated', __( 'Token could not be generated', 'wp-job-manager' ) );
 		}
 	}
 

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -74,7 +74,7 @@ class WP_Job_Manager_Helper {
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-options.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-api.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-helper-language-packs.php';
-		include_once dirname( __FILE__ ) . '/class-wp-job-manager-com-auth-token.php';
+		include_once dirname( __FILE__ ) . '/class-wp-job-manager-site-trust-token.php';
 
 		$this->api = WP_Job_Manager_Helper_API::instance();
 

--- a/includes/helper/class-wp-job-manager-site-trust-token.php
+++ b/includes/helper/class-wp-job-manager-site-trust-token.php
@@ -34,9 +34,9 @@ class WP_Job_Manager_Site_Trust_Token {
 	/**
 	 * The singleton instance of the class.
 	 *
-	 * @var self
+	 * @var ?self
 	 */
-	private static $instance;
+	private static $instance = null;
 
 	/**
 	 * WP_Job_Manager_Site_Trust_Token constructor.

--- a/includes/helper/class-wp-job-manager-site-trust-token.php
+++ b/includes/helper/class-wp-job-manager-site-trust-token.php
@@ -127,6 +127,7 @@ class WP_Job_Manager_Site_Trust_Token {
 		if ( false === $metadatas ) {
 			return false;
 		}
+		$found = false;
 		foreach ( $metadatas as $metadata ) {
 			if ( ! $this->is_valid_format( $metadata ) ) {
 				// If the metadata structure isn't valid, just ignore it.
@@ -139,10 +140,10 @@ class WP_Job_Manager_Site_Trust_Token {
 			}
 			if ( $this->is_valid_token( $metadata, $token ) ) {
 				delete_metadata( $object_type, $object_id, self::META_KEY, $metadata );
-				return true;
+				$found = true;
 			}
 		}
-		return false;
+		return $found;
 	}
 
 

--- a/includes/helper/class-wp-job-manager-site-trust-token.php
+++ b/includes/helper/class-wp-job-manager-site-trust-token.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the class WP_Job_Manager_Com_Auth_Token.
+ * File containing the class WP_Job_Manager_Site_Trust_Token.
  *
  * @package wp-job-manager
  */
@@ -10,12 +10,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Helper functions used for creating and validating tokens used for authenticating with WPJobManager.com.
+ * Helper functions used for creating and validating tokens used for verification with WPJobManager.com.
  *
  * @package wp-job-manager
  * @since   $$next-version$$
  */
-class WP_Job_Manager_Com_Auth_Token {
+class WP_Job_Manager_Site_Trust_Token {
 	/**
 	 * The meta key used to store the tokens.
 	 */
@@ -39,7 +39,7 @@ class WP_Job_Manager_Com_Auth_Token {
 	private static $instance;
 
 	/**
-	 * WP_Job_Manager_Com_Auth_Token constructor.
+	 * WP_Job_Manager_Site_Trust_Token constructor.
 	 */
 	private function __construct() {}
 

--- a/includes/helper/class-wp-job-manager-site-trust-token.php
+++ b/includes/helper/class-wp-job-manager-site-trust-token.php
@@ -88,11 +88,7 @@ class WP_Job_Manager_Site_Trust_Token {
 			$hash = random_bytes( 48 );
 			//phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			$base64 = base64_encode( $hash );
-			$result = str_replace( [ '+', '/', '=' ], '', $base64 );
-			if ( empty( $result ) ) {
-				$result = substr( bin2hex( $hash ), 0, 64 );
-			}
-			return $result;
+			return strtr( $base64, '+/=', '._-' );
 		} catch ( Exception $e ) {
 			return new WP_Error( 'wpjobmanager-site-trust-token-not-generated', __( 'Token could not be generated', 'wp-job-manager' ) );
 		}

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-site-trust-token.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-site-trust-token.php
@@ -1,27 +1,27 @@
 <?php
 
-require_once JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-com-auth-token.php';
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-site-trust-token.php';
 
 /**
  * @group helper
  * @group helper-base
  */
-class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
+class WP_Test_WP_Job_Manager_Site_Trust_Token extends WPJM_BaseTest {
 
 	public function testInstance_WhenCalled_ReturnSameInstance() {
 		// Arrange.
-		$instance  = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance  = WP_Job_Manager_Site_Trust_Token::instance();
 
 		// Act.
 
 		// Assert.
-		$this->assertInstanceOf( 'WP_Job_Manager_Com_Auth_Token', $instance );
+		$this->assertInstanceOf( 'WP_Job_Manager_Site_Trust_Token', $instance );
 	}
 
 	public function testInstance_WhenCalled_ReturnCorrectType() {
 		// Arrange.
-		$instance  = WP_Job_Manager_Com_Auth_Token::instance();
-		$instance2 = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance  = WP_Job_Manager_Site_Trust_Token::instance();
+		$instance2 = WP_Job_Manager_Site_Trust_Token::instance();
 
 		// Act.
 
@@ -31,7 +31,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testGenerate_WhenPassedInvalidObjectType_ShouldReturnError() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 
 		// Act.
 		$result = $instance->generate( 'comment', 1);
@@ -44,7 +44,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testGenerate_WhenPassedInvalidObjectID_ShouldReturnError() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 
 		// Act.
 		$result = $instance->generate( 'user', 'invalid_id' );
@@ -56,7 +56,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testGenerate_WhenPassedUser_ShouldPersistMeta() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$user = $this->factory->user->create_and_get();
 
 		// Act.
@@ -64,12 +64,12 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 		// Assert.
 		$this->assertIsString( $result );
-		$this->assertNotEmpty( get_user_meta( $user->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+		$this->assertNotEmpty( get_user_meta( $user->ID, WP_Job_Manager_Site_Trust_Token::META_KEY ) );
 	}
 
 	public function testGenerate_WhenPassedPost_ShouldPersistMeta() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$post = $this->factory->post->create_and_get();
 
 		// Act.
@@ -77,12 +77,12 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 		// Assert.
 		$this->assertIsString( $result );
-		$this->assertNotEmpty( get_post_meta( $post->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+		$this->assertNotEmpty( get_post_meta( $post->ID, WP_Job_Manager_Site_Trust_Token::META_KEY ) );
 	}
 
 	public function testValidate_WhenPassedInvalidObjectType_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 
 		// Act.
 		$result = $instance->validate( 'comment', 1, 'test' );
@@ -93,7 +93,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedInvalidObjectID_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 
 		// Act.
 		$result = $instance->validate( 'user', 'test', 'test' );
@@ -104,7 +104,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedUserWithoutMeta_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$user = $this->factory->user->create_and_get();
 
 		// Act.
@@ -116,7 +116,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedUserWithMetaButInvalidToken_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$user = $this->factory->user->create_and_get();
 		$token = $instance->generate('user', $user->ID );
 
@@ -129,7 +129,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedPostWithMetaButInvalidToken_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$post = $this->factory->post->create_and_get();
 		$token = $instance->generate( 'post', $post->ID );
 
@@ -142,7 +142,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedUserWithMetaAndValidTokenTwice_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$user = $this->factory->user->create_and_get();
 		$token = $instance->generate( 'user', $user->ID );
 
@@ -156,7 +156,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedPostWithMetaAndValidTokenTwice_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$post = $this->factory->post->create_and_get();
 		$token = $instance->generate( 'post', $post->ID );
 
@@ -170,7 +170,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenCalledWithUser_ShouldDeleteExpiredTokens() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$user = $this->factory->user->create_and_get();
 		$instance->generate( 'user', $user->ID );
 		$this->expire_tokens( 'user', $user->ID );
@@ -179,12 +179,12 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$instance->validate( 'user', $user->ID, 'test' );
 
 		// Assert.
-		$this->assertEmpty( get_metadata( 'user', $user->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+		$this->assertEmpty( get_metadata( 'user', $user->ID, WP_Job_Manager_Site_Trust_Token::META_KEY ) );
 	}
 
 	public function testValidate_WhenCalledWithPost_ShouldDeleteExpiredTokens() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$post = $this->factory->post->create_and_get();
 		$instance->generate( 'post', $post->ID );
 		$this->expire_tokens( 'post', $post->ID );
@@ -193,12 +193,12 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 		$instance->validate( 'post', $post->ID, 'test' );
 
 		// Assert.
-		$this->assertEmpty( get_metadata( 'user', $post->ID, WP_Job_Manager_Com_Auth_Token::META_KEY ) );
+		$this->assertEmpty( get_metadata( 'user', $post->ID, WP_Job_Manager_Site_Trust_Token::META_KEY ) );
 	}
 
 	public function testValidate_WhenPassedValidUserButTokenIsExpired_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$user = $this->factory->user->create_and_get();
 		$token = $instance->generate( 'user', $user->ID );
 		$this->expire_tokens( 'user', $user->ID );
@@ -212,7 +212,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedValidPostButTokenIsExpired_ShouldReturnFalse() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$post = $this->factory->post->create_and_get();
 		$token = $instance->generate('post', $post->ID);
 		$this->expire_tokens( 'post', $post->ID );
@@ -225,19 +225,19 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 	}
 
 	private function expire_tokens( $object_type, $object_id ) {
-		$metadatas = get_metadata( $object_type, $object_id, WP_Job_Manager_Com_Auth_Token::META_KEY );
+		$metadatas = get_metadata( $object_type, $object_id, WP_Job_Manager_Site_Trust_Token::META_KEY );
 		foreach ( $metadatas as $metadata ) {
 			$new_metadata = [
 				'token' => $metadata['token'],
 				'ts' => $metadata['ts'] - HOUR_IN_SECONDS
 			];
-			update_metadata( $object_type, $object_id, WP_Job_Manager_Com_Auth_Token::META_KEY, $new_metadata, $metadata);
+			update_metadata( $object_type, $object_id, WP_Job_Manager_Site_Trust_Token::META_KEY, $new_metadata, $metadata);
 		}
 	}
 
 	public function testValidate_WhenPassedUserWithMetaAndValidToken_ShouldReturnTrue() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$user = $this->factory->user->create_and_get();
 		$token = $instance->generate( 'user', $user->ID );
 
@@ -250,7 +250,7 @@ class WP_Test_WP_Job_Manager_Com_Auth_Token extends WPJM_BaseTest {
 
 	public function testValidate_WhenPassedPostWithMetaAndValidToken_ShouldReturnTrue() {
 		// Arrange.
-		$instance = WP_Job_Manager_Com_Auth_Token::instance();
+		$instance = WP_Job_Manager_Site_Trust_Token::instance();
 		$post = $this->factory->post->create_and_get();
 		$token = $instance->generate( 'post', $post->ID );
 

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-site-trust-token.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-site-trust-token.php
@@ -38,7 +38,7 @@ class WP_Test_WP_Job_Manager_Site_Trust_Token extends WPJM_BaseTest {
 
 		// Assert.
 		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( 'wpjobmanager-com-invalid-type' , $result->get_error_code() );
+		$this->assertEquals( 'wpjobmanager-site-trust-invalid-object-type' , $result->get_error_code() );
 	}
 
 
@@ -51,7 +51,7 @@ class WP_Test_WP_Job_Manager_Site_Trust_Token extends WPJM_BaseTest {
 
 		// Assert.
 		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( 'wpjobmanager-com-token-not-saved' , $result->get_error_code() );
+		$this->assertEquals( 'wpjobmanager-site-trust-token-not-saved' , $result->get_error_code() );
 	}
 
 	public function testGenerate_WhenPassedUser_ShouldPersistMeta() {


### PR DESCRIPTION
This PR is sibling to the one in  458-gh-Automattic/wpjobmanager.com

### Changes proposed in this Pull Request

This PR was sent to change some small things in the previously called "Site Authentication" feature:


* Rename class from `WP_Job_Manager_Com_Auth_TOKEN` to `WP_Job_Manager_Site_Trust_Token`, to align with the name used in WPJMCOM
* Change meta key to have a `_` prefix (so it is considered "private" and can't be edited by the user), and refer to the token in plural, as the meta key might save more than one token
* Improve error codes/messages used on the `WP_Job_Manager_Site_Trust_Token` class
* Fix a rare case where the token might be empty, which could generate weird results

### Testing instructions

The changes are fairly small, but, if you want to test in practice, you can run the unit tests and experiment creating tokens using WP-CLI Shell:

```php
$instance = WP_Job_Manager_Site_Trust_Token::instance(); // To get the instance of the class
$token = $instance->generate( 'user', 1 ); // Create a token associated with the User ID 1
// Maybe await a minute using sleep(60)?
var_dump($instance->validate( 'user', 1, $token));
// Make the same test with a valid post instead of user
```