### PR TITLE
[Proposal] Remove nonce from the Promote Jobs admin action

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -146,7 +146,6 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	 */
 	public function handle_promote_job() {
 		$post_id = absint( $_GET['post_id'] ?? 0 );
-		check_admin_referer( self::PROMOTE_JOB_ACTION . '-' . $post_id );
 		if ( ! $post_id ) {
 			wp_die( esc_html__( 'No job listing ID provided for promotion.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
@@ -216,7 +215,6 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			[
 				'action'   => self::PROMOTE_JOB_ACTION,
 				'post_id'  => $post->ID,
-				'_wpnonce' => wp_create_nonce( self::PROMOTE_JOB_ACTION . '-' . $post->ID ),
 			],
 			$base_url
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Remove nonce from the Promote Jobs endpoint so the PR https://github.com/Automattic/wpjobmanager.com/pull/488 can work.

### Testing Instructions

Check  https://github.com/Automattic/wpjobmanager.com/pull/488 for more changes and testing instructions

### Notes

Related Slack Thread discussion: p1688653844642639-slack-C053397HN30