### PR TITLE
 Release WP Job Manager 1.42.0 (Fix 2)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     name: WPJM Release
     steps:
+      - uses: actions/checkout@v2
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: gh pr comment ${{ github.event.number }} --body "🚀 Starting release ..."
-      - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'


### PR DESCRIPTION
> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version to WPJobManager.com and the WordPress.com store.
>

## WP Job Manager - Alerts 2.1.0

> [!NOTE]
> These release notes between the two  lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Fix: Fix my-alerts.php template HTML
* Fix: Make 'Add alert' link relative
* Fix: Fix redirection after actions on My alerts page
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WPJobManager.com
> - Create a GitHub release in the add-on repo that will be automatically deployed to the WordPress.com store.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 398ce1b846074075d754a316cf283c9952075887 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2603-398ce1b8.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2603-398ce1b8)             |

<!-- /wpjm:plugin-zip -->
