### PR TITLE
Sync salary fields in promoted jobs API with api documentation

### DIFF
--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -301,7 +301,7 @@
                 "type": "string",
                 "example": "USD"
               },
-              "value": {
+              "amount": {
                 "type": "string",
                 "example": "$50,000 - $100,000"
               },

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -174,9 +174,9 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'is_remote'    => (bool) get_post_meta( $item->ID, '_remote_position', true ),
 			'job_type'     => $terms_array,
 			'salary'       => [
-				'salary_amount'   => get_post_meta( $item->ID, '_job_salary', true ),
-				'salary_currency' => get_the_job_salary_currency( $item ),
-				'salary_unit'     => get_the_job_salary_unit_display_text( $item ),
+				'amount'   => get_post_meta( $item->ID, '_job_salary', true ),
+				'currency' => get_the_job_salary_currency( $item ),
+				'unit'     => get_the_job_salary_unit_display_text( $item ),
 			],
 		];
 	}


### PR DESCRIPTION
Based on #2549
Adjusts a few things reported by @aaronfc's [review](https://github.com/Automattic/WP-Job-Manager/pull/2549#discussion_r1277213753)

### Changes proposed in this Pull Request

* Remove `salary_` prefix from the salary fields in Promoted Jobs API
* Rename `value` to `amount` in API Doc for Promoted Jobs API

### Testing instructions

1. Enable all the salary related options on WPJM's settings
2. Create a job, fill all the salary info
3. Visit the `/wp-json/wpjm-internal/v1/promoted-jobs/JOB_ID`  endpoint and make sure that the salary fields don't have the `salary_` prefix
4. Verify if the doc for the API matches the result of that endpoint
