### PR TITLE
Fix notice dismiss JS dependency error

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -130,7 +130,7 @@ class WP_Job_Manager_Admin {
 			);
 		}
 
-		WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', [], true );
+		WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', null, true );
 		wp_enqueue_script( 'job_manager_notice_dismiss' );
 
 		WP_Job_Manager::register_style( 'job_manager_admin_menu_css', 'css/menu.css', [] );


### PR DESCRIPTION
Fixes #2556

### Changes proposed in this Pull Request

* Fixes a fatal JS error because the `wp-dom-ready` was not being loaded. 

### Testing instructions

* Go to the Job Listings page (`/wp-admin/edit.php?post_type=job_listing`)
* Check in the browser dev tools console that there is no TypeError in `wpjm-notice-dismiss.js`

