### PR TITLE
Add promote modal on job save

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies.
+ */
+import { postOpenPromoteModal, postOpenDeactivateModal } from './admin/promote-job-modals';
+
 jQuery(document).ready(function($) {
 	// Tooltips
 	$( '.tips, .help_tip' ).each( function() {
@@ -179,46 +184,27 @@ jQuery(document).ready(function($) {
 	});
 });
 
-function wpjmModal( selector, dialogSelector, action ) {
-	let item   = document.querySelectorAll( selector );
-	let dialog = document.querySelector( dialogSelector );
-	populateTemplate( item, dialog, action );
-}
+function wpjmModal( selector, dialogSelector, openCallback ) {
+	const elements = document.querySelectorAll( selector );
+	const dialog = document.querySelector( dialogSelector );
 
-function populateTemplate( item, dialog, action ) {
-	if ( typeof action !== 'undefined' ) {
-		item.forEach( function( element ) {
-			element.addEventListener( 'click', function( event ) {
-				event.preventDefault();
-				dialog.showModal();
-				if ( 'promote' === action ) {
-					dialog.innerHTML = `
-					<form class="dialog" method="dialog">
-						<button class="dialog-close" type="submit">X</button>
-					</form>
-					<promote-job-template>
-						<div slot="buttons" class="promote-buttons-group">
-							<a id="wpjm-promote-button" class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ this.getAttribute( 'data-href' ) }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
-							<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
-						</div>
-					<promote-job-template>`;
-
-					dialog.querySelector( '#wpjm-promote-button' ).addEventListener( 'click', function() {
-						dialog.close();
-					} );
-				}
-
-				if ( 'deactivate' === action ) {
-					let deactivateButton = dialog.querySelector( '.deactivate-promotion' );
-					deactivateButton.setAttribute( 'href', this.getAttribute( 'data-href' ) );
-				}
-			} );
+	elements.forEach( ( element ) => {
+		element.addEventListener( 'click', function( event ) {
+			event.preventDefault();
+			dialog.showModal();
+			openCallback( element, dialog );
 		} );
-	}
+	} );
 }
 
-wpjmModal( '.promote_job', '#promote-dialog', 'promote' );
-wpjmModal( '.jm-promoted__deactivate', '#deactivate-dialog', 'deactivate' );
+wpjmModal( '.promote_job', '#promote-dialog', ( element, dialog ) => {
+	const href = element.getAttribute( 'data-href' );
+	postOpenPromoteModal( dialog, href );
+} );
+wpjmModal( '.jm-promoted__deactivate', '#deactivate-dialog', ( element, dialog ) => {
+	const href = element.getAttribute( 'data-href' );
+	postOpenDeactivateModal( dialog, href );
+} );
 
 customElements.define( 'promote-job-template',
 	class extends HTMLElement {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import { postOpenPromoteModal, postOpenDeactivateModal } from './admin/promote-job-modals';
+import { initializePromoteModals } from './admin/promote-job-modals';
 
 jQuery(document).ready(function($) {
 	// Tooltips
@@ -184,37 +184,4 @@ jQuery(document).ready(function($) {
 	});
 });
 
-function wpjmModal( selector, dialogSelector, openCallback ) {
-	const elements = document.querySelectorAll( selector );
-	const dialog = document.querySelector( dialogSelector );
-
-	elements.forEach( ( element ) => {
-		element.addEventListener( 'click', function( event ) {
-			event.preventDefault();
-			dialog.showModal();
-			openCallback( element, dialog );
-		} );
-	} );
-}
-
-wpjmModal( '.promote_job', '#promote-dialog', ( element, dialog ) => {
-	const href = element.getAttribute( 'data-href' );
-	postOpenPromoteModal( dialog, href );
-} );
-wpjmModal( '.jm-promoted__deactivate', '#deactivate-dialog', ( element, dialog ) => {
-	const href = element.getAttribute( 'data-href' );
-	postOpenDeactivateModal( dialog, href );
-} );
-
-customElements.define( 'promote-job-template',
-	class extends HTMLElement {
-		constructor() {
-			super();
-			const promoteJobs = document.getElementById( 'promote-job-template' ).content;
-			const shadowRoot  = this.attachShadow( {
-				mode: 'open',
-			} );
-			shadowRoot.appendChild( promoteJobs.cloneNode( true ) );
-		}
-	} );
-
+initializePromoteModals();

--- a/assets/js/admin/editor-lifecycle.js
+++ b/assets/js/admin/editor-lifecycle.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { subscribe, select } from '@wordpress/data';
+
+/**
+ * Helper function to fire callbacks on editor lifecycles.
+ *
+ * @param {Object}   options
+ * @param {Function} options.subscribeListener Callback called everytime the subscribe listener is called.
+ * @param {Function} options.onSetDirty        Callback called when the editor becomes dirty.
+ * @param {Function} options.onSaveStart       Callback called when editor starts saving.
+ * @param {Function} options.onSave            Callback called when a save is completed.
+ *
+ * @return {Function} Unsubscribe function.
+ */
+const editorLifecycle = ( {
+	subscribeListener = () => {},
+	onSetDirty = () => {},
+	onSaveStart = () => {},
+	onSave = () => {},
+} ) => {
+	const coreEditorSelector = select( 'core/editor' );
+	let wasSaving = false;
+	let wasDirty = false;
+
+	const unsubscribe = subscribe( () => {
+		subscribeListener();
+
+		const isDirty = coreEditorSelector.isEditedPostDirty();
+
+		const isSaving =
+			coreEditorSelector.isSavingPost() &&
+			! coreEditorSelector.isAutosavingPost();
+
+		if ( ! wasDirty && isDirty ) {
+			// If editor becomes dirty.
+			wasDirty = true;
+			onSetDirty();
+		} else {
+			wasDirty = isDirty;
+		}
+
+		if ( wasSaving && ! isSaving ) {
+			// If it completed a saving.
+			wasSaving = isSaving;
+			onSave();
+		} else if ( ! wasSaving && isSaving ) {
+			// If it started saving.
+			wasSaving = isSaving;
+			onSaveStart();
+		} else {
+			wasSaving = isSaving;
+		}
+	} );
+
+	return unsubscribe;
+};
+
+export default editorLifecycle;

--- a/assets/js/admin/editor-lifecycle.js
+++ b/assets/js/admin/editor-lifecycle.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { subscribe, select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Helper function to fire callbacks on editor lifecycles.
@@ -20,7 +21,7 @@ const editorLifecycle = ( {
 	onSaveStart = () => {},
 	onSave = () => {},
 } ) => {
-	const coreEditorSelector = select( 'core/editor' );
+	const coreEditorSelector = select( editorStore );
 	let wasSaving = false;
 	let wasDirty = false;
 

--- a/assets/js/admin/editor-lifecycle.js
+++ b/assets/js/admin/editor-lifecycle.js
@@ -24,9 +24,13 @@ const editorLifecycle = ( {
 	const coreEditorSelector = select( editorStore );
 	let wasSaving = false;
 	let wasDirty = false;
+	let isNew    = false;
 
 	const unsubscribe = subscribe( () => {
 		subscribeListener();
+
+		// Once identified as new, it will be considered new until the save.
+		isNew = coreEditorSelector.isEditedPostNew() || isNew;
 
 		const isDirty = coreEditorSelector.isEditedPostDirty();
 
@@ -45,11 +49,12 @@ const editorLifecycle = ( {
 		if ( wasSaving && ! isSaving ) {
 			// If it completed a saving.
 			wasSaving = isSaving;
-			onSave();
+			onSave( isNew );
+			isNew = false;
 		} else if ( ! wasSaving && isSaving ) {
 			// If it started saving.
 			wasSaving = isSaving;
-			onSaveStart();
+			onSaveStart( isNew );
 		} else {
 			wasSaving = isSaving;
 		}

--- a/assets/js/admin/editor-lifecycle.js
+++ b/assets/js/admin/editor-lifecycle.js
@@ -24,13 +24,9 @@ const editorLifecycle = ( {
 	const coreEditorSelector = select( editorStore );
 	let wasSaving = false;
 	let wasDirty = false;
-	let isNew    = false;
 
 	const unsubscribe = subscribe( () => {
 		subscribeListener();
-
-		// Once identified as new, it will be considered new until the save.
-		isNew = coreEditorSelector.isEditedPostNew() || isNew;
 
 		const isDirty = coreEditorSelector.isEditedPostDirty();
 
@@ -49,12 +45,11 @@ const editorLifecycle = ( {
 		if ( wasSaving && ! isSaving ) {
 			// If it completed a saving.
 			wasSaving = isSaving;
-			onSave( isNew );
-			isNew = false;
+			onSave();
 		} else if ( ! wasSaving && isSaving ) {
 			// If it started saving.
 			wasSaving = isSaving;
-			onSaveStart( isNew );
+			onSaveStart();
 		} else {
 			wasSaving = isSaving;
 		}

--- a/assets/js/admin/job-editor.js
+++ b/assets/js/admin/job-editor.js
@@ -3,21 +3,29 @@
  */
 import { select } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import domReady from '@wordpress/dom-ready';
 
 /**
  * Internal dependencies
  */
 import editorLifecycle from './editor-lifecycle';
+import { postOpenPromoteModal } from './promote-job-modals';
 
-const coreEditorSelector = select( editorStore );
+domReady( () => {
+	const coreEditorSelector = select( editorStore );
+	const promoteDialog = document.querySelector( '#promote-dialog' );
 
-editorLifecycle( {
-	onSaveStart: () => {
-		// Check if status is being changed to publish.
-		if ( 'publish' === coreEditorSelector.getEditedPostAttribute( 'status' ) && 'publish' !== coreEditorSelector.getCurrentPostAttribute( 'status' ) ) {
-			const jobId = coreEditorSelector.getCurrentPostId();
-
-			console.log( jobId );
-		}
+	if ( ! promoteDialog ) {
+		return;
 	}
+
+	editorLifecycle( {
+		onSaveStart: () => {
+			// Check if status is being changed to publish.
+			if ( 'publish' === coreEditorSelector.getEditedPostAttribute( 'status' ) && 'publish' !== coreEditorSelector.getCurrentPostAttribute( 'status' ) ) {
+				promoteDialog.showModal();
+				postOpenPromoteModal( promoteDialog, window.wpjm.promoteUrl );
+			}
+		}
+	} );
 } );

--- a/assets/js/admin/job-editor.js
+++ b/assets/js/admin/job-editor.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import editorLifecycle from './editor-lifecycle';
+
+const coreEditorSelector = select( editorStore );
+
+editorLifecycle( {
+	onSaveStart: () => {
+		// Check if status is being changed to publish.
+		if ( 'publish' === coreEditorSelector.getEditedPostAttribute( 'status' ) && 'publish' !== coreEditorSelector.getCurrentPostAttribute( 'status' ) ) {
+			const jobId = coreEditorSelector.getCurrentPostId();
+
+			console.log( jobId );
+		}
+	}
+} );

--- a/assets/js/admin/promote-job-modals.js
+++ b/assets/js/admin/promote-job-modals.js
@@ -1,0 +1,21 @@
+export const postOpenPromoteModal = ( dialog, href ) => {
+	dialog.innerHTML = `
+	<form class="dialog" method="dialog">
+		<button class="dialog-close" type="submit">X</button>
+	</form>
+	<promote-job-template>
+		<div slot="buttons" class="promote-buttons-group">
+			<a id="wpjm-promote-button" class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ href }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
+			<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
+		</div>
+	<promote-job-template>`;
+
+	dialog.querySelector( '#wpjm-promote-button' ).addEventListener( 'click', function() {
+		dialog.close();
+	} );
+};
+
+export const postOpenDeactivateModal = ( dialog, href ) => {
+	const deactivateButton = dialog.querySelector( '.deactivate-promotion' );
+	deactivateButton.setAttribute( 'href', href );
+};

--- a/assets/js/admin/promote-job-modals.js
+++ b/assets/js/admin/promote-job-modals.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import wpjmModal from './wpjm-modal';
+
 export const postOpenPromoteModal = ( dialog, href ) => {
 	dialog.innerHTML = `
 	<form class="dialog" method="dialog">
@@ -19,3 +24,26 @@ export const postOpenDeactivateModal = ( dialog, href ) => {
 	const deactivateButton = dialog.querySelector( '.deactivate-promotion' );
 	deactivateButton.setAttribute( 'href', href );
 };
+
+export const initializePromoteModals = () => {
+	wpjmModal( '.promote_job', '#promote-dialog', ( element, dialog ) => {
+		const href = element.getAttribute( 'data-href' );
+		postOpenPromoteModal( dialog, href );
+	} );
+	wpjmModal( '.jm-promoted__deactivate', '#deactivate-dialog', ( element, dialog ) => {
+		const href = element.getAttribute( 'data-href' );
+		postOpenDeactivateModal( dialog, href );
+	} );
+
+	customElements.define( 'promote-job-template',
+		class extends HTMLElement {
+			constructor() {
+				super();
+				const promoteJobs = document.getElementById( 'promote-job-template' ).content;
+				const shadowRoot  = this.attachShadow( {
+					mode: 'open',
+				} );
+				shadowRoot.appendChild( promoteJobs.cloneNode( true ) );
+			}
+		} );
+}

--- a/assets/js/admin/wpjm-modal.js
+++ b/assets/js/admin/wpjm-modal.js
@@ -1,0 +1,21 @@
+/**
+ * Job Manager admin modal.
+ *
+ * @param {string}   selector
+ * @param {string}   dialogSelector
+ * @param {Function} openCallback
+ */
+const wpjmModal = ( selector, dialogSelector, openCallback ) => {
+	const elements = document.querySelectorAll( selector );
+	const dialog = document.querySelector( dialogSelector );
+
+	elements.forEach( ( element ) => {
+		element.addEventListener( 'click', function( event ) {
+			event.preventDefault();
+			dialog.showModal();
+			openCallback( element, dialog );
+		} );
+	} );
+}
+
+export default wpjmModal;

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -128,6 +128,11 @@ class WP_Job_Manager_Admin {
 			);
 		}
 
+		if ( 'job_listing' === $screen->id ) {
+			WP_Job_manager::register_script( 'job_manager_job_editor_js', 'js/admin/job-editor.js', [], true );
+			wp_enqueue_script( 'job_manager_job_editor_js' );
+		}
+
 		WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', [], true );
 		wp_enqueue_script( 'job_manager_notice_dismiss' );
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -128,7 +128,7 @@ class WP_Job_Manager_Admin {
 			);
 		}
 
-		if ( 'job_listing' === $screen->id ) {
+		if ( 'job_listing' === $screen->id && $screen->is_block_editor() ) { // Check if it's block editor in job post.
 			$post = get_post();
 
 			if ( ! empty( $post ) ) {

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -129,8 +129,18 @@ class WP_Job_Manager_Admin {
 		}
 
 		if ( 'job_listing' === $screen->id ) {
-			WP_Job_manager::register_script( 'job_manager_job_editor_js', 'js/admin/job-editor.js', [], true );
-			wp_enqueue_script( 'job_manager_job_editor_js' );
+			$post = get_post();
+
+			if ( ! empty( $post ) ) {
+				WP_Job_manager::register_script( 'job_manager_job_editor_js', 'js/admin/job-editor.js', [], true );
+				wp_enqueue_script( 'job_manager_job_editor_js' );
+
+				wp_add_inline_script(
+					'job_manager_job_editor_js',
+					sprintf( 'window.wpjm = window.wpjm || {}; window.wpjm.promoteUrl = "%s";', WP_Job_Manager_Promoted_Jobs_Admin::get_promote_url( $post->ID ) ),
+					'before'
+				);
+			}
 		}
 
 		WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', [], true );

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -297,37 +297,42 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	 */
 	public function promoted_jobs_admin_footer() {
 		$screen = get_current_screen();
-		if ( 'edit-job_listing' !== $screen->id ) {
-			return;
-		}
-		?>
-		<template id="promote-job-template">
-			<?php echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</template>
-		<dialog class="wpjm-dialog" id="promote-dialog"></dialog>
 
-		<dialog class="wpjm-dialog deactivate-dialog" id="deactivate-dialog">
-			<form class="dialog deactivate-button" method="dialog">
-				<button class="dialog-close" type="submit">X</button>
-			</form>
-			<h2 class="deactivate-modal-heading">
-				<?php esc_html_e( 'Are you sure you want to deactivate promotion for this job?', 'wp-job-manager' ); ?>
-			</h2>
-			<p>
-				<?php esc_html_e( 'If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.', 'wp-job-manager' ); ?>
-			</p>
-			<form method="dialog">
-				<div class="deactivate-action promote-buttons-group">
-					<button class="dialog-close button button-secondary" type="submit">
-						<?php esc_html_e( 'Cancel', 'wp-job-manager' ); ?>
-					</button>
-					<a class="deactivate-promotion button button-primary">
-						<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
-					</a>
-				</div>
-			</form>
-		</dialog>
-		<?php
+		if ( in_array( $screen->id, [ 'edit-job_listing', 'job_listing' ], true ) ) { // Job listing and job editor.
+			?>
+			<template id="promote-job-template">
+				<?php echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			</template>
+			<dialog class="wpjm-dialog" id="promote-dialog"></dialog>
+
+			<?php
+		}
+
+		if ( 'job_listing' === $screen->id ) { // Job editor.
+			?>
+			<dialog class="wpjm-dialog deactivate-dialog" id="deactivate-dialog">
+				<form class="dialog deactivate-button" method="dialog">
+					<button class="dialog-close" type="submit">X</button>
+				</form>
+				<h2 class="deactivate-modal-heading">
+					<?php esc_html_e( 'Are you sure you want to deactivate promotion for this job?', 'wp-job-manager' ); ?>
+				</h2>
+				<p>
+					<?php esc_html_e( 'If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled.', 'wp-job-manager' ); ?>
+				</p>
+				<form method="dialog">
+					<div class="deactivate-action promote-buttons-group">
+						<button class="dialog-close button button-secondary" type="submit">
+							<?php esc_html_e( 'Cancel', 'wp-job-manager' ); ?>
+						</button>
+						<a class="deactivate-promotion button button-primary">
+							<?php esc_html_e( 'Deactivate', 'wp-job-manager' ); ?>
+						</a>
+					</div>
+				</form>
+			</dialog>
+			<?php
+		}
 	}
 
 }

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -222,25 +222,10 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			return;
 		}
 
-		$base_url    = admin_url( 'admin.php' );
-		$promote_url = add_query_arg(
-			[
-				'action'   => self::PROMOTE_JOB_ACTION,
-				'post_id'  => $post->ID,
-				'_wpnonce' => wp_create_nonce( self::PROMOTE_JOB_ACTION . '-' . $post->ID ),
-			],
-			$base_url
-		);
+		$promote_url = self::get_promote_url( $post->ID );
 
 		if ( $this->is_promoted( $post->ID ) ) {
-			$deactivate_action_link = add_query_arg(
-				[
-					'action'   => self::DEACTIVATE_PROMOTION_ACTION,
-					'post_id'  => $post->ID,
-					'_wpnonce' => wp_create_nonce( self::DEACTIVATE_PROMOTION_ACTION . '-' . $post->ID ),
-				],
-				$base_url
-			);
+			$deactivate_action_link = self::get_deactivate_url( $post->ID );
 			echo '
 			<span class="jm-promoted__status-promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>
 			<div class="row-actions">
@@ -252,6 +237,42 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		} else {
 			echo '<button class="promote_job button button-primary" data-href=' . esc_url( $promote_url ) . '>' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		}
+	}
+
+	/**
+	 * Get the promote URL.
+	 *
+	 * @param int|string $post_id Post ID placeholder string.
+	 *
+	 * @return string
+	 */
+	public static function get_promote_url( $post_id ) {
+		return add_query_arg(
+			[
+				'action'   => self::PROMOTE_JOB_ACTION,
+				'post_id'  => $post_id,
+				'_wpnonce' => wp_create_nonce( self::PROMOTE_JOB_ACTION . '-' . $post_id ),
+			],
+			admin_url( 'admin.php' )
+		);
+	}
+
+	/**
+	 * Get the deactivate URL.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return string
+	 */
+	public static function get_deactivate_url( $post_id ) {
+		return add_query_arg(
+			[
+				'action'   => self::DEACTIVATE_PROMOTION_ACTION,
+				'post_id'  => $post_id,
+				'_wpnonce' => wp_create_nonce( self::DEACTIVATE_PROMOTION_ACTION . '-' . $post_id ),
+			],
+			$base_url
+		);
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -304,11 +304,10 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 				<?php echo $this->get_promote_jobs_template(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</template>
 			<dialog class="wpjm-dialog" id="promote-dialog"></dialog>
-
 			<?php
 		}
 
-		if ( 'job_listing' === $screen->id ) { // Job editor.
+		if ( 'edit-job_listing' === $screen->id ) { // Job listing.
 			?>
 			<dialog class="wpjm-dialog deactivate-dialog" id="deactivate-dialog">
 				<form class="dialog deactivate-button" method="dialog">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const files = {
 	'js/job-submission': 'js/job-submission.js',
 	'js/multiselect': 'js/multiselect.js',
 	'js/term-multiselect': 'js/term-multiselect.js',
+	'js/admin/job-editor': 'js/admin/job-editor.js',
 	'js/admin/wpjm-notice-dismiss': 'js/admin/wpjm-notice-dismiss.js',
 	'css/admin': 'css/admin.scss',
 	'css/admin-notices': 'css/admin-notices.scss',


### PR DESCRIPTION
Fixes #2518

### Changes proposed in this Pull Request

* Extract some logic related to the modals, so we can use it in the editor.
* Display promote modal when a post is changed from any status to publish.
  * It doesn't work with Classic Editor.

### Testing instructions

* Make sure the promote and deactivate modals continue working properly in the job listing.
* Create a new job, and publish.
* Make sure it displays a modal to promote the job and it works properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://github.com/Automattic/WP-Job-Manager/assets/876340/16ba5448-1a1e-45c5-acfc-5357dbbd6f97

