### PR TITLE
Populate continue and relist actions in dashboard

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -261,10 +261,11 @@ class WP_Job_Manager_Shortcodes {
 
 						$query_args = [
 							'job_id' => absint( $job_id ),
+							'action' => $action,
 						];
+
 						if ( 'renew' === $action ) {
-							$query_args['action'] = $action;
-							$query_args['nonce']  = wp_create_nonce( 'job_manager_renew_job_' . $job_id );
+							$query_args['nonce'] = wp_create_nonce( 'job_manager_renew_job_' . $job_id );
 						}
 						wp_safe_redirect( add_query_arg( $query_args, job_manager_get_permalink( 'submit_job_form' ) ) );
 						exit;


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

* Adds 'relist' and 'continue' as url argumants in the dashboard
* Needed for this PR: https://github.com/Automattic/wpjm-addons/pull/84

### Testing instructions

* Make sure that no submit job flows are broken