### PR TITLE
Do not throw error on Promoted Jobs API if Job Listing Types are disabled

### DIFF
--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -148,14 +148,17 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * @return array|\WP_Error The response, or WP_Error on failure.
 	 */
 	private function prepare_item_for_response( WP_Post $item ) {
-		$terms = get_the_terms( $item->ID, 'job_listing_type' );
+		$terms = [];
+		if ( get_option( 'job_manager_enable_types' ) ) {
+			// Only query for terms if the listing types are enabled.
+			$terms = get_the_terms( $item->ID, 'job_listing_type' );
+		}
 		if ( false === $terms ) {
 			$terms = [];
 		}
 		if ( is_wp_error( $terms ) ) {
 			return $terms;
 		}
-
 		$terms_array = wp_list_pluck( $terms, 'slug' );
 
 		return [

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -217,10 +217,14 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		if ( 'job_listing' !== get_post_type( $job_id ) ) {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
+		$job_data = $this->prepare_item_for_response( get_post( $job_id ) );
+		if ( is_wp_error( $job_data ) ) {
+			return $job_data;
+		}
 
 		return rest_ensure_response(
 			[
-				'job_data' => $this->prepare_item_for_response( get_post( $job_id ) ),
+				'job_data' => $job_data,
 			]
 		);
 	}


### PR DESCRIPTION
Fix issue reported on Slack p1689351424769739-slack-C053397HN30 

### Changes proposed in this Pull Request

* Only call `get_the_terms` in Promoted Jobs API if Job Listing Types are enabled on WPJM Settings
* Also handle a case where, if the job data couldn't be formatted, it caused the `http://YOUR.WPJM.INSTANCE/wp-json/wpjm-internal/v1/promoted-jobs/JOB_ID` endpoint to return an error in the structure `{ "job_data": WP_ERROR }`, which wasn't handled well by WPJMCOM.

### Testing instructions

Using this branch of the plugin:

1. Create a job, get the post ID of the created job
2. Set the `_promoted` meta field to `1` (`wp post meta set JOB_ID _promoted 1`)
3. Visit `http://YOUR.WPJM.INSTANCE/wp-json/wpjm-internal/v1/promoted-jobs` and make sure all the data appears there
4. Now, go to Job Listings -> Settings -> Job Listings and uncheck the field "Enable listing types". Save the modified setting.
5. Visit `http://YOUR.WPJM.INSTANCE/wp-json/wpjm-internal/v1/promoted-jobs` again and make sure all the data appears there, without any errors or anything like that