### PR TITLE
Show/Hide company logo File Upload button

### DIFF
--- a/assets/js/ajax-file-upload.js
+++ b/assets/js/ajax-file-upload.js
@@ -102,6 +102,8 @@ jQuery(function($) {
 						if ( $.inArray( file.extension, image_types ) >= 0 ) {
 							html = $.parseHTML( job_manager_ajax_file_upload.js_field_html_img );
 							$( html ).find('.job-manager-uploaded-file-preview img').attr( 'src', file.url );
+							$( '#company_logo' ).hide();
+							$( '.fieldset-company_logo small.description' ).hide();
 						} else {
 							html = $.parseHTML( job_manager_ajax_file_upload.js_field_html );
 							$( html ).find('.job-manager-uploaded-file-name code').text( file.name );

--- a/assets/js/job-submission.js
+++ b/assets/js/job-submission.js
@@ -5,6 +5,9 @@ jQuery(document).ready(function($) {
 		$(this).closest( '.job-manager-uploaded-file' ).remove();
 		$inputField.trigger( 'update_status' );
 
+		$( '#company_logo' ).show();
+		$( '.fieldset-company_logo small.description' ).show();
+
 		return false;
 	});
 


### PR DESCRIPTION
Fixes #2294

The issue was that when you uploaded a Company Logo, you still had the prompt of "No File Selected" which can appear confusing as you just uploaded a file.

### Changes proposed in this Pull Request

* When you upload a Company Logo, the upload button and max file size is hidden
* If you remove the company logo you just added, it becomes visible

### Testing instructions

* Go to Post a Job
* Add a company logo
* Verify that the file upload button and the Max File size is gone
* Remove logo
* Verify that the button and file size is back

### Screenshot / Video
![company_logo](https://github.com/Automattic/WP-Job-Manager/assets/3220162/9ba01e0b-1631-461c-86d3-5aa62d97a973)

