### PR TITLE
Add/usage tracking improvements

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+# Re-format PHP files with PHPCBF
+2dc64b85a9a640f4fa1878f4c2e2a1b34c85f432
+

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -700,6 +700,7 @@ class WP_Job_Manager_CPT {
 	 * @return array
 	 */
 	public function sort_columns( $vars ) {
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Query used in admin only.
 		if ( isset( $vars['orderby'] ) ) {
 			if ( 'job_expires' === $vars['orderby'] ) {
 				$vars = array_merge(
@@ -719,6 +720,8 @@ class WP_Job_Manager_CPT {
 				);
 			}
 		}
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+
 		return $vars;
 	}
 

--- a/includes/admin/class-wp-job-manager-setup.php
+++ b/includes/admin/class-wp-job-manager-setup.php
@@ -119,7 +119,7 @@ class WP_Job_Manager_Setup {
 			}
 
 			// Handle step 2 -> step 3 (setting up pages).
-			if ( 3 === $step && ! empty( $_POST ) ) {
+			if ( 3 === $step && ! empty( $_POST ) && empty( $_POST['skip-setup'] ) ) {
 				if (
 					! isset( $_REQUEST['setup_wizard'] )
 					|| false === wp_verify_nonce( wp_unslash( $_REQUEST['setup_wizard'] ), 'step_3' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.

--- a/includes/admin/views/html-admin-setup-opt-in-usage-tracking.php
+++ b/includes/admin/views/html-admin-setup-opt-in-usage-tracking.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input
 			type="checkbox"
 			name="job_manager_usage_tracking_enabled"
-			value="1" />
+			value="1"
+			checked="checked" />
 		<?php
 		echo wp_kses(
 			$this->opt_in_text(),

--- a/includes/admin/views/html-admin-setup-step-1.php
+++ b/includes/admin/views/html-admin-setup-step-1.php
@@ -11,6 +11,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <h3><?php esc_html_e( 'Welcome to the Setup Wizard!', 'wp-job-manager' ); ?></h3>
 
+<script type="text/javascript">
+	document.addEventListener('DOMContentLoaded', function() {
+		const usageTrackingEnabled = document.querySelector("input[name='job_manager_usage_tracking_enabled']");
+
+		if (usageTrackingEnabled) {
+			usageTrackingEnabled.checked = true;
+		}
+	});
+</script>
+
 <p><?php echo wp_kses_post( __( 'Thanks for installing <em>WP Job Manager</em>! Let\'s get your site ready to accept job listings.', 'wp-job-manager' ) ); ?></p>
 <p><?php echo wp_kses_post( __( 'This setup wizard will walk you through the process of creating pages for job submissions, management, and listings.', 'wp-job-manager' ) ); ?></p>
 <p>

--- a/includes/admin/views/html-admin-setup-step-1.php
+++ b/includes/admin/views/html-admin-setup-step-1.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <p>
 	<?php
 	// translators: Placeholder %s is the path to WPJM documentation site.
-	echo wp_kses_post( sprintf( __( 'If you\'d prefer to skip this and set up your pages manually, our <a href="%s">documentation</a> will walk you through each step.', 'wp-job-manager' ), 'https://wpjobmanager.com/documentation/' ) );
+	echo wp_kses_post( sprintf( __( 'If you\'d prefer to skip this and set up your pages manually, our <a target="_blank" href="%s">documentation</a> will walk you through each step.', 'wp-job-manager' ), 'https://wpjobmanager.com/documentation/' ) );
 	?>
 </p>
 

--- a/includes/admin/views/html-admin-setup-step-1.php
+++ b/includes/admin/views/html-admin-setup-step-1.php
@@ -11,16 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <h3><?php esc_html_e( 'Welcome to the Setup Wizard!', 'wp-job-manager' ); ?></h3>
 
-<script type="text/javascript">
-	document.addEventListener('DOMContentLoaded', function() {
-		const usageTrackingEnabled = document.querySelector("input[name='job_manager_usage_tracking_enabled']");
-
-		if (usageTrackingEnabled) {
-			usageTrackingEnabled.checked = true;
-		}
-	});
-</script>
-
 <p><?php echo wp_kses_post( __( 'Thanks for installing <em>WP Job Manager</em>! Let\'s get your site ready to accept job listings.', 'wp-job-manager' ) ); ?></p>
 <p><?php echo wp_kses_post( __( 'This setup wizard will walk you through the process of creating pages for job submissions, management, and listings.', 'wp-job-manager' ) ); ?></p>
 <p>

--- a/includes/admin/views/html-admin-setup-step-1.php
+++ b/includes/admin/views/html-admin-setup-step-1.php
@@ -30,13 +30,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	?>
 </p>
 
-<form method="post" action="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>">
+<form method="post">
 	<input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'enable-usage-tracking' ) ); ?>" />
 
 	<?php $this->maybe_output_opt_in_checkbox(); ?>
 
 	<p class="submit">
-		<input type="submit" value="<?php esc_html_e( 'Start setup', 'wp-job-manager' ); ?>" class="button button-primary" />
-		<a href="<?php echo esc_url( add_query_arg( 'skip-job-manager-setup', 1, admin_url( 'index.php?page=job-manager-setup&step=3' ) ) ); ?>" class="button"><?php esc_html_e( 'Skip setup. I will set up the plugin manually.', 'wp-job-manager' ); ?></a>
+		<input type="submit" name="start-setup" value="<?php esc_html_e( 'Start setup', 'wp-job-manager' ); ?>" class="button button-primary" formaction="<?php echo esc_url( add_query_arg( 'step', 2 ) ); ?>" />
+
+		<input type="submit" name="skip-setup" value="<?php esc_html_e( 'Save and skip setup', 'wp-job-manager' ); ?>" class="button" formaction="<?php echo esc_url( add_query_arg( 'step', 3 ) ); ?>">
+
 	</p>
 </form>

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -381,9 +381,9 @@ class WP_Job_Manager_Data_Cleaner {
 		global $wpdb;
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery -- Delete data across all users.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Delete data across all users.
 			$wpdb->delete( $wpdb->usermeta, [ 'meta_key' => $meta_key ] );
-			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		}
 	}
 

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -114,6 +114,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_promoted_jobs_status_update_last_check',
 		'job_manager_promoted_jobs_webhook_interval',
 		'job_manager_promoted_jobs_cron_interval',
+		'job_manager_display_usage_tracking_once',
 	];
 
 	/**

--- a/includes/class-wp-job-manager-dependency-checker.php
+++ b/includes/class-wp-job-manager-dependency-checker.php
@@ -26,15 +26,15 @@ class WP_Job_Manager_Dependency_Checker {
 	 */
 	public static function check_dependencies() {
 		if ( ! self::check_php() ) {
-			add_action( 'admin_notices', array( 'WP_Job_Manager_Dependency_Checker', 'add_php_notice' ) );
-			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
+			add_action( 'admin_notices', [ 'WP_Job_Manager_Dependency_Checker', 'add_php_notice' ] );
+			add_action( 'admin_init', [ __CLASS__, 'deactivate_self' ] );
 
 			return false;
 		}
 
 		if ( ! self::check_wp() ) {
-			add_action( 'admin_notices', array( 'WP_Job_Manager_Dependency_Checker', 'add_wp_notice' ) );
-			add_filter( 'plugin_action_links_' . JOB_MANAGER_PLUGIN_BASENAME, array( 'WP_Job_Manager_Dependency_Checker', 'wp_version_plugin_action_notice' ) );
+			add_action( 'admin_notices', [ 'WP_Job_Manager_Dependency_Checker', 'add_wp_notice' ] );
+			add_filter( 'plugin_action_links_' . JOB_MANAGER_PLUGIN_BASENAME, [ 'WP_Job_Manager_Dependency_Checker', 'wp_version_plugin_action_notice' ] );
 		}
 
 		return true;
@@ -66,7 +66,7 @@ class WP_Job_Manager_Dependency_Checker {
 		$message = sprintf( __( '<strong>WP Job Manager</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'wp-job-manager' ), self::MINIMUM_PHP_VERSION, phpversion() );
 
 		echo '<div class="error"><p>';
-		echo wp_kses( $message, array( 'strong' => array() ) );
+		echo wp_kses( $message, [ 'strong' => [] ] );
 		$php_update_url = 'https://wordpress.org/support/update-php/';
 		if ( function_exists( 'wp_get_update_php_url' ) ) {
 			$php_update_url = wp_get_update_php_url();
@@ -146,6 +146,6 @@ class WP_Job_Manager_Dependency_Checker {
 	 * @return array
 	 */
 	private static function get_critical_screen_ids() {
-		return array( 'dashboard', 'plugins', 'plugins-network', 'edit-job_listing', 'job_listing_page_job-manager-settings' );
+		return [ 'dashboard', 'plugins', 'plugins-network', 'edit-job_listing', 'job_listing_page_job-manager-settings' ];
 	}
 }

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -600,7 +600,7 @@ final class WP_Job_Manager_Email_Notifications {
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => -1,
-				'meta_query'     => [
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
 					[
 						'key'   => '_job_expires',
 						'value' => $notice_before_datetime->format( 'Y-m-d' ),

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -34,6 +34,8 @@ class WP_Job_Manager_Install {
 			$is_new_install = true;
 		}
 
+		require_once __DIR__ . '/../lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php';
+
 		// On new installs display the usage tracking notice with one week delay and for existing installs display it right away.
 		if ( false === get_option( WP_Job_Manager_Usage_Tracking_Base::DISPLAY_ONCE_OPTION ) ) {
 			$time_to_show_notice = $is_new_install ? time() + WEEK_IN_SECONDS : time() - 10;

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -34,6 +34,12 @@ class WP_Job_Manager_Install {
 			$is_new_install = true;
 		}
 
+		// On new installs display the usage tracking notice with one week delay and for existing installs display it right away.
+		if ( false === get_option( 'job_manager_display_usage_tracking_once' ) ) {
+			$time_to_show_notice = $is_new_install ? time() + WEEK_IN_SECONDS : time() - 10;
+			update_option( 'job_manager_display_usage_tracking_once', $time_to_show_notice );
+		}
+
 		// Update featured posts ordering.
 		if ( version_compare( get_option( 'wp_job_manager_version', JOB_MANAGER_VERSION ), '1.22.0', '<' ) ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One time data update.

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -35,9 +35,9 @@ class WP_Job_Manager_Install {
 		}
 
 		// On new installs display the usage tracking notice with one week delay and for existing installs display it right away.
-		if ( false === get_option( 'job_manager_display_usage_tracking_once' ) ) {
+		if ( false === get_option( WP_Job_Manager_Usage_Tracking_Base::DISPLAY_ONCE_OPTION ) ) {
 			$time_to_show_notice = $is_new_install ? time() + WEEK_IN_SECONDS : time() - 10;
-			update_option( 'job_manager_display_usage_tracking_once', $time_to_show_notice );
+			update_option( WP_Job_Manager_Usage_Tracking_Base::DISPLAY_ONCE_OPTION, $time_to_show_notice );
 		}
 
 		// Update featured posts ordering.

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -584,8 +584,8 @@ class WP_Job_Manager_Post_Types {
 			'ignore_sticky_posts' => 1,
 			'posts_per_page'      => $input_posts_per_page,
 			'paged'               => absint( get_query_var( 'paged', 1 ) ),
-			'tax_query'           => [],
-			'meta_query'          => [],
+			'tax_query'           => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Empty.
+			'meta_query'          => [], //// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
 		];
 
 		if ( ! empty( $input_search_location ) ) {
@@ -739,7 +739,7 @@ class WP_Job_Manager_Post_Types {
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => -1,
-				'meta_query'     => [
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
 					'relation' => 'AND',
 					[
 						'key'     => '_job_expires',
@@ -1370,7 +1370,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		if ( ! isset( $query_args['meta_query'] ) ) {
-			$query_args['meta_query'] = [];
+			$query_args['meta_query'] = []; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
 		}
 
 		$query_args['meta_query'][] = [

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -585,7 +585,7 @@ class WP_Job_Manager_Post_Types {
 			'posts_per_page'      => $input_posts_per_page,
 			'paged'               => absint( get_query_var( 'paged', 1 ) ),
 			'tax_query'           => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Empty.
-			'meta_query'          => [], //// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
+			'meta_query'          => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
 		];
 
 		if ( ! empty( $input_search_location ) ) {

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -905,6 +905,7 @@ class WP_Job_Manager_Shortcodes {
 			$args['posts_per_page'] = $atts['limit'];
 			$args['orderby']        = 'rand';
 			if ( ! is_null( $atts['featured'] ) ) {
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Query results are limited.
 				$args['meta_query'] = [
 					[
 						'key'     => '_featured',

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -191,7 +191,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				'post_type'   => 'job_listing',
 				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
-				'tax_query'   => [
+				'tax_query'   => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Used in production with no issues.
 					[
 						'field'    => 'slug',
 						'taxonomy' => 'job_listing_type',
@@ -217,7 +217,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				'post_type'   => 'job_listing',
 				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
-				'meta_query'  => [
+				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
 					[
 						'key'     => '_thumbnail_id',
 						'compare' => 'EXISTS',
@@ -242,7 +242,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				'post_type'   => 'job_listing',
 				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
-				'tax_query'   => [
+				'tax_query'   => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Used in production with no issues.
 					[
 						'taxonomy' => 'job_listing_type',
 						'operator' => 'EXISTS',
@@ -267,7 +267,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				'post_type'   => 'job_listing',
 				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
-				'meta_query'  => [
+				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
 					[
 						'key'     => $meta_key,
 						'value'   => '[^[:space:]]',
@@ -294,7 +294,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				'post_type'   => 'job_listing',
 				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
-				'meta_query'  => [
+				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
 					[
 						'key'   => $meta_key,
 						'value' => '1',

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -227,7 +227,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			// translators: Placeholder %s is a URL to the document on wpjobmanager.com with info on usage tracking.
 			__(
 				'We\'d love if you helped us make WP Job Manager better by allowing us to collect
-				<a href="%s">usage tracking data</a>. No sensitive information is
+				<a target="_blank" href="%s">usage tracking data</a>. No sensitive information is
 				collected, and you can opt out at any time.',
 				'wp-job-manager'
 			),
@@ -266,7 +266,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 			// translators: the href tag contains the URL for the page telling users what data WPJM tracks.
 			__(
 				'Help us make WP Job Manager better by allowing us to collect
-				<a href="%s">usage tracking data</a>.
+				<a target="_blank" href="%s">usage tracking data</a>.
 				No sensitive information is collected.',
 				'wp-job-manager'
 			),

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require dirname( __FILE__ ) . '/../lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php';
+require_once __DIR__ . '/../lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php';
 
 /**
  * WPJM Usage Tracking subclass.

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require dirname( __FILE__ ) . '/../lib/usage-tracking/class-usage-tracking-base.php';
+require dirname( __FILE__ ) . '/../lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php';
 
 /**
  * WPJM Usage Tracking subclass.
@@ -182,7 +182,9 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	/**
-	 * Get the text domain used in the plugin.
+	 * Get the text domain used in the plugin. Deprecated - use 'wp-job-manager' directly.
+	 *
+	 * @deprecated 1.41.1
 	 *
 	 * @return string
 	 */

--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -184,7 +184,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	/**
 	 * Get the text domain used in the plugin. Deprecated - use 'wp-job-manager' directly.
 	 *
-	 * @deprecated 1.41.1
+	 * @deprecated $$next-version$$
 	 *
 	 * @return string
 	 */

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -152,6 +152,11 @@ class WP_Job_Manager {
 		if ( version_compare( JOB_MANAGER_VERSION, get_option( 'wp_job_manager_version' ), '>' ) ) {
 			WP_Job_Manager_Install::install();
 
+			// Set the Usage Tracking notice to show again, but only do it one time.
+			if ( ! get_option( 'display_usage_tracking_on_update_once' ) ) {
+				update_option( 'job_manager_usage_tracking_opt_in_hide', false );
+				add_option( 'display_usage_tracking_on_update_once', true );
+			}
 			flush_rewrite_rules();
 		}
 	}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -141,7 +141,6 @@ class WP_Job_Manager {
 		$this->post_types->register_post_types();
 		remove_filter( 'pre_option_job_manager_enable_types', '__return_true' );
 		WP_Job_Manager_Install::install();
-		$this->set_activation_time();
 		flush_rewrite_rules();
 	}
 
@@ -152,11 +151,6 @@ class WP_Job_Manager {
 		if ( version_compare( JOB_MANAGER_VERSION, get_option( 'wp_job_manager_version' ), '>' ) ) {
 			WP_Job_Manager_Install::install();
 
-			// Set the Usage Tracking notice to show again, but only do it one time.
-			if ( ! get_option( 'display_usage_tracking_on_update_once' ) ) {
-				update_option( 'job_manager_usage_tracking_opt_in_hide', false );
-				add_option( 'display_usage_tracking_on_update_once', true );
-			}
 			flush_rewrite_rules();
 		}
 	}
@@ -620,16 +614,5 @@ class WP_Job_Manager {
 		if ( is_admin() && ! class_exists( 'WP_Job_Manager_Admin' ) ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-admin.php';
 		}
-	}
-
-	/**
-	 * Sets a transient to track the activation time of WP Job Manager plugin.
-	 *
-	 * @return void
-	 *
-	 * @since $$next-version$$
-	 */
-	public function set_activation_time() {
-		set_transient( 'job_manager_activation_time', time() );
 	}
 }

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -628,10 +628,6 @@ class WP_Job_Manager {
 	 * @return void
 	 *
 	 * @since $$next-version$$
-	 *
-	 * @author Your Name
-	 *
-	 * @see set_transient()
 	 */
 	public function set_activation_time() {
 		set_transient( 'job_manager_activation_time', time() );

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -627,7 +627,7 @@ class WP_Job_Manager {
 	 *
 	 * @return void
 	 *
-	 * @since 1.0.0
+	 * @since $$next-version$$
 	 *
 	 * @author Your Name
 	 *

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -141,6 +141,7 @@ class WP_Job_Manager {
 		$this->post_types->register_post_types();
 		remove_filter( 'pre_option_job_manager_enable_types', '__return_true' );
 		WP_Job_Manager_Install::install();
+		$this->set_activation_time();
 		flush_rewrite_rules();
 	}
 
@@ -614,5 +615,20 @@ class WP_Job_Manager {
 		if ( is_admin() && ! class_exists( 'WP_Job_Manager_Admin' ) ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-admin.php';
 		}
+	}
+
+	/**
+	 * Sets a transient to track the activation time of WP Job Manager plugin.
+	 *
+	 * @return void
+	 *
+	 * @since 1.0.0
+	 *
+	 * @author Your Name
+	 *
+	 * @see set_transient()
+	 */
+	public function set_activation_time() {
+		set_transient( 'job_manager_activation_time', time() );
 	}
 }

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -187,7 +187,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
 			'posts_per_page'      => -1,
-			'meta_query'          => [
+			'meta_query'          => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Returns promoted jobs only which should be a small number.
 				[
 					'key'     => WP_Job_Manager_Promoted_Jobs::PROMOTED_META_KEY,
 					'compare' => 'EXISTS',

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -213,7 +213,7 @@ class WP_Job_Manager_Promoted_Jobs {
 				'post_status'    => 'any',
 				'posts_per_page' => 1,
 				'fields'         => 'ids',
-				'meta_query'     => [
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Returns promoted jobs only which should be a small number.
 					[
 						'key'     => self::PROMOTED_META_KEY,
 						'value'   => '1',

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -452,6 +452,23 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	/**
+	 * Check if the plugin option is active.
+	 *
+	 * @return bool Returns true if the plugin option is active, false otherwise.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @author /Users/mikeyarce/Local Sites/wpjm/app/public/wp-content/plugins/WP-Job-Manager/lib/usage-tracking/class-usage-tracking-base.php
+	 */
+	function delay_tracking_notice() {
+		$activation_time = get_transient( 'job_manager_activation_time' );
+		if ( $activation_time && ( time() - $activation_time ) > 604800 ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * If needed, display opt-in dialog to enable tracking. Should not be
 	 * called externally.
 	 **/
@@ -459,8 +476,9 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		$opt_in_hidden         = $this->is_opt_in_hidden();
 		$user_tracking_enabled = $this->is_tracking_enabled();
 		$can_manage_tracking   = $this->current_user_can_manage_tracking();
+		$delay_tracking_notice   = $this->delay_tracking_notice();
 
-		if ( ! $user_tracking_enabled && ! $opt_in_hidden && $can_manage_tracking ) { ?>
+		if ( ! $user_tracking_enabled && ! $opt_in_hidden && $can_manage_tracking && ! $delay_tracking_notice ) { ?>
 			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-notice" class="notice notice-info"
 				data-nonce="<?php echo esc_attr( wp_create_nonce( 'tracking-opt-in' ) ); ?>">
 				<p>

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -50,7 +50,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *
 	 * @var array
 	 **/
-	private static $instances = array();
+	private static $instances = [];
 
 	/**
 	 * Gets the singleton instance of this class. Subclasses should implement
@@ -128,7 +128,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @return array
 	 */
 	protected function get_base_system_data() {
-		return array();
+		return [];
 	}
 
 	/*
@@ -150,14 +150,14 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		$this->job_name                         = $this->get_prefix() . '_usage_tracking_send_usage_data';
 
 		// Set up the opt-in dialog.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_script_deps' ) );
-		add_action( 'admin_footer', array( $this, 'output_opt_in_js' ) );
-		add_action( 'admin_notices', array( $this, 'maybe_display_tracking_opt_in' ) );
-		add_action( 'wp_ajax_' . $this->get_prefix() . '_handle_tracking_opt_in', array( $this, 'handle_tracking_opt_in' ) );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_script_deps' ] );
+		add_action( 'admin_footer', [ $this, 'output_opt_in_js' ] );
+		add_action( 'admin_notices', [ $this, 'maybe_display_tracking_opt_in' ] );
+		add_action( 'wp_ajax_' . $this->get_prefix() . '_handle_tracking_opt_in', [ $this, 'handle_tracking_opt_in' ] );
 
 		// Set up schedule and action needed for cron job.
-		add_filter( 'cron_schedules', array( $this, 'add_usage_tracking_two_week_schedule' ) );
-		add_action( $this->job_name, array( $this, 'send_usage_data' ) );
+		add_filter( 'cron_schedules', [ $this, 'add_usage_tracking_two_week_schedule' ] );
+		add_action( $this->job_name, [ $this, 'send_usage_data' ] );
 	}
 
 	/**
@@ -200,7 +200,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *
 	 * @return null|WP_Error
 	 **/
-	public function send_event( $event, $properties = array(), $event_timestamp = null ) {
+	public function send_event( $event, $properties = [], $event_timestamp = null ) {
 
 		// Only continue if tracking is enabled.
 		if ( ! $this->is_tracking_enabled() ) {
@@ -225,7 +225,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		$properties['_en'] = $event_name;
 		$properties['_ts'] = $event_timestamp . '000';
 		$properties['_rt'] = round( microtime( true ) * 1000 );  // log time.
-		$p                 = array();
+		$p                 = [];
 
 		foreach ( $properties as $key => $value ) {
 			$p[] = rawurlencode( $key ) . '=' . rawurlencode( $value );
@@ -234,13 +234,13 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		$pixel   .= '?' . implode( '&', $p ) . '&_=_'; // EOF marker.
 		$response = wp_remote_get(
 			$pixel,
-			array(
+			[
 				'blocking'    => true,
 				'timeout'     => 1,
 				'redirection' => 2,
 				'httpversion' => '1.1',
 				'user-agent'  => $this->get_event_prefix() . '_usage_tracking',
-			)
+			]
 		);
 
 		if ( is_wp_error( $response ) ) {
@@ -329,10 +329,10 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 **/
 	public function add_usage_tracking_two_week_schedule( $schedules ) {
 		$day_in_seconds = 86400;
-		$schedules[ $this->get_prefix() . '_usage_tracking_two_weeks' ] = array(
+		$schedules[ $this->get_prefix() . '_usage_tracking_two_weeks' ] = [
 			'interval' => 15 * $day_in_seconds,
 			'display'  => esc_html__( 'Every Two Weeks', $this->get_text_domain() ),
-		);
+		];
 
 		return $schedules;
 	}
@@ -376,7 +376,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @return array List of plugins. Index is friendly name, value is version.
 	 */
 	protected function get_plugin_data() {
-		$plugins = array();
+		$plugins = [];
 		foreach ( $this->get_plugins() as $plugin_basename => $plugin ) {
 			$plugin_name             = $this->get_plugin_name( $plugin_basename );
 			$plugins[ $plugin_name ] = $plugin['Version'];
@@ -430,11 +430,11 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @return bool true if the opt-in is hidden, false otherwise.
 	 **/
 	protected function is_opt_in_hidden() {
-		$delayed_notice_timestamp  = (int) get_option( 'job_manager_display_usage_tracking_once' );
+		$delayed_notice_timestamp = (int) get_option( 'job_manager_display_usage_tracking_once' );
 
 		// Display only once they delayed notice regardless if the user has declined in the past.
 		if ( $delayed_notice_timestamp > 0 && $delayed_notice_timestamp < time() ) {
-			update_option('job_manager_display_usage_tracking_once', 0 );
+			update_option( 'job_manager_display_usage_tracking_once', 0 );
 			update_option( $this->hide_tracking_opt_in_option_name, false );
 		}
 
@@ -448,15 +448,15 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @return array the html tags.
 	 **/
 	protected function opt_in_dialog_text_allowed_html() {
-		return array(
-			'a'      => array(
-				'href'   => array(),
-				'title'  => array(),
-				'target' => array(),
-			),
-			'em'     => array(),
-			'strong' => array(),
-		);
+		return [
+			'a'      => [
+				'href'   => [],
+				'title'  => [],
+				'target' => [],
+			],
+			'em'     => [],
+			'strong' => [],
+		];
 	}
 
 	/**
@@ -493,7 +493,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-failure" class="notice notice-error hidden">
 				<p><?php esc_html_e( 'Something went wrong. Please try again later.', $this->get_text_domain() ); ?></p>
 			</div>
-		<?php
+			<?php
 		}
 	}
 
@@ -522,8 +522,11 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	public function enqueue_script_deps() {
 		// Ensure jQuery is loaded.
 		wp_enqueue_script(
-			$this->get_prefix() . '_usage-tracking-notice', '',
-			array( 'jquery' ), null, true
+			$this->get_prefix() . '_usage-tracking-notice',
+			'',
+			[ 'jquery' ],
+			null,
+			true
 		);
 	}
 
@@ -532,7 +535,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * externally.
 	 **/
 	public function output_opt_in_js() {
-?>
+		?>
 <script type="text/javascript">
 	(function( prefix ) {
 		jQuery( document ).ready( function() {
@@ -580,6 +583,6 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 		});
 	})( "<?php echo esc_js( $this->get_prefix() ); ?>" );
 </script>
-<?php
+		<?php
 	}
 }

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -456,7 +456,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *
 	 * @return bool Returns true if the plugin option is active, false otherwise.
 	 *
-	 * @since 1.0.0
+	 * @since $$next-version$$
 	 *
 	 * @author /Users/mikeyarce/Local Sites/wpjm/app/public/wp-content/plugins/WP-Job-Manager/lib/usage-tracking/class-usage-tracking-base.php
 	 */

--- a/lib/usage-tracking/class-usage-tracking-base.php
+++ b/lib/usage-tracking/class-usage-tracking-base.php
@@ -452,13 +452,11 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	}
 
 	/**
-	 * Check if the plugin option is active.
+	 * Check if the plugin has been active for more than a week.
 	 *
-	 * @return bool Returns true if the plugin option is active, false otherwise.
+	 * @return bool Returns true if the plugin has been active for more than a week, false otherwise.
 	 *
 	 * @since $$next-version$$
-	 *
-	 * @author /Users/mikeyarce/Local Sites/wpjm/app/public/wp-content/plugins/WP-Job-Manager/lib/usage-tracking/class-usage-tracking-base.php
 	 */
 	function delay_tracking_notice() {
 		$activation_time = get_transient( 'job_manager_activation_time' );

--- a/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
+++ b/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
@@ -2,6 +2,8 @@
 /**
  * Reusable Usage Tracking library. For sending plugin usage data and events to
  * Tracks.
+ *
+ * @package wp-job-manager
  **/
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -64,6 +66,8 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 *
 	 * This function cannot be abstract (because it is static) but it *must* be
 	 * implemented by subclasses.
+	 *
+	 * @throws Exception When get_instance is not implemented.
 	 */
 	public static function get_instance() {
 		throw new Exception( 'Usage Tracking subclasses must implement get_instance. See class-usage-tracking-base.php' );
@@ -328,10 +332,9 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @return array of $schedules.
 	 **/
 	public function add_usage_tracking_two_week_schedule( $schedules ) {
-		$day_in_seconds = 86400;
 		$schedules[ $this->get_prefix() . '_usage_tracking_two_weeks' ] = [
-			'interval' => 15 * $day_in_seconds,
-			'display'  => esc_html__( 'Every Two Weeks', $this->get_text_domain() ),
+			'interval' => 15 * DAY_IN_SECONDS,
+			'display'  => esc_html__( 'Every Two Weeks', 'wp-job-manager' ),
 		];
 
 		return $schedules;
@@ -476,22 +479,22 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 				</p>
 				<p>
 					<button class="button button-primary" data-enable-tracking="yes">
-						<?php esc_html_e( 'Enable Usage Tracking', $this->get_text_domain() ); ?>
+						<?php esc_html_e( 'Enable Usage Tracking', 'wp-job-manager' ); ?>
 					</button>
 					<button class="button" data-enable-tracking="no">
-						<?php esc_html_e( 'Disable Usage Tracking', $this->get_text_domain() ); ?>
+						<?php esc_html_e( 'Disable Usage Tracking', 'wp-job-manager' ); ?>
 					</button>
 					<span id="progress" class="spinner alignleft"></span>
 				</p>
 			</div>
 			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-enable-success" class="notice notice-success hidden">
-				<p><?php esc_html_e( 'Usage data enabled. Thank you!', $this->get_text_domain() ); ?></p>
+				<p><?php esc_html_e( 'Usage data enabled. Thank you!', 'wp-job-manager' ); ?></p>
 			</div>
 			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-disable-success" class="notice notice-success hidden">
-				<p><?php esc_html_e( 'Disabled usage tracking.', $this->get_text_domain() ); ?></p>
+				<p><?php esc_html_e( 'Disabled usage tracking.', 'wp-job-manager' ); ?></p>
 			</div>
 			<div id="<?php echo esc_attr( $this->get_prefix() ); ?>-usage-tracking-failure" class="notice notice-error hidden">
-				<p><?php esc_html_e( 'Something went wrong. Please try again later.', $this->get_text_domain() ); ?></p>
+				<p><?php esc_html_e( 'Something went wrong. Please try again later.', 'wp-job-manager' ); ?></p>
 			</div>
 			<?php
 		}
@@ -521,6 +524,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 **/
 	public function enqueue_script_deps() {
 		// Ensure jQuery is loaded.
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Enqueue is used to include dependencies only.
 		wp_enqueue_script(
 			$this->get_prefix() . '_usage-tracking-notice',
 			'',

--- a/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
+++ b/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
@@ -70,7 +70,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @throws Exception When get_instance is not implemented.
 	 */
 	public static function get_instance() {
-		throw new Exception( 'Usage Tracking subclasses must implement get_instance. See class-usage-tracking-base.php' );
+		throw new Exception( 'Usage Tracking subclasses must implement get_instance. See class-wp-job-manager-usage-tracking-base.php' );
 	}
 
 
@@ -85,14 +85,6 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @return string The prefix string.
 	 **/
 	abstract protected function get_prefix();
-
-	/**
-	 * Get the text domain used by this plugin. This class will add some
-	 * strings to be translated.
-	 *
-	 * @return string The text domain string.
-	 **/
-	abstract protected function get_text_domain();
 
 	/**
 	 * Determine whether usage tracking is enabled.

--- a/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
+++ b/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
@@ -429,13 +429,21 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	protected function is_opt_in_hidden() {
 		$delayed_notice_timestamp = (int) get_option( self::DISPLAY_ONCE_OPTION );
 
-		// Display only once the delayed notice regardless if the user has declined in the past.
-		if ( $delayed_notice_timestamp > 0 && $delayed_notice_timestamp < time() ) {
-			update_option( self::DISPLAY_ONCE_OPTION, 0 );
-			update_option( $this->hide_tracking_opt_in_option_name, false );
+		// The delay has passed, hide the notice if the user refused.
+		if ( 0 === $delayed_notice_timestamp ) {
+			return (bool) get_option( $this->hide_tracking_opt_in_option_name );
 		}
 
-		return (bool) get_option( $this->hide_tracking_opt_in_option_name );
+		// When the delay passes, display the tracking notice regardless if the user refused to enable usage tracking in the past.
+		if ( $delayed_notice_timestamp < time() ) {
+			update_option( self::DISPLAY_ONCE_OPTION, 0 );
+			update_option( $this->hide_tracking_opt_in_option_name, false );
+
+			return false;
+		}
+
+		// The delay hasn't passed, hide the notice.
+		return true;
 	}
 
 	/**

--- a/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
+++ b/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
@@ -427,7 +427,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	protected function is_opt_in_hidden() {
 		$delayed_notice_timestamp = (int) get_option( 'job_manager_display_usage_tracking_once' );
 
-		// Display only once they delayed notice regardless if the user has declined in the past.
+		// Display only once the delayed notice regardless if the user has declined in the past.
 		if ( $delayed_notice_timestamp > 0 && $delayed_notice_timestamp < time() ) {
 			update_option( 'job_manager_display_usage_tracking_once', 0 );
 			update_option( $this->hide_tracking_opt_in_option_name, false );

--- a/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
+++ b/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
@@ -17,6 +17,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class WP_Job_Manager_Usage_Tracking_Base {
 	const PLUGIN_PREFIX = 'plugin_';
 
+	const DISPLAY_ONCE_OPTION = 'job_manager_display_usage_tracking_once';
+
 	/*
 	 * Instance variables.
 	 */
@@ -425,11 +427,11 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @return bool true if the opt-in is hidden, false otherwise.
 	 **/
 	protected function is_opt_in_hidden() {
-		$delayed_notice_timestamp = (int) get_option( 'job_manager_display_usage_tracking_once' );
+		$delayed_notice_timestamp = (int) get_option( self::DISPLAY_ONCE_OPTION );
 
 		// Display only once the delayed notice regardless if the user has declined in the past.
 		if ( $delayed_notice_timestamp > 0 && $delayed_notice_timestamp < time() ) {
-			update_option( 'job_manager_display_usage_tracking_once', 0 );
+			update_option( self::DISPLAY_ONCE_OPTION, 0 );
 			update_option( $this->hide_tracking_opt_in_option_name, false );
 		}
 

--- a/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -1,10 +1,10 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/../../class-usage-tracking-base.php';
+require_once dirname( __FILE__ ) . '/../../class-wp-job-manager-usage-tracking-base.php';
 
 /**
  * Usage Tracking subclass for testing. Please update the superclass name to
- * match the one used by your plugin (usage-tracking/class-usage-tracking-base.php).
+ * match the one used by your plugin (usage-tracking/class-wp-job-manager-usage-tracking-base.php).
  */
 class Usage_Tracking_Test_Subclass extends WP_Job_Manager_Usage_Tracking_Base {
 

--- a/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -18,10 +18,6 @@ class Usage_Tracking_Test_Subclass extends WP_Job_Manager_Usage_Tracking_Base {
 		return 'testing';
 	}
 
-	public function get_text_domain() {
-		return 'text-domain';
-	}
-
 	public function get_tracking_enabled() {
 		return get_option( self::TRACKING_ENABLED_OPTION_NAME ) || false;
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,10 +15,8 @@
 	<exclude-pattern>tmp/</exclude-pattern>
 	<exclude-pattern>build/</exclude-pattern>
 	<exclude-pattern>assets/dist/</exclude-pattern>
-
-	<!-- Temporarily exclude templates and lib for now -->
+	<exclude-pattern>lib/emogrifier</exclude-pattern>
 	<exclude-pattern>templates/</exclude-pattern>
-	<exclude-pattern>lib/</exclude-pattern>
 
 	<!-- PHP Config -->
 	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
@@ -29,23 +27,16 @@
 
 	<!-- Rules -->
 	<rule ref="PHPCompatibilityWP"/>
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 
 	<rule ref="WordPress.Security.ValidatedSanitizedInput" />
 	<rule ref="WordPress.DB.DirectDatabaseQuery" />
 
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
-		<exclude-pattern>includes/class-wp-job-manager-dependency-checker.php</exclude-pattern>
-		<exclude-pattern>/wp-job-manager.php</exclude-pattern>
-		<exclude-pattern>/uninstall.php</exclude-pattern>
-	</rule>
-
-	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
-		<include-pattern>includes/class-wp-job-manager-dependency-checker.php</include-pattern>
-		<include-pattern>/wp-job-manager.php</include-pattern>
-		<include-pattern>/uninstall.php</include-pattern>
-	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
 	<!-- Temporary Rule Exclusions -->
 	<rule ref="VariableAnalysis">

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,10 +21,10 @@ if ( ! is_multisite() ) {
 	}
 } elseif ( function_exists( 'get_sites' ) ) {
 	$blog_ids = get_sites(
-		array(
+		[
 			'fields'            => 'ids',
 			'update_site_cache' => false,
-		)
+		]
 	);
 
 	$original_blog_id = get_current_blog_id();

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -62,8 +62,8 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			'posts_per_page'         => intval( $args['posts_per_page'] ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Known slow query.
 			'orderby'                => $args['orderby'],
 			'order'                  => $args['order'],
-			'tax_query'              => [],
-			'meta_query'             => [],
+			'tax_query'              => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Empty.
+			'meta_query'             => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
 			'update_post_term_cache' => false,
 			'update_post_meta_cache' => false,
 			'cache_results'          => false,
@@ -390,8 +390,8 @@ if ( ! function_exists( 'get_featured_job_ids' ) ) :
 				'suppress_filters' => false,
 				'post_type'        => 'job_listing',
 				'post_status'      => 'publish',
-				'meta_key'         => '_featured',
-				'meta_value'       => '1',
+				'meta_key'         => '_featured', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Used in production with no issues.
+				'meta_value'       => '1', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Used in production with no issues.
 				'fields'           => 'ids',
 			]
 		);

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -48,8 +48,8 @@ function WPJM() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 $GLOBALS['job_manager'] = WPJM();
 
 // Activation - works with symlinks.
-register_activation_hook( basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ ), array( WPJM(), 'activate' ) );
+register_activation_hook( basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ ), [ WPJM(), 'activate' ] );
 
 // Cleanup on deactivation.
-register_deactivation_hook( __FILE__, array( WPJM(), 'unschedule_cron_jobs' ) );
-register_deactivation_hook( __FILE__, array( WPJM(), 'usage_tracking_cleanup' ) );
+register_deactivation_hook( __FILE__, [ WPJM(), 'unschedule_cron_jobs' ] );
+register_deactivation_hook( __FILE__, [ WPJM(), 'usage_tracking_cleanup' ] );


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2580

### Changes proposed in this Pull Request

* Usage tracking checkbox in Setup is now checked by default
* The "Usage Tracking" notice will show up 1 week after the plugin has been activated
* When the plugin is updated, we'll show the "Usage Tracking" notice again, but only one time. If it's dismissed, it won't show up on future updates
* I also added a few `target="_blank"` attributes to some links that did not have them.

### Testing instructions

* Pull this branch to a test site
* Make sure you DON'T have usage tracking enabled
* Go to run a setup on this page:  `/wp-admin/index.php?page=job-manager-setup`
* See that the box is checked by default
* Click `Save and Skip setup` and make sure the option is saved properly
---
* To mimic the 1 week wait, you can edit the time in `delay_tracking_notice` to display the notice.
* To mimic a plugin update, you can edit the `WP_Job_manager::updater()` function so that the condition is true and so that the code runs
* Make sure that the usage tracking prompt shows up after that.