### PR TITLE
Integrate deactivate promotion action

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -17,6 +17,16 @@ a.wpjm-activate-licence-link:active {
 	color: orangered;
 }
 
+.column-promoted_jobs {
+	.jm-promoted__status-promoted {
+		font-weight: bold;
+	}
+
+	.jm-promoted__deactivate {
+		color: #b32d2e;
+	}
+}
+
 /** Promote Job Modal **/
 .promote-buttons-group {
 	.button {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -180,21 +180,13 @@ jQuery(document).ready(function($) {
 });
 
 function wpjmModal( selector, dialogSelector, action ) {
-	let item = document.querySelectorAll( selector );
+	let item   = document.querySelectorAll( selector );
 	let dialog = document.querySelector( dialogSelector );
-	let cancelButton = dialog.querySelectorAll( '.dialog-close' );
-
-	cancelButton.forEach( function( element ) {
-		element.addEventListener( 'click', function( event ) {
-			event.preventDefault();
-			dialog.close();
-		});
-	});
 	populateTemplate( item, dialog, action );
 }
 
 function populateTemplate( item, dialog, action ) {
-	if ( typeof action !== 'undefined' )  {
+	if ( typeof action !== 'undefined' ) {
 		item.forEach( function( element ) {
 			element.addEventListener( 'click', function( event ) {
 				event.preventDefault();
@@ -206,32 +198,32 @@ function populateTemplate( item, dialog, action ) {
 					</form>
 					<promote-job-template>
 						<div slot="buttons" class="promote-buttons-group">
-								<button class="promote-button button button-primary" type="submit" href="${ this.getAttribute( 'data-post') }">Promote your jobs</button>
-								<button class="promote-button button button-secondary" type="submit" href="#">Learn More</button>
+								<a class="promote-button button button-primary" target="_blank" href="${ this.getAttribute( 'data-href' ) }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
+								<a class="promote-button button button-secondary" target="_blank" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
 						</div>
 					<promote-job-template>`;
 				}
 				if ( 'deactivate' === action ) {
-					let deactivateButton = document.querySelector('.deactivate-promotion');
-					deactivateButton.setAttribute( 'href', this.getAttribute( 'data-post' ) );
+					let deactivateButton = dialog.querySelector( '.deactivate-promotion' );
+					deactivateButton.setAttribute( 'href', this.getAttribute( 'data-href' ) );
 				}
-			});
-		});
+			} );
+		} );
 	}
 }
 
 wpjmModal( '.promote_job', '#promote-dialog', 'promote' );
-wpjmModal( '.deactivate-job', '#deactivate-dialog', 'deactivate' );
+wpjmModal( '.jm-promoted__deactivate', '#deactivate-dialog', 'deactivate' );
 
-customElements.define('promote-job-template',
-class extends HTMLElement {
-	constructor() {
-		super();
-		const promoteJobs = document.getElementById('promote-job-template').content;
-		const shadowRoot = this.attachShadow({
-			mode: 'open'
-		});
-		shadowRoot.appendChild(promoteJobs.cloneNode(true));
-	}
-});
+customElements.define( 'promote-job-template',
+	class extends HTMLElement {
+		constructor() {
+			super();
+			const promoteJobs = document.getElementById( 'promote-job-template' ).content;
+			const shadowRoot  = this.attachShadow( {
+				mode: 'open',
+			} );
+			shadowRoot.appendChild( promoteJobs.cloneNode( true ) );
+		}
+	} );
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -110,7 +110,7 @@ class WP_Job_Manager_Admin {
 				'job_manager_admin_js',
 				'job_manager_admin_params',
 				[
-					'user_selection_strings' => [
+					'user_selection_strings'      => [
 						'no_matches'        => _x( 'No matches found', 'user selection', 'wp-job-manager' ),
 						'ajax_error'        => _x( 'Loading failed', 'user selection', 'wp-job-manager' ),
 						'input_too_short_1' => _x( 'Please enter 1 or more characters', 'user selection', 'wp-job-manager' ),
@@ -118,8 +118,12 @@ class WP_Job_Manager_Admin {
 						'load_more'         => _x( 'Loading more results&hellip;', 'user selection', 'wp-job-manager' ),
 						'searching'         => _x( 'Searching&hellip;', 'user selection', 'wp-job-manager' ),
 					],
-					'ajax_url'               => admin_url( 'admin-ajax.php' ),
-					'search_users_nonce'     => wp_create_nonce( 'search-users' ),
+					'job_listing_promote_strings' => [
+						'promote_job' => _x( 'Promote your jobs', 'job promotion', 'wp-job-manager' ),
+						'learn_more'  => _x( 'Learn More', 'job promotion', 'wp-job-manager' ),
+					],
+					'ajax_url'                    => admin_url( 'admin-ajax.php' ),
+					'search_users_nonce'          => wp_create_nonce( 'search-users' ),
 				]
 			);
 		}

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -135,7 +135,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return boolean
 	 */
 	public function deactivate_promotion( $post_id ) {
-		return update_post_meta( $post_id, '_promoted', 1 );
+		return update_post_meta( $post_id, '_promoted', 0 );
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -35,6 +35,7 @@ class WP_Job_Manager_Promoted_Jobs {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new self();
 		}
+
 		return self::$instance;
 	}
 
@@ -45,51 +46,138 @@ class WP_Job_Manager_Promoted_Jobs {
 		add_filter( 'manage_edit-job_listing_columns', [ $this, 'promoted_jobs_columns' ] );
 		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'promoted_jobs_custom_columns' ], 2 );
 		add_action( 'admin_footer', [ $this, 'promoted_jobs_admin_footer' ] );
+		add_action( 'load-edit.php', [ $this, 'handle_deactivate_promotion' ] );
+		add_action( 'wpjm_job_listing_bulk_actions', [ $this, 'add_action_notice' ] );
+
 	}
 
 	/**
 	 * Add a column to the job listings admin page.
 	 *
 	 * @param array $columns Columns.
+	 *
 	 * @return array
 	 */
 	public function promoted_jobs_columns( $columns ) {
 		$columns['promoted_jobs'] = __( 'Promote', 'wp-job-manager' );
+
 		return $columns;
+	}
+
+	/**
+	 * Handle request to deactivate promotion for a job.
+	 */
+	public function handle_deactivate_promotion() {
+		if ( ! isset( $_GET['action'] ) || 'deactivate_promotion' !== $_GET['action'] ) {
+			return;
+		}
+
+		$post_id = absint( $_GET['post_id'] ?? 0 );
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Nonce should not be modified.
+		if ( ! $post_id || empty( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], 'deactivate_promotion_' . $_GET['post_id'] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_job_listings', $post_id ) || 'job_listing' !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		$this->deactivate_promotion( $post_id );
+
+		wp_safe_redirect(
+			add_query_arg(
+				[
+					'action_performed' => 'promotion_deactivated',
+					'handled_jobs'     => [ $post_id ],
+				],
+				remove_query_arg( [ 'action', 'post_id', 'nonce' ] )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Add feedback notice after successful deactivation.
+	 *
+	 * @param array $actions_handled
+	 *
+	 * @return array
+	 */
+	public function add_action_notice( $actions_handled ) {
+
+		$actions_handled['promotion_deactivated'] = [
+			// translators: Placeholder (%s) is the name of the job listing affected.
+			'notice' => __( 'Promotion for %s deactivated', 'wp-job-manager' ),
+		];
+
+		return $actions_handled;
 	}
 
 	/**
 	 * Check if a job is promoted.
 	 *
 	 * @param int $post_id
+	 *
 	 * @return boolean
 	 */
 	public function is_promoted( $post_id ) {
 		$promoted = get_post_meta( $post_id, '_promoted', true );
-		return $promoted ? true : false;
+
+		return (bool) $promoted;
+	}
+
+	/**
+	 * Deactivate promotion for a job.
+	 *
+	 * @param int $post_id
+	 *
+	 * @return boolean
+	 */
+	public function deactivate_promotion( $post_id ) {
+		return update_post_meta( $post_id, '_promoted', 1 );
 	}
 
 	/**
 	 * Handle display of new column
 	 *
-	 * @param  string $column
+	 * @param string $column
 	 */
 	public function promoted_jobs_custom_columns( $column ) {
 		global $post;
-		if ( 'promoted_jobs' === $column ) {
-			if ( $this->is_promoted( $post->ID ) ) {
-				echo '
-					Live
-					<br />
-					<a href="#">Edit promotion</a>
-					<br />
-					<a class="deactivate-job"href="#" data-post=' . esc_attr( $post->ID ) . '>Deactivate</a>
-				';
-			} else {
-				echo '<button class="promote_job button button-primary" data-post=' . esc_attr( $post->ID ) . '>Promote</button>';
-			}
+
+		if ( 'promoted_jobs' !== $column ) {
+			return;
+		}
+
+		if ( $this->is_promoted( $post->ID ) ) {
+			$nonce                  = wp_create_nonce( 'deactivate_promotion_' . $post->ID );
+			$deactivate_action_link = add_query_arg(
+				[
+					'action'  => 'deactivate_promotion',
+					'post_id' => $post->ID,
+					'nonce'   => $nonce,
+				]
+			);
+			echo '
+			<span class="jm-promoted__status-promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>
+			<div class="row-actions">
+				<a href="#" class="jm-promoted__edit">' . esc_html__( 'Edit', 'wp-job-manager' ) . '</a>
+				|
+				<a class="jm-promoted__deactivate delete" href="#" data-href="' . esc_url( $deactivate_action_link ) . '">' . esc_html__( 'Deactivate', 'wp-job-manager' ) . '</a>
+			</div>
+			';
+		} else {
+			$promote_url = add_query_arg(
+				[
+					'job_id' => $post->ID,
+				],
+				'https://wpjobmanager.com/promote-job/'
+			);
+			echo '<button class="promote_job button button-primary" data-href=' . esc_url( $promote_url ) . '>' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		}
 	}
+
 	/**
 	 * Store the promoted jobs template from wpjobmanager.com
 	 *
@@ -228,30 +316,32 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function promoted_jobs_admin_footer() {
 		?>
-			<template id="promote-job-template">
-				<?php echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-			</template>
-			<dialog class="wpjm-dialog" id="promote-dialog"></dialog>
+		<template id="promote-job-template">
+			<?php echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		</template>
+		<dialog class="wpjm-dialog" id="promote-dialog"></dialog>
 
-			<dialog class="wpjm-dialog deactivate-dialog" id="deactivate-dialog">
-				<form class="dialog deactivate-button" method="dialog">
-					<button class="dialog-close" type="submit">X</button>
-				</form>
-				<h2 class="deactivate-modal-heading">
-					<?php esc_html_e( 'Are you sure you want to deactivate promotion for this job?', 'wp-job-manager' ); ?>
-				</h2>
-				<p>
-					<?php esc_html_e( 'If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.', 'wp-job-manager' ); ?>
-				</p>
+		<dialog class="wpjm-dialog deactivate-dialog" id="deactivate-dialog">
+			<form class="dialog deactivate-button" method="dialog">
+				<button class="dialog-close" type="submit">X</button>
+			</form>
+			<h2 class="deactivate-modal-heading">
+				<?php esc_html_e( 'Are you sure you want to deactivate promotion for this job?', 'wp-job-manager' ); ?>
+			</h2>
+			<p>
+				<?php esc_html_e( 'If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.', 'wp-job-manager' ); ?>
+			</p>
+			<form method="dialog">
 				<div class="deactivate-action promote-buttons-group">
 					<button class="dialog-close button button-secondary" type="submit">
 						<?php esc_html_e( 'Cancel', 'wp-job-manager' ); ?>
 					</button>
-					<button class="deactivate-promotion button button-primary" type="submit">
-						<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
-					</button>
+					<a class="deactivate-promotion button button-primary"">
+					<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
+					</a>
 				</div>
-			</dialog>
+			</form>
+		</dialog>
 		<?php
 	}
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs.php
@@ -336,7 +336,7 @@ class WP_Job_Manager_Promoted_Jobs {
 					<button class="dialog-close button button-secondary" type="submit">
 						<?php esc_html_e( 'Cancel', 'wp-job-manager' ); ?>
 					</button>
-					<a class="deactivate-promotion button button-primary"">
+					<a class="deactivate-promotion button button-primary">
 					<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
 					</a>
 				</div>


### PR DESCRIPTION
Fixes #2440

### Changes proposed in this Pull Request

* Add an admin action that deactivates promotion for the job
* Add `Promotion for "Job title" deactivated` notice after action
* Add localization support for the strings
* Tweak the column to be less busy — move action to hover, like row-actions, and make 'Deactivate' red and scary

### Testing instructions

* Add `'_promoted' => 1 `meta to a few job listings
* Open the Job listings page. See that they are marked as promoted
* Click deactivate in the promote column, and confirm in modal
* Job should no longer be marked as promoted

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1101" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/1056e80a-3e13-4ccc-9a52-6da6bb7ce0ce">

