### PR TITLE
Update extension page design, add search bar

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -790,6 +790,7 @@ tr.email-setting-row {
 			margin-left: auto;
 			align-self: center;
 			display: flex;
+			gap: 2px;
 		}
 	}
 }

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -613,8 +613,8 @@ a.wpjm-activate-license-link:active {
 	max-width: 1244px;
 
 	.products {
-		display: flex;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 400px), 1fr));
 		margin-top: 0;
 		gap: 20px;
 	}
@@ -625,7 +625,6 @@ a.wpjm-activate-license-link:active {
 		padding: 18px;
 		background: #ffffff;
 		border: 1px solid #cccccc;
-		width: 401px;
 		box-sizing: border-box;
 		gap: 18px;
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -946,3 +946,72 @@ h2 .nav-tab-active, nav .nav-tab-active {
 		}
 	}
 }
+
+/**
+ * Core Add-on Bundle SVG Styles
+ */
+.jm-logo {
+	perspective: 450px;
+	perspective-origin: 50% 50%;
+	position: relative;
+	cursor: pointer;
+	clip-path: circle(50% at 50% 50%);
+	background: #ffef82;
+}
+
+.jm-logo__wrapper.jm-logo__wrapper {
+	gap: calc(var(--happy-sizing-scale) * (16 - 12) + 12px);
+}
+
+.jm-logo__wrapper,
+.jm-logo__wrapper path,
+.jm-logo__wrapper.jm-logo__wrapper a[href]
+{
+	color: #2404EB;
+	fill: currentColor;
+	text-decoration: none !important;
+}
+
+.jm-logo, .jm-logo__inner, .jm-logo__head, .jm-logo__face, .jm-logo__letters {
+	width: 48px;
+	height: 48px;
+}
+
+.jm-logo__inner {
+	clip-path: circle(40px);
+}
+
+.jm-logo__inner, .jm-logo__face, .jm-logo__letters {
+	position: absolute;
+	left: 0;
+	top: 0;
+}
+
+.jm-logo__head {
+	transform: scale(1);
+}
+
+.jm-logo__face, .jm-logo__letters {
+	transform-origin: 50% 50% -60px;
+	transform-style: preserve-3d;
+	backface-visibility: hidden;
+	transition: all 888ms cubic-bezier(.32, 1.29, .9, .98);
+}
+.jm-logo .jm-logo__face {
+	transform: rotateY(-90deg);
+	animation: jm-logo__face 888ms 1000ms cubic-bezier(.32, 1.29, .9, .98) alternate;
+	animation-iteration-count: 2;
+}
+
+.jm-logo .jm-logo__letters {
+	animation: jm-logo__letters 888ms 1000ms cubic-bezier(.32, 1.29, .9, .98) alternate;
+	animation-iteration-count: 2;
+}
+
+.jm-logo__wrapper:hover .jm-logo__face {
+	transform: rotateY(0deg);
+}
+
+.jm-logo__wrapper:hover .jm-logo__letters {
+	transform: rotateY(90deg);
+}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -815,7 +815,6 @@ tr.email-setting-row {
 @media screen and (max-width: 428px ) {
 	.wp_job_manager_add_ons_wrap .wpjm-extensions-filter-search {
 		.extension-search {
-			// display: flex;
 			margin: 0;
 			align-self: auto;
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -637,7 +637,7 @@ a.wpjm-activate-license-link:active {
 			img {
 				width: 48px;
 				height: 48px;
-				object-fit: cover;
+				object-fit: contain;
 				&.wpjm-core-bundle {
 					border-radius: 50%;
 				}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -610,54 +610,76 @@ a.wpjm-activate-license-link:active {
 
 /* Addons */
 .wp_job_manager_add_ons_wrap {
+	max-width: 1244px;
 
 	.products {
-		overflow: hidden;
+		display: flex;
+		flex-wrap: wrap;
+		margin-top: 0;
+		gap: 20px;
+	}
 
-		li {
-			float: left;
-			margin: 0 1em 1em 0 !important;
-			padding: 0;
-			vertical-align: top;
-			width: 350px;
+	.product {
+		display: flex;
+		flex-direction: column;
+		padding: 18px;
+		background: #ffffff;
+		border: 1px solid #cccccc;
+		width: 401px;
+		box-sizing: border-box;
+		gap: 18px;
 
-			a {
-				text-decoration: none;
-				color: inherit;
-				border: 1px solid #ddd;
-				display: block;
-				min-height: 220px;
-				overflow: hidden;
-				background: #f6f6f6;
-				-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
-				box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
-			}
+		.add-on-header {
+			display: flex;
+			flex-direction: row;
+			gap: 16px;
 
 			img {
-				display: inline-block;
-				width: auto;
-				max-height: 60px;
-				max-width: 90px;
-				margin: 0 5px 0 0;
-				float: left;
+				width: 48px;
+				height: 48px;
+				object-fit: cover;
+				&.wpjm-core-bundle {
+					border-radius: 50%;
+				}
 			}
-
-			h2 {
-				margin: 0 !important;
-				padding: 20px !important;
-				background: #fff;
-				height: 20px;
+			.title {
 				font-size: 16px;
+				font-weight: 600;
+				line-height: 24px;
 			}
-
+			a {
+				text-decoration: none;
+			}
+			a.button-secondary {
+				align-self: center;
+				text-decoration: none;
+				padding: 8px 12px;
+				line-height: 1.4em;
+				border-radius: 2px;
+				background: #ffffff;
+			}
+		}
+		.add-on-body {
 			p {
-				padding: 20px !important;
-				margin: 0 !important;
-				border-top: 1px solid #f1f1f1;
+				line-height: 20px;
+				color: #1E1E1E;
 			}
-
-			.price {
-				display: none;
+		}
+		.product-info {
+			flex: 1 1 0;
+			align-self: center;
+		}
+		.add-on-footer {
+			display: flex;
+			flex-direction: row;
+			margin-top: auto;
+			p {
+				margin: 0;
+			}
+			a {
+				align-self: center;
+				text-decoration: none;
+				margin-left: auto;
 			}
 		}
 	}
@@ -725,6 +747,125 @@ tr.email-setting-row {
 
 	td {
 		padding: 5px;
+	}
+}
+/**
+ * Extensions page
+ */
+.wp_job_manager_add_ons_wrap {
+	.wpjm-extensions-filter-search {
+		display: flex;
+		margin-top: 18px;
+		.wpjm-extension-search-input {
+			padding: 9px 12px;
+			border-radius: 2px;
+			line-height: 20px;
+			font-size: 13px;
+		}
+		.wpjm-extension-search-button {
+			padding: 5px 12px;
+			background: #ffffff;
+		}
+		.subsubsub {
+			text-align: left;
+			margin: 0;
+			align-self: end;
+			li {
+				margin: 0 0 6px 0;
+				a {
+					padding: 6px 8px;
+					background: #ffffff;
+					border-radius: 2px;
+					color: #3C434A;
+					font-weight: 400;
+					margin-right: 4px;
+					font-size: 13px;
+					&.current {
+						background: #1E1E1E;
+						color: #ffffff;
+					}
+				}
+			}
+		}
+		.extension-search {
+			margin-left: auto;
+			align-self: center;
+			display: flex;
+		}
+	}
+}
+@media screen and (max-width: 782px) {
+	.wp_job_manager_add_ons_wrap .wpjm-extensions-filter-search {
+		flex-direction: column-reverse;
+		gap: 18px;
+
+		.subsubsub {
+			align-self: start;
+		}
+		.extension-search {
+			margin-right: auto;
+			margin-left: 0;
+		}
+		.wpjm-extension-search-button {
+			padding: 0 15px;
+			margin-bottom: 0;
+		}
+	}
+}
+@media screen and (max-width: 428px ) {
+	.wp_job_manager_add_ons_wrap .wpjm-extensions-filter-search {
+		.extension-search {
+			// display: flex;
+			margin: 0;
+			align-self: auto;
+
+			.wpjm-extension-search-input {
+				flex-basis: 100%;
+				margin-right: 3px;
+			}
+		}
+	}
+}
+
+
+/**
+ * Nav Tabs
+ */
+.nav-tab-wrapper, .wrap h2.nav-tab-wrapper {
+	border-bottom: 0;
+	margin-bottom: 18px;
+}
+.nav-tab {
+	border: none;
+	border-bottom: 3px solid transparent;
+	font-weight: 500;
+	background: none;
+	padding: 5px 0;
+	margin-left: 0;
+	margin-right: 24px;
+	color: #000000;
+	&:hover, &:focus, &:focus:active {
+		background: none;
+	}
+}
+
+h2 .nav-tab-active, nav .nav-tab-active {
+	border-bottom: 3px solid #2270B1;
+	box-sizing: border-box;
+	&:hover, &:focus, &:focus:active {
+		border-bottom: 3px solid #2270B1;
+		box-sizing: border-box;
+	}
+}
+
+@media screen and (max-width: 600px) {
+	h2 {
+		.nav-tab:not(.nav-tab-active) {
+			border-bottom: 3px solid transparent;
+		}
+	}
+	nav .nav-tab:not(.nav-tab-active) {
+		border-bottom: 3px solid transparent;
 	}
 }
 

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -50,7 +50,20 @@ class WP_Job_Manager_Addons {
 	 * @return array of add-ons.
 	 */
 	private function get_add_ons( $category = null, $search_term = null ) {
-		if ( isset( $search_term ) && ! empty( $search_term ) ) {
+
+		if ( ! empty( $search_term ) && ! empty( $category ) ) {
+			$raw_add_ons = wp_remote_get(
+				add_query_arg(
+					[
+						[
+							'term'     => $search_term,
+							'category' => $category,
+						],
+					],
+					self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search'
+				)
+			);
+		} elseif ( ! empty( $search_term ) ) {
 			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'term' => $search_term ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );
 		} else {
 			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'category' => $category ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );
@@ -59,7 +72,7 @@ class WP_Job_Manager_Addons {
 		if ( ! is_wp_error( $raw_add_ons ) && ( 200 === wp_remote_retrieve_response_code( $raw_add_ons ) ) ) {
 			$add_ons = json_decode( wp_remote_retrieve_body( $raw_add_ons ) )->products;
 		}
-		return $add_ons;
+		return $add_ons ?? [];
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -56,7 +56,7 @@ class WP_Job_Manager_Addons {
 			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'category' => $category ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );
 		}
 
-		if ( ! is_wp_error( $raw_add_ons ) ) {
+		if ( ! is_wp_error( $raw_add_ons ) && ( 200 === wp_remote_retrieve_response_code( $raw_add_ons ) ) ) {
 			$add_ons = json_decode( wp_remote_retrieve_body( $raw_add_ons ) )->products;
 		}
 		return $add_ons;

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -50,7 +50,7 @@ class WP_Job_Manager_Addons {
 	 * @return array of add-ons.
 	 */
 	private function get_add_ons( $category = null, $search_term = null ) {
-		if ( isset( $search ) && ! empty( $search_term ) ) {
+		if ( isset( $search_term ) && ! empty( $search_term ) ) {
 			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'term' => $search_term ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );
 		} else {
 			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'category' => $category ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -97,6 +97,28 @@ class WP_Job_Manager_Addons {
 	}
 
 	/**
+	 * Get animated SVG logo.
+	 */
+	public function get_animated_logo() {
+		return '
+		<div class="wp-block-group jm-logo__wrapper is-nowrap is-layout-flex">
+			<div class="jm-logo">
+				<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__head" fill="currentColor" viewBox="0 0 80 80">
+					<path fill-rule="evenodd" d="M40 76c19.882 0 36-16.118 36-36S59.882 4 40 4 4 20.118 4 40s16.118 36 36 36Zm0 4c22.091 0 40-17.909 40-40S62.091 0 40 0 0 17.909 0 40s17.909 40 40 40Z"></path>
+				</svg>
+				<div class="jm-logo__inner">
+					<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__face" fill="currentColor" viewBox="0 0 80 80">
+						<path d="M28.842 41.536a1.611 1.611 0 0 1 2.216.53 10.466 10.466 0 0 0 8.935 5.006c3.778 0 7.09-2 8.935-5.005a1.611 1.611 0 1 1 2.747 1.685 13.689 13.689 0 0 1-11.682 6.543 13.689 13.689 0 0 1-11.682-6.543 1.611 1.611 0 0 1 .531-2.216Zm-.666-18.096a3.223 3.223 0 1 0-6.446 0 3.223 3.223 0 0 0 6.446 0Zm29.274 0a3.223 3.223 0 1 0-6.446 0 3.223 3.223 0 0 0 6.445 0Z"></path>
+					</svg>
+					<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__letters" fill="currentColor" viewBox="0 0 80 80">
+						<path d="M33.6 42.888V28h-7.2v14.888c0 .695-.12 1.184-.358 1.466-.24.282-.576.424-1.01.424-.521 0-.934-.185-1.238-.554-.304-.391-.456-1.054-.456-1.987h-7.135c0 2.953.825 5.201 2.476 6.743 1.65 1.542 3.877 2.313 6.679 2.313 2.606 0 4.626-.706 6.059-2.117 1.455-1.434 2.183-3.53 2.183-6.288ZM62.924 51.2V28h-8.829l-4.952 13.846L44.061 28H35.2v23.2h7.232V39.565L45.983 51.2h6.19l3.551-11.635V51.2h7.2Z"></path>
+					</svg>
+				</div>
+			</div>
+		</div>';
+	}
+
+	/**
 	 * Handles output of the reports page in admin.
 	 */
 	public function output() {

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -44,14 +44,14 @@ class WP_Job_Manager_Addons {
 	 *
 	 * @since  1.30.0
 	 *
-	 * @param  string $category
-	 * @param  string $search
+	 * @param string $category     Category slug.
+	 * @param string $search_term  Search term.
 	 *
 	 * @return array of add-ons.
 	 */
-	private function get_add_ons( $category = null, $search = null ) {
-		if ( isset( $search ) && ! empty( $search ) ) {
-			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'term' => $search ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );
+	private function get_add_ons( $category = null, $search_term = null ) {
+		if ( isset( $search ) && ! empty( $search_term ) ) {
+			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'term' => $search_term ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );
 		} else {
 			$raw_add_ons = wp_remote_get( add_query_arg( [ [ 'category' => $category ] ], self::WPJM_COM_PRODUCTS_API_BASE_URL . '/search' ) );
 		}

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -49,13 +49,7 @@ if ( empty( $add_ons ) ) {
 	echo '<ul class="products">';
 	foreach ( $add_ons as $add_on ) {
 		$class = '';
-
-		if ( 'Core Add-on&nbsp;Bundle' === $add_on->title ) {
-			$add_on->image = 'https://wpjobmanager.com/wp-content/uploads/2023/09/core-bundle-icon.gif';
-			$class         = 'wpjm-core-bundle';
-		}
-
-		$url = add_query_arg(
+		$url   = add_query_arg(
 			[
 				'utm_source'   => 'product',
 				'utm_medium'   => 'addonpage',
@@ -68,9 +62,29 @@ if ( empty( $add_ons ) ) {
 		<li class="product">
 
 			<div class="add-on-header">
-				<?php if ( ! empty( $add_on->image ) ) : ?>
-					<img class="<?php echo esc_attr( $class ); ?>" src="<?php echo esc_url( remove_query_arg( [ 'w', 'h', 'crop' ], $add_on->image ) ); ?>" />
+			<?php if ( 'https://wpjobmanager.com/add-ons/bundle/' === $add_on->link ) : ?>
+					<div class="wp-block-group jm-logo__wrapper is-nowrap is-layout-flex">
+						<div class="jm-logo">
+							<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__head" fill="currentColor" viewBox="0 0 80 80">
+								<path fill-rule="evenodd" d="M40 76c19.882 0 36-16.118 36-36S59.882 4 40 4 4 20.118 4 40s16.118 36 36 36Zm0 4c22.091 0 40-17.909 40-40S62.091 0 40 0 0 17.909 0 40s17.909 40 40 40Z"></path>
+							</svg>
+							<div class="jm-logo__inner">
+								<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__face" fill="currentColor" viewBox="0 0 80 80">
+									<path d="M28.842 41.536a1.611 1.611 0 0 1 2.216.53 10.466 10.466 0 0 0 8.935 5.006c3.778 0 7.09-2 8.935-5.005a1.611 1.611 0 1 1 2.747 1.685 13.689 13.689 0 0 1-11.682 6.543 13.689 13.689 0 0 1-11.682-6.543 1.611 1.611 0 0 1 .531-2.216Zm-.666-18.096a3.223 3.223 0 1 0-6.446 0 3.223 3.223 0 0 0 6.446 0Zm29.274 0a3.223 3.223 0 1 0-6.446 0 3.223 3.223 0 0 0 6.445 0Z"></path>
+								</svg>
+								<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__letters" fill="currentColor" viewBox="0 0 80 80">
+									<path d="M33.6 42.888V28h-7.2v14.888c0 .695-.12 1.184-.358 1.466-.24.282-.576.424-1.01.424-.521 0-.934-.185-1.238-.554-.304-.391-.456-1.054-.456-1.987h-7.135c0 2.953.825 5.201 2.476 6.743 1.65 1.542 3.877 2.313 6.679 2.313 2.606 0 4.626-.706 6.059-2.117 1.455-1.434 2.183-3.53 2.183-6.288ZM62.924 51.2V28h-8.829l-4.952 13.846L44.061 28H35.2v23.2h7.232V39.565L45.983 51.2h6.19l3.551-11.635V51.2h7.2Z"></path>
+								</svg>
+							</div>
+						</div>
+					</div>
+				<?php else : ?>
+					<?php if ( ! empty( $add_on->image ) && 'https://wpjobmanager.com/add-ons/bundle/' !== $add_on->link ) : ?>
+						<img class="<?php echo esc_attr( $class ); ?>" src="<?php echo esc_url( remove_query_arg( [ 'w', 'h', 'crop' ], $add_on->image ) ); ?>" />
+					<?php endif; ?>
 				<?php endif; ?>
+
+
 
 				<div class="product-info">
 					<div class="title"><?php echo esc_html( $add_on->title ); ?></div>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -10,9 +10,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 echo '<h1 class="screen-reader-text">' . esc_html__( 'WP Job Manager Add-ons', 'wp-job-manager' ) . '</h1>';
+echo '<div class="wpjm-extensions-filter-search">';
 if ( ! empty( $categories ) ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 	$current_category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '_all';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
+	if ( isset( $_GET['search'] ) && ! empty( $_GET['search'] ) ) {
+		$current_category = null;
+	}
 	echo '<ul class="subsubsub">';
 	foreach ( $categories as $category ) {
 		?>
@@ -26,7 +31,16 @@ if ( ! empty( $categories ) ) {
 	}
 	echo '</ul>';
 }
+?>
+<form class="extension-search" method="get" action="<?php esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons' ) ); ?>">
+	<input type="hidden" name="post_type" value="job_listing" />
+	<input type="hidden" name="page" value="job-manager-addons" />
+	<input class="wpjm-extension-search-input" type="text" name="search" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php echo esc_attr__( 'Search', 'wp-job-manager' ); ?>" />
+	<input class="wpjm-extension-search-button button" type="submit" value="<?php echo esc_attr__( 'Search', 'wp-job-manager' ); ?>" />
+</form>
+<?php
 
+echo '</div>';
 echo '<br class="clear" />';
 
 if ( empty( $add_ons ) ) {
@@ -34,6 +48,13 @@ if ( empty( $add_ons ) ) {
 } else {
 	echo '<ul class="products">';
 	foreach ( $add_ons as $add_on ) {
+		$class = '';
+
+		if ( 'Core Add-on&nbsp;Bundle' === $add_on->title ) {
+			$add_on->image = 'https://wpjobmanager.com/wp-content/uploads/2023/09/core-bundle-icon.gif';
+			$class         = 'wpjm-core-bundle';
+		}
+
 		$url = add_query_arg(
 			[
 				'utm_source'   => 'product',
@@ -45,17 +66,36 @@ if ( empty( $add_ons ) ) {
 		);
 		?>
 		<li class="product">
-			<a href="<?php echo esc_url( $url, [ 'http', 'https' ] ); ?>">
+
+			<div class="add-on-header">
 				<?php if ( ! empty( $add_on->image ) ) : ?>
-					<img src="<?php echo esc_url( $add_on->image ); ?>" />
+					<img class="<?php echo esc_attr( $class ); ?>" src="<?php echo esc_url( remove_query_arg( [ 'w', 'h', 'crop' ], $add_on->image ) ); ?>" />
 				<?php endif; ?>
-				<h2><?php echo esc_html( $add_on->title ); ?></h2>
-				<p><?php echo esc_html( $add_on->excerpt ); ?>
+
+				<div class="product-info">
+					<div class="title"><?php echo esc_html( $add_on->title ); ?></div>
+					<?php if ( ! empty( $add_on->vendor_name ) && ! empty( $add_on->vendor_link ) ) : ?>
+						<div class="author">By <a target="_blank" href="<?php echo esc_url( $add_on->vendor_link ); ?>"><?php echo esc_html( $add_on->vendor_name ); ?></a></div>
+					<?php endif; ?>
+				</div>
+
+				<a class="button-secondary" target="_blank" href="<?php echo esc_url( $url, [ 'http', 'https' ] ); ?>">Get Extension</a>
+
+			</div>
+
+			<div class="add-on-body">
+				<p><?php echo esc_html( $add_on->excerpt ); ?></p>
+			</div>
+			<div class="add-on-footer">
 				<?php if ( ! empty( $add_on->price ) ) : ?>
-					<span class="price"><?php echo esc_html( $add_on->price ); ?></span>
+					<strong>Paid Add-on</strong>
 				<?php endif; ?>
-				</p>
-			</a>
+
+				<?php if ( ! empty( $add_on->documentation ) ) : ?>
+					<a target="_blank" href="<?php echo esc_url( $add_on->documentation ); ?>">More details</a>
+				<?php endif; ?>
+			</div>
+
 		</li>
 		<?php
 	}

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -15,7 +15,7 @@ if ( ! empty( $categories ) ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 	$current_category = isset( $_GET['category'] ) ? sanitize_text_field( wp_unslash( $_GET['category'] ) ) : '_all';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
-	if ( isset( $_GET['search'] ) && ! empty( $_GET['search'] ) ) {
+	if ( ! empty( $_GET['search'] ) ) {
 		$current_category = null;
 	}
 	echo '<ul class="subsubsub">';

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -89,11 +89,11 @@ if ( empty( $add_ons ) ) {
 				<div class="product-info">
 					<div class="title"><?php echo esc_html( $add_on->title ); ?></div>
 					<?php if ( ! empty( $add_on->vendor_name ) && ! empty( $add_on->vendor_link ) ) : ?>
-						<div class="author">By <a target="_blank" href="<?php echo esc_url( $add_on->vendor_link ); ?>"><?php echo esc_html( $add_on->vendor_name ); ?></a></div>
+						<div class="author"><?php esc_html_e( 'By', 'wp-job-manager' ); ?> <a target="_blank" href="<?php echo esc_url( $add_on->vendor_link ); ?>"><?php echo esc_html( $add_on->vendor_name ); ?></a></div>
 					<?php endif; ?>
 				</div>
 
-				<a class="button-secondary" target="_blank" href="<?php echo esc_url( $url, [ 'http', 'https' ] ); ?>">Get Extension</a>
+				<a class="button-secondary" target="_blank" href="<?php echo esc_url( $url, [ 'http', 'https' ] ); ?>"><?php esc_html_e( 'Get Extension', 'wp-job-manager' ); ?></a>
 
 			</div>
 
@@ -102,11 +102,11 @@ if ( empty( $add_ons ) ) {
 			</div>
 			<div class="add-on-footer">
 				<?php if ( ! empty( $add_on->price ) ) : ?>
-					<strong>Paid Add-on</strong>
+					<strong><?php esc_html_e( 'Paid Add-on', 'wp-job-manager' ); ?></strong>
 				<?php endif; ?>
 
 				<?php if ( ! empty( $add_on->documentation ) ) : ?>
-					<a target="_blank" href="<?php echo esc_url( $add_on->documentation ); ?>">More details</a>
+					<a target="_blank" href="<?php echo esc_url( $add_on->documentation ); ?>"><?php esc_html_e( 'More details', 'wp-job-manager' ); ?></a>
 				<?php endif; ?>
 			</div>
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -48,16 +48,13 @@ if ( empty( $add_ons ) ) {
 } else {
 	echo '<ul class="products">';
 	foreach ( $add_ons as $add_on ) {
-		$class = '';
-		$url   = add_query_arg(
-			[
-				'utm_source'   => 'product',
-				'utm_medium'   => 'addonpage',
-				'utm_campaign' => 'wpjmplugin',
-				'utm_content'  => 'listing',
-			],
-			$add_on->link
-		);
+		$class     = '';
+		$link_args = [
+			'utm_source'   => 'product',
+			'utm_medium'   => 'addonpage',
+			'utm_campaign' => 'wpjmplugin',
+			'utm_content'  => 'listing',
+		];
 		?>
 		<li class="product">
 
@@ -89,11 +86,11 @@ if ( empty( $add_ons ) ) {
 				<div class="product-info">
 					<div class="title"><?php echo esc_html( $add_on->title ); ?></div>
 					<?php if ( ! empty( $add_on->vendor_name ) && ! empty( $add_on->vendor_link ) ) : ?>
-						<div class="author"><?php esc_html_e( 'By', 'wp-job-manager' ); ?> <a target="_blank" href="<?php echo esc_url( $add_on->vendor_link ); ?>"><?php echo esc_html( $add_on->vendor_name ); ?></a></div>
+						<div class="author"><?php esc_html_e( 'By', 'wp-job-manager' ); ?> <a target="_blank" href="<?php echo esc_url( add_query_arg( $link_args, $add_on->vendor_link ) ); ?>"><?php echo esc_html( $add_on->vendor_name ); ?></a></div>
 					<?php endif; ?>
 				</div>
 
-				<a class="button-secondary" target="_blank" href="<?php echo esc_url( $url, [ 'http', 'https' ] ); ?>"><?php esc_html_e( 'Get Extension', 'wp-job-manager' ); ?></a>
+				<a class="button-secondary" target="_blank" href="<?php echo esc_url( add_query_arg( $link_args, $add_on->link ), [ 'http', 'https' ] ); ?>"><?php esc_html_e( 'Get Extension', 'wp-job-manager' ); ?></a>
 
 			</div>
 
@@ -106,7 +103,7 @@ if ( empty( $add_ons ) ) {
 				<?php endif; ?>
 
 				<?php if ( ! empty( $add_on->documentation ) ) : ?>
-					<a target="_blank" href="<?php echo esc_url( $add_on->documentation ); ?>"><?php esc_html_e( 'More details', 'wp-job-manager' ); ?></a>
+					<a target="_blank" href="<?php echo esc_url( add_query_arg( $link_args, $add_on->documentation ) ); ?>"><?php esc_html_e( 'More details', 'wp-job-manager' ); ?></a>
 				<?php endif; ?>
 			</div>
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -60,21 +60,10 @@ if ( empty( $add_ons ) ) {
 
 			<div class="add-on-header">
 			<?php if ( 'https://wpjobmanager.com/add-ons/bundle/' === $add_on->link ) : ?>
-					<div class="wp-block-group jm-logo__wrapper is-nowrap is-layout-flex">
-						<div class="jm-logo">
-							<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__head" fill="currentColor" viewBox="0 0 80 80">
-								<path fill-rule="evenodd" d="M40 76c19.882 0 36-16.118 36-36S59.882 4 40 4 4 20.118 4 40s16.118 36 36 36Zm0 4c22.091 0 40-17.909 40-40S62.091 0 40 0 0 17.909 0 40s17.909 40 40 40Z"></path>
-							</svg>
-							<div class="jm-logo__inner">
-								<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__face" fill="currentColor" viewBox="0 0 80 80">
-									<path d="M28.842 41.536a1.611 1.611 0 0 1 2.216.53 10.466 10.466 0 0 0 8.935 5.006c3.778 0 7.09-2 8.935-5.005a1.611 1.611 0 1 1 2.747 1.685 13.689 13.689 0 0 1-11.682 6.543 13.689 13.689 0 0 1-11.682-6.543 1.611 1.611 0 0 1 .531-2.216Zm-.666-18.096a3.223 3.223 0 1 0-6.446 0 3.223 3.223 0 0 0 6.446 0Zm29.274 0a3.223 3.223 0 1 0-6.446 0 3.223 3.223 0 0 0 6.445 0Z"></path>
-								</svg>
-								<svg xmlns="http://www.w3.org/2000/svg" class="jm-logo__letters" fill="currentColor" viewBox="0 0 80 80">
-									<path d="M33.6 42.888V28h-7.2v14.888c0 .695-.12 1.184-.358 1.466-.24.282-.576.424-1.01.424-.521 0-.934-.185-1.238-.554-.304-.391-.456-1.054-.456-1.987h-7.135c0 2.953.825 5.201 2.476 6.743 1.65 1.542 3.877 2.313 6.679 2.313 2.606 0 4.626-.706 6.059-2.117 1.455-1.434 2.183-3.53 2.183-6.288ZM62.924 51.2V28h-8.829l-4.952 13.846L44.061 28H35.2v23.2h7.232V39.565L45.983 51.2h6.19l3.551-11.635V51.2h7.2Z"></path>
-								</svg>
-							</div>
-						</div>
-					</div>
+				<?php
+					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo ( new WP_Job_Manager_Addons() )->get_animated_logo();
+				?>
 				<?php else : ?>
 					<?php if ( ! empty( $add_on->image ) && 'https://wpjobmanager.com/add-ons/bundle/' !== $add_on->link ) : ?>
 						<img class="<?php echo esc_attr( $class ); ?>" src="<?php echo esc_url( remove_query_arg( [ 'w', 'h', 'crop' ], $add_on->image ) ); ?>" />


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2583

### Changes Proposed in this Pull Request

* New design for Add-on cards
* New Search Bar at top
* New top tab design (also for Settings page)

### Testing Instructions

* This PR depends on API updates to wpjobmanager.com - take a look at these PRs ( https://github.com/Automattic/wpjobmanager.com/pull/656 and https://github.com/Automattic/wpjobmanager.com/pull/665)
* If you don't use those updated PRs then the things you will miss are the new Category Filters and the Add-on cards won't have complete information (missing Vendor name, Vendor Link and Documentation link)

* Look at responsive screens and make sure it looks good for small devices
* Inspect the Extension cards to make sure logos / text looks good
* Ensure Search works as expected
* Check to see if WPJM -> Settings looks good with updated tab design
* Make sure the filtering works for the Add-ons

### Release Notes

* Update Add-ons (now Marketplace) page with new design to better highlight our paid extensions.
* Updated settings tab design

### Screenshot / Video

![extension-page](https://github.com/Automattic/WP-Job-Manager/assets/3220162/666cc02b-1081-48c3-a930-12a84b2b35d8)



















<!-- wpjm:plugin-zip -->
----

| Plugin build for 3fae4d1c710e0efcd90d6440cc77a507b3875550 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2595-3fae4d1c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2595-3fae4d1c)             |

<!-- /wpjm:plugin-zip -->




























