### PR TITLE
Add plugin upload and playground setup to PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,49 +1,51 @@
 name: Plugin Build
 
-on: pull_request
+on:
+  - pull_request
 
 jobs:
-    build:
-        name: Plugin Build
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - name: Get npm cache directory
-              id: npm-cache
-              run: |
-                  echo "::set-output name=dir::$(npm config get cache)"
-            - uses: actions/cache@v2
-              with:
-                  path: ${{ steps.npm-cache.outputs.dir }}
-                  key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
-            - uses: shivammathur/setup-php@v2
-              with:
-                php-version: '7.4'
-                tools: composer
-                coverage: none
-            - name: Get composer cache directory
-              id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-            - uses: actions/cache@v2
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-
-            - name: Install JS dependencies
-              run: npm ci
-            - name: Install PHP dependencies
-              run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
-            - name: Build Plugin
-              run: npm run build
-            - name: Decompress plugin
-              run: unzip wp-job-manager.zip -d wp-job-manager
-            - name: Store Artifact
-              uses: actions/upload-artifact@v2
-              with:
-                name: wp-job-manager-${{ github.event.pull_request.head.sha }}
-                path: ${{ github.workspace }}/wp-job-manager/
-                retention-days: 7
-                  
+  build:
+    name: Plugin Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install JS dependencies
+        run: npm ci
+      - name: Install PHP dependencies
+        run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+      - name: Build Plugin
+        run: npm run build
+      - name: Decompress plugin
+        run: unzip wp-job-manager.zip -d wp-job-manager
+      - name: Store Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wp-job-manager-${{ github.event.pull_request.head.sha }}
+          path: ${{ github.workspace }}/wp-job-manager/
+          retention-days: 7
+      - name: Save plugin zip and add link to it in a comment 
+        run: node scripts/upload-and-link-plugin-zip.mjs --pr ${{ github.event.number }} --commit ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.merged && '--merged' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,4 +50,5 @@ jobs:
       - name: Save plugin zip and add link to it in a comment 
         env:
           WPJMCOM_API_LOGIN: ${{ secrets.WPJMCOM_API_LOGIN }}
+          GH_TOKEN: ${{ github.token }}
         run: node scripts/upload-and-link-plugin-zip.mjs --pr ${{ github.event.number }} --commit ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.merged && '--merged' || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,6 @@ jobs:
           path: ${{ github.workspace }}/wp-job-manager/
           retention-days: 7
       - name: Save plugin zip and add link to it in a comment 
+        env:
+          WPJMCOM_API_LOGIN: ${{ secrets.WPJMCOM_API_LOGIN }}
         run: node scripts/upload-and-link-plugin-zip.mjs --pr ${{ github.event.number }} --commit ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.merged && '--merged' || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           name: wp-job-manager-${{ github.event.pull_request.head.sha }}
           path: ${{ github.workspace }}/wp-job-manager/
           retention-days: 7
