### PR TITLE
Protect Get Promoted Job API with same condition as used by WP

### DIFF
--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -222,7 +222,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
 		$controller = get_post_type_object( 'job_listing' )->get_rest_controller();
-		if ( $controller instanceof WP_REST_Posts_Controller && ! $controller->check_read_permission( $post ) ) {
+		if ( ! ( $controller instanceof WP_REST_Posts_Controller ) || ! $controller->check_read_permission( $post ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to view this job.', 'wp-job-manager' ), [ 'status' => rest_authorization_required_code() ] );
 		}
 		$job_data = $this->prepare_item_for_response( get_post( $job_id ) );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -217,7 +217,8 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 */
 	public function get_job_data( $request ) {
 		$job_id = $request->get_param( 'job_id' );
-		if ( 'job_listing' !== get_post_type( $job_id ) ) {
+		$post   = get_post( $job_id );
+		if ( 'job_listing' !== get_post_type( $post ) ) {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
 		$job_data = $this->prepare_item_for_response( get_post( $job_id ) );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -227,7 +227,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		 * @var WP_REST_Posts_Controller $controller
 		 */
 		$controller = get_post_type_object( 'job_listing' )->get_rest_controller();
-		if ( ! $controller->check_read_permission( $post ) ) {
+		if ( $controller instanceof WP_REST_Posts_Controller && ! $controller->check_read_permission( $post ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to view this job.', 'wp-job-manager' ), [ 'status' => rest_authorization_required_code() ] );
 		}
 		$job_data = $this->prepare_item_for_response( get_post( $job_id ) );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -221,11 +221,6 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		if ( 'job_listing' !== get_post_type( $post ) ) {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
-		/**
-		 * The REST controller for job listings.
-		 *
-		 * @var WP_REST_Posts_Controller $controller
-		 */
 		$controller = get_post_type_object( 'job_listing' )->get_rest_controller();
 		if ( $controller instanceof WP_REST_Posts_Controller && ! $controller->check_read_permission( $post ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to view this job.', 'wp-job-manager' ), [ 'status' => rest_authorization_required_code() ] );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -221,6 +221,15 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		if ( 'job_listing' !== get_post_type( $post ) ) {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
+		/**
+		 * The REST controller for job listings.
+		 *
+		 * @var WP_REST_Posts_Controller $controller
+		 */
+		$controller = get_post_type_object( 'job_listing' )->get_rest_controller();
+		if ( ! $controller->check_read_permission( $post ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to view this job.', 'wp-job-manager' ), [ 'status' => rest_authorization_required_code() ] );
+		}
 		$job_data = $this->prepare_item_for_response( get_post( $job_id ) );
 		if ( is_wp_error( $job_data ) ) {
 			return $job_data;


### PR DESCRIPTION
Fixes #2514

### Changes proposed in this Pull Request

* Use same permission check as WP REST Controller to validate whether we should return data or not

### Testing instructions

1. Create a job listing 
2. Publish it 
3. Visit `http://your.wpjm.site/wp-json/wpjm-internal/v1/promoted-jobs/JOB_ID` replacing JOB_ID with the post id of the job listing and make sure you can view the post data as appropriate
4. Move it to draft (or just move to trash)
5. Visit the same endpoint again and make sure you see the error "Sorry, you are not allowed to view this job"

