### PR TITLE
Fix some issues on the Promoted Jobs API and refactor it to be more consistent with WPJMCOM

### DIFF
--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -129,9 +129,9 @@
         }
       }
     },
-    "/wp-json/wpjm-internal/v1/promoted-jobs/:id": {
+    "/wp-json/wpjm-internal/v1/promoted-jobs/{id}": {
       "put": {
-        "summary": "Promoted Jobs - Update the after job is promoted or expired in JobTarget",
+        "summary": "Promoted Jobs - Update the status of the job in JobTarget",
         "description": "Update promoted job status",
         "operationId": "update-promotedjob",
         "tags": [
@@ -143,22 +143,25 @@
             "in": "header",
             "schema": {
               "type": "string",
-              "default": "application/json"
+              "default": "application/x-www-form-urlencoded"
             },
-            "description": "application/json"
+            "description": "The format to put results in"
           },
           {
             "name": "id",
             "in": "path",
-            "type": "integer",
+            "schema": {
+              "type": "integer"
+            },
             "required": true
           }
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
+                "required": true,
                 "properties": {
                   "status": {
                     "type": "boolean"
@@ -207,11 +210,7 @@
                       "example": "The promoted job was not found"
                     },
                     "data": {
-                      "$ref": "#/components/schemas/Error",
-                      "description": "The error object",
-                      "example": {
-                        "status": 404
-                      }
+                      "$ref": "#/components/schemas/ErrorData",
                     }
                   }
                 }
@@ -225,12 +224,16 @@
   },
   "components": {
     "schemas": {
-      "Error": {
+      "ErrorData": {
         "type": "object",
+        "description": "Additional details about the error",
         "properties": {
           "status": {
             "type": "integer"
           }
+        },
+        "example": {
+          "status": 404
         }
       }
     }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -51,14 +51,12 @@ class WP_Job_Manager_Promoted_Jobs_API {
 					'permission_callback' => '__return_true',
 					'args'                => [
 						'id'     => [
-							'validate_callback' => function( $param ) {
-								return is_numeric( $param );
-							},
+							'type' => 'integer',
+							'required' => true,
 						],
 						'status' => [
-							'validate_callback' => function( $param ) {
-								return is_bool( $param );
-							},
+							'type' => 'boolean',
+							'required' => true,
 						],
 					],
 				],

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -82,7 +82,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 				[
 					'key'     => WP_Job_Manager_Promoted_Jobs::META_KEY,
 					'value'   => '1',
-					'compare' => '==',
+					'compare' => '=',
 				],
 			],
 		];

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -69,7 +69,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	/**
 	 * Get all promoted jobs.
 	 *
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response The response, or WP_Error on failure.
 	 */
 	public function get_items() {
 		$args = [
@@ -133,7 +133,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * Update the promoted job status.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response The response, or WP_Error on failure.
 	 */
 	public function update_job_status( $request ) {
 		$post_id = $request->get_param( 'id' );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -138,7 +138,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
 
-		$result = update_post_meta( $post_id, WP_Job_Manager_Promoted_Jobs::META_KEY, $status );
+		$result = update_post_meta( $post_id, WP_Job_Manager_Promoted_Jobs::META_KEY, $status ? '1' : '0' );
 		return new WP_REST_Response(
 			[
 				'data'    => $result,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -87,10 +87,6 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		$items = get_posts( $args );
 
-		if ( empty( $items ) ) {
-			return rest_ensure_response( $items );
-		}
-
 		$data = array_map( [ $this, 'prepare_item_for_response' ], $items );
 
 		return new WP_REST_Response( [ 'jobs' => $data ], 200 );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -51,11 +51,11 @@ class WP_Job_Manager_Promoted_Jobs_API {
 					'permission_callback' => '__return_true',
 					'args'                => [
 						'id'     => [
-							'type' => 'integer',
+							'type'     => 'integer',
 							'required' => true,
 						],
 						'status' => [
-							'type' => 'boolean',
+							'type'     => 'boolean',
 							'required' => true,
 						],
 					],

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -78,6 +78,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'post_status'         => 'publish',
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
+			'posts_per_page'      => -1,
 			'meta_query'          => [
 				[
 					'key'     => WP_Job_Manager_Promoted_Jobs::META_KEY,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -42,9 +42,8 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			]
 		);
 		register_rest_route(
-			$this->namespace,
-			'/' .
-			$this->rest_base . '/(?P<id>[\d]+)',
+			self::NAMESPACE,
+			self::REST_BASE . '/(?P<id>[\d]+)',
 			[
 				[
 					'methods'             => WP_REST_Server::EDITABLE,


### PR DESCRIPTION
This PR fixes a few issues that I found on #2469 and improves the validation of arguments in #2484

### Changes proposed in this Pull Request

* Do not extend on `WP_REST_Controller` anymore, as we do on other classes in WPJMCOM
* Use constants instead of properties with set values - As these values won't change anyway
* Use `type` instead of `validate_callback` to validate if an argument has the correct type
* Use the `=` as meta query's compare operator, as `==` isn't recognized officially by WP
* Use `get_posts` instead of `WP_Query` to query for jobs
* **FIX**: Remove pagination for the API endpoint to query all the promoted jobs, otherwise we would get only 10 jobs and only that;
* **FIX**: Return the same format of response if there's no promoted jobs listed
* **FIX**: Persist meta as '1' or '0' instead of using a boolean there

### Testing instructions

Check if the behavior described in #2484 and on #2469 is still working.

Also check:

-  if all the jobs are returned when the promoted when there are more than 10 promoted jobs registered
- If the response is `{"jobs": [] }` when there are no promoted jobs registered
