### PR TITLE
Add Promoted badge on job listings

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -372,6 +372,22 @@ a.wpjm-activate-licence-link:active {
 		}
 	}
 
+	.column-job_position {
+		.job_manager_admin_badge {
+			display: inline-block;
+			margin-left: 5px;
+			padding: 0 5px;
+			border-radius: 10px;
+			font-size: 12px;
+			font-weight: regular;
+
+			&--promoted {
+				background-color: #1b00e6;
+				color: #fff;
+			}
+		}
+	}
+
 	.column-job_listing_type {
 		text-align: left;
 		width: 6em;

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -610,6 +610,15 @@ class WP_Job_Manager_CPT {
 				// translators: %d is the post ID for the job listing.
 				echo '<a href="' . esc_url( admin_url( 'post.php?post=' . $post->ID . '&action=edit' ) ) . '" class="tips job_title" data-tip="' . sprintf( esc_html__( 'ID: %d', 'wp-job-manager' ), intval( $post->ID ) ) . '">' . wp_kses_post( wpjm_get_the_job_title() ) . '</a>';
 
+				/**
+				 * Fires after the job title in the Job Listings admin list table.
+				 *
+				 * @since $$next-version$$
+				 *
+				 * @param WP_Post $post The current job listing post object.
+				 */
+				do_action( 'job_manager_admin_after_job_title', $post );
+
 				echo '<div class="company">';
 
 				if ( get_the_company_website() ) {

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -58,6 +58,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	public function __construct() {
 		add_filter( 'manage_edit-job_listing_columns', [ $this, 'promoted_jobs_columns' ] );
 		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'promoted_jobs_custom_columns' ], 2 );
+		add_action( 'job_manager_admin_after_job_title', [ $this, 'add_promoted_badge' ] );
 		add_action( 'admin_action_' . self::PROMOTE_JOB_ACTION, [ $this, 'handle_promote_job' ] );
 		add_action( 'admin_action_' . self::DEACTIVATE_PROMOTION_ACTION, [ $this, 'handle_deactivate_promotion' ] );
 		add_action( 'admin_footer', [ $this, 'promoted_jobs_admin_footer' ] );
@@ -107,6 +108,25 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Add promoted badge to promoted job listings.
+	 *
+	 * @internal
+	 *
+	 * @param \WP_Post $post        The post object.
+	 */
+	public function add_promoted_badge( $post ) {
+		if (
+			is_null( $post )
+			|| 'job_listing' !== $post->post_type
+			|| ! $this->is_promoted( $post->ID )
+		) {
+			return;
+		}
+
+		echo '<span title="' . esc_attr__( 'This job has been promoted to external job boards.', 'wp-job-manager' ) . '" class="job_manager_admin_badge job_manager_admin_badge--promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #[2530](https://github.com/Automattic/WP-Job-Manager/issues/2530)

### Changes proposed in this Pull Request

* Adds a `Promoted` badge next to job listings in WP admin when they've been promoted.

### Testing instructions
* Manually add a `_promoted` meta to a job listing.
* Ensure the `Promoted` badge shows up.

<img width="281" alt="Screenshot 2023-07-19 at 11 42 58 pm" src="https://github.com/Automattic/WP-Job-Manager/assets/68693/e4bffafe-68b0-453c-b03c-5cf3959d90fc">


## New Hooks
`job_manager_admin_after_job_title` : Needed to inject content here since we're not using `get_post_states`