### PR TITLE
Fix bulk update URL

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -60,7 +60,7 @@ class WP_Job_Manager_Helper_API {
 	 */
 	public function bulk_update_check( array $plugins ) {
 		return $this->request_endpoint(
-			'wp-json/wpjmcom-licensing/v1/updates',
+			'/wp-json/wpjmcom-licensing/v1/updates',
 			[
 				'method' => 'POST',
 				'body'   => wp_json_encode(


### PR DESCRIPTION
There was a conflict in @fjorgemota's changes (https://github.com/Automattic/wp-job-manager/commit/3a47aa09203d6b50672bad6c1ff38a693a9d6b1a) in the feature branch and my bulk update check in `trunk`. 

### Changes proposed in this Pull Request

* Adds the preceding slash to the bulk updates request.

### Testing instructions

* With Query Monitor, verify the bulk update request succeed when you visit WP Admin > Dashboard > Updates. You may need to clear both site/network transients.
