### PR TITLE
Change check if promoted jobs feature was used or not

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,8 +209,6 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
-		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::USED_PROMOTED_JOBS_OPTION_KEY, true );
-
 		$url = add_query_arg(
 			[
 				'user_id'             => $current_user,

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -339,6 +339,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * @return WP_REST_Response The response.
 	 */
 	public function refresh_status( $request ) {
+		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::USED_PROMOTED_JOBS_OPTION_KEY, true );
 		$this->status_handler->fetch_updates();
 		return new WP_REST_Response( [ 'success' => true ] );
 	}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -23,7 +23,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	const LAST_EXECUTION_OPTION_KEY = self::CRON_HOOK . '_last_execution';
 
 	/**
-	 * The name of the option that stores whether the site has promoted jobs or not.
+	 * The name of the option that stores whether the site used promoted jobs or not.
 	 */
 	const USED_PROMOTED_JOBS_OPTION_KEY = 'job_manager_used_promoted_jobs';
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We have a check if the user used the promoted jobs feature to start running the CRON to request job status changes.
* Currently, we're marking it as used when the user clicks on "Promote".
* Reflecting on this, my proposal with this PR is to have fewer sites running the CRON and making requests to wpjobmanager.com, so I moved the option creation to the `refresh-status` endpoint, running the CRON only when the user completed a job promotion. Notice that if it fails the first time the user uses this feature, the site will never get a status update from wpjobmanager.com until it changes status again, requesting `refresh-status`. IMO, we could try this approach, and if we have users complaining about that, we can iterate to a better approach.

### Testing instructions

* Make sure you don't have the option `job_manager_used_promoted_jobs` on your site.
* Click on "Promote" for a job.
* Make sure the option `job_manager_used_promoted_jobs` wasn't created yet.
* Complete the promotion, submitting the promote form, and going through the JobTarget checkout.
* Run `vip dev-env -- exec wp cron event run wpjobmanager_com_sync_promoted_job_status` in order to sync the status.
* Make sure the option `job_manager_used_promoted_jobs` was created.