### PR TITLE
Prepend slash to url

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -82,7 +82,7 @@ class WP_Job_Manager_Helper_API {
 	public function plugin_information( $args ) {
 		$args = wp_parse_args( $args );
 		$data = $this->request_endpoint(
-			'wp-json/wpjmcom-licensing/v1/plugin-information',
+			'/wp-json/wpjmcom-licensing/v1/plugin-information',
 			[
 				'method' => 'GET',
 				'body'   => [
@@ -92,6 +92,7 @@ class WP_Job_Manager_Helper_API {
 				],
 			]
 		);
+
 		if ( ! is_array( $data ) ) {
 			return false;
 		}
@@ -177,7 +178,7 @@ class WP_Job_Manager_Helper_API {
 	public function deactivate( $args ) {
 		$args     = wp_parse_args( $args );
 		$response = $this->request_endpoint(
-			'wp-json/wpjmcom-licensing/v1/deactivate',
+			'/wp-json/wpjmcom-licensing/v1/deactivate',
 			[
 				'method' => 'POST',
 				'body'   => wp_json_encode(

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -793,7 +793,7 @@ class WP_Job_Manager_Helper {
 				$this->activate_license( $product_slug, $license_key, '' );
 				break;
 			case 'deactivate':
-				$this->deactivate_license( $product_slug );
+				$this->deactivate_license( $product_slug, true );
 				break;
 		}
 	}
@@ -901,13 +901,18 @@ class WP_Job_Manager_Helper {
 			$this->add_error( $product_slug, __( 'license is not active.', 'wp-job-manager' ) );
 			return;
 		}
-		$this->api->deactivate(
+		$response = $this->api->deactivate(
 			[
 				'api_product_id' => $product_slug,
 				'license_key'    => $license['license_key'],
 				'email'          => $license['email'],
 			]
 		);
+
+		if ( false === $response ) {
+			$this->add_error( $product_slug, __( 'There was an error while deactivating the plugin.', 'wp-job-manager' ) );
+			return;
+		}
 
 		WP_Job_Manager_Helper_Options::delete( $product_slug, 'license_key' );
 		WP_Job_Manager_Helper_Options::delete( $product_slug, 'email' );


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Fixes a regression that was introduced after merging the job promotion feature PR
*  was changed in the feature branch to remove the slash causing the recently introduced changes on deactivation and plugin information to not work.
* I also added a few things in deactivation:
   * On failure a notice is displayed
   * On success a success message is displayed.

### Testing Instructions

* Follow testing instructions in https://github.com/Automattic/WP-Job-Manager/pull/2588#event-10539911106 and in https://github.com/Automattic/WP-Job-Manager/pull/2585#event-10539905211 and make sure that they work now.
* Deactivate a plugin and make sure that a notice appears
* Make the deactivation request to fail (by removing a slash for example 😛 ) and check the failure notice.

@fjorgemota would be great to merge this before the release. Good thing that we had tests and caught this!

<!-- wpjm:plugin-zip -->
----

| Plugin build for 191fb1c0c1bbdcec3f19ad8848d4b07f1d511319 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2598-191fb1c0.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2598-191fb1c0)             |

<!-- /wpjm:plugin-zip -->
