### PR TITLE
Rename licence -> license throughout codebase

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -9,18 +9,18 @@
 	}
 }
 
-a.wpjm-activate-licence-link,
-a.wpjm-activate-licence-link:link,
-a.wpjm-activate-licence-link:hover,
-a.wpjm-activate-licence-link:visited,
-a.wpjm-activate-licence-link:active {
+a.wpjm-activate-license-link,
+a.wpjm-activate-license-link:link,
+a.wpjm-activate-license-link:hover,
+a.wpjm-activate-license-link:visited,
+a.wpjm-activate-license-link:active {
 	color: orangered;
 }
 
-.wpjm-licences {
+.wpjm-licenses {
 	margin-top: 10px;
 
-	.licence-row {
+	.license-row {
 		align-items: center;
 		border: solid 1px #e2e0e2;
 		display: flex;
@@ -41,34 +41,34 @@ a.wpjm-activate-licence-link:active {
 			font-weight: 400;
 		}
 	}
-	.plugin-licence {
+	.plugin-license {
 		flex: 1;
 		flex-basis: 40%;
 		padding-bottom: 5px;
 	}
-	.plugin-licence-icon {
+	.plugin-license-icon {
 		width: 44px;
 		height: 44px;
 		margin: 14px 16px 14px 12px;
 	}
-	.plugin-licence-form {
+	.plugin-license-form {
 		text-align: right;
 		margin-right: 24px;
 		line-height: 36px;
 		height: 36px;
 	}
-	.plugin-licence-checkmark {
+	.plugin-license-checkmark {
 		// The resulting color shoudl be #008A20. Computed using https://codepen.io/sosuke/pen/Pjoqqp
 		filter: invert(23%) sepia(74%) saturate(6542%) hue-rotate(143deg) brightness(100%) contrast(101%);
 		vertical-align: middle;
 	}
-	.plugin-licence-label {
+	.plugin-license-label {
 		line-height: 36px;
 		font-weight: 600;
 		margin-left: 22px;
 		white-space: nowrap;
 	}
-	.plugin-licence-field {
+	.plugin-license-field {
 		height: 36px;
 		margin-left: 25px;
 		width: 100%;
@@ -77,13 +77,13 @@ a.wpjm-activate-licence-link:active {
 			border: 1px solid #CC1818;
 		}
 	}
-	.plugin-licence-button {
+	.plugin-license-button {
 		margin-left: 30px;
 		height: 36px;
 		width: 100%;
 		max-width: 140px;
 	}
-	.plugin-licence-notice {
+	.plugin-license-notice {
 		width: 100%;
 		margin: 0 24px 14px 12px;
 		// Apply background colors from gutenberg notices in the HTML for each notice type
@@ -162,26 +162,26 @@ a.wpjm-activate-licence-link:active {
 	}
 }
 
-.plugin-licence-search {
+.plugin-license-search {
 	width: 100%;
 	margin: 18px 0;
 	display: flex;
 	justify-content: end;
 	min-height: 40px;
-	.plugin-licence-search-field {
+	.plugin-license-search-field {
 		max-width: 180px;
 		width: 100%;
 		min-height: 40px;
 		margin-right: 3px;
 	}
-	.plugin-licence-search-button {
+	.plugin-license-search-button {
 		min-height: 40px;
 		max-width: 75px;
 		width: 100%;
 	}
 }
 
-.plugin-licence-section {
+.plugin-license-section {
 	font-size: 13px;
 	line-height: 16px;
 	font-weight: 700;
@@ -733,13 +733,13 @@ tr.email-setting-row {
  */
 @media only screen and (max-width: 782px) {
 
-	.wpjm-licences {
+	.wpjm-licenses {
 
 		.plugin-info {
 			padding: 10px;
 		}
 
-		.plugin-licence {
+		.plugin-license {
 			padding: 10px;
 		}
 	}

--- a/includes/3rd-party/wpcom.php
+++ b/includes/3rd-party/wpcom.php
@@ -20,7 +20,7 @@ function wpjm_dotcom_marketplace_configure_license_for_wp_job_manager_addon( $re
 	}
 
 	$helper = WP_Job_Manager_Helper::instance();
-	$helper->activate_licence( $payload['wpjm_product_slug'], $payload['license_code'], $payload['email_address'] );
+	$helper->activate_license( $payload['wpjm_product_slug'], $payload['license_code'], $payload['email_address'] );
 
 	$messages = $helper->get_messages( $payload['wpjm_product_slug'] );
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -146,7 +146,7 @@ class WP_Job_Manager_Admin {
 	public function admin_menu() {
 		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), __( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', [ $this->settings_page, 'output' ] );
 
-		if ( WP_Job_Manager_Helper::instance()->has_licenced_products() || apply_filters( 'job_manager_show_addons_page', true ) ) {
+		if ( WP_Job_Manager_Helper::instance()->has_licensed_products() || apply_filters( 'job_manager_show_addons_page', true ) ) {
 			add_submenu_page( 'edit.php?post_type=job_listing', __( 'WP Job Manager Add-ons', 'wp-job-manager' ), __( 'Add-ons', 'wp-job-manager' ), 'manage_options', 'job-manager-addons', [ $this, 'addons_page' ] );
 		}
 	}

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -331,7 +331,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 
 		if ( $licensed_only ) {
 			foreach ( $active_plugins as $plugin_slug => $data ) {
-				if ( ! $helper->has_plugin_licence( $plugin_slug ) ) {
+				if ( ! $helper->has_plugin_license( $plugin_slug ) ) {
 					unset( $active_plugins[ $plugin_slug ] );
 				}
 			}

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -87,7 +87,7 @@ class WP_Job_Manager_Helper_API {
 	}
 
 	/**
-	 * Attempt to activate a plugin licence.
+	 * Attempt to activate a plugin license.
 	 *
 	 * @param array $args The arguments to pass to the API.
 	 * @return array|false JSON response or false if failed.
@@ -95,7 +95,7 @@ class WP_Job_Manager_Helper_API {
 	public function activate( $args ) {
 		$args         = wp_parse_args( $args );
 		$product_slug = $args['api_product_id'];
-		$response     = $this->bulk_activate( $args['licence_key'], [ $product_slug ] );
+		$response     = $this->bulk_activate( $args['license_key'], [ $product_slug ] );
 		if ( false === $response || ! array_key_exists( $product_slug, $response ) ) {
 			return false;
 		}
@@ -115,13 +115,13 @@ class WP_Job_Manager_Helper_API {
 	}
 
 	/**
-	 * Attempt to activate multiple WPJM products with a single licence key.
+	 * Attempt to activate multiple WPJM products with a single license key.
 	 *
-	 * @param string $licence_key The licence key to activate.
+	 * @param string $license_key The license key to activate.
 	 * @param array  $product_slugs The slugs of the products to activate.
 	 * @return array|false The response, or false if the request failed.
 	 */
-	public function bulk_activate( $licence_key, $product_slugs ) {
+	public function bulk_activate( $license_key, $product_slugs ) {
 		return $this->request_endpoint(
 			'wp-json/wpjmcom-licensing/v1/activate',
 			[
@@ -129,7 +129,7 @@ class WP_Job_Manager_Helper_API {
 				'body'   => wp_json_encode(
 					[
 						'site_url'      => $this->get_site_url(),
-						'license_key'   => $licence_key,
+						'license_key'   => $license_key,
 						'product_slugs' => $product_slugs,
 					]
 				),
@@ -138,7 +138,7 @@ class WP_Job_Manager_Helper_API {
 	}
 
 	/**
-	 * Attempt to deactivate a plugin licence.
+	 * Attempt to deactivate a plugin license.
 	 *
 	 * @param array|string $args
 	 * @return array|false JSON response or false if failed.
@@ -151,7 +151,7 @@ class WP_Job_Manager_Helper_API {
 	}
 
 	/**
-	 * Make a licence helper API request.
+	 * Make a license helper API request.
 	 *
 	 * @param array $args The arguments to pass to the API.
 	 * @param bool  $return_error If we should return the error details or not.
@@ -183,7 +183,7 @@ class WP_Job_Manager_Helper_API {
 	}
 
 	/**
-	 * Make a licence helper API request to a WP REST API Endpoint.
+	 * Make a license helper API request to a WP REST API Endpoint.
 	 *
 	 * @param string $endpoint The endpoint to make the API request to.
 	 * @param array  $args The arguments to pass to the request.

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -168,6 +168,12 @@ class WP_Job_Manager_Helper_API {
 			'email'          => '',
 		];
 
+		// These legacy endpoints are temporary. For now, translate `license_key` => `licence_key` at this point.
+		if ( ! empty( $args['license_key'] ) ) {
+			$args['licence_key'] = $args['license_key'];
+			unset( $args['license_key'] );
+		}
+
 		$args     = wp_parse_args( $args, $defaults );
 		$response = wp_safe_remote_get(
 			$this->get_api_base_url() . '?' . http_build_query( $args, '', '&' ),

--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -159,6 +159,12 @@ class WP_Job_Manager_Helper_API {
 	 * @return array|false The response as an array, or false if the request failed.
 	 */
 	protected function request( $args, $return_error = false ) {
+		// These legacy endpoints are temporary. For now, translate `license_key` => `licence_key` at this point.
+		if ( ! empty( $args['license_key'] ) ) {
+			$args['licence_key'] = $args['license_key'];
+			unset( $args['license_key'] );
+		}
+
 		$defaults = [
 			'instance'       => $this->get_site_url(),
 			'plugin_name'    => '',
@@ -167,12 +173,6 @@ class WP_Job_Manager_Helper_API {
 			'licence_key'    => '',
 			'email'          => '',
 		];
-
-		// These legacy endpoints are temporary. For now, translate `license_key` => `licence_key` at this point.
-		if ( ! empty( $args['license_key'] ) ) {
-			$args['licence_key'] = $args['license_key'];
-			unset( $args['license_key'] );
-		}
 
 		$args     = wp_parse_args( $args, $defaults );
 		$response = wp_safe_remote_get(

--- a/includes/helper/class-wp-job-manager-helper-options.php
+++ b/includes/helper/class-wp-job-manager-helper-options.php
@@ -26,6 +26,10 @@ class WP_Job_Manager_Helper_Options {
 	 * @return bool
 	 */
 	public static function update( $product_slug, $key, $value ) {
+		if ( '_' === substr( $product_slug, 0, 1 ) ) {
+			return false;
+		}
+
 		$options = self::get_license_option();
 		if ( ! isset( $options[ $product_slug ] ) ) {
 			$options[ $product_slug ] = [];
@@ -44,6 +48,10 @@ class WP_Job_Manager_Helper_Options {
 	 * @return mixed
 	 */
 	public static function get( $product_slug, $key, $default = false ) {
+		if ( '_' === substr( $product_slug, 0, 1 ) ) {
+			return $default;
+		}
+
 		$options = self::get_license_option();
 		if ( ! isset( $options[ $product_slug ] ) ) {
 			$options[ $product_slug ] = self::attempt_legacy_restore( $product_slug );
@@ -64,6 +72,10 @@ class WP_Job_Manager_Helper_Options {
 	 * @return bool
 	 */
 	public static function delete( $product_slug, $key ) {
+		if ( '_' === substr( $product_slug, 0, 1 ) ) {
+			return false;
+		}
+
 		$options = self::get_license_option();
 		if ( ! isset( $options[ $product_slug ] ) ) {
 			$options[ $product_slug ] = [];

--- a/includes/helper/class-wp-job-manager-helper-options.php
+++ b/includes/helper/class-wp-job-manager-helper-options.php
@@ -16,7 +16,7 @@ class WP_Job_Manager_Helper_Options {
 	const OPTION_NAME = 'job_manager_helper';
 
 	/**
-	 * Update a WPJM plugin's licence data.
+	 * Update a WPJM plugin's license data.
 	 *
 	 * @param string $product_slug
 	 * @param string $key
@@ -34,7 +34,7 @@ class WP_Job_Manager_Helper_Options {
 	}
 
 	/**
-	 * Retrieve a WPJM plugin's licence data.
+	 * Retrieve a WPJM plugin's license data.
 	 *
 	 * @param string $product_slug
 	 * @param string $key
@@ -54,7 +54,7 @@ class WP_Job_Manager_Helper_Options {
 	}
 
 	/**
-	 * Delete a WPJM plugin's licence data.
+	 * Delete a WPJM plugin's license data.
 	 *
 	 * @param string $product_slug
 	 * @param string $key
@@ -71,7 +71,7 @@ class WP_Job_Manager_Helper_Options {
 	}
 
 	/**
-	 * Attempt to retrieve licence data from legacy storage.
+	 * Attempt to retrieve license data from legacy storage.
 	 *
 	 * @param string $product_slug
 	 *

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -298,7 +298,7 @@ class WP_Job_Manager_Helper {
 
 			$plugin_package[ $plugin_slug ] = [
 				'installed_version' => $plugin['Version'],
-				'license_key'       => $license_key['license_key'] ?? '',
+				'license_key'       => $license_key['license_key'] ? $license_key['license_key'] : '',
 			];
 		}
 		ksort( $plugin_package );

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -103,15 +103,15 @@ class WP_Job_Manager_Helper {
 		$deprecated_methods = [
 			'has_licenced_products' => [
 				'replacement' => [ $this, 'has_licensed_products' ],
-				'version'     => '$$next-version',
+				'version'     => '$$next-version$$',
 			],
 			'get_plugin_licence'    => [
 				'replacement' => [ $this, 'get_plugin_license' ],
-				'version'     => '$$next-version',
+				'version'     => '$$next-version$$',
 			],
 			'licence_output'        => [
 				'replacement' => [ $this, 'license_output' ],
-				'version'     => '$$next-version',
+				'version'     => '$$next-version$$',
 			],
 			'licence_error_notices' => [
 				'replacement' => [ $this, 'maybe_add_license_error_notices' ],

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -102,7 +102,7 @@ class WP_Job_Manager_Helper {
 	public function __call( $name, $arguments ) {
 		$deprecated_methods = [
 			'has_licenced_products' => [
-				'replacement' => [ $this, 'has_licenced_products' ],
+				'replacement' => [ $this, 'has_licensed_products' ],
 				'version'     => '$$next-version',
 			],
 			'get_plugin_licence'    => [

--- a/includes/helper/views/html-licenses.php
+++ b/includes/helper/views/html-licenses.php
@@ -16,7 +16,7 @@ $plugin_section_first = 'plugin-license-section--first';
 	<?php if ( ! empty( $licensed_plugins ) ) : ?>
 		<?php
 		if ( ! empty( $show_bulk_activate ) ) :
-			$notices   = WP_Job_Manager_Helper::get_messages( 'bulk-activate' );
+			$notices   = WP_Job_Manager_Helper::instance()->get_messages( 'bulk-activate' );
 			$has_error = in_array( 'error', array_column( $notices, 'type' ), true );
 			?>
 		<div class="wpjm-bulk-activate">
@@ -32,7 +32,7 @@ $plugin_section_first = 'plugin-license-section--first';
 				<?php wp_nonce_field( 'wpjm-manage-license' ); ?>
 				<?php
 				foreach ( $licensed_plugins as $product_slug => $plugin_data ) :
-					$license = WP_Job_Manager_Helper::get_plugin_license( $product_slug );
+					$license = WP_Job_Manager_Helper::instance()->get_plugin_license( $product_slug );
 					if ( empty( $license['license_key'] ) ) :
 						?>
 					<input type="hidden" name="product_slugs[]" value="<?php echo esc_attr( $product_slug ); ?>"/>
@@ -64,7 +64,7 @@ $plugin_section_first = 'plugin-license-section--first';
 		</div>
 			<?php foreach ( $active_plugins as $product_slug => $plugin_data ) : ?>
 				<?php
-				$license = WP_Job_Manager_Helper::get_plugin_license( $product_slug );
+				$license = WP_Job_Manager_Helper::instance()->get_plugin_license( $product_slug );
 				?>
 		<div class="license-row">
 				<?php // translators: placeholder is the addon name. ?>
@@ -83,7 +83,7 @@ $plugin_section_first = 'plugin-license-section--first';
 			</div>
 			<div class="plugin-license">
 				<?php
-				$notices = WP_Job_Manager_Helper::get_messages( $product_slug );
+				$notices = WP_Job_Manager_Helper::instance()->get_messages( $product_slug );
 				if ( empty( $notices ) && ! empty( $license['errors'] ) ) {
 					$notices = [];
 					foreach ( $license['errors'] as $key => $error_message ) {
@@ -129,7 +129,7 @@ $plugin_section_first = 'plugin-license-section--first';
 				</div>
 			<?php foreach ( $inactive_plugins as $product_slug => $plugin_data ) : ?>
 				<?php
-				$license = WP_Job_Manager_Helper::get_plugin_license( $product_slug );
+				$license = WP_Job_Manager_Helper::instance()->get_plugin_license( $product_slug );
 				?>
 				<div class="license-row">
 					<?php // translators: placeholder is the addon name. ?>
@@ -148,7 +148,7 @@ $plugin_section_first = 'plugin-license-section--first';
 					</div>
 					<div class="plugin-license">
 						<?php
-						$notices = WP_Job_Manager_Helper::get_messages( $product_slug );
+						$notices = WP_Job_Manager_Helper::instance()->get_messages( $product_slug );
 						if ( empty( $notices ) && ! empty( $license['errors'] ) ) {
 							$notices = [];
 							foreach ( $license['errors'] as $key => $error_message ) {

--- a/includes/helper/views/html-licenses.php
+++ b/includes/helper/views/html-licenses.php
@@ -9,11 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$plugin_section_first = 'plugin-licence-section--first';
+$plugin_section_first = 'plugin-license-section--first';
 ?>
 <h1 class="screen-reader-text"><?php esc_html_e( 'Licenses', 'wp-job-manager' ); ?></h1>
-<div class="wpjm-licences">
-	<?php if ( ! empty( $licenced_plugins ) ) : ?>
+<div class="wpjm-licenses">
+	<?php if ( ! empty( $licensed_plugins ) ) : ?>
 		<?php
 		if ( ! empty( $show_bulk_activate ) ) :
 			$notices   = WP_Job_Manager_Helper::get_messages( 'bulk-activate' );
@@ -29,18 +29,18 @@ $plugin_section_first = 'plugin-licence-section--first';
 
 			<form method="post" class="wpjm-bulk-activate--form">
 				<input type="hidden" name="action" value="bulk_activate" />
-				<?php wp_nonce_field( 'wpjm-manage-licence' ); ?>
+				<?php wp_nonce_field( 'wpjm-manage-license' ); ?>
 				<?php
-				foreach ( $licenced_plugins as $product_slug => $plugin_data ) :
-					$licence = WP_Job_Manager_Helper::get_plugin_licence( $product_slug );
-					if ( empty( $licence['licence_key'] ) ) :
+				foreach ( $licensed_plugins as $product_slug => $plugin_data ) :
+					$license = WP_Job_Manager_Helper::get_plugin_license( $product_slug );
+					if ( empty( $license['license_key'] ) ) :
 						?>
 					<input type="hidden" name="product_slugs[]" value="<?php echo esc_attr( $product_slug ); ?>"/>
 						<?php
 					endif;
 				endforeach;
 				?>
-				<input type="text" name="licence_key" class="wpjm-bulk-activate--field<?php echo $has_error ? ' wpjm-bulk-activate--field-error' : ''; ?>" placeholder="<?php esc_attr_e( 'ENTER YOUR LICENSE KEY', 'wp-job-manager' ); ?>"/>
+				<input type="text" name="license_key" class="wpjm-bulk-activate--field<?php echo $has_error ? ' wpjm-bulk-activate--field-error' : ''; ?>" placeholder="<?php esc_attr_e( 'ENTER YOUR LICENSE KEY', 'wp-job-manager' ); ?>"/>
 				<input type="submit" class="button button-primary wpjm-bulk-activate--button" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
 			</form>
 			<?php
@@ -50,12 +50,12 @@ $plugin_section_first = 'plugin-licence-section--first';
 			?>
 		</div>
 		<?php endif; ?>
-		<form method="post" class="plugin-licence-search">
-			<input type="search" class="plugin-licence-search-field" name="s" value="<?php echo esc_attr( $search_term ?? '' ); ?>" placeholder="<?php esc_attr_e( 'Search', 'wp-job-manager' ); ?>" />
-			<input type="submit" class="button plugin-licence-search-button" value="<?php esc_attr_e( 'Search', 'wp-job-manager' ); ?>" />
+		<form method="post" class="plugin-license-search">
+			<input type="search" class="plugin-license-search-field" name="s" value="<?php echo esc_attr( $search_term ?? '' ); ?>" placeholder="<?php esc_attr_e( 'Search', 'wp-job-manager' ); ?>" />
+			<input type="submit" class="button plugin-license-search-button" value="<?php esc_attr_e( 'Search', 'wp-job-manager' ); ?>" />
 		</form>
 		<?php if ( ! empty( $active_plugins ) ) : ?>
-		<div class='plugin-licence-section <?php echo esc_attr( $plugin_section_first ); ?>'>
+		<div class='plugin-license-section <?php echo esc_attr( $plugin_section_first ); ?>'>
 			<?php
 			$plugin_section_first = '';
 			// translators: placeholder is the number of active addons, which will never be zero.
@@ -64,11 +64,11 @@ $plugin_section_first = 'plugin-licence-section--first';
 		</div>
 			<?php foreach ( $active_plugins as $product_slug => $plugin_data ) : ?>
 				<?php
-				$licence = WP_Job_Manager_Helper::get_plugin_licence( $product_slug );
+				$license = WP_Job_Manager_Helper::get_plugin_license( $product_slug );
 				?>
-		<div class="licence-row">
+		<div class="license-row">
 				<?php // translators: placeholder is the addon name. ?>
-			<img src="<?php echo esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/wpjm-logo.png' ); ?>" aria-hidden="true" alt="<?php echo esc_attr( sprintf( __( 'Plugin Icon for %s', 'wp-job-manager' ), $plugin_data['Name'] ) ); ?>" class="plugin-licence-icon"/>
+			<img src="<?php echo esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/wpjm-logo.png' ); ?>" aria-hidden="true" alt="<?php echo esc_attr( sprintf( __( 'Plugin Icon for %s', 'wp-job-manager' ), $plugin_data['Name'] ) ); ?>" class="plugin-license-icon"/>
 			<div class="plugin-info">
 				<?php echo esc_html( $plugin_data['Name'] ); ?>
 				<div class="plugin-author">
@@ -81,12 +81,12 @@ $plugin_section_first = 'plugin-licence-section--first';
 					?>
 				</div>
 			</div>
-			<div class="plugin-licence">
+			<div class="plugin-license">
 				<?php
 				$notices = WP_Job_Manager_Helper::get_messages( $product_slug );
-				if ( empty( $notices ) && ! empty( $licence['errors'] ) ) {
+				if ( empty( $notices ) && ! empty( $license['errors'] ) ) {
 					$notices = [];
-					foreach ( $licence['errors'] as $key => $error_message ) {
+					foreach ( $license['errors'] as $key => $error_message ) {
 						$notices[] = [
 							'type'    => 'error',
 							'message' => $error_message,
@@ -95,16 +95,16 @@ $plugin_section_first = 'plugin-licence-section--first';
 				}
 				if ( apply_filters( 'wpjm_display_license_form_for_addon', true, $product_slug ) ) {
 					?>
-					<form method="post" class="plugin-licence-form">
-						<?php wp_nonce_field( 'wpjm-manage-licence' ); ?>
-						<img src="<?php echo esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/icons/checkmark-icon.svg' ); ?>" class='plugin-licence-checkmark' aria-hidden='true' alt='<?php esc_attr_e( 'Plugin is activated', 'wp-job-manager' ); ?>'/>
+					<form method="post" class="plugin-license-form">
+						<?php wp_nonce_field( 'wpjm-manage-license' ); ?>
+						<img src="<?php echo esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/icons/checkmark-icon.svg' ); ?>" class='plugin-license-checkmark' aria-hidden='true' alt='<?php esc_attr_e( 'Plugin is activated', 'wp-job-manager' ); ?>'/>
 						<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="deactivate"/>
 						<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
 
-						<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" class="plugin-licence-label"><?php esc_html_e( 'LICENSE', 'wp-job-manager' ); ?></label>
-						<input type="text" disabled="disabled" class="plugin-licence-field" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $licence['licence_key'] ); ?>"/>
+						<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_license_key" class="plugin-license-label"><?php esc_html_e( 'LICENSE', 'wp-job-manager' ); ?></label>
+						<input type="text" disabled="disabled" class="plugin-license-field" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_license_key" name="license_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $license['license_key'] ); ?>"/>
 
-						<input type="submit" class="button plugin-licence-button" name="submit" value="<?php esc_attr_e( 'Deactivate License', 'wp-job-manager' ); ?>" />
+						<input type="submit" class="button plugin-license-button" name="submit" value="<?php esc_attr_e( 'Deactivate License', 'wp-job-manager' ); ?>" />
 					</form>
 					<?php
 				}
@@ -113,14 +113,14 @@ $plugin_section_first = 'plugin-licence-section--first';
 			</div>
 				<?php
 				foreach ( $notices as $message ) {
-					echo '<div class="notice inline notice-' . esc_attr( $message['type'] ) . ' plugin-licence-notice"><p>' . wp_kses_post( $message['message'] ) . '</p></div>';
+					echo '<div class="notice inline notice-' . esc_attr( $message['type'] ) . ' plugin-license-notice"><p>' . wp_kses_post( $message['message'] ) . '</p></div>';
 				}
 				?>
 		</div>
 	<?php endforeach; ?>
 		<?php endif; ?>
 		<?php if ( ! empty( $inactive_plugins ) ) : ?>
-			<div class='plugin-licence-section <?php echo esc_attr( $plugin_section_first ); ?>'>
+			<div class='plugin-license-section <?php echo esc_attr( $plugin_section_first ); ?>'>
 			<?php
 				$plugin_section_first = '';
 				// translators: placeholder is the number of inactive addons, which will never be zero.
@@ -129,11 +129,11 @@ $plugin_section_first = 'plugin-licence-section--first';
 				</div>
 			<?php foreach ( $inactive_plugins as $product_slug => $plugin_data ) : ?>
 				<?php
-				$licence = WP_Job_Manager_Helper::get_plugin_licence( $product_slug );
+				$license = WP_Job_Manager_Helper::get_plugin_license( $product_slug );
 				?>
-				<div class="licence-row">
+				<div class="license-row">
 					<?php // translators: placeholder is the addon name. ?>
-					<img src="<?php echo esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/wpjm-logo.png' ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Plugin Icon for %s', 'wp-job-manager' ), $plugin_data['Name'] ) ); ?>" class="plugin-licence-icon"/>
+					<img src="<?php echo esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/wpjm-logo.png' ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Plugin Icon for %s', 'wp-job-manager' ), $plugin_data['Name'] ) ); ?>" class="plugin-license-icon"/>
 					<div class="plugin-info">
 						<?php echo esc_html( $plugin_data['Name'] ); ?>
 						<div class="plugin-author">
@@ -146,12 +146,12 @@ $plugin_section_first = 'plugin-licence-section--first';
 							?>
 						</div>
 					</div>
-					<div class="plugin-licence">
+					<div class="plugin-license">
 						<?php
 						$notices = WP_Job_Manager_Helper::get_messages( $product_slug );
-						if ( empty( $notices ) && ! empty( $licence['errors'] ) ) {
+						if ( empty( $notices ) && ! empty( $license['errors'] ) ) {
 							$notices = [];
-							foreach ( $licence['errors'] as $key => $error_message ) {
+							foreach ( $license['errors'] as $key => $error_message ) {
 								$notices[] = [
 									'type'    => 'error',
 									'message' => $error_message,
@@ -161,13 +161,13 @@ $plugin_section_first = 'plugin-licence-section--first';
 						if ( apply_filters( 'wpjm_display_license_form_for_addon', true, $product_slug ) ) {
 							$has_error = in_array( 'error', array_column( $notices, 'type' ), true );
 							?>
-							<form method="post" class='plugin-licence-form'>
-								<?php wp_nonce_field( 'wpjm-manage-licence' ); ?>
+							<form method="post" class='plugin-license-form'>
+								<?php wp_nonce_field( 'wpjm-manage-license' ); ?>
 								<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="activate"/>
 								<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
-								<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" class="plugin-licence-label"><?php esc_html_e( 'LICENSE', 'wp-job-manager' ); ?></label>
-								<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_licence_key" class="plugin-licence-field<?php echo $has_error ? ' plugin-licence-field--error' : ''; ?>" name="licence_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
-								<input type="submit" class="button plugin-licence-button" name="submit" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
+								<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_license_key" class="plugin-license-label"><?php esc_html_e( 'LICENSE', 'wp-job-manager' ); ?></label>
+								<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_license_key" class="plugin-license-field<?php echo $has_error ? ' plugin-license-field--error' : ''; ?>" name="license_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
+								<input type="submit" class="button plugin-license-button" name="submit" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
 							</form>
 							<?php
 						}
@@ -176,7 +176,7 @@ $plugin_section_first = 'plugin-licence-section--first';
 					</div>
 					<?php
 					foreach ( $notices as $message ) {
-						echo '<div class="notice inline notice-' . esc_attr( $message['type'] ) . ' plugin-licence-notice"><p>' . wp_kses_post( $message['message'] ) . '</p></div>';
+						echo '<div class="notice inline notice-' . esc_attr( $message['type'] ) . ' plugin-license-notice"><p>' . wp_kses_post( $message['message'] ) . '</p></div>';
 					}
 					?>
 				</div>

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -72,7 +72,7 @@ msgid "WP Job Manager Add-ons"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-addons.php:104
-#: includes/helper/views/html-licences.php:14
+#: includes/helper/views/html-licenses.php:14
 msgid "Licenses"
 msgstr ""
 
@@ -1982,8 +1982,8 @@ msgid "Manage License"
 msgstr ""
 
 #: includes/helper/class-wp-job-manager-helper.php:340
-#: includes/helper/views/html-licences.php:44
-#: includes/helper/views/html-licences.php:170
+#: includes/helper/views/html-licenses.php:44
+#: includes/helper/views/html-licenses.php:170
 #: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:259
 msgid "Activate License"
 msgstr ""
@@ -2020,68 +2020,68 @@ msgstr ""
 msgid "An unknown error occurred while attempting to activate the license"
 msgstr ""
 
-#. translators: %1$s is the URL to the licence key page, %2$s is the plugin name.
+#. translators: %1$s is the URL to the license key page, %2$s is the plugin name.
 #: includes/helper/class-wp-job-manager-helper.php:936
 msgid "<a href=\"%1$s\">Please enter your license key</a> to get updates for \"%2$s\"."
 msgstr ""
 
-#. translators: %1$s is the plugin name, %2$s is the URL to the licence key page.
+#. translators: %1$s is the plugin name, %2$s is the URL to the license key page.
 #: includes/helper/class-wp-job-manager-helper.php:968
 msgid "There is a problem with the license for \"%1$s\". Please <a href=\"%2$s\">manage the license</a> to check for a solution and continue receiving updates."
 msgstr ""
 
-#: includes/helper/views/html-licences.php:24
+#: includes/helper/views/html-licenses.php:24
 msgid "Activate Job Manager Licenses"
 msgstr ""
 
-#: includes/helper/views/html-licences.php:27
+#: includes/helper/views/html-licenses.php:27
 msgid "Activate all licenses at once. Easy, everything in one place."
 msgstr ""
 
-#: includes/helper/views/html-licences.php:43
+#: includes/helper/views/html-licenses.php:43
 msgid "ENTER YOUR LICENSE KEY"
 msgstr ""
 
-#: includes/helper/views/html-licences.php:54
-#: includes/helper/views/html-licences.php:55
+#: includes/helper/views/html-licenses.php:54
+#: includes/helper/views/html-licenses.php:55
 msgid "Search"
 msgstr ""
 
 #. translators: placeholder is the number of active addons, which will never be zero.
-#: includes/helper/views/html-licences.php:62
+#: includes/helper/views/html-licenses.php:62
 msgid "Active (%d)"
 msgstr ""
 
 #. translators: placeholder is the addon name.
-#: includes/helper/views/html-licences.php:71
-#: includes/helper/views/html-licences.php:136
+#: includes/helper/views/html-licenses.php:71
+#: includes/helper/views/html-licenses.php:136
 msgid "Plugin Icon for %s"
 msgstr ""
 
-#: includes/helper/views/html-licences.php:100
+#: includes/helper/views/html-licenses.php:100
 msgid "Plugin is activated"
 msgstr ""
 
-#: includes/helper/views/html-licences.php:104
-#: includes/helper/views/html-licences.php:168
+#: includes/helper/views/html-licenses.php:104
+#: includes/helper/views/html-licenses.php:168
 msgid "LICENSE"
 msgstr ""
 
-#: includes/helper/views/html-licences.php:107
+#: includes/helper/views/html-licenses.php:107
 msgid "Deactivate License"
 msgstr ""
 
 #. translators: placeholder is the number of inactive addons, which will never be zero.
-#: includes/helper/views/html-licences.php:127
+#: includes/helper/views/html-licenses.php:127
 msgid "Inactive (%d)"
 msgstr ""
 
 #. translators: Placeholder %s is the lost license key URL.
-#: includes/helper/views/html-licences.php:186
+#: includes/helper/views/html-licenses.php:186
 msgid "Lost your license key? <a href=\"%s\">Retrieve it here</a>."
 msgstr ""
 
-#: includes/helper/views/html-licences.php:188
+#: includes/helper/views/html-licenses.php:188
 msgid "No plugins are activated that have licenses managed by WP Job Manager."
 msgstr ""
 

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -188,7 +188,7 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_BaseTest {
 			'plugin_name'    => 'test',
 			'version'        => '1.0.0',
 			'api_product_id' => 'test',
-			'licence_key'    => 'abcd',
+			'license_key'    => 'abcd',
 			'email'          => 'test@local.dev',
 		];
 	}

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-options.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-options.php
@@ -10,10 +10,10 @@ class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_BaseTest {
 	 */
 	public function test_update_simple() {
 		$this->setup_master_option();
-		WP_Job_Manager_Helper_Options::update( 'test', 'licence_key', 'new-value' );
+		WP_Job_Manager_Helper_Options::update( 'test', 'license_key', 'new-value' );
 		$new_option = $this->get_master_option();
-		$this->assertTrue( isset( $new_option['test']['licence_key'] ) );
-		$this->assertEquals( 'new-value', $new_option['test']['licence_key'] );
+		$this->assertTrue( isset( $new_option['test']['license_key'] ) );
+		$this->assertEquals( 'new-value', $new_option['test']['license_key'] );
 	}
 
 	/**
@@ -22,7 +22,7 @@ class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_BaseTest {
 	 */
 	public function test_get_return_default() {
 		$result_expected = 'simple';
-		$result          = WP_Job_Manager_Helper_Options::get( 'test', 'licence_key', $result_expected );
+		$result          = WP_Job_Manager_Helper_Options::get( 'test', 'license_key', $result_expected );
 		$this->assertEquals( $result_expected, $result );
 	}
 
@@ -32,7 +32,7 @@ class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_BaseTest {
 	 */
 	public function test_get_return_value() {
 		$this->setup_master_option();
-		$result = WP_Job_Manager_Helper_Options::get( 'test', 'licence_key', 'simple' );
+		$result = WP_Job_Manager_Helper_Options::get( 'test', 'license_key', 'simple' );
 		$this->assertEquals( 'abcd', $result );
 	}
 
@@ -43,8 +43,8 @@ class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_BaseTest {
 	 */
 	public function test_get_return_legacy() {
 		$this->setup_legacy_options();
-		$licence_key_result = WP_Job_Manager_Helper_Options::get( 'legacy', 'licence_key', 'simple' );
-		$this->assertEquals( 'legacy-abcd', $licence_key_result );
+		$license_key_result = WP_Job_Manager_Helper_Options::get( 'legacy', 'license_key', 'simple' );
+		$this->assertEquals( 'legacy-abcd', $license_key_result );
 
 		$email_result = WP_Job_Manager_Helper_Options::get( 'legacy', 'email', 'simple' );
 		$this->assertEquals( 'legacy@test.dev', $email_result );
@@ -62,14 +62,14 @@ class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_BaseTest {
 	 */
 	public function test_delete_simple() {
 		$this->setup_master_option();
-		$result = WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
+		$result = WP_Job_Manager_Helper_Options::delete( 'test', 'license_key' );
 
 		$new_option = $this->get_master_option();
-		$this->assertFalse( isset( $new_option['test']['licence_key'] ) );
+		$this->assertFalse( isset( $new_option['test']['license_key'] ) );
 	}
 
 	private function setup_legacy_options() {
-		update_option( 'legacy_licence_key', 'legacy-abcd' );
+		update_option( 'legacy_license_key', 'legacy-abcd' );
 		update_option( 'legacy_email', 'legacy@test.dev' );
 		update_option( 'legacy_errors', 'legacy-errors' );
 		update_option( 'legacy_hide_key_notice', 'legacy-hide' );
@@ -79,7 +79,7 @@ class WP_Test_WP_Job_Manager_Helper_Options extends WPJM_BaseTest {
 		if ( null === $value ) {
 			$value = [
 				'test' => [
-					'licence_key'     => 'abcd',
+					'license_key'     => 'abcd',
 					'email'           => 'local@local.dev',
 					'errors'          => null,
 					'hide_key_notice' => false,

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php
@@ -91,10 +91,10 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 		// Arrange.
 		$this->enable_update_plugins_cap();
 		$instance = $this->getMockBuilder( WP_Job_Manager_Helper::class )
-			->onlyMethods( [ 'get_licence_managed_plugin', 'get_plugin_licence' ] )
+			->onlyMethods( [ 'get_license_managed_plugin', 'get_plugin_license' ] )
 			->getMock();
 
-		$instance->method( 'get_licence_managed_plugin' )->willReturn(
+		$instance->method( 'get_license_managed_plugin' )->willReturn(
 			[
 				'_product_slug' => 'test',
 				'_filename'     => 'test/test.php',
@@ -103,9 +103,9 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 			]
 		);
 
-		$instance->method( 'get_plugin_licence' )->willReturn(
+		$instance->method( 'get_plugin_license' )->willReturn(
 			[
-				'licence_key' => 'xxxx-xxxx-xxxx-xxxx',
+				'license_key' => 'xxxx-xxxx-xxxx-xxxx',
 				'email'       => 'me@example.com',
 				'errors'      => [
 					'invalid_key' => 'Invalid license key',
@@ -126,10 +126,10 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 		// Arrange.
 		$this->enable_update_plugins_cap();
 		$instance = $this->getMockBuilder( WP_Job_Manager_Helper::class )
-			->onlyMethods( [ 'get_licence_managed_plugin', 'get_plugin_licence' ] )
+			->onlyMethods( [ 'get_license_managed_plugin', 'get_plugin_license' ] )
 			->getMock();
 
-		$instance->method( 'get_licence_managed_plugin' )->willReturn(
+		$instance->method( 'get_license_managed_plugin' )->willReturn(
 			[
 				'_product_slug' => 'test',
 				'_filename'     => 'test/test.php',
@@ -138,9 +138,9 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 			]
 		);
 
-		$instance->method( 'get_plugin_licence' )->willReturn(
+		$instance->method( 'get_plugin_license' )->willReturn(
 			[
-				'licence_key' => null,
+				'license_key' => null,
 				'email'       => null,
 				'errors'      => null,
 			]
@@ -159,10 +159,10 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 		// Arrange.
 		$this->enable_update_plugins_cap();
 		$instance = $this->getMockBuilder( WP_Job_Manager_Helper::class )
-			->onlyMethods( [ 'get_licence_managed_plugin' ] )
+			->onlyMethods( [ 'get_license_managed_plugin' ] )
 			->getMock();
 
-		$instance->method( 'get_licence_managed_plugin' )->willReturn( false );
+		$instance->method( 'get_license_managed_plugin' )->willReturn( false );
 
 		// Act.
 		$actions = $instance->plugin_links( [], 'test/test.php' );
@@ -175,10 +175,10 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 	public function testPluginLinks_NoCaps_NoActions() {
 		// Arrange.
 		$instance = $this->getMockBuilder( WP_Job_Manager_Helper::class )
-			->onlyMethods( [ 'get_licence_managed_plugin' ] )
+			->onlyMethods( [ 'get_license_managed_plugin' ] )
 			->getMock();
 
-		$instance->method( 'get_licence_managed_plugin' )->willReturn(
+		$instance->method( 'get_license_managed_plugin' )->willReturn(
 			[
 				'_product_slug' => 'test',
 				'_filename'     => 'test/test.php',
@@ -243,7 +243,7 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 		$this->assertFalse( $result );
 	}
 
-	public function testHasLicencedProducts_WithLicencedProduct_ReturnsTrue() {
+	public function testHasLicensedProducts_WithLicensedProduct_ReturnsTrue() {
 		// Arrange.
 		$instance = $this->getMockBuilder( WP_Job_Manager_Helper::class )
 			->onlyMethods( [ 'get_installed_plugins' ] )
@@ -261,14 +261,14 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 		);
 
 		// Act.
-		$result = $instance->has_licenced_products();
+		$result = $instance->has_licensed_products();
 
 		// Assert.
 		$this->assertTrue( $result );
 	}
 
 
-	public function testHasLicencedProducts_WithoutLicencedProduct_ReturnsFalse() {
+	public function testHasLicensedProducts_WithoutLicensedProduct_ReturnsFalse() {
 		// Arrange.
 		$instance = $this->getMockBuilder( WP_Job_Manager_Helper::class )
 			->onlyMethods( [ 'get_installed_plugins' ] )
@@ -277,34 +277,34 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 		$instance->method( 'get_installed_plugins' )->willReturn( [] );
 
 		// Act.
-		$result = $instance->has_licenced_products();
+		$result = $instance->has_licensed_products();
 
 		// Assert.
 		$this->assertFalse( $result );
 	}
 
-	public function testGetPluginLicence_WithLicense_ReturnsLicense() {
+	public function testGetPluginLicense_WithLicense_ReturnsLicense() {
 		// Arrange.
 		$license_key = '1234';
 		$email       = 'me@example.com';
 		$errors      = [ 'error' ];
 
-		WP_Job_Manager_Helper_Options::update( 'test', 'licence_key', $license_key );
+		WP_Job_Manager_Helper_Options::update( 'test', 'license_key', $license_key );
 		WP_Job_Manager_Helper_Options::update( 'test', 'email', $email );
 		WP_Job_Manager_Helper_Options::update( 'test', 'errors', $errors );
 
 		$instance = new WP_Job_Manager_Helper();
 
 		// Act.
-		$result = $instance->get_plugin_licence( 'test' );
-		WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
+		$result = $instance->get_plugin_license( 'test' );
+		WP_Job_Manager_Helper_Options::delete( 'test', 'license_key' );
 		WP_Job_Manager_Helper_Options::delete( 'test', 'email' );
 		WP_Job_Manager_Helper_Options::delete( 'test', 'errors' );
 
 		// Assert.
 		$this->assertEquals(
 			[
-				'licence_key' => $license_key,
+				'license_key' => $license_key,
 				'email'       => $email,
 				'errors'      => $errors,
 			],
@@ -312,28 +312,28 @@ class WP_Test_WP_Job_Manager_Helper extends WPJM_BaseTest {
 		);
 	}
 
-	public function testGetPluginLicence_WithoutLicense_ReturnsLicense() {
+	public function testGetPluginLicense_WithoutLicense_ReturnsLicense() {
 		// Arrange.
 		$license_key = '1234';
 		$email       = 'me@example.com';
 		$errors      = [ 'error' ];
 
-		WP_Job_Manager_Helper_Options::update( 'test', 'licence_key', $license_key );
+		WP_Job_Manager_Helper_Options::update( 'test', 'license_key', $license_key );
 		WP_Job_Manager_Helper_Options::update( 'test', 'email', $email );
 		WP_Job_Manager_Helper_Options::update( 'test', 'errors', $errors );
 
 		$instance = new WP_Job_Manager_Helper();
 
 		// Act.
-		$result = $instance->get_plugin_licence( 'rhino' );
-		WP_Job_Manager_Helper_Options::delete( 'test', 'licence_key' );
+		$result = $instance->get_plugin_license( 'rhino' );
+		WP_Job_Manager_Helper_Options::delete( 'test', 'license_key' );
 		WP_Job_Manager_Helper_Options::delete( 'test', 'email' );
 		WP_Job_Manager_Helper_Options::delete( 'test', 'errors' );
 
 		// Assert.
 		$this->assertEquals(
 			[
-				'licence_key' => null,
+				'license_key' => null,
 				'email'       => null,
 				'errors'      => null,
 			],

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -780,7 +780,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * Adds fake license to one of the products.
 	 */
 	private function set_fake_license() {
-		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'licence_key', 'FAKE-LICENSE' );
+		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'license_key', 'FAKE-LICENSE' );
 		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'email', 'fake@example.com' );
 		WP_Job_Manager_Helper_Options::update( 'wp-job-manager-official-licensed-tester', 'errors', [] );
 	}
@@ -789,7 +789,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * Removes fake license to one of the products.
 	 */
 	private function remove_fake_license() {
-		WP_Job_Manager_Helper_Options::delete( 'wp-job-manager-official-licensed-tester', 'licence_key' );
+		WP_Job_Manager_Helper_Options::delete( 'wp-job-manager-official-licensed-tester', 'license_key' );
 		WP_Job_Manager_Helper_Options::delete( 'wp-job-manager-official-licensed-tester', 'email' );
 		WP_Job_Manager_Helper_Options::delete( 'wp-job-manager-official-licensed-tester', 'errors' );
 	}


### PR DESCRIPTION
Built off of #2552 

While working on #2552, I realized we have a very brittle setup with the usage of `licence` vs (US) `license`. This finally standardizes it to use `license` and migrates the licenses appropriately. Our strings should previously all been updated, but this switches over the code/options.

### Changes proposed in this Pull Request

* Migrate `licence` to `license` in code and options.

### Testing instructions

* On `trunk`, activate licenses for products.
* Switch to this branch (note: needs an asset rebuild) and ensure licenses aren't lost. Try activating, deactivating, etc and see how it goes.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `WP_Job_Manager_Helper::has_licenced_products` -> `WP_Job_Manager_Helper::has_licensed_products`
* `WP_Job_Manager_Helper::get_plugin_licence` -> `WP_Job_Manager_Helper::get_plugin_license`
* `WP_Job_Manager_Helper::licence_output` -> `WP_Job_Manager_Helper::licence_output`
* `WP_Job_Manager_Helper::activate_licence` -> `WP_Job_Manager_Helper::activate_license`
* `WP_Job_Manager_Helper::deactivate_licence` -> `WP_Job_Manager_Helper::deactivate_license`