### PR TITLE
Endpoint to update promoted job status

### DIFF
--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -177,10 +177,14 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "example": true,
+                      "description": "The status of the job after it is updated"
                     },
                     "message": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "Promoted job status updated",
+                      "description": "The message returned after the job is updated"
                     }
                   }
                 }
@@ -195,13 +199,19 @@
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "not_found"
                     },
                     "message": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "The promoted job was not found"
                     },
                     "data": {
-                      "$ref": "#/components/schemas/Error"
+                      "$ref": "#/components/schemas/Error",
+                      "description": "The error object",
+                      "example": {
+                        "status": 404
+                      }
                     }
                   }
                 }

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -161,7 +161,7 @@
                 "type": "object",
                 "properties": {
                   "status": {
-                    "type": "integer"
+                    "type": "boolean"
                   }
                 }
               }

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -128,6 +128,101 @@
           }
         }
       }
+    },
+    "/wp-json/wpjm-internal/v1/promoted-jobs/:id": {
+      "put": {
+        "summary": "Promoted Jobs - Update the after job is promoted or expired in JobTarget",
+        "description": "Update promoted job status",
+        "operationId": "update-promotedjob",
+        "tags": [
+          "promoted-jobs"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "description": "application/json"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The promoted job was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": []
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer"
+          }
+        }
+      }
     }
   }
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -157,7 +157,7 @@ class WP_Job_Manager_Promoted_Jobs_API extends WP_REST_Controller {
 		$post    = get_post( $post_id );
 
 		if ( empty( $post ) ) {
-			return new WP_Error( 'not_found', __( 'Post not found', 'wp-job-manager' ), [ 'status' => 404 ] );
+			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
 
 		$result = update_post_meta( $post_id, WP_Job_Manager_Promoted_Jobs::META_KEY, $status );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -67,7 +67,7 @@ class WP_Job_Manager_Promoted_Jobs_API extends WP_REST_Controller {
 						],
 						'status' => [
 							'validate_callback' => function( $param ) {
-								return is_numeric( $param );
+								return is_bool( $param );
 							},
 						],
 					],


### PR DESCRIPTION
Fixes #2442

### Changes proposed in this Pull Request

* Exposes an endpoint to update the status of a promoted job when it changes from Job Target.
* Documents schema in `/docs/api/internal.json` 

### Testing instructions

* Make a `PUT` request to: `/wp-json/wpjm-internal/v1/promoted-jobs/{id}` with the body `status: 0 or 1`.
* Ensure the post is a promoted job.
* See that it's status has changed
* Note: this endpoint is not authenticated, there's another [issue](https://github.com/Automattic/wpjobmanager.com/issues/433) for it.
