### PR TITLE
Add utm parameters to learn more link

### DIFF
--- a/assets/js/admin/promote-job-modals.js
+++ b/assets/js/admin/promote-job-modals.js
@@ -11,7 +11,7 @@ export const postOpenPromoteModal = ( dialog, href ) => {
 	<promote-job-template>
 		<div slot="buttons" class="promote-buttons-group">
 			<a id="wpjm-promote-button" class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ href }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
-			<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="https://wpjobmanager.com/document/promoted-jobs">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
+			<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="https://wpjobmanager.com/document/promoted-jobs?utm_source=plugin_wpjm&utm_medium=promote-dialog&utm_campaign=promoted-jobs">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
 		</div>
 	<promote-job-template>`;
 


### PR DESCRIPTION
Part of https://github.com/Automattic/wpjobmanager.com/issues/333 and https://github.com/Automattic/wpjobmanager.com/issues/334
Pair with https://github.com/Automattic/wpjobmanager.com/pull/540

### Changes proposed in this Pull Request

* It adds utm parameters to the learn more link in the modal.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)
-->
* Click on "Promote" on a job in WPJM (WP Admin > Job Listings).
* Make sure the link contains the utm parameters.