### PR TITLE
Add support for setting update interval dynamically from WPJMCOM

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,6 +209,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
+		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::LAST_CHECK_OPTION_KEY, time() - ( 5 * MINUTE_IN_SECONDS ), '', false );
 		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS, '', false );
 		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::WEBHOOK_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS, '', false );
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,7 +209,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
-		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS );
+		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS );
 		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::WEBHOOK_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS );
 
 		$url = add_query_arg(

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,9 +209,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
-		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::LAST_CHECK_OPTION_KEY, time() - ( 5 * MINUTE_IN_SECONDS ), '', false );
-		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS, '', false );
-		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::WEBHOOK_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS, '', false );
+		WP_Job_Manager_Promoted_Jobs_Status_Handler::initialize_defaults();
 
 		$url = add_query_arg(
 			[

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,8 +209,8 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
-		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS );
-		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::WEBHOOK_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS );
+		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS, '', false );
+		add_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::WEBHOOK_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS, '', false );
 
 		$url = add_query_arg(
 			[

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -209,7 +209,8 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$verify_endpoint_url = rest_url( '/wpjm-internal/v1/promoted-jobs/verify-token', 'https' );
 		$verify_endpoint_url = substr( $verify_endpoint_url, strlen( $site_url ) );
 
-		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::USED_PROMOTED_JOBS_OPTION_KEY, true );
+		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS );
+		update_option( WP_Job_Manager_Promoted_Jobs_Status_Handler::WEBHOOK_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS );
 
 		$url = add_query_arg(
 			[

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -112,6 +112,8 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_enable_salary_currency',
 		'job_manager_default_salary_currency',
 		'job_manager_promoted_jobs_status_update_last_execution',
+		'job_manager_promoted_jobs_webhook_interval',
+		'job_manager_promoted_jobs_cron_interval',
 	];
 
 	/**

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -111,7 +111,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_default_salary_unit',
 		'job_manager_enable_salary_currency',
 		'job_manager_default_salary_currency',
-		'job_manager_promoted_jobs_status_update_last_execution',
+		'job_manager_promoted_jobs_status_update_last_check',
 		'job_manager_promoted_jobs_webhook_interval',
 		'job_manager_promoted_jobs_cron_interval',
 	];

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -251,7 +251,7 @@ class WP_Job_Manager {
 			wp_schedule_event( time(), 'daily', 'job_manager_email_daily_notices' );
 		}
 		if ( ! wp_next_scheduled( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'twicedaily', WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK );
+			wp_schedule_event( time(), 'hourly', WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK );
 		}
 	}
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -139,7 +139,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		if ( array_key_exists( $header_name, $headers ) ) {
 			$header = $headers [ $header_name ];
 			if ( rest_is_integer( $header ) ) {
-				update_option( $option_name, (int) $header );
+				update_option( $option_name, (int) $header, false );
 			}
 		}
 	}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -104,11 +104,11 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	private function request_site_feed() {
 		$url      = $this->get_site_feed_url();
 		$response = wp_remote_get( $url );
+		$this->update_interval( $response, 'X-WPJM-Cron-Interval', self::CRON_INTERVAL_OPTION_KEY );
+		$this->update_interval( $response, 'X-WPJM-Webhook-Interval', self::WEBHOOK_INTERVAL_OPTION_KEY );
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return [];
 		}
-		$this->update_interval( $response, 'X-WPJM-Cron-Interval', self::CRON_INTERVAL_OPTION_KEY );
-		$this->update_interval( $response, 'X-WPJM-Webhook-Interval', self::WEBHOOK_INTERVAL_OPTION_KEY );
 		$body = wp_remote_retrieve_body( $response );
 		$json = \json_decode( $body, true );
 		if ( ! array_key_exists( 'jobs', $json ) ) {

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -164,7 +164,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 */
 	public static function initialize_defaults() {
 		$webhook_interval = 5 * MINUTE_IN_SECONDS;
-		add_option( self::LAST_CHECK_OPTION_KEY, time() - $webhook_interval, '', false );
+		update_option( self::LAST_CHECK_OPTION_KEY, time() - $webhook_interval, '', false );
 		add_option( self::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS, '', false );
 		add_option( self::WEBHOOK_INTERVAL_OPTION_KEY, $webhook_interval, '', false );
 	}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -80,7 +80,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 			// If the interval is not set or is zero, we don't update.
 			return false;
 		}
