### PR TITLE
Enhance removing promoted jobs experience

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -65,6 +65,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		add_action( 'wpjm_job_listing_bulk_actions', [ $this, 'add_action_notice' ] );
 		add_action( 'wpjm_admin_notices', [ $this, 'maybe_add_promoted_jobs_notice' ] );
 		add_action( 'wpjm_admin_notices', [ $this, 'maybe_add_trash_notice' ] );
+		add_action( 'post_row_actions', [ $this, 'remove_delete_from_promoted_jobs' ], 10, 2 );
 	}
 
 	/**
@@ -436,6 +437,33 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		];
 
 		return $notices;
+	}
+
+	/**
+	 * Remove delete link from promoted jobs.
+	 * The delete action is also canceled as part of
+	 * `WP_Job_Manager_Promoted_Jobs::cancel_promoted_jobs_deletion`.
+	 *
+	 * @internal
+	 *
+	 * @param array   $actions
+	 * @param WP_Post $post
+	 *
+	 * @return array
+	 */
+	public function remove_delete_from_promoted_jobs( $actions, $post ) {
+		if ( WP_Job_Manager_Promoted_Jobs::is_promoted( $post->ID ) ) {
+			$title = __( 'You need to deactivate the promotion before deleting the job.', 'wp-job-manager' );
+
+			$actions['delete'] = preg_replace(
+				'/<a(.*?)>/',
+				'<a onclick="return false;" style="opacity:0.3; cursor:help;" title="' . $title . '" $1>',
+				$actions['delete'],
+				1
+			);
+		}
+
+		return $actions;
 	}
 }
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -457,7 +457,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 
 			$actions['delete'] = preg_replace(
 				'/<a(.*?)>/',
-				'<a onclick="return false;" style="opacity:0.3; cursor:help;" title="' . $title . '" $1>',
+				'<a onclick="return false;" style="opacity:0.3; cursor:help;" title="' . $title . '" data-tip="' . $title . '" class="tips" $1>',
 				$actions['delete'],
 				1
 			);

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -420,8 +420,8 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			'type'        => 'user',
 			'dismissible' => false,
 			'level'       => 'info',
