### PR TITLE
Add more plugin statistics

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -30,7 +30,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			$categories = wp_count_terms( 'job_listing_category', [ 'hide_empty' => false ] );
 		}
 
-		return [
+		$usage_data = [
 			'employers'                   => self::get_employer_count(),
 			'job_categories'              => $categories,
 			'job_categories_desc'         => self::get_job_category_has_description_count(),
@@ -60,9 +60,19 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_part_time'              => self::get_jobs_by_type_count( 'part-time' ),
 			'jobs_temp'                   => self::get_jobs_by_type_count( 'temporary' ),
 			'jobs_by_guests'              => self::get_jobs_by_guests(),
-			'official_extensions'         => self::get_official_extensions_count(),
-			'licensed_extensions'         => self::get_licensed_extensions_count(),
 		];
+
+		$all_extenstions     = self::get_official_extensions( false );
+		$licensed_extensions = self::get_official_extensions( true );
+
+		$usage_data['official_extensions'] = count( $all_extenstions );
+		$usage_data['licensed_extensions'] = count( $licensed_extensions );
+
+		foreach ( array_keys( $all_extenstions ) as $installed_plugin ) {
+			$usage_data[ $installed_plugin ] = isset( $licensed_extensions[ $installed_plugin ] ) ? 'licensed' : 'unlicensed';
+		}
+
+		return $usage_data;
 	}
 
 	/**
@@ -345,13 +355,6 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	private static function get_official_extensions_count() {
 		return count( self::get_official_extensions( false ) );
-	}
-
-	/**
-	 * Gets the count of all official extensions that are installed, activated, and have active license.
-	 */
-	private static function get_licensed_extensions_count() {
-		return count( self::get_official_extensions( true ) );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -242,7 +242,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @return bool
 	 */
 	protected function do_track_plugin( $plugin_slug ) {
-		if ( 1 === preg_match( '/^wp\-job\-manager/', $plugin_slug ) ) {
+		if ( 1 === preg_match( '/wp\-job\-manager/', $plugin_slug ) ) {
 			return true;
 		}
 		$third_party_plugins = [
@@ -252,6 +252,11 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			'wordpress-seo', // Yoast.
 			'sitepress-multilingual-cms', // WPML.
 			'bibblio-related-posts', // Related Posts for WordPress.
+			'classic-editor',
+			'disable-gutenberg',
+			'mailpoet',
+			'woocommerce',
+			'woocommerce-subscriptions',
 		];
 		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {
 			return true;

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -235,37 +235,6 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 		);
 	}
 
-	/**
-	 * Check if we should track the status of a plugin.
-	 *
-	 * @param string $plugin_slug
-	 * @return bool
-	 */
-	protected function do_track_plugin( $plugin_slug ) {
-		if ( 1 === preg_match( '/wp\-job\-manager/', $plugin_slug ) ) {
-			return true;
-		}
-		$third_party_plugins = [
-			'all-in-one-seo-pack',
-			'polylang',
-			'jetpack',
-			'wordpress-seo', // Yoast.
-			'sitepress-multilingual-cms', // WPML.
-			'bibblio-related-posts', // Related Posts for WordPress.
-			'classic-editor',
-			'disable-gutenberg',
-			'mailpoet',
-			'woocommerce',
-			'woocommerce-subscriptions',
-		];
-		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-
 	/*
 	 * Public functions.
 	 */

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -606,6 +606,8 @@ class WP_Job_Manager_Helper {
 			$keyed_by_filename = false;
 		}
 
+		$clear_plugin_cache = ! function_exists( 'did_filter' ) || did_filter( 'extra_plugin_headers' );
+
 		/**
 		 * Clear the plugin cache on first request for installed WPJM add-on plugins. This happens in installations
 		 * that get_plugins() is called before WPJM has a chance to register its custom plugin headers.
@@ -615,7 +617,7 @@ class WP_Job_Manager_Helper {
 		 *
 		 * @param bool $clear_plugin_cache True if we should clear the plugin cache.
 		 */
-		if ( ! self::$cleared_plugin_cache && apply_filters( 'job_manager_clear_plugin_cache', did_filter( 'extra_plugin_headers' ) ) ) {
+		if ( ! self::$cleared_plugin_cache && apply_filters( 'job_manager_clear_plugin_cache', $clear_plugin_cache ) ) {
 			// Reset the plugin cache on the first call. Some plugins prematurely hydrate the cache.
 			wp_clean_plugins_cache( false );
 			self::$cleared_plugin_cache = true;

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -613,7 +613,7 @@ class WP_Job_Manager_Helper {
 		 * that get_plugins() is called before WPJM has a chance to register its custom plugin headers.
 		 *
 		 * @since 1.29.1
-		 * @since $$next-version$$ Only do this when get_plugins is called before this filter.
+		 * @since $$next-version$$ Only do this when get_plugins was called before this filter.
 		 *
 		 * @param bool $clear_plugin_cache True if we should clear the plugin cache.
 		 */

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -606,23 +606,23 @@ class WP_Job_Manager_Helper {
 			$keyed_by_filename = false;
 		}
 
-		$wpjm_plugins = [];
-		$plugins      = get_plugins();
-
 		/**
-		 * Clear the plugin cache on first request for installed WPJM add-on plugins when no plugins found.
+		 * Clear the plugin cache on first request for installed WPJM add-on plugins. This happens in installations
+		 * that get_plugins() is called before WPJM has a chance to register its custom plugin headers.
 		 *
 		 * @since 1.29.1
-		 * @since $$next-version$$ Only do this when we don't see WP Job Manager in the plugins list.
+		 * @since $$next-version$$ Only do this when get_plugins is called before this filter.
 		 *
 		 * @param bool $clear_plugin_cache True if we should clear the plugin cache.
 		 */
-		if ( ! self::$cleared_plugin_cache && apply_filters( 'job_manager_clear_plugin_cache', ! isset( $plugins[ JOB_MANAGER_PLUGIN_BASENAME ] ) ) ) {
+		if ( ! self::$cleared_plugin_cache && apply_filters( 'job_manager_clear_plugin_cache', did_filter( 'extra_plugin_headers' ) ) ) {
 			// Reset the plugin cache on the first call. Some plugins prematurely hydrate the cache.
 			wp_clean_plugins_cache( false );
 			self::$cleared_plugin_cache = true;
-			$plugins                    = get_plugins();
 		}
+
+		$wpjm_plugins = [];
+		$plugins      = get_plugins();
 
 		foreach ( $plugins as $filename => $data ) {
 			if ( empty( $data['WPJM-Product'] ) || ( true === $active_only && ! is_plugin_active( $filename ) ) ) {

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -123,16 +123,6 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	abstract protected function opt_in_dialog_text();
 
 	/**
-	 * Checks if we should send an activated plugin's installed version in the
-	 * `system_log` event.
-	 *
-	 * @param string $plugin_slug the plugin slug to check.
-	 *
-	 * @return bool true if we send the version, false if not.
-	 */
-	abstract protected function do_track_plugin( $plugin_slug );
-
-	/**
 	 * Gets the base data returned with system information.
 	 *
 	 * @return array
@@ -372,11 +362,9 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 
 		$plugin_data = $this->get_plugin_data();
 		foreach ( $plugin_data as $plugin_name => $plugin_version ) {
-			if ( $this->do_track_plugin( $plugin_name ) ) {
-				$plugin_friendly_name       = preg_replace( '/[^a-z0-9]/', '_', $plugin_name );
-				$plugin_key                 = self::PLUGIN_PREFIX . $plugin_friendly_name;
-				$system_data[ $plugin_key ] = $plugin_version;
-			}
+			$plugin_friendly_name       = preg_replace( '/[^a-z0-9]/', '_', $plugin_name );
+			$plugin_key                 = self::PLUGIN_PREFIX . $plugin_friendly_name;
+			$system_data[ $plugin_key ] = $plugin_version;
 		}
 
 		return $system_data;

--- a/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -38,13 +38,6 @@ class Usage_Tracking_Test_Subclass extends WP_Job_Manager_Usage_Tracking_Base {
 		return 'Please enable Usage Tracking!';
 	}
 
-	public function do_track_plugin( $plugin_slug ) {
-		if ( in_array( $plugin_slug, array( 'hello', 'test', 'my-favorite-plugin' ), true ) ) {
-			return true;
-		}
-		return false;
-	}
-
 	protected function get_plugins() {
 		return array(
 			'Hello.php'                                 => array(

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -385,8 +385,8 @@ class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'plugin_test', $system_data, '`plugin_test` key must exist in system data' );
 		$this->assertEquals( '1.0.0', $system_data['plugin_test'], '`plugin_test` does not match expected value' );
 
-		$this->assertArrayNotHasKey( 'plugin_jetpack', $system_data, '`plugin_jetpack` key must NOT exist in system data' );
-		$this->assertArrayNotHasKey( 'plugin_test_dev', $system_data, '`plugin_test_dev` key must NOT exist in system data' );
+		$this->assertArrayHasKey( 'plugin_jetpack', $system_data, '`plugin_jetpack` key must exist in system data' );
+		$this->assertArrayHasKey( 'plugin_test_dev', $system_data, '`plugin_test_dev` key must exist in system data' );
 
 		$plugin_prefix_count = 0;
 		foreach ( $system_data as $key => $value ) {
@@ -395,7 +395,7 @@ class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 			}
 		}
 
-		$this->assertEquals( 3, $plugin_prefix_count );
+		$this->assertEquals( 5, $plugin_prefix_count );
 	}
 
 	/* END tests for system data */


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a few more plugins to track to our stats
* Starts tracking plugins that have `wp-job-manager` anywhere in their slug, not just the start
* Specifically tracks which plugins have an active license
* Fixes an issue where WPJM plugins weren't reported. The issue was caused in installations where a plugin calls `get_plugins` before WPJM has a chance to register the `WPJM-Product` custom header. In that case the header wasn't populated and the plugins weren't included in the results of `get_installed_plugins`

### Testing instructions

* As the changes are in data that are submitted to Tracks, it is easier if you simply add some logging to see the reported data.
* Install some plugins like classic editor, Woo etc. Also install a few of our paid plugins.
* Run the `job_manager_usage_tracking_send_usage_data` cronjob. You can use WP Control plugin for that.
* Observe that the data reported are correctly.
* Activate/deactivate licenses to our plugins and observe that the data are still correct.