-		$last_execution = get_option( self::LAST_EXECUTION_OPTION_KEY, 0 );
+		$last_execution = (int) get_option( self::LAST_EXECUTION_OPTION_KEY, 0 );
 		return $current_time - $last_execution >= $interval;
 	}
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -146,4 +146,16 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		}
 	}
 
+	/**
+	 * Initialize the default options for the Promoted Jobs Status Handler.
+	 *
+	 * @return void
+	 */
+	public static function initialize_defaults() {
+		$webhook_interval = 5 * MINUTE_IN_SECONDS;
+		add_option( self::LAST_CHECK_OPTION_KEY, time() - $webhook_interval, '', false );
+		add_option( self::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS, '', false );
+		add_option( self::WEBHOOK_INTERVAL_OPTION_KEY, $webhook_interval, '', false );
+	}
+
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -18,9 +18,9 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	const CRON_HOOK = 'job_manager_promoted_jobs_status_update';
 
 	/**
-	 * The name of the option that stores the last time the cron job was executed.
+	 * The name of the option that stores the last time the check was made.
 	 */
-	const LAST_EXECUTION_OPTION_KEY = self::CRON_HOOK . '_last_execution';
+	const LAST_CHECK_OPTION_KEY = self::CRON_HOOK . '_last_check';
 
 	/**
 	 * The name of the option that stores the time interval (in seconds) between update fetches from the site
@@ -59,7 +59,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		}
 
 		// We always update the last execution time, even if the request fails.
-		update_option( self::LAST_EXECUTION_OPTION_KEY, $current_time, false );
+		update_option( self::LAST_CHECK_OPTION_KEY, $current_time, false );
 
 		$jobs     = $this->request_site_feed();
 		$statuses = wp_list_pluck( $jobs, 'wpjm_status', 'wpjm_id' );
@@ -80,7 +80,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 			// If the interval is not set or is zero, we don't update.
 			return false;
 		}
-		$last_execution = (int) get_option( self::LAST_EXECUTION_OPTION_KEY, 0 );
+		$last_execution = (int) get_option( self::LAST_CHECK_OPTION_KEY, 0 );
 		return $current_time - $last_execution >= $interval;
 	}
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -138,7 +138,9 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		$headers = wp_remote_retrieve_headers( $response );
 		if ( array_key_exists( $header_name, $headers ) ) {
 			$header = $headers [ $header_name ];
-			if ( rest_is_integer( $header ) ) {
+			if ( 'false' === $header ) {
+				delete_option( $option_name );
+			} elseif ( rest_is_integer( $header ) ) {
 				update_option( $option_name, (int) $header, false );
 			}
 		}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -59,7 +59,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		}
 
 		// We always update the last execution time, even if the request fails.
-		update_option( self::LAST_EXECUTION_OPTION_KEY, $current_time );
+		update_option( self::LAST_EXECUTION_OPTION_KEY, $current_time, false );
 
 		$jobs     = $this->request_site_feed();
 		$statuses = wp_list_pluck( $jobs, 'wpjm_status', 'wpjm_id' );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -163,10 +163,10 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 * @return void
 	 */
 	public static function initialize_defaults() {
-		$webhook_interval = 5 * MINUTE_IN_SECONDS;
-		update_option( self::LAST_CHECK_OPTION_KEY, time() - $webhook_interval, '', false );
-		add_option( self::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS, '', false );
+		$webhook_interval = get_option( self::WEBHOOK_INTERVAL_OPTION_KEY, 5 * MINUTE_IN_SECONDS );
+		update_option( self::LAST_CHECK_OPTION_KEY, time() - $webhook_interval, false );
 		add_option( self::WEBHOOK_INTERVAL_OPTION_KEY, $webhook_interval, '', false );
+		add_option( self::CRON_INTERVAL_OPTION_KEY, 12 * HOUR_IN_SECONDS, '', false );
 	}
 
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -139,9 +139,20 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 		if ( isset( $headers[ $header_name ] ) ) {
 			$header = $headers [ $header_name ];
 			if ( 'false' === $header ) {
+				$header = '0';
+			} elseif ( ! rest_is_integer( $header ) ) {
+				return;
+			}
+			$value = (int) $header;
+			if ( self::WEBHOOK_INTERVAL_OPTION_KEY === $option_name && 0 === $value ) {
+				// If the webhook interval is zero, we don't remove the option, to not block webhook updates.
+				return;
+			}
+			if ( 0 === $value ) {
+				// If the interval is zero, we remove the option, because it is the default anyway.
 				delete_option( $option_name );
-			} elseif ( rest_is_integer( $header ) ) {
-				update_option( $option_name, (int) $header, false );
+			} else {
+				update_option( $option_name, $value, false );
 			}
 		}
 	}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php
