### PR TITLE
Fix notification logic to align with site notification endpoint in WPJMCOM

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -63,7 +63,6 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		add_action( 'admin_action_' . self::DEACTIVATE_PROMOTION_ACTION, [ $this, 'handle_deactivate_promotion' ] );
 		add_action( 'admin_footer', [ $this, 'promoted_jobs_admin_footer' ] );
 		add_action( 'wpjm_job_listing_bulk_actions', [ $this, 'add_action_notice' ] );
-		add_filter( 'allowed_redirect_hosts', [ $this, 'add_to_allowed_redirect_hosts' ] );
 	}
 
 	/**
@@ -141,19 +140,6 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		];
 
 		return $actions_handled;
-	}
-
-	/**
-	 * Add the host of the Promote Job form to the array of allowed redirect hosts.
-	 *
-	 * @param array $hosts Allowed redirect hosts.
-	 *
-	 * @return array Updated array of allowed redirect hosts.
-	 */
-	public function add_to_allowed_redirect_hosts( $hosts ) {
-		$hosts[] = wp_parse_url( WP_Job_Manager_Helper_API::get_wpjmcom_url(), PHP_URL_HOST );
-
-		return $hosts;
 	}
 
 	/**

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -98,11 +98,23 @@ class WP_Job_Manager {
 
 		// Filters.
 		add_filter( 'wp_privacy_personal_data_exporters', [ 'WP_Job_Manager_Data_Exporter', 'register_wpjm_user_data_exporter' ] );
+		add_filter( 'allowed_redirect_hosts', [ $this, 'add_to_allowed_redirect_hosts' ] );
 
 		add_action( 'init', [ $this, 'usage_tracking_init' ] );
 
 		// Defaults for WPJM core actions.
 		add_action( 'wpjm_notify_new_user', 'wp_job_manager_notify_new_user', 10, 2 );
+	}
+
+	/**
+	 * Add the WPJMCOM host to the array of allowed redirect hosts.
+	 *
+	 * @param array $hosts Allowed redirect hosts.
+	 * @return array Updated array of allowed redirect hosts.
+	 */
+	public function add_to_allowed_redirect_hosts( $hosts ) {
+		$hosts[] = wp_parse_url( WP_Job_Manager_Helper_API::get_wpjmcom_url(), PHP_URL_HOST );
+		return $hosts;
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -112,6 +112,8 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * @return WP_Error|WP_REST_Response The response, or WP_Error on failure.
 	 */
 	public function get_items() {
+		global $wpdb;
+
 		$args = [
 			'post_type'           => 'job_listing',
 			'post_status'         => 'publish',
@@ -128,6 +130,14 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		];
 
 		$items = get_posts( $args );
+
+		if ( ! empty( $wpdb->last_errors ) ) {
+			return new WP_Error(
+				'wpjm_error_getting_jobs',
+				$wpdb->last_errors,
+				[ 'status' => 500 ]
+			);
+		}
 
 		$data = array_map( [ $this, 'prepare_item_for_response' ], $items );
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -145,9 +145,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 		$site_url = home_url();
 		// We want to have the URL to the home-page of the site, not the URL to WordPress.
 		$feed_url = rest_url( 'wpjm-internal/v1/promoted-jobs' );
-		if ( str_starts_with( $feed_url, $site_url ) ) {
-			$feed_url = substr( $feed_url, strlen( $site_url ) );
-		}
+		$feed_url = substr( $feed_url, strlen( $site_url ) );
 		return add_query_arg(
 			[
 				'site_url' => $site_url,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -152,8 +152,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 */
 	private function get_notification_data() {
 		$site_url = home_url();
-		// We want to have the URL to the home-page of the site, not the URL to WordPress.
-		$feed_url = rest_url( 'wpjm-internal/v1/promoted-jobs' );
+		$feed_url = rest_url( '/wpjm-internal/v1/promoted-jobs' );
 		$feed_url = substr( $feed_url, strlen( $site_url ) );
 		return [
 			'site_url' => $site_url,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -200,6 +200,8 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 * @return void
 	 */
 	public function send_notification( $retry = 0 ) {
+		// Clear any scheduled retries.
+		wp_unschedule_hook( self::RETRY_JOB_NAME );
 		$response = wp_safe_remote_post( $this->get_notification_url() );
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			if ( ! $this->has_scheduled_retry() && $retry < self::NUMBER_OF_RETRIES ) {
@@ -210,9 +212,6 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 					[ $retry + 1 ]
 				);
 			}
-		} else {
-			// Clear any scheduled retries.
-			wp_unschedule_hook( self::RETRY_JOB_NAME );
 		}
 	}
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -21,7 +21,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 *
 	 * @var string
 	 */
-	const NOTIFICATION_URL = 'https://wpjobmanager.com/wp-json/promoted-jobs/v1/site/{site_id}/update';
+	const NOTIFICATION_URL = 'https://wpjobmanager.com/wp-json/promoted-jobs/v1/site/update';
 
 	/**
 	 * The name of the job that will be scheduled to run if notification fails.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -182,7 +182,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 * @return bool
 	 */
 	private function is_promoted_job( $post_id ) {
-		return get_post_meta( $post_id, '_promoted', true );
+		return '1' === get_post_meta( $post_id, '_promoted', true );
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -151,7 +151,13 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 * @return string
 	 */
 	private function get_notification_url() {
-		return str_replace( '{site_id}', $this->get_site_id(), self::NOTIFICATION_URL );
+		return add_query_arg(
+			[
+				'site_url' => site_url(),
+				'feed_url' => rest_url( 'wpjm-internal/v1/promoted-jobs' ),
+			],
+			self::NOTIFICATION_URL
+		);
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -142,10 +142,16 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 * @return string
 	 */
 	private function get_notification_url() {
+		$site_url = home_url();
+		// We want to have the URL to the home-page of the site, not the URL to WordPress.
+		$feed_url = rest_url( 'wpjm-internal/v1/promoted-jobs' );
+		if ( str_starts_with( $feed_url, $site_url ) ) {
+			$feed_url = substr( $feed_url, strlen( $site_url ) );
+		}
 		return add_query_arg(
 			[
-				'site_url' => site_url(),
-				'feed_url' => rest_url( 'wpjm-internal/v1/promoted-jobs' ),
+				'site_url' => $site_url,
+				'feed_url' => $feed_url,
 			],
 			self::NOTIFICATION_URL
 		);

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -137,15 +137,6 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	}
 
 	/**
-	 * Get the site ID.
-	 *
-	 * @return int|string
-	 */
-	private function get_site_id() {
-		return get_current_blog_id();
-	}
-
-	/**
 	 * Get the notification URL.
 	 *
 	 * @return string

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -17,11 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WP_Job_Manager_Promoted_Jobs_Notifications {
 
 	/**
-	 * The URL to notify. Sending this notification will trigger a sync of the site's jobs.
+	 * The endpoint in WPJMCOM to notify. Sending this notification will trigger a sync of the site's jobs.
 	 *
 	 * @var string
 	 */
-	const NOTIFICATION_URL = 'https://wpjobmanager.com/wp-json/promoted-jobs/v1/site/update';
+	const NOTIFICATION_ENDPOINT = '/wp-json/promoted-jobs/v1/site/update';
 
 	/**
 	 * The name of the job that will be scheduled to run if notification fails.
@@ -151,7 +151,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 				'site_url' => $site_url,
 				'feed_url' => $feed_url,
 			],
-			self::NOTIFICATION_URL
+			WP_Job_Manager_Helper_API::get_wpjmcom_url() . self::NOTIFICATION_ENDPOINT
 		);
 	}
 


### PR DESCRIPTION
Fixes 463-gh-Automattic/wpjobmanager.com

### Changes proposed in this Pull Request

- Fix communication with WPJMCOM for pinging about changes in a promoted job
- Move method `add_to_allowed_redirect_hosts` to WP_Job_Manager class
- Return error if `get_posts` return error on WPJM feed


### Testing instructions

Using this branch of the WPJM plugin, and a WPJMCOM instance based on 490-gh-Automattic/wpjobmanager.com 

1. Create a job in your WPJM instance
2. Promote that job by manually clicking on "Promote"
3. Mark the job as promoted by setting the _promoted meta to 1: `wp post meta set _promoted 1`
4. Make sure the `_wpjmcom_url` meta on the Promoted Site created in WPJMCOM has the URL of your WPJM instance. If needed, change it by running on your WPJMCOM instance: `wp post meta set SITE_ID _wpjmcom_url SITE_URL`
5. Edit the job on your WPJM instance, and make sure the changes are synced to your local WPJMCOM instance
6. Deactivate the job (or just remove the job altogether), and make sure the job is appropriately removed from your local WPJMCOM instance as well