### PR TITLE
Check if user can promote job before presenting button

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -90,7 +90,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			wp_die( esc_html__( 'No job listing ID provided for deactivation of the promotion.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 
-		if ( ! current_user_can( 'manage_job_listings', $post_id ) || 'job_listing' !== get_post_type( $post_id ) ) {
+		if ( ! $this->can_promote_job( $post_id ) ) {
 			wp_die( esc_html__( 'You do not have permission to deactivate the promotion for this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 
@@ -110,6 +110,21 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Check if a user can promote a job. They must have permission to manage job listings and the post type must be a published job_listing.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return bool Returns true if they can promote a job.
+	 */
+	private function can_promote_job( int $post_id ) {
+		if ( 'job_listing' !== get_post_type( $post_id ) || 'publish' !== get_post_status( $post_id ) ) {
+			return false;
+		}
+
+		return current_user_can( 'manage_job_listings', $post_id );
 	}
 
 	/**
@@ -212,6 +227,11 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		if ( 'promoted_jobs' !== $column ) {
 			return;
 		}
+
+		if ( ! $this->can_promote_job( $post->ID ) ) {
+			return;
+		}
+
 		$base_url    = admin_url( 'admin.php' );
 		$promote_url = add_query_arg(
 			[

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -165,7 +165,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		if ( ! $post_id ) {
 			wp_die( esc_html__( 'No job listing ID provided for promotion.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
-		if ( ! current_user_can( 'manage_job_listings', $post_id ) || 'job_listing' !== get_post_type( $post_id ) ) {
+		if ( ! $this->can_promote_job( $post_id ) ) {
 			wp_die( esc_html__( 'You do not have permission to promote this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 		$current_user = get_current_user_id();


### PR DESCRIPTION
Fixes #2494 
Fixes #2497 

Based off of #2481 

### Changes proposed in this Pull Request

* Require correct permissions to promote or deactivate job
* Require job be published.

### Testing instructions

Use this snippet to play with the permissions. As is, it will just give the capability to jobs with `job` in the title.

```php
add_filter(
  'user_has_cap',
  function( $allcaps, $caps, $args ) {
	if ( ! in_array( 'manage_job_listings', $caps, true ) ) {
	  return $allcaps;
	}
	
	$job_id = $args[2] ?? null;
	if ( ! $job_id ) {
	  return $allcaps;
	}
	
	$job = get_post( $job_id );
	if ( 'job_listing' !== $job->post_type ) {
	  return $allcaps;
	}
	
	if ( str_contains( strtolower( $job->post_title ), 'job' ) ) {
	  $allcaps['manage_job_listings'] = true;

	  return $allcaps;
	}
	
	unset( $allcaps['manage_job_listings'] );
	
	return $allcaps;
  },
  10,
  3
);
```

<img width="1477" alt="Screenshot 2023-07-11 at 6 05 22 pm" src="https://github.com/Automattic/WP-Job-Manager/assets/68693/fd77b6fc-39c8-430f-afbb-140d46a1fb33">
