### PR TITLE
Separate promoted job endpoint into verify token and job data retrieval.

### DIFF
--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -61,16 +61,18 @@
         }
       }
     },
-    "/wp-json/wpjm-internal/v1/promoted-jobs/{id}": {
-      "get": {
-        "tags": ["promoted-jobs"],
-        "summary": "Retrieve job data for a job that will be promoted",
-        "operationId": "get-promotedjob",
+    "/wp-json/wpjm-internal/v1/promoted-jobs/verify-token": {
+      "post": {
+        "tags": [
+          "promoted-jobs"
+        ],
+        "summary": "Verify if the token is valid",
+        "operationId": "post-verifyToken",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the job to retrieve",
+            "name": "job_id",
+            "in": "query",
+            "description": "ID of the job that token grants access to",
             "required": true,
             "schema": {
               "type": "integer"
@@ -101,35 +103,54 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "description": "The request is completely valid and the job data is returned",
-                      "properties": {
-                        "verified": {
-                          "type": "boolean",
-                          "enum": [
-                            true
-                          ]
-                        },
-                        "job_data": {
-                          "$ref": "#/components/schemas/JobData"
-                        }
-                      }
-                    },
-                    {
-                      "type": "object",
-                      "description": "The token/user ID is expired or invalid",
-                      "properties": {
-                        "verified": {
-                          "type": "boolean",
-                          "enum": [
-                            false
-                          ]
-                        }
-                      }
+                  "type": "object",
+                  "description": "The request is completely valid and the job data is returned",
+                  "properties": {
+                    "verified": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
                     }
-                  ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wp-json/wpjm-internal/v1/promoted-jobs/{id}": {
+      "get": {
+        "tags": [
+          "promoted-jobs"
+        ],
+        "summary": "Retrieve job data for a job that will be promoted",
+        "operationId": "get-promotedjob",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the job to retrieve",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "The request is completely valid and the job data is returned",
+                  "properties": {
+                    "job_data": {
+                      "$ref": "#/components/schemas/JobData"
+                    }
+                  }
                 }
               }
             }
@@ -255,13 +276,13 @@
             "type": "string",
             "example": "ACME Inc."
           },
-          "is_remote":  {
+          "is_remote": {
             "type": "boolean",
             "example": false
           },
-          "job_type":  {
+          "job_type": {
             "type": "array",
-            "items" : {
+            "items": {
               "type": "string",
               "enum": [
                 "freelance",
@@ -273,7 +294,7 @@
               ]
             }
           },
-          "salary":  {
+          "salary": {
             "type": "object",
             "properties": {
               "currency": {
@@ -298,7 +319,7 @@
           }
         }
       },
-      "WP_Error" : {
+      "WP_Error": {
         "type": "object",
         "properties": {
           "code": {

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -41,9 +41,9 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
 	 *
+	 * @return self Main instance.
 	 * @since  $$next-version$$
 	 * @static
-	 * @return self Main instance.
 	 */
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {
@@ -132,10 +132,12 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	 * Add the host of the Promote Job form to the array of allowed redirect hosts.
 	 *
 	 * @param array $hosts Allowed redirect hosts.
+	 *
 	 * @return array Updated array of allowed redirect hosts.
 	 */
 	public function add_to_allowed_redirect_hosts( $hosts ) {
 		$hosts[] = wp_parse_url( WP_Job_Manager_Helper_API::get_wpjmcom_url(), PHP_URL_HOST );
+
 		return $hosts;
 	}
 
@@ -159,17 +161,21 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		if ( is_wp_error( $token ) ) {
 			wp_die( esc_html( $token->get_error_message() ) );
 		}
-		$site_url         = home_url( '', 'https' );
-		$job_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/' . $post_id, 'https' );
-		$job_endpoint_url = substr( $job_endpoint_url, strlen( $site_url ) );
+		$site_url            = home_url( '', 'https' );
+		$job_endpoint_url    = rest_url( '/wpjm-internal/v1/promoted-jobs/' . $post_id, 'https' );
+		$job_endpoint_url    = substr( $job_endpoint_url, strlen( $site_url ) );
+		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
+		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
 		$url = add_query_arg(
 			[
-				'user_id'          => $current_user,
-				'job_endpoint_url' => $job_endpoint_url,
-				'token'            => $token,
-				'site_url'         => $site_url,
-				'locale'           => get_user_locale( $current_user ),
+				'user_id'             => $current_user,
+				'job_id'              => $post_id,
+				'job_endpoint_url'    => $job_endpoint_url,
+				'verify_endpoint_url' => $verify_endpoint_url,
+				'token'               => $token,
+				'site_url'            => $site_url,
+				'locale'              => get_user_locale( $current_user ),
 			],
 			WP_Job_Manager_Helper_API::get_wpjmcom_url() . self::PROMOTE_JOB_FORM_PATH
 		);
@@ -403,7 +409,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 						<?php esc_html_e( 'Cancel', 'wp-job-manager' ); ?>
 					</button>
 					<a class="deactivate-promotion button button-primary">
-					<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
+						<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
 					</a>
 				</div>
 			</form>

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -117,7 +117,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'post_status'         => 'publish',
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
-			'posts_per_page'      => - 1,
+			'posts_per_page'      => -1,
 			'meta_query'          => [
 				[
 					'key'     => WP_Job_Manager_Promoted_Jobs::META_KEY,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -71,10 +71,23 @@ class WP_Job_Manager_Promoted_Jobs_API {
 					'callback'            => [ $this, 'get_job_data' ],
 					'permission_callback' => '__return_true',
 					'args'                => [
-						'job_id'  => [
+						'job_id' => [
 							'required' => true,
 							'type'     => 'integer',
 						],
+					],
+				],
+			]
+		);
+		register_rest_route(
+			self::NAMESPACE,
+			self::REST_BASE . '/verify-token',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'verify_token' ],
+					'permission_callback' => '__return_true',
+					'args'                => [
 						'user_id' => [
 							'required' => true,
 							'type'     => 'integer',
@@ -82,6 +95,10 @@ class WP_Job_Manager_Promoted_Jobs_API {
 						'token'   => [
 							'required' => true,
 							'type'     => 'string',
+						],
+						'job_id'  => [
+							'required' => true,
+							'type'     => 'integer',
 						],
 					],
 				],
@@ -100,7 +117,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'post_status'         => 'publish',
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
-			'posts_per_page'      => -1,
+			'posts_per_page'      => - 1,
 			'meta_query'          => [
 				[
 					'key'     => WP_Job_Manager_Promoted_Jobs::META_KEY,
@@ -121,6 +138,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * Prepare the item for the REST response
 	 *
 	 * @param WP_Post $item WordPress representation of the item.
+	 *
 	 * @return array The response
 	 */
 	private function prepare_item_for_response( WP_Post $item ) {
@@ -152,6 +170,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * Update the promoted job status.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
+	 *
 	 * @return WP_Error|WP_REST_Response The response, or WP_Error on failure.
 	 */
 	public function update_job_status( $request ) {
@@ -164,6 +183,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		}
 
 		$result = update_post_meta( $post_id, WP_Job_Manager_Promoted_Jobs::META_KEY, $status ? '1' : '0' );
+
 		return new WP_REST_Response(
 			[
 				'data'    => $result,
@@ -174,29 +194,49 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	}
 
 	/**
-	 * Get the job data, but only if the user has permission to manage the job and the token is valid.
+	 * Get the job data or error if the job is not found.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
+	 *
 	 * @return WP_REST_Response|WP_Error The response, or WP_Error on failure.
 	 */
 	public function get_job_data( $request ) {
-		$token    = $request->get_param( 'token' );
-		$user_id  = $request->get_param( 'user_id' );
-		$job_id   = $request->get_param( 'job_id' );
-		$verified = WP_Job_Manager_Site_Trust_Token::instance()->validate( 'user', $user_id, $token );
-		$result   = [
-			'verified' => $verified,
-		];
-		if ( $verified ) {
-			// We only want to return the job data if the specified user has permission to manage the job.
-			if ( 'job_listing' !== get_post_type( $job_id ) ) {
-				return new WP_Error( __( 'Job not found.', 'wp-job-manager' ), [ 'status' => 404 ] );
-			}
-			if ( ! user_can( $user_id, 'manage_job_listings', $job_id ) ) {
-				return new WP_Error( __( 'User does not have enough permissions to get data for this job.', 'wp-job-manager' ), [ 'status' => 401 ] );
-			}
-			$result['job_data'] = $this->prepare_item_for_response( get_post( $job_id ) );
+		$job_id = $request->get_param( 'job_id' );
+		if ( 'job_listing' !== get_post_type( $job_id ) ) {
+			return new WP_Error( __( 'Job not found.', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
-		return rest_ensure_response( $result );
+
+		return rest_ensure_response(
+			[
+				'job_data' => $this->prepare_item_for_response( get_post( $job_id ) ),
+			]
+		);
+	}
+
+	/**
+	 * Verify if the token is valid or not. Checks that the job exists and the user has access to it.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @return WP_REST_Response The result of the validation.
+	 */
+	public function verify_token( $request ) {
+		$token   = $request->get_param( 'token' );
+		$user_id = $request->get_param( 'user_id' );
+		$job_id  = $request->get_param( 'job_id' );
+
+		$verified = false;
+		// We only verify the token if the job_id exists and user has access to it.
+		if ( 'job_listing' === get_post_type( $job_id ) ) {
+			if ( user_can( $user_id, 'manage_job_listings', $job_id ) ) {
+				$verified = WP_Job_Manager_Site_Trust_Token::instance()->validate( 'user', $user_id, $token );
+			}
+		}
+
+		return rest_ensure_response(
+			[
+				'verified' => $verified,
+			]
+		);
 	}
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -203,7 +203,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	public function get_job_data( $request ) {
 		$job_id = $request->get_param( 'job_id' );
 		if ( 'job_listing' !== get_post_type( $job_id ) ) {
-			return new WP_Error( __( 'Job not found.', 'wp-job-manager' ), [ 'status' => 404 ] );
+			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
 
 		return rest_ensure_response(

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.40.2' );
+define( 'JOB_MANAGER_VERSION', '1.40.2-dev' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Fixes #2511 

### Changes proposed in this Pull Request
* Added new `/promoted-jobs/verify-token` endpoint.
* Removed token verification logic and relaxed checks on `/promoted-jobs/<job_id>` to return job data.

### Testing instructions
* The easiest way is to test this together with 501-gh-Automattic/wpjobmanager.com
* As an alternative you can play around with the curls below.

### Curls
#### Get job data
```
$ curl --request GET \
  --url https://wpjm.local/wp-json/wpjm-internal/v1/promoted-jobs/32
```

#### Verify token
```
curl --request POST \
  --url 'https://wpjm.local/wp-json/wpjm-internal/v1/promoted-jobs/verify-token?job_id=32&token=TOKEN&user_id=1'
```