### PR TITLE
Use new "Deactivate License" endpoint for deactivating licenses on WPJMCOM

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -144,10 +144,24 @@ class WP_Job_Manager_Helper_API {
 	 * @return array|false JSON response or false if failed.
 	 */
 	public function deactivate( $args ) {
-		$args            = wp_parse_args( $args );
-		$args['wc-api']  = 'wp_plugin_licencing_activation_api';
-		$args['request'] = 'deactivate';
-		return $this->request( $args, false );
+		$args     = wp_parse_args( $args );
+		$response = $this->request_endpoint(
+			'wp-json/wpjmcom-licensing/v1/deactivate',
+			[
+				'method' => 'POST',
+				'body'   => wp_json_encode(
+					[
+						'product_slug' => $args['api_product_id'],
+						'license_key'  => $args['license_key'],
+						'site_url'     => $this->get_site_url(),
+					]
+				),
+			]
+		);
+		if ( ! is_array( $response ) || ! array_key_exists( 'success', $response ) ) {
+			return false;
+		}
+		return $response;
 	}
 
 	/**

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -214,7 +214,7 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_BaseTest {
 	}
 
 	protected function default_valid_response() {
-		return [ 'status' => 1 ];
+		return [ 'success' => true ];
 	}
 
 	protected function default_invalid_response() {

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -162,18 +162,19 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_BaseTest {
 	 *
 	 * @param string $endpoint The request URI/path of the endpoint to mock the response for.
 	 * @param mixed $body The response body to return for the specified endpoint.
+	 * @param int $status The HTTP status code to return for the specified endpoint.
 	 *
 	 * @return void
 	 */
-	protected function mock_http_request($endpoint, $body) {
-		add_filter('pre_http_request', function($preempt, $args, $url) use ($endpoint, $body) {
+	protected function mock_http_request($endpoint, $body, $status = 200) {
+		add_filter('pre_http_request', function($preempt, $args, $url) use ($endpoint, $body, $status) {
 			if ($endpoint === wp_parse_url($url, PHP_URL_PATH)) {
 				return array(
 					'headers' => array(),
 					'body' => wp_json_encode($body),
 					'response' => array(
-						'code' => 200,
-						'message' => 'OK',
+						'code' => $status,
+						'message' => 200 === $status ? 'OK' : 'Error'
 					),
 					'cookies' => array(),
 				);

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -127,16 +127,8 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_BaseTest {
 	 */
 	public function test_deactivate_valid() {
 		$base_args = $this->get_base_args();
-		$this->set_expected_response(
-			[
-				'args' => wp_parse_args(
-					[
-						'wc-api'  => 'wp_plugin_licencing_activation_api',
-						'request' => 'deactivate',
-					],
-					$base_args
-				),
-			]
+		$this->mock_http_request( '/wp-json/wpjmcom-licensing/v1/deactivate',
+			$this->default_valid_response()
 		);
 		$instance = new WP_Job_Manager_Helper_API();
 		$response = $instance->deactivate( $base_args );
@@ -151,6 +143,12 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_BaseTest {
 	 */
 	public function test_deactivate_invalid() {
 		$base_args = $this->get_base_args();
+		$this->mock_http_request( '/wp-json/wpjmcom-licensing/v1/deactivate',
+			[
+				'error_code' => 'license_not_found'
+			],
+			404
+		);
 		$instance  = new WP_Job_Manager_Helper_API();
 		$response  = $instance->deactivate( $base_args );
 


### PR DESCRIPTION
Part of #2417

### Changes proposed in this Pull Request

- Change endpoint used to deactivate licenses in `WP_Job_Manager_Helper_API`

### Testing instructions

On a WPJM installation based on this version of the plugin:

1. Install a WPJM addon;
2. Activate the license for that addon
3. Make sure the license is correctly associated with the host of your WP installation on wpjobmanager.com
4. Deactivate the license for that addon via WPJM UI (just click on the "Deactivate License" button)
5. Make sure the license is correctly disassociated with the host of your WP installation on wpjobmanager.com