### PR TITLE
Add event to datepicker method

### DIFF
--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -9,19 +9,21 @@ jQuery(document).on( 'ready', function() {
 	}
 
 	var initializeDatepicker = function ( targetInput ) {
-		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: jQuery(targetInput).attr( 'name' ) } ).insertAfter( jQuery( targetInput ) );
-		jQuery(targetInput).attr( 'name', jQuery(targetInput).attr( 'name' ) + '-datepicker' );
-		jQuery(targetInput).keyup( function() {
-			if ( '' === jQuery(targetInput).val() ) {
+		var $target = jQuery( targetInput );
+		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: $target.attr( 'name' ) } ).insertAfter( $target );
+
+		$target.attr( 'name', $target.attr( 'name' ) + '-datepicker' );
+		$target.keyup( function() {
+			if ( '' === $target.val() ) {
 				$hidden_input.val( '' );
 			}
 		} );
-		jQuery(targetInput).datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
-		if ( jQuery(targetInput).val() ) {
-			var dateParts = jQuery(targetInput).val().split('-');
+		$target.datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
+		if ( $target.val() ) {
+			var dateParts = $target.val().split('-');
 			if ( 3 === dateParts.length ) {
 				var selectedDate = new Date(parseInt(dateParts[0], 10), (parseInt(dateParts[1], 10) - 1), parseInt(dateParts[2], 10));
-				jQuery(targetInput).datepicker('setDate', selectedDate);
+				$target.datepicker('setDate', selectedDate);
 			}
 		}
 	};

--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -1,5 +1,5 @@
 /* global job_manager_datepicker */
-jQuery(document).on( 'ready', function() {
+jQuery(document).ready( function() {
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
 	};
@@ -13,7 +13,7 @@ jQuery(document).on( 'ready', function() {
 		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: $target.attr( 'name' ) } ).insertAfter( $target );
 
 		$target.attr( 'name', $target.attr( 'name' ) + '-datepicker' );
-		$target.keyup( function() {
+		$target.on( 'keyup', function() {
 			if ( '' === $target.val() ) {
 				$hidden_input.val( '' );
 			}

--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -1,5 +1,5 @@
 /* global job_manager_datepicker */
-jQuery(document).on( 'ready wpJobManagerFieldAdded', function() {
+jQuery(document).on( 'ready', function() {
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
 	};
@@ -8,21 +8,30 @@ jQuery(document).on( 'ready wpJobManagerFieldAdded', function() {
 		datePickerOptions.dateFormat = job_manager_datepicker.date_format;
 	}
 
-	jQuery( 'input.job-manager-datepicker, input#_job_expires' ).each( function(){
-		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: jQuery(this).attr( 'name' ) } ).insertAfter( jQuery( this ) );
-		jQuery(this).attr( 'name', jQuery(this).attr( 'name' ) + '-datepicker' );
-		jQuery(this).keyup( function() {
-			if ( '' === jQuery(this).val() ) {
+	var initializeDatepicker = function ( targetInput ) {
+		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: jQuery(targetInput).attr( 'name' ) } ).insertAfter( jQuery( targetInput ) );
+		jQuery(targetInput).attr( 'name', jQuery(targetInput).attr( 'name' ) + '-datepicker' );
+		jQuery(targetInput).keyup( function() {
+			if ( '' === jQuery(targetInput).val() ) {
 				$hidden_input.val( '' );
 			}
 		} );
-		jQuery(this).datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
-		if ( jQuery(this).val() ) {
-			var dateParts = jQuery(this).val().split("-");
+		jQuery(targetInput).datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
+		if ( jQuery(targetInput).val() ) {
+			var dateParts = jQuery(targetInput).val().split('-');
 			if ( 3 === dateParts.length ) {
 				var selectedDate = new Date(parseInt(dateParts[0], 10), (parseInt(dateParts[1], 10) - 1), parseInt(dateParts[2], 10));
-				jQuery(this).datepicker('setDate', selectedDate);
+				jQuery(targetInput).datepicker('setDate', selectedDate);
 			}
 		}
+	};
+
+	jQuery( 'input.job-manager-datepicker, input#_job_expires' ).each( function() {
+		initializeDatepicker( this );
+	} );
+
+
+	jQuery( document ).on( 'wpJobManagerFieldAdded', function ( e ) {
+		initializeDatepicker( e.target );
 	});
 });

--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -1,26 +1,27 @@
 /* global job_manager_datepicker */
-jQuery(document).ready(function($) {
+jQuery(document).on( 'ready wpJobManagerFieldAdded', function() {
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
 	};
+
 	if ( typeof job_manager_datepicker !== 'undefined' ) {
 		datePickerOptions.dateFormat = job_manager_datepicker.date_format;
 	}
 
-	$( 'input.job-manager-datepicker, input#_job_expires' ).each( function(){
-		var $hidden_input = $( '<input />', { type: 'hidden', name: $(this).attr( 'name' ) } ).insertAfter( $( this ) );
-		$(this).attr( 'name', $(this).attr( 'name' ) + '-datepicker' );
-		$(this).keyup( function() {
-			if ( '' === $(this).val() ) {
+	jQuery( 'input.job-manager-datepicker, input#_job_expires' ).each( function(){
+		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: jQuery(this).attr( 'name' ) } ).insertAfter( jQuery( this ) );
+		jQuery(this).attr( 'name', jQuery(this).attr( 'name' ) + '-datepicker' );
+		jQuery(this).keyup( function() {
+			if ( '' === jQuery(this).val() ) {
 				$hidden_input.val( '' );
 			}
 		} );
-		$(this).datepicker( $.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
-		if ( $(this).val() ) {
-			var dateParts = $(this).val().split("-");
+		jQuery(this).datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
+		if ( jQuery(this).val() ) {
+			var dateParts = jQuery(this).val().split("-");
 			if ( 3 === dateParts.length ) {
 				var selectedDate = new Date(parseInt(dateParts[0], 10), (parseInt(dateParts[1], 10) - 1), parseInt(dateParts[2], 10));
-				$(this).datepicker('setDate', selectedDate);
+				jQuery(this).datepicker('setDate', selectedDate);
 			}
 		}
 	});


### PR DESCRIPTION
This issue came up while I was having a look at this ticket: 6733381-zd-a8c

It seems that although we support a type of 'date' in WPJM forms, we don't support this type in fields that are generated dynamically. This happens in resumes.

### Changes proposed in this Pull Request

* Adds a wpJobManagerFieldAdded event to datepicker method

### Testing instructions

* Tested as part of this PR: 115-gh-Automattic/wpjm-addons

### Release Notes

* Support dynamically added date form fields