-			'heading'     => __( 'You have promoted jobs on trash.', 'wp-job-manager' ),
-			'message'     => __( 'Deactivate trashed jobs in order to stop the promotion or publish it again, so applicants can see the job on your site.', 'wp-job-manager' ),
+			'heading'     => __( 'You have promoted jobs in the trash.', 'wp-job-manager' ),
+			'message'     => __( 'Trashed jobs are not be available to your applicants. Deactivate the promotion or publish the job again to fix this.', 'wp-job-manager' ),
 			'conditions'  => [
 				[
 					'type'    => 'screens',

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -457,7 +457,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 
 			$actions['delete'] = preg_replace(
 				'/<a(.*?)>/',
-				'<a onclick="return false;" style="opacity:0.3; cursor:help;" title="' . $title . '" data-tip="' . $title . '" class="tips" $1>',
+				'<a onclick="return false;" style="opacity:0.3; cursor:help;" title="' . esc_attr( $title ) . '" data-tip="' . esc_attr( $title ) . '" class="tips" $1>',
 				$actions['delete'],
 				1
 			);

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -64,6 +64,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		add_action( 'admin_footer', [ $this, 'promoted_jobs_admin_footer' ] );
 		add_action( 'wpjm_job_listing_bulk_actions', [ $this, 'add_action_notice' ] );
 		add_action( 'wpjm_admin_notices', [ $this, 'maybe_add_promoted_jobs_notice' ] );
+		add_action( 'wpjm_admin_notices', [ $this, 'maybe_add_trash_notice' ] );
 	}
 
 	/**
@@ -384,6 +385,52 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 				[
 					'type'    => 'screens',
 					'screens' => [ 'edit-job_listing' ],
+				],
+			],
+		];
+
+		return $notices;
+	}
+
+	/**
+	 * Add a notice to the job listing admin page if there are promoted jobs on trash.
+	 *
+	 * @internal
+	 *
+	 * @param array $notices Notices to filter on.
+	 *
+	 * @return array
+	 */
+	public function maybe_add_trash_notice( $notices ) {
+		$promoted_trash_count = WP_Job_Manager_Promoted_Jobs::query_promoted_jobs_count( [ 'post_status' => 'trash' ] );
+		if ( 0 === $promoted_trash_count ) {
+			return $notices;
+		}
+
+		$trash_url = add_query_arg(
+			[
+				'post_type'   => 'job_listing',
+				'post_status' => 'trash',
+			],
+			admin_url( 'edit.php' )
+		);
+
+		$notices['promoted-job-on-trash'] = [
+			'type'        => 'user',
+			'dismissible' => false,
+			'level'       => 'info',
+			'heading'     => __( 'You have promoted jobs on trash.', 'wp-job-manager' ),
+			'message'     => __( 'Deactivate trashed jobs in order to stop the promotion or publish it again, so applicants can see the job on your site.', 'wp-job-manager' ),
+			'conditions'  => [
+				[
+					'type'    => 'screens',
+					'screens' => [ 'edit-job_listing' ],
+				],
+			],
+			'actions'     => [
+				[
+					'label' => __( 'Check the trash', 'wp-job-manager' ),
+					'url'   => $trash_url,
 				],
 			],
 		];

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -64,7 +64,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	/**
 	 * Includes promoted jobs dependencies.
 	 *
-	 * @access private
+	 * @internal
 	 * @return void
 	 */
 	public function include_dependencies() {
@@ -75,7 +75,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	/**
 	 * Loads the REST API functionality.
 	 *
-	 * @access private
+	 * @internal
 	 */
 	public function rest_init() {
 		( new WP_Job_Manager_Promoted_Jobs_API() )->register_routes();
@@ -84,7 +84,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	/**
 	 * Cancel promoted jobs deletion.
 	 *
-	 * @access private
+	 * @internal
 	 *
 	 * @param WP_Post|false|null $delete
 	 * @param WP_Post            $post

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -58,6 +58,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	public function __construct() {
 		add_action( 'init', [ $this, 'include_dependencies' ] );
 		add_action( 'rest_api_init', [ $this, 'rest_init' ] );
+		add_filter( 'pre_delete_post', [ $this, 'cancel_promoted_jobs_deletion' ], 10, 2 );
 	}
 
 	/**
@@ -73,9 +74,32 @@ class WP_Job_Manager_Promoted_Jobs {
 
 	/**
 	 * Loads the REST API functionality.
+	 *
+	 * @access private
 	 */
 	public function rest_init() {
 		( new WP_Job_Manager_Promoted_Jobs_API() )->register_routes();
+	}
+
+	/**
+	 * Cancel promoted jobs deletion.
+	 *
+	 * @access private
+	 *
+	 * @param WP_Post|false|null $delete
+	 * @param WP_Post            $post
+	 *
+	 * @return WP_Post|false|null
+	 */
+	public function cancel_promoted_jobs_deletion( $delete, $post ) {
+		if (
+			'job_listing' !== $post->post_type
+			|| ! self::is_promoted( $post->ID )
+		) {
+			return $delete;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -147,6 +147,38 @@ class WP_Job_Manager_Promoted_Jobs {
 	}
 
 	/**
+	 * Get the number of active promoted jobs filtering with specific args.
+	 *
+	 * @internal
+	 *
+	 * @param array $args Extra args for the counter query.
+	 *
+	 * @return int
+	 */
+	public static function query_promoted_jobs_count( $args = [] ) {
+		$args = wp_parse_args(
+			$args,
+			[
+				'post_type'      => 'job_listing',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'meta_query'     => [
+					[
+						'key'     => self::PROMOTED_META_KEY,
+						'value'   => '1',
+						'compare' => '=',
+					],
+				],
+			]
+		);
+
+		$promoted_jobs = new WP_Query( $args );
+
+		return $promoted_jobs->found_posts;
+	}
+
+	/**
 	 * Get the number of active promoted jobs.
 	 *
 	 * @return int
@@ -155,23 +187,7 @@ class WP_Job_Manager_Promoted_Jobs {
 		$promoted_jobs_count = get_option( self::PROMOTED_JOB_TRACK_OPTION );
 
 		if ( false === $promoted_jobs_count ) {
-			$promoted_jobs = new WP_Query(
-				[
-					'post_type'      => 'job_listing',
-					'post_status'    => 'any',
-					'posts_per_page' => 1,
-					'fields'         => 'ids',
-					'meta_query'     => [
-						[
-							'key'     => self::PROMOTED_META_KEY,
-							'value'   => '1',
-							'compare' => '=',
-						],
-					],
-				]
-			);
-
-			$promoted_jobs_count = $promoted_jobs->found_posts;
+			$promoted_jobs_count = self::query_promoted_jobs_count();
 
 			update_option( self::PROMOTED_JOB_TRACK_OPTION, $promoted_jobs_count );
 		}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -92,10 +92,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return WP_Post|false|null
 	 */
 	public function cancel_promoted_jobs_deletion( $delete, $post ) {
-		if (
-			'job_listing' !== $post->post_type
-			|| ! self::is_promoted( $post->ID )
-		) {
+		if ( ! self::is_promoted( $post->ID ) ) {
 			return $delete;
 		}
 


### PR DESCRIPTION
Fixes #2546

### Changes proposed in this Pull Request

* Cancel promoted jobs deletion.
* Add a notice when there are promoted jobs on trash.
* Notice that tied to this, we also have [this PR](https://github.com/Automattic/WP-Job-Manager/pull/2544), making sure that users can deactivate jobs from trash, and we [highlight the promoted badge](https://github.com/Automattic/WP-Job-Manager/pull/2544#issuecomment-1652334761).

### Testing instructions

* Create 2 jobs, and promote 1 of them.
* Send both jobs to trash.
* Check that a notice is displayed that you have promoted jobs on the trash.
* Click on the button to navigate to the trash.
* Try to delete the jobs permanently. Make sure you can't delete the promoted job.
* Restore the promoted job, and make sure the notice is not displayed anymore.
* Try to create normal posts and delete them permanently, and make sure it continues working properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1460" alt="Screenshot 2023-07-26 at 17 09 02" src="https://github.com/Automattic/WP-Job-Manager/assets/876340/69afa847-3f2b-41cb-8ac7-d00c7cd8aedc">
