### PR TITLE
Configure lint-staged to run phpcs in a way that do not skip warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "lint-staged": {
     "*.php": [
       "php -l -d display_errors=0",
-      "./vendor/bin/phpcs --standard=phpcs.xml.dist --colors --encoding=utf-8 -n -p"
+      "./vendor/bin/phpcs --standard=phpcs.xml.dist --colors --encoding=utf-8 -p"
     ]
   },
   "config": {


### PR DESCRIPTION
Unfortunately, `phpcs` considers some mistakes, like unaligned `=>` in an array, as only warnings, instead of errors. This means that, while `phpcs` on Github Actions catches these warnings (and report them as appropriate), the `phpcs` command run by `lint-staged` on pre-commit doesn't, and so you can end up pushing code that simply doesn't match our code style.

This PR changes that, by removing a single parameter from the `phpcs` call run by `lint-staged`.

### Changes proposed in this Pull Request

* Remove `-n`  argument from the `phpcs` call made by `lint-staged`, so it doesn't ignore warnings and it blocks the commit as appropriate

### Testing instructions

Modify any PHP file in WPJM with an array definition containing multiple key/values (like for instance `includes/admin/class-wp-job-manager-setup.php`, in the method `create_page`) so their `=>` are unaligned. In the mentioned method in the mentioned file, for instance, you can modify it so:

```php
$page_data = [
			'post_status'    => 'publish',
			'post_type'      => 'page',
			'post_author'    => 1,
			'post_name'      => sanitize_title( $title ),
			'post_title'     => $title,
			'post_content'   => $content,
			'post_parent'    => 0,
			'comment_status' => 'closed',
];
```

Becomes:

```php
$page_data = [
			'post_status'    => 'publish',
			'post_type'      => 'page',
			'post_author'  => 1,
			'post_name'      => sanitize_title( $title ),
			'post_title'     => $title,
			'post_content'   => $content,
			'post_parent'    => 0,
			'comment_status' => 'closed',
];
```

Then, try to commit the modified file.

Without this PR, the modification will be committed as usual. With this PR, `phpcs` will complain that there's a warning on the modified file and will block the commit. :tada: 