### PR TITLE
Fix tests

### DIFF
--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -225,6 +225,24 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_BaseTest {
 	}
 
 	protected function build_url( $args ) {
+		// The legacy endpoints are temporary. For now, translate `license_key` => `licence_key` at this point.
+		$args = $this->updateArrayKey( $args, 'license_key', 'licence_key' );
+
 		return 'https://wpjobmanager.com/?' . http_build_query( $args, '', '&' );
+	}
+
+	private function updateArrayKey( $array, $oldKey, $newKey ) {
+		if ( array_key_exists( $oldKey, $array ) ) {
+			$newArray = array();
+			foreach ( $array as $key => $value ) {
+				if ( $key === $oldKey ) {
+					$newArray[ $newKey ] = $value;
+				} else {
+					$newArray[ $key ] = $value;
+				}
+			}
+			return $newArray;
+		}
+		return $array;
 	}
 }


### PR DESCRIPTION
The tests were broken because of the license -> license renaming. The reason is that in the tests, the `get_base_args` is used for some functions, and also to create the URL, but [we temporarily didn't change the URL to keep backward compatibility](https://github.com/Automattic/WP-Job-Manager/commit/50787702ab2b68900ea55487fe90946109eba472).

So my temporary approach here was to replace the key only when creating the URL.