### PR TITLE
Fix deactivate promotion URL

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -291,7 +291,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 				'post_id'  => $post_id,
 				'_wpnonce' => wp_create_nonce( self::DEACTIVATE_PROMOTION_ACTION . '-' . $post_id ),
 			],
-			$base_url
+			admin_url( 'admin.php' )
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* If fixes and undefined variable.

### Testing instructions

* Change a job to promoted adding the post meta `_promoted` as `1`.
* In the job listing click on "Deactivate" and make sure it works properly.