### PR TITLE
Consider all promoted jobs as promoted even if it's not published

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -380,10 +380,15 @@ a.wpjm-activate-licence-link:active {
 			border-radius: 10px;
 			font-size: 12px;
 			font-weight: regular;
+			cursor: help;
 
 			&--promoted {
 				background-color: #1b00e6;
 				color: #fff;
+			}
+
+			&--not_published {
+				background-color: #f00;
 			}
 		}
 	}

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -256,6 +256,11 @@
             "example": "9788656",
             "description": "The unique identifier for the job in the site (post ID)."
           },
+          "post_status": {
+            "type": "string",
+            "example": "publish",
+            "description": "The job post status."
+          },
           "title": {
             "type": "string",
             "example": "Senior Software Engineer"

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -256,10 +256,10 @@
             "example": "9788656",
             "description": "The unique identifier for the job in the site (post ID)."
           },
-          "post_status": {
+          "job_status": {
             "type": "string",
             "example": "publish",
-            "description": "The job post status."
+            "description": "The job status."
           },
           "title": {
             "type": "string",

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -256,7 +256,7 @@
             "example": "9788656",
             "description": "The unique identifier for the job in the site (post ID)."
           },
-          "job_status": {
+          "status": {
             "type": "string",
             "example": "publish",
             "description": "The job status."

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -246,7 +246,8 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		} elseif ( 'publish' === $post->post_status ) {
 			echo '<button class="promote_job button button-primary" data-href=' . esc_url( $promote_url ) . '>' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		} else {
-			echo '<button class="button button-primary" disabled="disabled" title="' . esc_attr__( 'The job needs to be published in order to be promoted.', 'wp-job-manager' ) . '">' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
+			$title = __( 'The job needs to be published in order to be promoted.', 'wp-job-manager' );
+			echo '<button type="button" class="button button-primary tips disabled" aria-disabled="true" title="' . esc_attr( $title ) . '" data-tip="' . esc_attr( $title ) . '">' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -138,7 +138,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	 * @return bool Returns true if they can promote a job.
 	 */
 	private function can_promote_job( int $post_id ) {
-		if ( 'job_listing' !== get_post_type( $post_id ) || 'publish' !== get_post_status( $post_id ) ) {
+		if ( 'job_listing' !== get_post_type( $post_id ) ) {
 			return false;
 		}
 
@@ -231,7 +231,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 				<a class="jm-promoted__deactivate delete" href="#" data-href="' . esc_url( $deactivate_action_link ) . '">' . esc_html__( 'Deactivate', 'wp-job-manager' ) . '</a>
 			</div>
 			';
-		} else {
+		} elseif ( 'publish' === $post->post_status ) {
 			echo '<button class="promote_job button button-primary" data-href=' . esc_url( $promote_url ) . '>' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		}
 	}

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -127,7 +127,17 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			return;
 		}
 
-		echo '<span title="' . esc_attr__( 'This job has been promoted to external job boards.', 'wp-job-manager' ) . '" class="job_manager_admin_badge job_manager_admin_badge--promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>';
+		$tooltip      = '';
+		$status_class = '';
+
+		if ( 'publish' !== $post->post_status ) {
+			$tooltip      = __( 'Your job is promoted and being exposed through API but it\'s not published in your site. You can fix it by publishing it again or deactivating the promotion.', 'wp-job-manager' );
+			$status_class = 'job_manager_admin_badge--not_published';
+		} else {
+			$tooltip = __( 'This job has been promoted to external job boards.', 'wp-job-manager' );
+		}
+
+		echo '<span title="' . esc_attr( $tooltip ) . '" class="job_manager_admin_badge job_manager_admin_badge--promoted ' . esc_attr( $status_class ) . '">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>';
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -245,6 +245,8 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			';
 		} elseif ( 'publish' === $post->post_status ) {
 			echo '<button class="promote_job button button-primary" data-href=' . esc_url( $promote_url ) . '>' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
+		} else {
+			echo '<button class="button button-primary" disabled="disabled" title="' . esc_attr__( 'The job needs to be published in order to be promoted', 'wp-job-manager' ) . '">' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -172,7 +172,9 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		if ( ! $post_id ) {
 			wp_die( esc_html__( 'No job listing ID provided for promotion.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
-		if ( ! $this->can_promote_job( $post_id ) ) {
+
+		$is_promoted_or_published = WP_Job_Manager_Promoted_Jobs::is_promoted( $post_id ) || 'publish' === get_post_status( $post_id );
+		if ( ! $this->can_promote_job( $post_id ) || ! $is_promoted_or_published ) {
 			wp_die( esc_html__( 'You do not have permission to promote this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 		$current_user = get_current_user_id();

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -127,17 +127,17 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			return;
 		}
 
-		$tooltip      = '';
+		$title        = '';
 		$status_class = '';
 
 		if ( 'publish' !== $post->post_status ) {
-			$tooltip      = __( 'Your job is promoted and being exposed through API but it\'s not published in your site. You can fix it by publishing it again or deactivating the promotion.', 'wp-job-manager' );
+			$title        = __( 'Your job is promoted and being exposed through API but it\'s not published in your site. You can fix it by publishing it again or deactivating the promotion.', 'wp-job-manager' );
 			$status_class = 'job_manager_admin_badge--not_published';
 		} else {
-			$tooltip = __( 'This job has been promoted to external job boards.', 'wp-job-manager' );
+			$title = __( 'This job has been promoted to external job boards.', 'wp-job-manager' );
 		}
 
-		echo '<span title="' . esc_attr( $tooltip ) . '" class="job_manager_admin_badge job_manager_admin_badge--promoted ' . esc_attr( $status_class ) . '">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>';
+		echo '<span class="job_manager_admin_badge job_manager_admin_badge--promoted ' . esc_attr( $status_class ) . ' tips" title="' . esc_attr( $title ) . '" data-tip="' . esc_attr( $title ) . '">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>';
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -246,7 +246,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		} elseif ( 'publish' === $post->post_status ) {
 			echo '<button class="promote_job button button-primary" data-href=' . esc_url( $promote_url ) . '>' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		} else {
-			echo '<button class="button button-primary" disabled="disabled" title="' . esc_attr__( 'The job needs to be published in order to be promoted', 'wp-job-manager' ) . '">' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
+			echo '<button class="button button-primary" disabled="disabled" title="' . esc_attr__( 'The job needs to be published in order to be promoted.', 'wp-job-manager' ) . '">' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		}
 	}
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -89,7 +89,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			wp_die( esc_html__( 'No job listing ID provided for deactivation of the promotion.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 
-		if ( ! $this->can_promote_job( $post_id ) ) {
+		if ( ! $this->can_manage_job_promotion( $post_id ) ) {
 			wp_die( esc_html__( 'You do not have permission to deactivate the promotion for this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 
@@ -141,13 +141,13 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	}
 
 	/**
-	 * Check if a user can promote a job. They must have permission to manage job listings and the post type must be a published job_listing.
+	 * Check if a user can manage job promotion. They must have permission to manage job listings.
 	 *
 	 * @param int $post_id Post ID.
 	 *
 	 * @return bool Returns true if they can promote a job.
 	 */
-	private function can_promote_job( int $post_id ) {
+	private function can_manage_job_promotion( int $post_id ) {
 		if ( 'job_listing' !== get_post_type( $post_id ) ) {
 			return false;
 		}
@@ -183,10 +183,18 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			wp_die( esc_html__( 'No job listing ID provided for promotion.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
 		}
 
-		$is_promoted_or_published = WP_Job_Manager_Promoted_Jobs::is_promoted( $post_id ) || 'publish' === get_post_status( $post_id );
-		if ( ! $this->can_promote_job( $post_id ) || ! $is_promoted_or_published ) {
-			wp_die( esc_html__( 'You do not have permission to promote this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
+		$is_editing = WP_Job_Manager_Promoted_Jobs::is_promoted( $post_id );
+		$can_manage = $this->can_manage_job_promotion( $post_id );
+		if ( $is_editing ) {
+			if ( ! $can_manage ) {
+				wp_die( esc_html__( 'You do not have permission to edit this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
+			}
+		} else {
+			if ( ! $can_manage || 'publish' !== get_post_status( $post_id ) ) {
+				wp_die( esc_html__( 'You do not have permission to promote this job listing.', 'wp-job-manager' ), '', [ 'back_link' => true ] );
+			}
 		}
+
 		$current_user = get_current_user_id();
 		$site_trust   = WP_Job_Manager_Site_Trust_Token::instance();
 		$token        = $site_trust->generate( 'user', $current_user );
@@ -227,7 +235,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			return;
 		}
 
-		if ( ! $this->can_promote_job( $post->ID ) ) {
+		if ( ! $this->can_manage_job_promotion( $post->ID ) ) {
 			return;
 		}
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -166,7 +166,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		return [
 			'id'           => (string) $item->ID,
-			'post_status'  => $item->post_status,
+			'job_status'   => $item->post_status,
 			'title'        => $item->post_title,
 			'description'  => $item->post_content,
 			'permalink'    => get_permalink( $item ),

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -116,7 +116,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		$args = [
 			'post_type'           => 'job_listing',
-			'post_status'         => array_merge( get_job_listing_post_statuses(), [ 'trash' ] ),
+			'post_status'         => array_merge( array_keys( get_job_listing_post_statuses() ), [ 'trash' ] ),
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
 			'posts_per_page'      => -1,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -116,7 +116,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		$args = [
 			'post_type'           => 'job_listing',
-			'post_status'         => [ 'any', 'trash' ],
+			'post_status'         => array_merge( get_job_listing_post_statuses(), [ 'trash' ] ),
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
 			'posts_per_page'      => -1,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -166,7 +166,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		return [
 			'id'           => (string) $item->ID,
-			'job_status'   => $item->post_status,
+			'status'       => $item->post_status,
 			'title'        => $item->post_title,
 			'description'  => $item->post_content,
 			'permalink'    => get_permalink( $item ),

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -166,6 +166,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		return [
 			'id'           => (string) $item->ID,
+			'post_status'  => $item->post_status,
 			'title'        => $item->post_title,
 			'description'  => $item->post_content,
 			'permalink'    => get_permalink( $item ),

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -116,7 +116,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		$args = [
 			'post_type'           => 'job_listing',
-			'post_status'         => 'publish',
+			'post_status'         => [ 'any', 'trash' ],
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
 			'posts_per_page'      => -1,


### PR DESCRIPTION
Fixes #2477

I'm anticipating it while it's still in discussion in p6r3EZ-1Hf-p2, in order to try to accelerate it a little. We can continue the discussion iterating this PR.

### Changes proposed in this Pull Request

* Allow jobs of any post status on the promoted feed.
* Add the post_status to the job object in the feed and in the job data, in case we want to iterate handling it differently in the future without depending on a plugin update.
* Allow edit/deactivate promoted jobs that aren't published.

### Testing instructions

* Create and publish a job.
* Promote the job.
* Change the job status to draft, or any other status (even moving to trash).
* Make sure you can still deactivate the promotion.
* Create a new job as draft, and make sure you can't promote it.