### PR TITLE
Add system for syncing status for Promoted Jobs from WPJMCOM to WPJM

### DIFF
--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -244,6 +244,48 @@
         }
       },
       "parameters": []
+    },
+    "/wp-json/wpjm-internal/v1/promoted-jobs/refresh-status": {
+      "post": {
+        "summary": "Promoted Jobs - Refresh status of the Promoted Jobs",
+        "description": "Refresh promoted jobs status",
+        "operationId": "refresh-promotedjobs-status",
+        "tags": [
+          "promoted-jobs"
+        ],
+        "parameters": [
+          {
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "description": "application/json"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the status was refreshed successfully. It's always true",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,7 +209,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
-		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::HAS_PROMOTED_JOBS_OPTION_KEY, true );
+		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::USED_PROMOTED_JOBS_OPTION_KEY, true );
 
 		$url = add_query_arg(
 			[

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,6 +209,8 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
+		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::HAS_PROMOTED_JOBS_OPTION_KEY, true );
+
 		$url = add_query_arg(
 			[
 				'user_id'             => $current_user,

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -111,6 +111,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_default_salary_unit',
 		'job_manager_enable_salary_currency',
 		'job_manager_default_salary_currency',
+		'job_manager_promoted_jobs_status_update_last_execution',
 	];
 
 	/**

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -89,7 +89,7 @@ class WP_Job_Manager {
 		$this->post_types = WP_Job_Manager_Post_Types::instance();
 
 		// Schedule cron jobs.
-		add_action( 'init', [ $this, 'maybe_schedule_cron_jobs' ] );
+		add_action( 'init', [ __CLASS__, 'maybe_schedule_cron_jobs' ] );
 
 		// Switch theme.
 		add_action( 'after_switch_theme', [ 'WP_Job_Manager_Ajax', 'add_endpoint' ], 10 );
@@ -240,7 +240,7 @@ class WP_Job_Manager {
 	/**
 	 * Schedule cron jobs for WPJM events.
 	 */
-	public function maybe_schedule_cron_jobs() {
+	public static function maybe_schedule_cron_jobs() {
 		if ( ! wp_next_scheduled( 'job_manager_check_for_expired_jobs' ) ) {
 			wp_schedule_event( time(), 'hourly', 'job_manager_check_for_expired_jobs' );
 		}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -89,7 +89,7 @@ class WP_Job_Manager {
 		$this->post_types = WP_Job_Manager_Post_Types::instance();
 
 		// Schedule cron jobs.
-		self::maybe_schedule_cron_jobs();
+		add_action( 'init', [ $this, 'maybe_schedule_cron_jobs' ] );
 
 		// Switch theme.
 		add_action( 'after_switch_theme', [ 'WP_Job_Manager_Ajax', 'add_endpoint' ], 10 );
@@ -240,7 +240,7 @@ class WP_Job_Manager {
 	/**
 	 * Schedule cron jobs for WPJM events.
 	 */
-	public static function maybe_schedule_cron_jobs() {
+	public function maybe_schedule_cron_jobs() {
 		if ( ! wp_next_scheduled( 'job_manager_check_for_expired_jobs' ) ) {
 			wp_schedule_event( time(), 'hourly', 'job_manager_check_for_expired_jobs' );
 		}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -250,6 +250,9 @@ class WP_Job_Manager {
 		if ( ! wp_next_scheduled( 'job_manager_email_daily_notices' ) ) {
 			wp_schedule_event( time(), 'daily', 'job_manager_email_daily_notices' );
 		}
+		if ( ! wp_next_scheduled( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'twicedaily', WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK );
+		}
 	}
 
 	/**

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -263,6 +263,7 @@ class WP_Job_Manager {
 		wp_clear_scheduled_hook( 'job_manager_delete_old_previews' );
 		wp_clear_scheduled_hook( 'job_manager_email_daily_notices' );
 		wp_clear_scheduled_hook( 'job_manager_promoted_jobs_notification' );
+		wp_clear_scheduled_hook( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK );
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -147,7 +147,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 */
 	public function add_nocache_headers_to_rest_response( $response, $server, $request ) {
 		// Check if the request belongs to the specified namespace and the response is successful.
-		if ( strpos( $request->get_route(), '/' . self::NAMESPACE ) === 0 && $response->get_status() >= 200 && $response->get_status() < 300 ) {
+		if ( str_starts_with( $request->get_route(), '/' . self::NAMESPACE ) && $response->get_status() >= 200 && $response->get_status() < 300 ) {
 			// Get the no-cache headers array.
 			$nocache_headers = wp_get_nocache_headers();
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -41,7 +41,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	public function __construct( WP_Job_Manager_Promoted_Jobs_Status_Handler $status_handler ) {
 		$this->status_handler = $status_handler;
 
-		add_filter( 'rest_post_dispatch', [ $this, 'add_nocache_headers_to_rest_response' ], 10, 3 );
+		add_filter( 'rest_post_dispatch', [ $this, 'add_nocache_headers' ], 10, 3 );
 	}
 
 
@@ -137,7 +137,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	}
 
 	/**
-	 * Adds no-cache headers to the REST response if they're related to the Promoted Jobs API.
+	 * Adds no-cache headers to the REST response if they're in the Promoted Jobs API namespace.
 	 *
 	 * @param WP_REST_Response $response The response data.
 	 * @param WP_REST_Server   $server The REST server instance.
@@ -145,7 +145,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 *
 	 * @return WP_REST_Response The response data.
 	 */
-	public function add_nocache_headers_to_rest_response( $response, $server, $request ) {
+	public function add_nocache_headers( $response, $server, $request ) {
 		// Check if the request belongs to the specified namespace and the response is successful.
 		if ( str_starts_with( $request->get_route(), '/' . self::NAMESPACE ) && $response->get_status() >= 200 && $response->get_status() < 300 ) {
 			// Get the no-cache headers array.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -156,7 +156,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 */
 	public function add_nocache_headers( $response, $server, $request ) {
 		// Check if the request belongs to the specified namespace and the response is successful.
-		if ( str_starts_with( $request->get_route(), '/' . self::NAMESPACE ) && $response->get_status() >= 200 && $response->get_status() < 300 ) {
+		if ( str_starts_with( $request->get_route(), '/' . self::NAMESPACE . self::REST_BASE ) && $response->get_status() >= 200 && $response->get_status() < 300 ) {
 			// Get the no-cache headers array.
 			$nocache_headers = wp_get_nocache_headers();
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -44,6 +44,15 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		add_filter( 'rest_post_dispatch', [ $this, 'add_nocache_headers' ], 10, 3 );
 	}
 
+	/**
+	 * Initializes the REST API.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+	}
+
 
 	/**
 	 * Register the routes for the objects of the controller.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -27,6 +27,23 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	private const REST_BASE = '/promoted-jobs';
 
 	/**
+	 * The status handler.
+	 *
+	 * @var WP_Job_Manager_Promoted_Jobs_Status_Handler
+	 */
+	private WP_Job_Manager_Promoted_Jobs_Status_Handler $status_handler;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WP_Job_Manager_Promoted_Jobs_Status_Handler $status_handler The status handler.
+	 */
+	public function __construct( WP_Job_Manager_Promoted_Jobs_Status_Handler $status_handler ) {
+		$this->status_handler = $status_handler;
+	}
+
+
+	/**
 	 * Register the routes for the objects of the controller.
 	 */
 	public function register_routes() {

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -121,6 +121,17 @@ class WP_Job_Manager_Promoted_Jobs_API {
 				],
 			]
 		);
+		register_rest_route(
+			self::NAMESPACE,
+			self::REST_BASE . '/refresh-status',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'refresh_status' ],
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
 	}
 
 	/**
@@ -280,5 +291,16 @@ class WP_Job_Manager_Promoted_Jobs_API {
 				'verified' => $verified,
 			]
 		);
+	}
+
+	/**
+	 * Refreshes the status of the promoted jobs.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response The response.
+	 */
+	public function refresh_status( $request ) {
+		$this->status_handler->fetch_updates();
+		return new WP_REST_Response( [ 'success' => true ] );
 	}
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -20,7 +20,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	/**
 	 * The name of the option that stores the last time the cron job was executed.
 	 */
-	private const OPTION_KEY = self::CRON_HOOK . '_last_execution';
+	const OPTION_KEY = self::CRON_HOOK . '_last_execution';
 
 	/**
 	 * The frequency at which the cron job should be executed.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -23,6 +23,11 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	const LAST_EXECUTION_OPTION_KEY = self::CRON_HOOK . '_last_execution';
 
 	/**
+	 * The name of the option that stores whether the site has promoted jobs or not.
+	 */
+	const HAS_PROMOTED_JOBS_OPTION_KEY = 'job_manager_has_promoted_jobs';
+
+	/**
 	 * The frequency at which the cron job should be executed.
 	 */
 	private const FREQUENCY_UPDATE = HOUR_IN_SECONDS;

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -25,7 +25,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	/**
 	 * The name of the option that stores whether the site has promoted jobs or not.
 	 */
-	const HAS_PROMOTED_JOBS_OPTION_KEY = 'job_manager_has_promoted_jobs';
+	const USED_PROMOTED_JOBS_OPTION_KEY = 'job_manager_used_promoted_jobs';
 
 	/**
 	 * The frequency at which the cron job should be executed.
@@ -51,7 +51,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 * Updates the promotion status of the jobs accordingly.
 	 */
 	public function fetch_updates() {
-		if ( ! get_option( self::HAS_PROMOTED_JOBS_OPTION_KEY, false ) ) {
+		if ( ! get_option( self::USED_PROMOTED_JOBS_OPTION_KEY, false ) ) {
 			// We don't fetch updates if the site doesn't have promoted jobs.
 			return;
 		}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -15,7 +15,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	/**
 	 * The name of the cron hook for updating the promoted job status.
 	 */
-	private const CRON_HOOK = 'wpjm_promoted_jobs_status_update';
+	const CRON_HOOK = 'wpjm_promoted_jobs_status_update';
 
 	/**
 	 * The name of the option that stores the last time the cron job was executed.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -88,12 +88,12 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	}
 
 	/**
-	 * Gets the URL for the site feed of promoted jobs.
+	 * Gets the URL for the site feed of promoted jobs in WPJMCOM.
 	 *
-	 * @return string The site feed URL.
+	 * @return string The site feed URL in WPJMCOM.
 	 */
 	private function get_site_feed_url() {
-		return add_query_arg( 'site_url', home_url( '', 'https' ), WP_Job_Manager_Helper_API::get_wpjmcom_url() . '/wp-json/wpjm/v1/promoted-jobs/job_status' );
+		return add_query_arg( 'site_url', home_url( '', 'https' ), WP_Job_Manager_Helper_API::get_wpjmcom_url() . '/wp-json/promoted-jobs/v1/site/jobs' );
 	}
 
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -90,7 +90,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 * @return string The site feed URL in WPJMCOM.
 	 */
 	private function get_site_feed_url() {
-		return add_query_arg( 'site_url', home_url( '', 'https' ), WP_Job_Manager_Helper_API::get_wpjmcom_url() . '/wp-json/promoted-jobs/v1/site/jobs' );
+		return add_query_arg( 'site', home_url( '', 'https' ), WP_Job_Manager_Helper_API::get_wpjmcom_url() . '/wp-json/promoted-jobs/v1/site/jobs' );
 	}
 
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager_Promoted_Jobs_Status_Handler.
+ *
+ * @package wp-job-manager
+ */
+
+/**
+ * Handles functionality related to the Promoted Jobs Status Update.
+ *
+ * @since $$next-version$$
+ */
+class WP_Job_Manager_Promoted_Jobs_Status_Handler {
+
+	/**
+	 * The name of the cron hook for updating the promoted job status.
+	 */
+	private const CRON_HOOK = 'wpjm_promoted_jobs_status_update';
+
+	/**
+	 * The name of the option that stores the last time the cron job was executed.
+	 */
+	private const OPTION_KEY = self::CRON_HOOK . '_last_execution';
+
+	/**
+	 * The frequency at which the cron job should be executed.
+	 */
+	private const FREQUENCY_UPDATE = HOUR_IN_SECONDS;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+	/**
+	 * Initialize the status handler, sets up the cron job and hooks for fetching updates.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function init() {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'twicedaily', self::CRON_HOOK );
+		}
+		add_action( self::CRON_HOOK, [ $this, 'fetch_updates' ] );
+	}
+
+	/**
+	 * Fetches updates for promoted jobs from the site feed.
+	 * Updates the promotion status of the jobs accordingly.
+	 */
+	public function fetch_updates() {
+		$last_execution_time = get_option( self::OPTION_KEY, 0 );
+		$current_time        = time();
+
+		if ( $current_time - $last_execution_time < self::FREQUENCY_UPDATE ) {
+			// We block the execution if the last execution was less than 1 hour ago.
+			return;
+		}
+
+		// We always update the last execution time, even if the request fails.
+		update_option( self::OPTION_KEY, $current_time );
+
+		$jobs     = $this->request_site_feed();
+		$statuses = wp_list_pluck( $jobs, 'wpjm_status', 'wpjm_id' );
+		foreach ( $statuses as $job_id => $job_status ) {
+			WP_Job_Manager_Promoted_Jobs::update_promotion( $job_id, '1' === $job_status );
+		}
+	}
+
+	/**
+	 * Requests the site feed for promoted jobs.
+	 * Retrieves and decodes the response, returning the jobs data as an array.
+	 *
+	 * @return array An array of promoted jobs.
+	 */
+	private function request_site_feed() {
+		$url      = $this->get_site_feed_url();
+		$response = wp_remote_get( $url );
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return [];
+		}
+		$body = wp_remote_retrieve_body( $response );
+		$json = \json_decode( $body, true );
+		if ( ! array_key_exists( 'jobs', $json ) ) {
+			return [];
+		}
+		return $json['jobs'];
+	}
+
+	/**
+	 * Gets the URL for the site feed of promoted jobs.
+	 *
+	 * @return string The site feed URL.
+	 */
+	private function get_site_feed_url() {
+		return add_query_arg( 'site_url', home_url( '', 'https' ), WP_Job_Manager_Helper_API::get_wpjmcom_url() . '/wp-json/wpjm/v1/promoted-jobs/job_status' );
+	}
+
+}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -51,6 +51,10 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 * Updates the promotion status of the jobs accordingly.
 	 */
 	public function fetch_updates() {
+		if ( ! get_option( self::HAS_PROMOTED_JOBS_OPTION_KEY, false ) ) {
+			// We don't fetch updates if the site doesn't have promoted jobs.
+			return;
+		}
 		$last_execution_time = get_option( self::LAST_EXECUTION_OPTION_KEY, 0 );
 		$current_time        = time();
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -38,9 +38,6 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 * @since $$next-version$$
 	 */
 	public function init() {
-		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'twicedaily', self::CRON_HOOK );
-		}
 		add_action( self::CRON_HOOK, [ $this, 'fetch_updates' ] );
 	}
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -20,7 +20,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	/**
 	 * The name of the option that stores the last time the cron job was executed.
 	 */
-	const OPTION_KEY = self::CRON_HOOK . '_last_execution';
+	const LAST_EXECUTION_OPTION_KEY = self::CRON_HOOK . '_last_execution';
 
 	/**
 	 * The frequency at which the cron job should be executed.
@@ -46,7 +46,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 * Updates the promotion status of the jobs accordingly.
 	 */
 	public function fetch_updates() {
-		$last_execution_time = get_option( self::OPTION_KEY, 0 );
+		$last_execution_time = get_option( self::LAST_EXECUTION_OPTION_KEY, 0 );
 		$current_time        = time();
 
 		if ( $current_time - $last_execution_time < self::FREQUENCY_UPDATE ) {
@@ -55,7 +55,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		}
 
 		// We always update the last execution time, even if the request fails.
-		update_option( self::OPTION_KEY, $current_time );
+		update_option( self::LAST_EXECUTION_OPTION_KEY, $current_time );
 
 		$jobs     = $this->request_site_feed();
 		$statuses = wp_list_pluck( $jobs, 'wpjm_status', 'wpjm_id' );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -15,7 +15,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	/**
 	 * The name of the cron hook for updating the promoted job status.
 	 */
-	const CRON_HOOK = 'wpjm_promoted_jobs_status_update';
+	const CRON_HOOK = 'job_manager_promoted_jobs_status_update';
 
 	/**
 	 * The name of the option that stores the last time the cron job was executed.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -28,9 +28,9 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	const USED_PROMOTED_JOBS_OPTION_KEY = 'job_manager_used_promoted_jobs';
 
 	/**
-	 * The frequency at which the cron job should be executed.
+	 * Time interval (in seconds) between update fetches from the site.
 	 */
-	private const FREQUENCY_UPDATE = HOUR_IN_SECONDS;
+	private const UPDATE_INTERVAL = 5 * MINUTE_IN_SECONDS;
 
 	/**
 	 * Constructor.
@@ -58,8 +58,8 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		$last_execution_time = get_option( self::LAST_EXECUTION_OPTION_KEY, 0 );
 		$current_time        = time();
 
-		if ( $current_time - $last_execution_time < self::FREQUENCY_UPDATE ) {
-			// We block the execution if the last execution was less than 1 hour ago.
+		if ( $current_time - $last_execution_time < self::UPDATE_INTERVAL ) {
+			// We block the execution if the last execution was less than self::UPDATE_INTERVAL seconds ago.
 			return;
 		}
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -39,6 +39,13 @@ class WP_Job_Manager_Promoted_Jobs {
 	const PROMOTED_JOB_TRACK_OPTION = 'jm_promoted_job_count';
 
 	/**
+	 * The status handler.
+	 *
+	 * @var WP_Job_Manager_Promoted_Jobs_Status_Handler
+	 */
+	private WP_Job_Manager_Promoted_Jobs_Status_Handler $status_handler;
+
+	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
 	 *
 	 * @since  $$next-version$$
@@ -71,6 +78,10 @@ class WP_Job_Manager_Promoted_Jobs {
 	public function include_dependencies() {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php';
+
+		$this->status_handler = new WP_Job_Manager_Promoted_Jobs_Status_Handler();
+		$this->status_handler->init();
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -63,31 +63,42 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'include_dependencies' ] );
-		add_action( 'init', [ $this, 'register_post_metas' ] );
-		add_action( 'rest_api_init', [ $this, 'rest_init' ] );
+		add_action( 'init', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Initializes Promoted Jobs feature.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->include_dependencies();
+		$this->register_post_metas();
+		$this->status_handler = new WP_Job_Manager_Promoted_Jobs_Status_Handler();
+		$this->status_handler->init();
+
+		( new WP_Job_Manager_Promoted_Jobs_API( $this->status_handler ) )->init();
+
 		add_filter( 'pre_delete_post', [ $this, 'cancel_promoted_jobs_deletion' ], 10, 2 );
 	}
 
 	/**
 	 * Includes promoted jobs dependencies.
 	 *
-	 * @internal
 	 * @return void
 	 */
-	public function include_dependencies() {
+	private function include_dependencies() {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php';
-
-		$this->status_handler = new WP_Job_Manager_Promoted_Jobs_Status_Handler();
-		$this->status_handler->init();
 	}
 
 	/**
 	 * Register post metas.
+	 *
+	 * @return void
 	 */
-	public function register_post_metas() {
+	private function register_post_metas() {
 		register_post_meta(
 			'job_listing',
 			self::PROMOTED_META_KEY,
@@ -100,15 +111,6 @@ class WP_Job_Manager_Promoted_Jobs {
 				},
 			]
 		);
-	}
-
-	/**
-	 * Loads the REST API functionality.
-	 *
-	 * @internal
-	 */
-	public function rest_init() {
-		( new WP_Job_Manager_Promoted_Jobs_API( $this->status_handler ) )->register_routes();
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -108,7 +108,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @internal
 	 */
 	public function rest_init() {
-		( new WP_Job_Manager_Promoted_Jobs_API() )->register_routes();
+		( new WP_Job_Manager_Promoted_Jobs_API( $this->status_handler ) )->register_routes();
 	}
 
 	/**


### PR DESCRIPTION
Fixes 433-gh-Automattic/wpjobmanager.com
Sibling PR to 527-gh-Automattic/wpjobmanager.com

### Changes proposed in this Pull Request

- Add `no-cache` headers to the REST API endpoints in Promoted Jobs namespace
- Create class to handle updating Promoted Jobs Status
  - Create endpoint to trigger update of the Promoted Jobs Status
  - Create cron that runs twice a day to trigger update of the Promoted Jobs Status
- Refactor initialization of the Promoted Jobs feature to match WPJMCOM implementation 

### Testing instructions

Check TBD of the 527-gh-Automattic/wpjobmanager.com PR

On this PR, check if the `no-cache` headers are added correctly for the endpoints in the Promoted Jobs REST API namespace. For instance, create a job, set the title and description, visit `/wp-json/wpjm-internal/v1/promoted-jobs/JOB_ID`, and check if that response returns the no-cache headers. 

You can also run the cron manually. Run `wp option delete wpjm_promoted_jobs_status_update_last_execution
` and then `wp cron event run wpjm_promoted_jobs_status_update` to run the cron job, verify if the request for WPJMCOM is being made correctly.