### PR TITLE
Use proper functions to get salary_currency and salary_unit on Promoted Job API

### DIFF
--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -175,8 +175,8 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'job_type'     => $terms_array,
 			'salary'       => [
 				'salary_amount'   => get_post_meta( $item->ID, '_job_salary', true ),
-				'salary_currency' => get_post_meta( $item->ID, '_job_salary_currency', true ),
-				'salary_unit'     => get_post_meta( $item->ID, '_job_salary_unit', true ),
+				'salary_currency' => get_the_job_salary_currency( $item ),
+				'salary_unit'     => get_the_job_salary_unit_display_text( $item ),
 			],
 		];
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wpjobmanager.com/issues/529

### Changes proposed in this Pull Request

* Use proper functions to get salary_currency and salary_unit on Promoted Job API

### Testing instructions

1. Enable all options related to salary currency and salary unit options on WPJM Settings
2. Set a default salary currency and salary unit 
3. Create a job
4. Set the value for the job, but not salary currency or unit (just leave the field empty)
5. Set the job as promoted (`wp post meta set JOB_ID _promoted 1`)
6. Visit the endpoint `/wp-json/wpjm-internal/v1/promoted-jobs/JOB_ID` and make sure that the data from `salary_currency` and `salary_unit` fields come from the default salary currency and salary unit fields you defined
