### PR TITLE
Display a notice in the job listings when at least one job was promoted

### DIFF
--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -31,14 +31,16 @@ class WP_Job_Manager_Admin_Notices {
 	const DISMISSED_NOTICES_USER_META   = 'wp_job_manager_dismissed_notices';
 
 	const ALLOWED_HTML = [
-		'div' => [
+		'div'    => [
 			'class' => [],
 		],
-		'a'   => [
+		'a'      => [
 			'target' => [],
 			'href'   => [],
 			'rel'    => [],
 		],
+		'em'     => [],
+		'strong' => [],
 	];
 
 	/**

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -376,9 +376,10 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		}
 
 		$notices['has-promoted-job'] = [
-			'type'       => 'info',
+			'type'       => 'user',
+			'level'      => 'info',
 			'heading'    => __( 'Congratulations! Your first job has been successfully promoted.', 'wp-job-manager' ),
-			'message'    => __( 'To manage your promoted job, use the <em>Edit</em> and <em>Deactivate</em> links beside the job listing under the <strong>Promote</strong> column. Unpublishing a post will not remove the promotion.', 'wp-job-manager' ),
+			'message'    => __( 'To manage your promoted job, use the <em>Edit</em> and <em>Deactivate</em> links beside the job listing under the <strong>Promote</strong> column. Unpublishing a job listing will not deactivate the promotion.', 'wp-job-manager' ),
 			'conditions' => [
 				[
 					'type'    => 'screens',

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -63,6 +63,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		add_action( 'admin_action_' . self::DEACTIVATE_PROMOTION_ACTION, [ $this, 'handle_deactivate_promotion' ] );
 		add_action( 'admin_footer', [ $this, 'promoted_jobs_admin_footer' ] );
 		add_action( 'wpjm_job_listing_bulk_actions', [ $this, 'add_action_notice' ] );
+		add_action( 'wpjm_admin_notices', [ $this, 'maybe_add_promoted_jobs_notice' ] );
 	}
 
 	/**
@@ -360,6 +361,34 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		}
 	}
 
+	/**
+	 * Add a notice to the job listing admin page if the user has promoted jobs.
+	 *
+	 * @internal
+	 *
+	 * @param array $notices Notices to filter on.
+	 *
+	 * @return array
+	 */
+	public function maybe_add_promoted_jobs_notice( $notices ) {
+		if ( WP_Job_Manager_Promoted_Jobs::get_promoted_jobs_count() === 0 ) {
+			return $notices;
+		}
+
+		$notices['has-promoted-job'] = [
+			'type'       => 'info',
+			'heading'    => __( 'Congratulations! Your first job has been successfully promoted.', 'wp-job-manager' ),
+			'message'    => __( 'To manage your promoted job, use the <em>Edit</em> and <em>Deactivate</em> links beside the job listing under the <strong>Promote</strong> column. Unpublishing a post will not remove the promotion.', 'wp-job-manager' ),
+			'conditions' => [
+				[
+					'type'    => 'screens',
+					'screens' => [ 'edit-job_listing' ],
+				],
+			],
+		];
+
+		return $notices;
+	}
 }
 
 WP_Job_Manager_Promoted_Jobs_Admin::instance();


### PR DESCRIPTION
Advances #2531 

### Changes proposed in this Pull Request

* Adds a notice when at least one job has been promoted.
* Caching the total count of active promoted posts so that we can easily use it in data collection stats later.
* **Note**: I've update the language for now. This PR might not totally be necessary without the issue of drafts removing promoted jobs. We could add something different if we'd think it would be helpful.

### Testing instructions

* In `wp shell` run `WP_Job_Manager_Promoted_Jobs::update_promotion( 775, true );` updating the post ID to one of your job posts.
* Go to WP Admin > Job Listings > All Jobs.
* Verify the notice appears.
* Dismiss the notice.
* Verify it doesn't reappear on page refresh.

### Screenshot
<img width="1610" alt="Screenshot 2023-07-24 at 6 42 25 pm" src="https://github.com/Automattic/WP-Job-Manager/assets/68693/7248f214-d199-4265-b141-abd0553cb831">

