### PR TITLE
Add learn more link to promote modal

### DIFF
--- a/assets/js/admin/promote-job-modals.js
+++ b/assets/js/admin/promote-job-modals.js
@@ -11,7 +11,7 @@ export const postOpenPromoteModal = ( dialog, href ) => {
 	<promote-job-template>
 		<div slot="buttons" class="promote-buttons-group">
 			<a id="wpjm-promote-button" class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ href }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
-			<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="#">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
+			<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="https://wpjobmanager.com/document/promoted-jobs">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
 		</div>
 	<promote-job-template>`;
 


### PR DESCRIPTION
Part of https://github.com/Automattic/WP-Job-Manager/issues/2490

### Changes proposed in this Pull Request

* It just adds the promoted jobs link to the learn more in the modal.