### PR TITLE
Fix notification site url

### DIFF
--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -152,7 +152,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 */
 	private function get_notification_data() {
 		$site_url = home_url( '', 'https' );
-		$feed_url = rest_url( '/wpjm-internal/v1/promoted-jobs' );
+		$feed_url = rest_url( '/wpjm-internal/v1/promoted-jobs', 'https' );
 		$feed_url = substr( $feed_url, strlen( $site_url ) );
 		return [
 			'site_url' => $site_url,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -151,7 +151,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	 * @return array The data to send.
 	 */
 	private function get_notification_data() {
-		$site_url = home_url();
+		$site_url = home_url( '', 'https' );
 		$feed_url = rest_url( '/wpjm-internal/v1/promoted-jobs' );
 		$feed_url = substr( $feed_url, strlen( $site_url ) );
 		return [


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It forces the `site_url` to be used with `https`, like it's being used when we promote the job.

### Testing instructions

* In an env without `https` create a job, and make sure the `site_url` received in wpjobmanage.com is with `https://` (not changed, just to compare with the change).
* Update a job, and make sure the received notification comes in the same way (with `https://`).