### PR TITLE
Don't open the promote modal on the editor when the job is already promoted

### DIFF
--- a/assets/js/admin/job-editor.js
+++ b/assets/js/admin/job-editor.js
@@ -30,8 +30,10 @@ domReady( () => {
 				'publish' !== coreEditorSelector.getCurrentPostAttribute( 'status' );
 		},
 		onSave: () => {
-			// Open dialog when job was published.
-			if ( jobWasPublished ) {
+			const meta = coreEditorSelector.getCurrentPostAttribute( 'meta' );
+
+			// Open dialog when job was published and it's not promoted.
+			if ( jobWasPublished && '1' !== meta?._promoted ) {
 				promoteDialog.showModal();
 				postOpenPromoteModal( promoteDialog, window.wpjm.promoteUrl );
 			}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -57,6 +57,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	public function __construct() {
 		add_action( 'init', [ $this, 'include_dependencies' ] );
+		add_action( 'init', [ $this, 'register_post_metas' ] );
 		add_action( 'rest_api_init', [ $this, 'rest_init' ] );
 	}
 
@@ -69,6 +70,24 @@ class WP_Job_Manager_Promoted_Jobs {
 	public function include_dependencies() {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php';
+	}
+
+	/**
+	 * Register post metas.
+	 */
+	public function register_post_metas() {
+		register_post_meta(
+			'job_listing',
+			self::PROMOTED_META_KEY,
+			[
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'string',
+				'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
+					return current_user_can( 'edit_post', $post_id );
+				},
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue reported by @aaronfc https://github.com/Automattic/WP-Job-Manager/pull/2544#pullrequestreview-1547036865

> The "Do you want to promote the job?" modal appears when publishing a job (even if it's already promoted). In this case it's the same job I trashed/restored and is now in draft.

### Changes proposed in this Pull Request

* Avoid opening the promote modal on the editor when the job is already promoted.

### Testing instructions

* Create a new job and publish it.
* Make sure you see the promote modal.
* Promote the job.
* Return to the job editor.
* Switch to draft.
* Publish again, and make sure you don't see the promote modal again.