@@ -136,7 +136,7 @@ class WP_Job_Manager_Promoted_Jobs_Status_Handler {
 	 */
 	private function update_interval( $response, $header_name, $option_name ) {
 		$headers = wp_remote_retrieve_headers( $response );
-		if ( array_key_exists( $header_name, $headers ) ) {
+		if ( isset( $headers[ $header_name ] ) ) {
 			$header = $headers [ $header_name ];
 			if ( 'false' === $header ) {
 				delete_option( $option_name );


### PR DESCRIPTION
Alternative to #2561

### Changes proposed in this Pull Request

* Changes the Promoted Jobs Status Handle to run the check hourly  (but it WILL NOT run hourly unless the server specifies to do so)
* Split the update interval setting into two different options: CRON and WEBHOOK. The first is considered when the WP-CRON is triggering the request, and the other is considering in every other call (usually coming out from the webhook).
* Every time the status handler fetches an update from the server, it will look for the `X-WPJM-Webhook-Interval` and `X-WPJM-Cron-Interval` headers and will update the value of the respective option accordingly (or delete it, if the header's value is `false`)
* The system considers always the last execution time (whether it comes from the cron or the webhook) when running the update, to not run very often
* From WPJM side, this PR is effectively identical to what's already implemented on the feature branch. Except that now we have the power to change the options at will from WPJM. :D 

### Testing instructions

**NOTE**: Consider that "running the webhook" is the same as running the command ` curl -X POST "http://your.wpjm.instance/?rest_route=/wpjm-internal/v1/promoted-jobs/refresh-status"`

**TIP**: You can use `wp option list --search="job_manager_promoted_jobs_*"` to see the options related to Promoted Jobs. :) 

On a clean WP installation running this branch and running a WPJMCOM instance based on 581-gh-Automattic/wpjobmanager.com.

1. Make sure the options `job_manager_promoted_jobs_cron_interval` and `job_manager_promoted_jobs_webhook_interval` aren't set
2. Try running the webhook using  and verify that it doesn't make any requests (you can check that by verifying if the option `job_manager_promoted_jobs_status_update_last_execution` doesn't exist)
3. Promote a job
4. Make sure the options `job_manager_promoted_jobs_cron_interval` and `job_manager_promoted_jobs_webhook_interval` are set and are numbers (the cron_interval should be set to 43200, and the webhook_interval to 300). Make sure the `job_manager_promoted_jobs_status_update_last_execution` option still doesn't exist (if it exists, delete it)
5. Try running the webhook now and make sure the option `job_manager_promoted_jobs_status_update_last_execution` is set
7. Delete the Promoted Site (and their Promoted Jobs) from WPJMCOM side
8. Delete the `job_manager_promoted_jobs_status_update_last_execution` (or set it to `0`, it is effectively the same)
9. Try running the webhook again and verify if the options  `job_manager_promoted_jobs_cron_interval` and `job_manager_promoted_jobs_webhook_interval` are deleted now

Sorry for the complicated testing instructions, by the way. :)