### PR TITLE
Fix terms handling on the promoted jobs API

### DIFF
--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -143,6 +143,9 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 */
 	private function prepare_item_for_response( WP_Post $item ) {
 		$terms = get_the_terms( $item->ID, 'job_listing_type' );
+		if ( false === $terms ) {
+			$terms = [];
+		}
 
 		$terms_array = [];
 		foreach ( $terms as $term ) {

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -147,10 +147,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			$terms = [];
 		}
 
-		$terms_array = [];
-		foreach ( $terms as $term ) {
-			$terms_array[] = $term->slug;
-		}
+		$terms_array = wp_list_pluck( $terms, 'slug' );
 
 		return [
 			'id'           => (string) $item->ID,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -139,12 +139,15 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 *
 	 * @param WP_Post $item WordPress representation of the item.
 	 *
-	 * @return array The response
+	 * @return array|\WP_Error The response, or WP_Error on failure.
 	 */
 	private function prepare_item_for_response( WP_Post $item ) {
 		$terms = get_the_terms( $item->ID, 'job_listing_type' );
 		if ( false === $terms ) {
 			$terms = [];
+		}
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
 		}
 
 		$terms_array = wp_list_pluck( $terms, 'slug' );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -131,6 +131,12 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		$data = array_map( [ $this, 'prepare_item_for_response' ], $items );
 
+		foreach ( $data as $job ) {
+			if ( is_wp_error( $job ) ) {
+				return $job;
+			}
+		}
+
 		return new WP_REST_Response( [ 'jobs' => $data ], 200 );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fixes an issue where, if there were no job listing types associated with a job, the Promoted Jobs API would return an error

### Testing instructions

Create a job without selecting any job listing types, promote it and make sure it still works (without any failures to get the token)