### PR TITLE
Encode url arguments

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -186,10 +186,10 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			[
 				'user_id'             => $current_user,
 				'job_id'              => $post_id,
-				'job_endpoint_url'    => $job_endpoint_url,
-				'verify_endpoint_url' => $verify_endpoint_url,
+				'job_endpoint_url'    => rawurlencode( $job_endpoint_url ),
+				'verify_endpoint_url' => rawurlencode( $verify_endpoint_url ),
 				'token'               => $token,
-				'site_url'            => $site_url,
+				'site_url'            => rawurlencode( $site_url ),
 				'locale'              => get_user_locale( $current_user ),
 			],
 			WP_Job_Manager_Helper_API::get_wpjmcom_url() . self::PROMOTE_JOB_FORM_PATH


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Encode URL arguments in order to avoid unexpected issues.
  * One issue I noticed is on wpjobmanager.com side. If it fails before the redirect with the token (still with `/wp-json/` in the URL) it doesn't include the WooCommerce styles.

### Testing instructions

* A way to reproduce an early error when promoting is changing the verification endpoint to something else. Search for `self::REST_BASE . '/verify-token'` and replace it with another string.
* Go to WP Admin > Job Listing.
* Try to promote a job.
* In wpjobmanager.com see that it displays the error with the WooCommerce styles.
* Revert your test change, try to promote a job, and make sure wpjobmanager.com can load the job data from the plugin.