### PR TITLE
Change deactivation approach

### DIFF
--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -300,8 +300,13 @@
           },
           "status": {
             "type": "string",
-            "example": "publish",
+            "example": true,
             "description": "The job status."
+          },
+          "promoted": {
+            "type": "boolean",
+            "example": false,
+            "description": "Whether the job has promoted status on the plugin."
           },
           "title": {
             "type": "string",

--- a/docs/api/internal.json
+++ b/docs/api/internal.json
@@ -300,7 +300,7 @@
           },
           "status": {
             "type": "string",
-            "example": true,
+            "example": "publish",
             "description": "The job status."
           },
           "promoted": {

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,6 +209,11 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
+		// Make sure the job contains the promoted job meta to be listed in the feed.
+		if ( ! $is_editing ) {
+			WP_Job_Manager_Promoted_Jobs::update_promotion( $post_id, false );
+		}
+
 		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::USED_PROMOTED_JOBS_OPTION_KEY, true );
 
 		$url = add_query_arg(

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -190,8 +190,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'meta_query'          => [
 				[
 					'key'     => WP_Job_Manager_Promoted_Jobs::PROMOTED_META_KEY,
-					'value'   => '1',
-					'compare' => '=',
+					'compare' => 'EXISTS',
 				],
 			],
 		];

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -234,6 +234,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		return [
 			'id'           => (string) $item->ID,
 			'status'       => $item->post_status,
+			'promoted'     => WP_Job_Manager_Promoted_Jobs::is_promoted( $item->ID ),
 			'title'        => $item->post_title,
 			'description'  => $item->post_content,
 			'permalink'    => get_permalink( $item ),

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -125,6 +125,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 
 	/**
 	 * Checks if we should send a notification to wpjobmanager.com after promoted meta key is deleted.
+	 * It happens when a job promotion is deactivated.
 	 *
 	 * @param string[] $meta_ids
 	 * @param int      $post_id  Post ID.

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -149,8 +149,9 @@ class WP_Job_Manager_Promoted_Jobs {
 	/**
 	 * Update promotion.
 	 *
-	 * @param int  $post_id
-	 * @param bool $promoted
+	 * @param int         $post_id
+	 * @param bool|string $promoted `true` to promoted, `false` to not promoted, `force_delete` to delete.
+	 *                              The deletion is used to force a removal from the feed, deactivating the promotion while syncing.
 	 *
 	 * @return boolean
 	 */
@@ -160,6 +161,10 @@ class WP_Job_Manager_Promoted_Jobs {
 		}
 
 		delete_option( self::PROMOTED_JOB_TRACK_OPTION );
+
+		if ( 'force_delete' === $promoted ) {
+			return delete_post_meta( $post_id, self::PROMOTED_META_KEY );
+		}
 
 		return update_post_meta( $post_id, self::PROMOTED_META_KEY, $promoted ? '1' : '0' );
 	}
@@ -172,7 +177,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return boolean
 	 */
 	public static function deactivate_promotion( $post_id ) {
-		return self::update_promotion( $post_id, false );
+		return self::update_promotion( $post_id, 'force_delete' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We identified an issue that could happen in intervals between syncs (WPJM <> wpjobmanager.com <> JobTarget). It could cause a promotion stop accidentally. The discussion: p1692125471733679-slack-C053397HN30.
* In order to fix it, we're implementing @fjorgemota's idea to keep all the jobs with `_promoted` meta key on the feed, even if it's not promoted. To represent it in the feed, we added the `promote` attribute, which is not currently used but it's useful if we want to iterate in the future, and it makes the endpoint more concise.

#### The previous issue:

1. User promote a job, completing the JobTarget checkout.
2. Before the 5 minutes polling interval (or more if they delay to complete the checkout), the user change something in another promoted jobs triggering a sync (WPJM -> [wpjobmanager.com](http://wpjobmanager.com/)).
3. Their job would still have `_promoted` `0` because it didn't sync with the new status yet ([wpjobmanager.com](http://wpjobmanager.com/) -> WPJM). So in the sync WPJM -> [wpjobmanager.com](http://wpjobmanager.com/), it would remove the job from [wpjobmanager.com](http://wpjobmanager.com/), removing from the feed that JobTarget will consume, which would deactivate their promotion.

### Testing instructions

* Make sure your env has at least one promote job.
* Promote a new job, completing the JobTarget checkout.
* Before the status is updated in WPJM, update another promoted job, and make sure the new job you created wasn't removed from wpjobmanager.com (Check it through WP Admin because the feed has cache, or just clear the cache).
* On wpjobmanager.com, run the job to update the statuses `vip dev-env -- exec wp cron event run wpjobmanager_com_sync_promoted_job_status`.
* Check that the job is marked as promoted on WPJM.
* Deactivate the job on WPJM job listings, and make sure it was removed from wpjobmanager.com.
* For another promoted job of your site, update the status to expired (see instructions on https://github.com/Automattic/wpjobmanager.com/pull/579).
* Make sure the job is marked as not promoted on job listings but continues on the feed of WPJM and wpjobmanager.com.