-      - name: Save plugin zip and add link to it in a comment 
+      - name: Save plugin zip and add link to the PR description
         env:
           WPJMCOM_API_LOGIN: ${{ secrets.WPJMCOM_API_LOGIN }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
           path: ${{ github.workspace }}/wp-job-manager/
           retention-days: 7
       - name: Save plugin zip and add link to it in a comment 
-        run: node scripts/upload-and-link-plugin-zip.mjs --pr ${{ github.event.number }} --commit ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.merged && '--merged' }}
+        run: node scripts/upload-and-link-plugin-zip.mjs --pr ${{ github.event.number }} --commit ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.merged && '--merged' || '' }}

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -39,7 +39,7 @@ const login = env.WPJMCOM_API_LOGIN;
 
 	try {
 		const zip = uploadZip();
-		addComment( zip );
+		addLinksToPR( zip );
 	} catch ( error ) {
 		console.log( 'Failed to upload plugin zip.' );
 		console.log( error.message );
@@ -90,11 +90,11 @@ function uploadZip() {
 }
 
 /**
- * Post a comment on the PR with a link to the plugin zip and playground.
+ * Add a link to the plugin zip and the playground to the PR description.
  *
  * @param {string} zip URL to plugin zip file.
  */
-function addComment( zip ) {
+function addLinksToPR( zip ) {
 
 	const [ , path, id ] = zip.match( 'wp-content/uploads/(.*)/wp-job-manager-zip-(.*).zip' );
 	const playgroundLink = `https://wpjobmanager.com/playground/?core=${ path }/${ id }`

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -15,7 +15,7 @@ const { values: { pr, commit, merged } } = parseArgs( {
 
 const MEDIA_LIBRARY_ENDPOINT = "https://wpjobmanager.com/wp-json/wp/v2/media"
 
-const login = `${ env.WPJMCOM_API_USER }:${ env.WPJMCOM_API_PASSWORD }`;
+const login = env.WPJMCOM_API_LOGIN;
 
 ( function main() {
 

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -19,13 +19,14 @@ const login = env.WPJMCOM_API_LOGIN;
 
 ( function main() {
 
-	deleteOldZips();
-
-	if ( merged ) {
-		return;
-	}
-
-	const zip = uploadZip();
+	// deleteOldZips();
+	//
+	// if ( merged ) {
+	// 	return;
+	// }
+	//
+	// const zip = uploadZip();
+	const zip = "https://wpjobmanager.com/wp-content/uploads/2023/09/wp-job-manager-zip-2577-26255dc9.zip";
 	addComment( zip );
 
 } )();
@@ -75,12 +76,22 @@ function addComment( zip ) {
 	const [ , path, id ] = zip.match( 'wp-content/uploads/(.*)/wp-job-manager-zip-(.*).zip' );
 	const playgroundLink = `https://wpjobmanager.com/playground/?core=${ path }/${ id }`
 
-	const body = `Plugin built with the proposed changes (${ commit }):
-📦 [Download plugin zip](${ zip })
-▶️ [Open in playground](${ playgroundLink })`;
+	const links = `
+<!-- wpjm:plugin-zip -->
+----
 
-	const hasComment = JSON.parse( execSync( `gh pr view ${ pr } --comments --json comments --jq '.comments | map(.author.login)'` ).toString() ).includes( 'github-actions' );
+| Plugin build for ${ commit } <a href="#"><img width=600></a> |
+| ------------------------------------------------------------ |
+| 📦 [Download plugin zip](${ zip })                       |
+| ▶️ [Open in playground](${ playgroundLink })             |
 
-	execSync( `gh pr comment ${ pr } ${ hasComment ? '--edit-last' : '' } --body "${ body.replaceAll( '"', '\\"' ) }"` )
-	console.log( chalk.green( '✓' ), 'Comment added to PR.' );
+<!-- /wpjm:plugin-zip -->
+`;
+
+	let body = execSync( `gh pr view ${ pr } --json body --jq .body` ).toString();
+
+	body = body.replace( /((<!-- wpjm:plugin-zip -->([\s\S]*)<!-- \/wpjm:plugin-zip -->)|$)/, links );
+
+	execSync( `gh pr edit ${ pr } --body "${ body.replaceAll( '"', '\\"' ) }"`, {stdio: 'inherit'} )
+	console.log( chalk.green( '✓' ), 'Plugin build links added to PR.' );
 }

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -19,15 +19,33 @@ const login = env.WPJMCOM_API_LOGIN;
 
 ( function main() {
 
-	// deleteOldZips();
-	//
-	// if ( merged ) {
-	// 	return;
-	// }
-	//
-	// const zip = uploadZip();
-	const zip = "https://wpjobmanager.com/wp-content/uploads/2023/09/wp-job-manager-zip-2577-26255dc9.zip";
-	addComment( zip );
+	if ( ! login ) {
+		console.log( 'WPJobManager.com secrets not available, exiting.' );
+		process.exit( 0 );
+	}
+
+	try {
+		deleteOldZips();
+	} catch ( error ) {
+		console.log( 'Failed to delete old plugin zips.' );
+		console.log( error.message );
+		console.log( error.stack );
+		process.exit( 1 );
+	}
+
+	if ( merged ) {
+		return;
+	}
+
+	try {
+		const zip = uploadZip();
+		addComment( zip );
+	} catch ( error ) {
+		console.log( 'Plugin upload failed.' );
+		console.log( error.message );
+		console.log( error.stack );
+		process.exit( 1 );
+	}
 
 } )();
 
@@ -92,6 +110,6 @@ function addComment( zip ) {
 
 	body = body.replace( /((<!-- wpjm:plugin-zip -->([\s\S]*)<!-- \/wpjm:plugin-zip -->)|$)/, links );
 
-	execSync( `gh pr edit ${ pr } --body "${ body.replaceAll( '"', '\\"' ) }"`, {stdio: 'inherit'} )
+	execSync( `gh pr edit ${ pr } --body "${ body.replaceAll( '"', '\\"' ) }"`, { stdio: 'inherit' } )
 	console.log( chalk.green( '✓' ), 'Plugin build links added to PR.' );
 }

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -62,7 +62,7 @@ function deleteOldZips() {
 	oldZips?.forEach( ( zip ) => {
 		const
 			title = zip.title.rendered;
-		if ( title.match( new RegExp( `wp-job-manager-zip-${pr}` ) ) ) {
+		if ( title.startsWith( `wp-job-manager-zip-${pr}-`  ) ) {
 			console.log( `Deleting old plugin build ${ title }.zip` );
 			execSync( `curl -s -u "${ login }" -X DELETE "${ MEDIA_LIBRARY_ENDPOINT }/${ zip.id }?force=true"` );
 		}

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -1,0 +1,86 @@
+import chalk from 'chalk';
+import { execSync } from "node:child_process";
+import process from "node:process";
+import { parseArgs } from "node:util";
+
+const { env } = process;
+
+const { values: { pr, commit, merged } } = parseArgs( {
+	options: {
+		pr: { type: "string" },
+		commit: { type: "string" },
+		merged: { type: "boolean", default: false },
+	},
+} );
+
+const MEDIA_LIBRARY_ENDPOINT = "https://wpjobmanager.com/wp-json/wp/v2/media"
+
+const login = `${ env.WPJMCOM_API_USER }:${ env.WPJMCOM_API_PASSWORD }`;
+
+( function main() {
+
+	deleteOldZips();
+
+	if ( merged ) {
+		return;
+	}
+
+	const zip = uploadZip();
+	addComment( zip );
+
+} )();
+
+/**
+ * Remove previously uploaded plugin zip files for the PR.
+ *
+ */
+function deleteOldZips() {
+
+	const oldZips = JSON.parse( execSync( `curl -s -u "${ login }" "${ MEDIA_LIBRARY_ENDPOINT }?mime_type=application/zip&_fields=id,date,title,source_url"` ).toString() );
+	if ( oldZips?.code || ! Array.isArray( oldZips ) ) {
+		console.log( `[${ oldZips.code }]`, oldZips.message );
+		return;
+	}
+	oldZips?.forEach( ( zip ) => {
+		const
+			title = zip.title.rendered;
+		if ( title.match( new RegExp( `wp-job-manager-zip-${pr}` ) ) ) {
+			console.log( `Deleting old plugin build ${ title }.zip` );
+			execSync( `curl -s -u "${ login }" -X DELETE "${ MEDIA_LIBRARY_ENDPOINT }/${ zip.id }?force=true"` );
+		}
+	} )
+}
+
+/**
+ * Upload plugin zip to media library.
+ *
+ * @returns {string} URL to plugin zip file.
+ */
+function uploadZip() {
+
+	const id = `${ pr }-${ commit }`;
+
+	const zip = execSync( `curl -u "${ login }" --http1.1 --data-binary @wp-job-manager.zip -H "Content-Disposition: attachment; filename=\"wp-job-manager-zip-${ id }.zip\"" ${ MEDIA_LIBRARY_ENDPOINT }?title=wp-job-manager-zip-${ id } | jq .source_url` ).toString().replaceAll( '"', '' ).trim();
+	console.log( chalk.green( '✓' ), `Plugin file uploaded to ${ zip }` )
+
+	return zip;
+}
+
+/**
+ * Post a comment on the PR with a link to the plugin zip and playground.
+ * @param {string} zip URL to plugin zip file.
+ */
+function addComment( zip ) {
+
+	const [ , path, id ] = zip.match( 'wp-content/uploads/(.*)/wp-job-manager-zip-(.*).zip' );
+	const playgroundLink = `https://wpjobmanager.com/playground/?core=${ path }/${ id }`
+
+	const body = `Plugin built with the proposed changes (${ commit }):
+📦 [Download plugin zip](${ zip })
+▶️ [Open in playground](${ playgroundLink })`;
+
+	const hasComment = JSON.parse( execSync( `gh pr view ${ pr } --comments --json comments --jq '.comments | map(.author.login)'` ).toString() ).includes( 'github-actions' );
+
+	execSync( `gh pr comment ${ pr } ${ hasComment ? '--edit-last' : '' } --body "${ body.replaceAll( '"', '\\"' ) }"` )
+	console.log( chalk.green( '✓' ), 'Comment added to PR.' );
+}

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -58,7 +58,7 @@ function deleteOldZips() {
  */
 function uploadZip() {
 
-	const id = `${ pr }-${ commit }`;
+	const id = `${ pr }-${ commit.substring( 0, 8 ) }`;
 
 	const zip = execSync( `curl -u "${ login }" --http1.1 --data-binary @wp-job-manager.zip -H "Content-Disposition: attachment; filename=\"wp-job-manager-zip-${ id }.zip\"" ${ MEDIA_LIBRARY_ENDPOINT }?title=wp-job-manager-zip-${ id } | jq .source_url` ).toString().replaceAll( '"', '' ).trim();
 	console.log( chalk.green( '✓' ), `Plugin file uploaded to ${ zip }` )


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Change the plugin build step action to upload the plugin zip file to wpjobmanager.com's media library, instead of as an artifact of the action
* Post the plugin zip link and a link to open it in a testing site ~as a comment~ to the PR
* Delete previous zips when a PR is updated or merged

See p6r3EZ-1PL-p2 for more details. 

### Testing instructions

* See GH action logs for this PR: https://github.com/Automattic/WP-Job-Manager/actions/runs/6176999314/job/16767164534?pr=2577
* See generated comment below








<!-- wpjm:plugin-zip -->
----

| Plugin build for d7b3e6dafe75c6d63749a71b7df2f249205ebbad <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/09/wp-job-manager-zip-2577-d7b3e6da.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/09/2577-d7b3e6da)             |

<!-- /wpjm:plugin-zip -->






















