### PR TITLE
Display promote dialog only after the save is complete

### DIFF
--- a/assets/js/admin/job-editor.js
+++ b/assets/js/admin/job-editor.js
@@ -11,6 +11,7 @@ import domReady from '@wordpress/dom-ready';
 import editorLifecycle from './editor-lifecycle';
 import { postOpenPromoteModal } from './promote-job-modals';
 
+// Open promote dialog when it's publishing a job.
 domReady( () => {
 	const coreEditorSelector = select( editorStore );
 	const promoteDialog = document.querySelector( '#promote-dialog' );
@@ -19,13 +20,21 @@ domReady( () => {
 		return;
 	}
 
+	let jobWasPublished = false;
+
 	editorLifecycle( {
 		onSaveStart: () => {
-			// Check if status is being changed to publish.
-			if ( 'publish' === coreEditorSelector.getEditedPostAttribute( 'status' ) && 'publish' !== coreEditorSelector.getCurrentPostAttribute( 'status' ) ) {
+			// Mark if status is being changed to publish.
+			jobWasPublished =
+				'publish' === coreEditorSelector.getEditedPostAttribute( 'status' ) &&
+				'publish' !== coreEditorSelector.getCurrentPostAttribute( 'status' );
+		},
+		onSave: () => {
+			// Open dialog when job was published.
+			if ( jobWasPublished ) {
 				promoteDialog.showModal();
 				postOpenPromoteModal( promoteDialog, window.wpjm.promoteUrl );
 			}
-		}
+		},
 	} );
 } );


### PR DESCRIPTION
Fixes #2538

### Changes proposed in this Pull Request

* Display promote dialog only after the save is complete. Otherwise, it could fetch the job data before it's created, returning an error in wpjobmanager.com.

### Testing instructions

* If you have some way to make your WPJM site slower, do it as a plus for this test (in my case, running the PHP debugger I could reproduce the issue easily).
* Create a new job.
* When publishing, make sure you see the dialog only after the save is complete.
* Click as soon as possible on the promote button.
* Make sure wpbjobmanager.com is able to fetch the job data properly.