### PR TITLE
Refactor promoted main methods centralizing it on `WP_Job_Manager_Promoted_Jobs_API`

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -121,7 +121,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		if (
 			is_null( $post )
 			|| 'job_listing' !== $post->post_type
-			|| ! $this->is_promoted( $post->ID )
+			|| ! WP_Job_Manager_Promoted_Jobs::is_promoted( $post->ID )
 		) {
 			return;
 		}
@@ -203,19 +203,6 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	}
 
 	/**
-	 * Check if a job is promoted.
-	 *
-	 * @param int $post_id
-	 *
-	 * @return boolean
-	 */
-	public function is_promoted( $post_id ) {
-		$promoted = get_post_meta( $post_id, '_promoted', true );
-
-		return (bool) $promoted;
-	}
-
-	/**
 	 * Deactivate promotion for a job.
 	 *
 	 * @param int $post_id
@@ -244,7 +231,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 
 		$promote_url = self::get_promote_url( $post->ID );
 
-		if ( $this->is_promoted( $post->ID ) ) {
+		if ( WP_Job_Manager_Promoted_Jobs::is_promoted( $post->ID ) ) {
 			$deactivate_action_link = self::get_deactivate_url( $post->ID );
 			echo '
 			<span class="jm-promoted__status-promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -92,7 +92,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			wp_die( esc_html__( 'You do not have permission to deactivate the promotion for this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 
-		$this->deactivate_promotion( $post_id );
+		WP_Job_Manager_Promoted_Jobs::deactivate_promotion( $post_id );
 
 		wp_safe_redirect(
 			add_query_arg(
@@ -200,17 +200,6 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		);
 		wp_safe_redirect( $url );
 		exit;
-	}
-
-	/**
-	 * Deactivate promotion for a job.
-	 *
-	 * @param int $post_id
-	 *
-	 * @return boolean
-	 */
-	public function deactivate_promotion( $post_id ) {
-		return update_post_meta( $post_id, '_promoted', 0 );
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -197,7 +197,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
 
-		$result = update_post_meta( $post_id, WP_Job_Manager_Promoted_Jobs::PROMOTED_META_KEY, $status ? '1' : '0' );
+		$result = WP_Job_Manager_Promoted_Jobs::update_promotion( $post_id, $status );
 
 		return new WP_REST_Response(
 			[

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -122,7 +122,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'posts_per_page'      => -1,
 			'meta_query'          => [
 				[
-					'key'     => WP_Job_Manager_Promoted_Jobs::META_KEY,
+					'key'     => WP_Job_Manager_Promoted_Jobs::PROMOTED_META_KEY,
 					'value'   => '1',
 					'compare' => '=',
 				],
@@ -197,7 +197,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
 
-		$result = update_post_meta( $post_id, WP_Job_Manager_Promoted_Jobs::META_KEY, $status ? '1' : '0' );
+		$result = update_post_meta( $post_id, WP_Job_Manager_Promoted_Jobs::PROMOTED_META_KEY, $status ? '1' : '0' );
 
 		return new WP_REST_Response(
 			[

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -78,7 +78,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	public function __construct() {
 		$this->watched_fields = [
 			'post' => [ 'post_name', 'post_title', 'post_content', 'post_status' ],
-			'meta' => [ '_promoted' ],
+			'meta' => [ WP_Job_Manager_Promoted_Jobs::PROMOTED_META_KEY ],
 		];
 		add_action( 'post_updated', [ $this, 'post_updated' ], 10, 3 );
 		add_action( 'update_postmeta', [ $this, 'meta_updated' ], 10, 4 );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -176,16 +176,6 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	}
 
 	/**
-	 * Check if a job is promoted.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return bool
-	 */
-	private function is_promoted_job( $post_id ) {
-		return '1' === get_post_meta( $post_id, '_promoted', true );
-	}
-
-	/**
 	 * Notify wpjobmanager.com when a Job Listing changes.
 	 *
 	 * @access private

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -93,7 +93,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 * @param WP_Post $post_before Post object before the update.
 	 */
 	public function post_updated( $post_id, $post_after, $post_before ) {
-		if ( ! $this->should_notify( $post_id ) ) {
+		if ( ! WP_Job_Manager_Promoted_Jobs::is_promoted( $post_id ) ) {
 			return;
 		}
 		$keys        = $this->watched_fields['post'];
@@ -125,7 +125,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 * @param mixed  $meta_value Meta value.
 	 */
 	public function meta_updated( $meta_id, $post_id, $meta_key, $meta_value ) {
-		if ( ! $this->should_notify( $post_id ) ) {
+		if ( ! WP_Job_Manager_Promoted_Jobs::is_promoted( $post_id ) ) {
 			return;
 		}
 		if ( in_array( $meta_key, $this->watched_fields['meta'], true ) ) {
@@ -183,22 +183,6 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 */
 	private function is_promoted_job( $post_id ) {
 		return '1' === get_post_meta( $post_id, '_promoted', true );
-	}
-
-	/**
-	 * Check if we should notify wpjobmanager.com of a change.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return bool
-	 */
-	public function should_notify( $post_id ) {
-		if ( 'job_listing' !== get_post_type( $post_id ) ) {
-			return false;
-		}
-		if ( ! $this->is_promoted_job( $post_id ) ) {
-			return false;
-		}
-		return true;
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -71,6 +71,29 @@ class WP_Job_Manager_Promoted_Jobs {
 		( new WP_Job_Manager_Promoted_Jobs_API() )->register_routes();
 	}
 
+	/**
+	 * Check if a job is promoted.
+	 *
+	 * @param int $post_id
+	 *
+	 * @return boolean
+	 */
+	public static function is_promoted( $post_id ) {
+		$promoted = get_post_meta( $post_id, '_promoted', true );
+
+		return (bool) $promoted;
+	}
+
+	/**
+	 * Deactivate promotion for a job.
+	 *
+	 * @param int $post_id
+	 *
+	 * @return boolean
+	 */
+	public static function deactivate_promotion( $post_id ) {
+		return update_post_meta( $post_id, '_promoted', 0 );
+	}
 }
 
 WP_Job_Manager_Promoted_Jobs::instance();

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -79,6 +79,10 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return boolean
 	 */
 	public static function is_promoted( $post_id ) {
+		if ( 'job_listing' !== get_post_type( $post_id ) ) {
+			return false;
+		}
+
 		$promoted = get_post_meta( $post_id, '_promoted', true );
 
 		return (bool) $promoted;
@@ -92,6 +96,10 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return boolean
 	 */
 	public static function deactivate_promotion( $post_id ) {
+		if ( 'job_listing' !== get_post_type( $post_id ) ) {
+			return false;
+		}
+
 		return update_post_meta( $post_id, '_promoted', 0 );
 	}
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -83,7 +83,7 @@ class WP_Job_Manager_Promoted_Jobs {
 			return false;
 		}
 
-		$promoted = get_post_meta( $post_id, '_promoted', true );
+		$promoted = get_post_meta( $post_id, self::PROMOTED_META_KEY, true );
 
 		return (bool) $promoted;
 	}
@@ -100,7 +100,7 @@ class WP_Job_Manager_Promoted_Jobs {
 			return false;
 		}
 
-		return update_post_meta( $post_id, '_promoted', 0 );
+		return update_post_meta( $post_id, self::PROMOTED_META_KEY, 0 );
 	}
 }
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -87,6 +87,22 @@ class WP_Job_Manager_Promoted_Jobs {
 	}
 
 	/**
+	 * Update promotion.
+	 *
+	 * @param int  $post_id
+	 * @param bool $promoted
+	 *
+	 * @return boolean
+	 */
+	public static function update_promotion( $post_id, $promoted ) {
+		if ( 'job_listing' !== get_post_type( $post_id ) ) {
+			return false;
+		}
+
+		return update_post_meta( $post_id, self::PROMOTED_META_KEY, $promoted ? '1' : '0' );
+	}
+
+	/**
 	 * Deactivate promotion for a job.
 	 *
 	 * @param int $post_id
@@ -94,11 +110,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return boolean
 	 */
 	public static function deactivate_promotion( $post_id ) {
-		if ( 'job_listing' !== get_post_type( $post_id ) ) {
-			return false;
-		}
-
-		return update_post_meta( $post_id, self::PROMOTED_META_KEY, 0 );
+		return self::update_promotion( $post_id, false );
 	}
 }
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -25,11 +25,11 @@ class WP_Job_Manager_Promoted_Jobs {
 	private static $instance = null;
 
 	/**
-	 * Associated post meta.
+	 * Name for post meta that identify a `job_listing` post as promoted.
 	 *
 	 * @var string
 	 */
-	const META_KEY = '_promoted';
+	const PROMOTED_META_KEY = '_promoted';
 
 	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -83,9 +83,7 @@ class WP_Job_Manager_Promoted_Jobs {
 			return false;
 		}
 
-		$promoted = get_post_meta( $post_id, self::PROMOTED_META_KEY, true );
-
-		return (bool) $promoted;
+		return '1' === get_post_meta( $post_id, self::PROMOTED_META_KEY, true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2480

### Changes proposed in this Pull Request

* Point references of "_promoted" meta key to a constant.
* Move main methods to a single class.
* Remove some duplicate code.

### Testing instructions

* Make a general test, and make sure the promotions still work being able to promote, edit, deactivate, and so on.