### PR TITLE
Close modal when clicking on promote

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -198,8 +198,8 @@ function populateTemplate( item, dialog, action ) {
 					</form>
 					<promote-job-template>
 						<div slot="buttons" class="promote-buttons-group">
-								<a class="promote-button button button-primary" target="_blank" href="${ this.getAttribute( 'data-href' ) }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
-								<a class="promote-button button button-secondary" target="_blank" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
+							<a class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ this.getAttribute( 'data-href' ) }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
+							<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
 						</div>
 					<promote-job-template>`;
 				}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -202,17 +202,15 @@ function populateTemplate( item, dialog, action ) {
 							<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
 						</div>
 					<promote-job-template>`;
+
+					dialog.querySelector( '#wpjm-promote-button' ).addEventListener( 'click', function() {
+						dialog.close();
+					} );
 				}
 
 				if ( 'deactivate' === action ) {
 					let deactivateButton = dialog.querySelector( '.deactivate-promotion' );
 					deactivateButton.setAttribute( 'href', this.getAttribute( 'data-href' ) );
-				}
-
-				if ( 'promote' === action ) {
-					dialog.querySelector( '#wpjm-promote-button' ).addEventListener( 'click', function() {
-						dialog.close();
-					} );
 				}
 			} );
 		} );

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -198,15 +198,20 @@ function populateTemplate( item, dialog, action ) {
 					</form>
 					<promote-job-template>
 						<div slot="buttons" class="promote-buttons-group">
-							<a class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ this.getAttribute( 'data-href' ) }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
+							<a id="wpjm-promote-button" class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ this.getAttribute( 'data-href' ) }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
 							<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
 						</div>
 					<promote-job-template>`;
 				}
+
 				if ( 'deactivate' === action ) {
 					let deactivateButton = dialog.querySelector( '.deactivate-promotion' );
 					deactivateButton.setAttribute( 'href', this.getAttribute( 'data-href' ) );
 				}
+
+				document.querySelector( '#wpjm-promote-button' ).addEventListener( 'click', function() {
+					dialog.close();
+				} );
 			} );
 		} );
 	}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -209,9 +209,11 @@ function populateTemplate( item, dialog, action ) {
 					deactivateButton.setAttribute( 'href', this.getAttribute( 'data-href' ) );
 				}
 
-				document.querySelector( '#wpjm-promote-button' ).addEventListener( 'click', function() {
-					dialog.close();
-				} );
+				if ( 'promote' === action ) {
+					dialog.querySelector( '#wpjm-promote-button' ).addEventListener( 'click', function() {
+						dialog.close();
+					} );
+				}
 			} );
 		} );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It closes the modal when clicking on Promote, so when the user returns to the tab the modal is not open anymore.

### Testing instructions

* Go to the job listing on WP Admin.
* Click on "Promote" on a job.
* Click on "Promote your job".
* Return to the original tab, and make sure the modal is closed.