### PR TITLE
Fix promote job button text

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -119,7 +119,7 @@ class WP_Job_Manager_Admin {
 						'searching'         => _x( 'Searching&hellip;', 'user selection', 'wp-job-manager' ),
 					],
 					'job_listing_promote_strings' => [
-						'promote_job' => _x( 'Promote your jobs', 'job promotion', 'wp-job-manager' ),
+						'promote_job' => _x( 'Promote your job', 'job promotion', 'wp-job-manager' ),
 						'learn_more'  => _x( 'Learn More', 'job promotion', 'wp-job-manager' ),
 					],
 					'ajax_url'                    => admin_url( 'admin-ajax.php' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It just fixes the CTA text from the promote modal.

### Testing instructions

* Open the promote modal, and see that the button is "Promote your job".

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="228" alt="Screenshot 2023-07-07 at 15 09 30" src="https://github.com/Automattic/WP-Job-Manager/assets/876340/98628e27-cd83-41ef-b6b9-e8a817638bdd">
