### PR TITLE
Change endpoint used for getting plugin information from WPJMCOM

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -84,14 +84,12 @@ class WP_Job_Manager_Helper_API {
 		$data = $this->request_endpoint(
 			'wp-json/wpjmcom-licensing/v1/plugin-information',
 			[
-				'method' => 'POST',
-				'body'   => wp_json_encode(
-					[
-						'site_url'     => $this->get_site_url(),
-						'license_key'  => $args['license_key'],
-						'product_slug' => $args['api_product_id'],
-					]
-				),
+				'method' => 'GET',
+				'body'   => [
+					'site_url'     => $this->get_site_url(),
+					'license_key'  => $args['license_key'],
+					'product_slug' => $args['api_product_id'],
+				],
 			]
 		);
 		if ( ! is_array( $data ) ) {

--- a/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
+++ b/tests/php/tests/includes/helper/test_class.wp-job-manager-helper-api.php
@@ -38,22 +38,44 @@ class WP_Test_WP_Job_Manager_Helper_API extends WPJM_BaseTest {
 	 */
 	public function test_plugin_information_valid() {
 		$base_args = $this->get_base_args();
-		$this->set_expected_response(
-			[
-				'args' => wp_parse_args(
-					[
-						'wc-api'  => 'wp_plugin_licencing_update_api',
-						'request' => 'plugininformation',
-					],
-					$base_args
-				),
-			]
-		);
+		$data = [
+			'name'         => 'Sample Plugin',
+			'slug'         => 'sample-plugin',
+			'version'      => '1.0.0',
+			'last_updated' => '2023-09-22',
+			'author'       => 'John Doe',
+			'requires'     => 'WordPress 5.0+',
+			'tested'       => 'WordPress 5.8',
+			'homepage'     => 'https://www.example.com/sample-plugin',
+			'sections'     => array(
+				'description' => 'This is a sample plugin for demonstration purposes.',
+				'changelog'   => 'Version 1.0.0 - Initial release',
+			),
+			'download_link' => 'https://www.example.com/sample-plugin/sample-plugin.zip',
+		];
+		$this->mock_http_request( '/wp-json/wpjmcom-licensing/v1/plugin-information', $data);
 		$instance = new WP_Job_Manager_Helper_API();
 		$response = $instance->plugin_information( $base_args );
 
 		// If a request was made that we don't expect, `$response` would be false.
-		$this->assertEquals( $this->default_valid_response(), $response );
+
+		$this->assertInstanceOf(stdClass::class, $response);
+		$this->assertEquals($data['name'], $response->name);
+		$this->assertEquals($data['slug'], $response->slug);
+		$this->assertEquals($data['version'], $response->version);
+		$this->assertEquals($data['last_updated'], $response->last_updated);
+		$this->assertEquals($data['author'], $response->author);
+		$this->assertEquals($data['requires'], $response->requires);
+		$this->assertEquals($data['tested'], $response->tested);
+		$this->assertEquals($data['homepage'], $response->homepage);
+
+		$this->assertEquals($data['sections']['description'], $response->sections['description']);
+		$this->assertEquals($data['sections']['changelog'], $response->sections['changelog']);
+
+		$this->assertEquals($data['download_link'], $response->download_link);
+
+		$expectedPlugin = $data['slug'] . '/' . $data['slug'] . '.php';
+		$this->assertEquals($expectedPlugin, $response->plugin);
 	}
 
 	/**


### PR DESCRIPTION
Based on #2585
Fixes #2417 

### Changes proposed in this Pull Request

- Use new endpoint on WPJMCOM for getting plugin information from WPJM

### Testing instructions

Using a WP installation running this branch of the WPJM plugin:

1. Install a WPJM addon, let's say, the `wp-job-manager-application-deadline` addon
2. Activate it with a license from WPJMCOM
3. Run the following code on `wp shell`:

```php
require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
var_dump(plugins_api('plugin_information', ['slug'=>'wp-job-manager-application-deadline']));
```
5. Make sure the plugin information printed makes sense (has the correct name, `plugin`, slug, version, etc.). Also, make sure the `download_link` isn't empty.
6. Now, deactivate the license for that plugin on the WPJM panel
7. Run the above snippet again, make sure the `download_link` is now empty.
