### PR TITLE
Do not check for plugin updates when there are no plugins

### DIFF
--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -250,7 +250,11 @@ class WP_Job_Manager_Helper {
 	 */
 	public function check_for_updates( $check_for_updates_data ) {
 		$installed_plugins = $this->get_installed_plugins( false, true );
-		$updates           = $this->get_plugin_update_info( $installed_plugins );
+		if ( empty( $installed_plugins ) ) {
+			return $check_for_updates_data;
+		}
+
+		$updates = $this->get_plugin_update_info( $installed_plugins );
 
 		$notice_data = [];
 


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Only sends plugin update requests when there are first-party plugins installed

### Testing Instructions

* Install Query Monitor. Test with no other WPJM plugins installed (activated or not).
* Clear all network/site transients.
* Ensure requests aren't made to https://wpjobmanager.com/wp-json/wpjmcom-licensing/v1/updates
* Add a first party add on.
* Observe a request is made to the `/updates` endpoint.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 678169ca88f8bbb165d45a5f9649e488481b47d6 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2605-678169ca.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2605-678169ca)             |

<!-- /wpjm:plugin-zip -->
