### PR TITLE
Use wpjm_get_the_job_types to get job listing types from a post

### DIFF
--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -158,16 +158,9 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * @return array|\WP_Error The response, or WP_Error on failure.
 	 */
 	private function prepare_item_for_response( WP_Post $item ) {
-		$terms = [];
-		if ( get_option( 'job_manager_enable_types' ) ) {
-			// Only query for terms if the listing types are enabled.
-			$terms = get_the_terms( $item->ID, 'job_listing_type' );
-		}
+		$terms = wpjm_get_the_job_types( $item );
 		if ( false === $terms ) {
 			$terms = [];
-		}
-		if ( is_wp_error( $terms ) ) {
-			return $terms;
 		}
 		$terms_array = wp_list_pluck( $terms, 'slug' );
 


### PR DESCRIPTION
Implement suggestion shared by @renatho here: https://github.com/Automattic/WP-Job-Manager/pull/2519/files#r1264103838

### Changes proposed in this Pull Request

* Call `wpjm_get_the_job_types` instead of using `get_the_terms` directly

### Testing instructions

Using this branch of the plugin:

1. Go to Job Listings -> Settings -> Job Listings and make sure both fields "Enable listing types" and "Allow multiple types for listings" are checked. Save the settings if needed.
2. Create a job, select a few listing types, get the post ID of the created job
3. Set the `_promoted` meta field to `1` (`wp post meta set JOB_ID _promoted 1`)
4. Visit `http://YOUR.WPJM.INSTANCE/wp-json/wpjm-internal/v1/promoted-jobs` and make sure all the data appears there, including the select job types
5. Go to Job Listings -> Settings -> Job Listings and uncheck the field "Allow multiple types for listings". Save it.
6. Repeat the test from step 4.
5. Go to Job Listings -> Settings -> Job Listings and uncheck the field "Enable listing types". Save it.
6. Repeat the test from step 4.