### PR TITLE
Revert continuing the submission of listings with pending payments

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -487,6 +487,7 @@ class WP_Job_Manager_Shortcodes {
 					];
 				}
 				break;
+			case 'pending_payment':
 			case 'pending':
 				if ( WP_Job_Manager_Post_Types::job_is_editable( $job->ID ) ) {
 					$actions['edit'] = [
@@ -495,7 +496,6 @@ class WP_Job_Manager_Shortcodes {
 					];
 				}
 				break;
-			case 'pending_payment':
 			case 'draft':
 			case 'preview':
 				$actions['continue'] = [


### PR DESCRIPTION
### Overview
This is a continuation of [this PR](https://github.com/Automattic/WP-Job-Manager/pull/2452). I think continuing the submission of listings with a status of `pending_payment` will need a bit more changes and the reason for that is that the `pending_payment` status can mean many things which are also different between SPL and WCPL.

For SPL a listing will have this status when the payment is initiated (e.g. clicking the PayPal link). For these cases specifically, the user will see a 'Pay' link in the dashboard so we shouldn't have any extra links:
![Screenshot 2023-06-29 at 17 49 46](https://github.com/Automattic/WP-Job-Manager/assets/53191348/abc64379-809c-48de-ae93-98d0cbe39a79)

For WCPL this status can mean a couple of things:
- The user stopped in the package selection screen.
- The user stopped at checkout.
- The user actually paid but with a payment method that requires approval (e.g. bank transfer, PayPal etc.)

The above scenarios should be handled differently I think (e.g. in the third case I would expect the 'Continue Submission' link to not show at all). Also I am not sure if the `Allow editing of pending listings` setting should affect this feature.

For this reason, I think that we should revert the change for now and come back with a better plan on how to handle all these cases.

### Changes proposed in this Pull Request

* Reverts this PR: https://github.com/Automattic/WP-Job-Manager/pull/2452

### Testing instructions

* With WCPL install, try to submit a job
* Stop in the package selection screen and visit the dashboard.
* Observe that the 'Continue submission' link is not availble.