### PR TITLE
Change promote jobs edit button

### DIFF
--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -255,7 +255,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			echo '
 			<span class="jm-promoted__status-promoted">' . esc_html__( 'Promoted', 'wp-job-manager' ) . '</span>
 			<div class="row-actions">
-				<a href="' . esc_url( $promote_url ) . '" class="jm-promoted__edit" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Edit', 'wp-job-manager' ) . '</a>
+				<a href="' . esc_url( $promote_url ) . '" class="jm-promoted__edit" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Manage', 'wp-job-manager' ) . '</a>
 				|
 				<a class="jm-promoted__deactivate delete" href="#" data-href="' . esc_url( $deactivate_action_link ) . '">' . esc_html__( 'Deactivate', 'wp-job-manager' ) . '</a>
 			</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR just renames the "Edit" button to "Manager". The reasons is that the user can do other things through that link, going navigating to the JobTarget system. More context: p1692989850428599-slack-C053397HN30

### Testing instructions

* Promote a job, or just add the post meta `_promoted` as `"1"` to one job.
* Go to the listings, and see that the button has the new text.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="345" alt="Screenshot 2023-08-25 at 17 55 17" src="https://github.com/Automattic/WP-Job-Manager/assets/876340/07b8bc26-32dc-4225-9f26-c7dc5877a11b">