### PR TITLE
Open Edit Promotion link for Promoted Jobs in a new tab

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -260,7 +260,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			echo '
 			<span class="jm-promoted__status-promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>
 			<div class="row-actions">
-				<a href="' . esc_url( $promote_url ) . '" class="jm-promoted__edit">' . esc_html__( 'Edit', 'wp-job-manager' ) . '</a>
+				<a href="' . esc_url( $promote_url ) . '" class="jm-promoted__edit" target="_blank">' . esc_html__( 'Edit', 'wp-job-manager' ) . '</a>
 				|
 				<a class="jm-promoted__deactivate delete" href="#" data-href="' . esc_url( $deactivate_action_link ) . '">' . esc_html__( 'Deactivate', 'wp-job-manager' ) . '</a>
 			</div>

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -260,7 +260,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			echo '
 			<span class="jm-promoted__status-promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>
 			<div class="row-actions">
-				<a href="' . esc_url( $promote_url ) . '" class="jm-promoted__edit" target="_blank">' . esc_html__( 'Edit', 'wp-job-manager' ) . '</a>
+				<a href="' . esc_url( $promote_url ) . '" class="jm-promoted__edit" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Edit', 'wp-job-manager' ) . '</a>
 				|
 				<a class="jm-promoted__deactivate delete" href="#" data-href="' . esc_url( $deactivate_action_link ) . '">' . esc_html__( 'Deactivate', 'wp-job-manager' ) . '</a>
 			</div>

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -391,8 +391,8 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 				</ul>
 
 				<slot name="buttons" class="promote-buttons-group">
-					<a class="promote-button button button-primary" type="submit" href="#">Promote your job</a>
-					<a class="promote-button button button-secondary" type="submit" href="#">Learn More</a>
+					<a class="promote-button button button-primary" href="#">Promote your job</a>
+					<a class="promote-button button button-secondary" href="#">Learn More</a>
 				</slot>
 			</div>
 			<div class="promote-job-modal-column-right">


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Makes "Edit" link to edit the job listing open in a new tab
* Also removes "type='submit'" attribute from link on the Promoted Jobs modal fallback

### Testing instructions

On WPJM running this branch of the code:

1. On a job listing with the `_promoted` meta set to `1`, verify if the Edit link now opens in a new tab
2. Also in a job listing that is not promoted yet, verify if the modal works correctly.