### PR TITLE
Change promoted jobs learn more link

### DIFF
--- a/assets/js/admin/promote-job-modals.js
+++ b/assets/js/admin/promote-job-modals.js
@@ -11,7 +11,7 @@ export const postOpenPromoteModal = ( dialog, href ) => {
 	<promote-job-template>
 		<div slot="buttons" class="promote-buttons-group">
 			<a id="wpjm-promote-button" class="promote-button button button-primary" target="_blank" rel="noopener noreferrer" href="${ href }">${ job_manager_admin_params.job_listing_promote_strings.promote_job }</a>
-			<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="https://wpjobmanager.com/document/promoted-jobs?utm_source=plugin_wpjm&utm_medium=promote-dialog&utm_campaign=promoted-jobs">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
+			<a class="promote-button button button-secondary" target="_blank" rel="noopener noreferrer" href="https://wpjobmanager.com/jobtarget?utm_source=plugin_wpjm&utm_medium=promote-dialog&utm_campaign=promoted-jobs">${ job_manager_admin_params.job_listing_promote_strings.learn_more }</a>
 		</div>
 	<promote-job-template>`;
 


### PR DESCRIPTION
Pair with https://github.com/Automattic/wpjobmanager.com/pull/562

It just updates the learn more link in the promote modal.