### PR TITLE
Add Applications and Resumes upsell pages

### DIFF
--- a/assets/css/admin-landing.scss
+++ b/assets/css/admin-landing.scss
@@ -1,0 +1,101 @@
+@import './wpjm-brand';
+
+.wpjm-landing {
+
+	&,
+	& * {
+		box-sizing: border-box;
+	}
+
+	& {
+		background: var(--wpjm-brand-color-shade-2);
+		border-radius: 2px;
+		padding: fluid(60, 20) fluid(80, 20);
+		display: flex;
+		gap: fluid(60, 20);
+		position: relative;
+		margin: fluid(32, 18) auto;
+		font-size: 14px;
+		color: #000;
+		flex-wrap: wrap;
+		align-items: center;
+		max-width: 1400px;
+	}
+
+	&__heading {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	&__left, &__right {
+		flex: 1;
+		min-width: min(100%, 400px);
+	}
+
+	&__left {
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+		align-items: flex-start;
+		justify-content: flex-start;
+		position: relative;
+	}
+
+	&__addon-logo {
+		flex-shrink: 0;
+		width: 60px;
+		height: 60px;
+		position: relative;
+	}
+
+	&__content {
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+		align-items: flex-start;
+		justify-content: flex-start;
+		flex: 1;
+		position: relative;
+		* {
+			margin: unset;
+		}
+		//max-width: 450px;
+		&, & p {
+			font-size: 14px;
+		}
+	}
+
+	&__title {
+		font-weight: 700;
+		font-size: 40px;
+		line-height: 120%;
+		letter-spacing: -0.8px;
+		margin: unset;
+	}
+	&__subtitle {
+		font-weight: 700;
+		font-size: 22px;
+		letter-spacing: -0.47px;
+		margin-top: -10px;
+	}
+
+	&__buttons {
+		margin-top: 10px;
+		display: flex;
+		gap: 20px;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		> * {
+			flex: 1;
+			white-space: nowrap;
+		}
+	}
+
+	&__right {
+	}
+	&__visual {
+		max-width: min(100%, 700px);
+	}
+}

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -20,4 +20,15 @@
 			content: "\e806";
 		}
 	}
+
+	li a[href="edit.php?post_type=job_listing&page=job-manager-landing-application"],
+	li a[href="edit.php?post_type=job_listing&page=job-manager-landing-resumes"],
+	{
+		border: solid 0 #5D6264;
+		border-width: 1px 0;
+		padding: 8px 12px 8px 12px !important;
+		margin-top: -1px;
+		position: relative;
+		top: 1px;
+	}
 }

--- a/assets/css/wpjm-brand.scss
+++ b/assets/css/wpjm-brand.scss
@@ -1,0 +1,75 @@
+:root {
+	--wpjm-brand-color-primary: #2404EB;
+	--wpjm-brand-color-secondary: #EDD00E;
+	--wpjm-brand-color-tertiary: #5842DE;
+	--wpjm-brand-color-shade-1: #F1F4F9;
+	--wpjm-brand-color-shade-2: #EBE8FF;
+	--wpjm-brand-color-shade-3: #D9E1FF;
+	--wpjm-brand-color-shade-4: #FFEF82;
+	--wpjm-brand-color-shade-5: #FFFCE8;
+	--wpjm-brand-sizing-scale: clamp(0px, (100vw - 400px) / (1200 - 400), 1px);
+}
+
+@function fluid($desktop, $mobile) {
+	@return calc(var(--wpjm-brand-sizing-scale) * (#{$desktop} - #{$mobile}) + #{$mobile}px);
+}
+
+.wpjm-button {
+
+	border-radius: 2px;
+	padding: 8px 12px;
+	font-size: 14px;
+	line-height: 20px;
+	display: flex;
+	gap: 10px;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid transparent;
+	text-decoration: none;
+
+	background: var(--wpjm-brand-color-primary);
+	color: #ffffff;
+
+	&:hover {
+		background: #1D00D0;
+		color: #ffffff;
+	}
+
+	&.is-outline {
+		background: transparent;
+		color: var(--wpjm-brand-color-primary);
+		border-color: currentColor;
+
+		&:hover {
+			background: var(--wpjm-brand-color-shade-3);
+			color: var(--wpjm-brand-color-primary);
+		}
+	}
+
+	&.is-link {
+		background: transparent;
+		color: var(--wpjm-brand-color-primary);
+
+		&:hover {
+			background: var(--wpjm-brand-color-shade-3);
+			color: var(--wpjm-brand-color-primary);
+		}
+	}
+
+	&.is-disabled {
+		filter: grayscale(1);
+		pointer-events: none;
+	}
+
+}
+
+.wpjm-list-checkmarks {
+	padding-left: 20px;
+	list-style-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='15' height='11' fill='none' viewBox='0 0 15 11'%3e%3cpath fill='black' d='M5.03 10.6 0 5.55 1.06 4.5l3.97 3.97L13.5 0l1.06 1.06'/%3e%3c/svg%3e");
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	li {
+		padding-left: 8px;
+	}
+}

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -47,10 +47,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_menu_items' ], 12 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ], 20 );
-
 		WP_Job_Manager::register_style( 'job_manager_admin_landing_css', 'css/admin-landing.css', [ 'job_manager_brand' ] );
-
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -47,13 +47,23 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_menu_items' ], 12 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_styles' ] );
+	}
+
+	/**
+	 * Register styles for landing pages.
+	 *
+	 * @access private
+	 * @since $$next-version$$
+	 */
+	public function register_styles() {
 		WP_Job_Manager::register_style( 'job_manager_admin_landing_css', 'css/admin-landing.css', [ 'job_manager_brand' ] );
 	}
 
 	/**
 	 * Add add-on menu items if needed.
 	 *
-	 * @access public
+	 * @access private
 	 * @since $$next-version$$
 	 */
 	public function add_menu_items() {
@@ -104,7 +114,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	/**
 	 * Render Applications landing page.
 	 *
-	 * @access public
+	 * @access private
 	 * @since $$next-version$$
 	 */
 	public function applications_landing_page() {
@@ -112,6 +122,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 		wp_enqueue_style( 'job_manager_admin_landing_css' );
 
 		$dismiss_action = 'dismiss_applications_landing_page';
+		$link           = 'https://wpjobmanager.com/add-ons/applications/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=applications';
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Nonce check.
 		if ( isset( $_GET[ $dismiss_action ] ) && wp_verify_nonce( $_GET['_wpnonce'] ?? null, $dismiss_action ) ) {
@@ -147,7 +158,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 						</p>
 						<ul class="wpjm-list-checkmarks">
 							<li>
-								<?php esc_html_e( 'Apply to jobs via forms and store applications', 'wp-job-manager' ); ?>
+								<?php esc_html_e( 'Apply to jobs via forms and save applications', 'wp-job-manager' ); ?>
 							</li>
 							<li>
 								<?php esc_html_e( 'List applications in the employer job and admin dashboard', 'wp-job-manager' ); ?>
@@ -161,11 +172,13 @@ class WP_Job_Manager_Addons_Landing_Page {
 
 					<div class="wpjm-landing__buttons">
 						<a class="wpjm-button"
-							href="https://wpjobmanager.com/add-ons/applications/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=applications">
+							target="_blank"
+							href="<?php echo esc_url( $link ); ?>">
 							<?php esc_html_e( 'Get Applications', 'wp-job-manager' ); ?>
 						</a>
 						<a class="wpjm-button is-link"
-							href="https://wpjobmanager.com/add-ons/applications/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=applications">
+							target="_blank"
+							href="<?php echo esc_url( $link ); ?>">
 							<?php esc_html_e( 'See all features', 'wp-job-manager' ); ?>
 						</a>
 					</div>
@@ -184,7 +197,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	/**
 	 * Render Resume Manager landing page.
 	 *
-	 * @access public
+	 * @access private
 	 * @since $$next-version$$
 	 */
 	public function resumes_landing_page() {
@@ -192,6 +205,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 		wp_enqueue_style( 'job_manager_admin_landing_css' );
 
 		$dismiss_action = 'dismiss_resumes_landing_page';
+		$link           = 'https://wpjobmanager.com/add-ons/resume-manager/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=resumes';
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Nonce check.
 		if ( isset( $_GET[ $dismiss_action ] ) && wp_verify_nonce( $_GET['_wpnonce'] ?? null, $dismiss_action ) ) {
@@ -241,11 +255,13 @@ class WP_Job_Manager_Addons_Landing_Page {
 
 					<div class="wpjm-landing__buttons">
 						<a class="wpjm-button"
-							href="https://wpjobmanager.com/add-ons/resume-manager/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=resumes">
+							target="_blank"
+							href="<?php echo esc_url( $link ); ?>">
 							<?php esc_html_e( 'Get Resume Manager', 'wp-job-manager' ); ?>
 						</a>
 						<a class="wpjm-button is-link"
-							href="https://wpjobmanager.com/add-ons/resume-manager/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=resumes">
+							target="_blank"
+							href="<?php echo esc_url( $link ); ?>">
 							<?php esc_html_e( 'See all features', 'wp-job-manager' ); ?>
 						</a>
 					</div>
@@ -258,8 +274,5 @@ class WP_Job_Manager_Addons_Landing_Page {
 			</div>
 		</div>
 		<?php
-
 	}
-
-
 }

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * File WP_Job_Manager_Addons_Landing_Page class.
+ *
+ * @package wp-job-manager
+ * @since $$next-version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Landing pages for Applications and Resumes add-ons.
+ *
+ * @since $$next-version$$
+ */
+class WP_Job_Manager_Addons_Landing_Page {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var self
+	 * @since  $$next-version$$
+	 */
+	private static $instance = null;
+
+	/**
+	 * Singleton accessor.
+	 *
+	 * @since  $$next-version$$
+	 * @static
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize class for landing pages.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'add_menu_items' ], 12 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ], 20 );
+
+		WP_Job_Manager::register_style( 'job_manager_admin_landing_css', 'css/admin-landing.css', [ 'job_manager_brand' ] );
+
+	}
+
+	/**
+	 * Add add-on menu items if needed.
+	 *
+	 * @access public
+	 * @since $$next-version$$
+	 */
+	public function add_menu_items() {
+
+		$parent_page = 'edit.php?post_type=job_listing';
+		$badge_text  = __( 'Pro', 'wp-job-manager' );
+
+		/**
+		 * Filters whether the 'Applications' landing page should be added to the Job Manager menu.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $show True if the menu should be added.
+		 */
+		if ( apply_filters( 'job_manager_addon_upsell_applications', ! get_option( 'job_manager_addon_upsell_applications' ) ) ) {
+
+			add_submenu_page(
+				$parent_page,
+				__( 'WP Job Manager - Applications', 'wp-job-manager' ),
+				sprintf( '%s <span class="awaiting-mod wpjm-addon-upsell__badge">%s</span>', __( 'Applications', 'wp-job-manager' ), $badge_text ),
+				'manage_options',
+				'job-manager-landing-application',
+				[ $this, 'applications_landing_page' ]
+			);
+		}
+
+		/**
+		 * Filters whether the 'Resumes' landing page should be added to the Job Manager menu.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $show True if the menu should be added.
+		 */
+		if ( apply_filters( 'job_manager_addon_upsell_resumes', ! get_option( 'job_manager_addon_upsell_resumes' ) ) ) {
+
+			add_submenu_page(
+				$parent_page,
+				__( 'WP Job Manager - Resumes', 'wp-job-manager' ),
+				sprintf( '%s <span class="awaiting-mod wpjm-addon-upsell__badge">%s</span>', __( 'Resumes', 'wp-job-manager' ), $badge_text ),
+				'manage_options',
+				'job-manager-landing-resumes',
+				[ $this, 'resumes_landing_page' ]
+			);
+		}
+
+	}
+
+	/**
+	 * Render Applications landing page.
+	 *
+	 * @access public
+	 * @since $$next-version$$
+	 */
+	public function applications_landing_page() {
+
+		wp_enqueue_style( 'job_manager_admin_landing_css' );
+
+		$dismiss_action = 'dismiss_applications_landing_page';
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Nonce check.
+		if ( isset( $_GET[ $dismiss_action ] ) && wp_verify_nonce( $_GET['_wpnonce'] ?? null, $dismiss_action ) ) {
+			update_option( 'job_manager_addon_upsell_applications', 'hide' );
+			wp_safe_redirect( admin_url( 'edit.php?post_type=job_listing' ) );
+			exit;
+		}
+
+		?>
+		<div class="wrap">
+			<div class="wpjm-landing__heading">
+				<h1 class="wp-heading-inline">
+					<?php esc_html_e( 'Applications', 'wp-job-manager' ); ?>
+				</h1>
+				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( $dismiss_action, 'true' ), $dismiss_action ) ); ?>">
+					<?php esc_html_e( 'Dismiss', 'wp-job-manager' ); ?>
+				</a>
+			</div>
+			<div class="wpjm-landing">
+				<div class="wpjm-landing__left">
+					<img class="wpjm-landing__addon-logo"
+						alt="<?php esc_html_e( 'Applications add-on logo', 'wp-job-manager' ); ?>"
+						src="https://wpjobmanager.com/wp-content/uploads/2014/07/Applications.png" />
+					<div class="wpjm-landing__content">
+						<h2 class="wpjm-landing__title">
+							<?php esc_html_e( 'Applications', 'wp-job-manager' ); ?>
+						</h2>
+						<h2 class="wpjm-landing__subtitle">
+							<?php esc_html_e( '$79.00 USD / year (one site)', 'wp-job-manager' ); ?>
+						</h2>
+						<p>
+							<?php esc_html_e( 'Allow candidates to apply to jobs using a form &amp; employers to view and manage the applications from their job dashboard.', 'wp-job-manager' ); ?>
+						</p>
+						<ul class="wpjm-list-checkmarks">
+							<li>
+								<?php esc_html_e( 'Apply to jobs via forms and store applications', 'wp-job-manager' ); ?>
+							</li>
+							<li>
+								<?php esc_html_e( 'List applications in the employer job and admin dashboard', 'wp-job-manager' ); ?>
+							</li>
+							<li>
+								<?php esc_html_e( 'Privately rate and comment on applications', 'wp-job-manager' ); ?>
+							</li>
+						</ul>
+
+					</div>
+
+					<div class="wpjm-landing__buttons">
+						<a class="wpjm-button"
+							href="https://wpjobmanager.com/add-ons/applications/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=applications">
+							<?php esc_html_e( 'Get Applications', 'wp-job-manager' ); ?>
+						</a>
+						<a class="wpjm-button is-link"
+							href="https://wpjobmanager.com/add-ons/applications/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=applications">
+							<?php esc_html_e( 'See all features', 'wp-job-manager' ); ?>
+						</a>
+					</div>
+				</div>
+
+				<div class="wpjm-landing__right">
+					<img class="wpjm-landing__visual"
+						src="https://wpjobmanager.com/wp-content/uploads/2023/10/Applications-upsell.png" />
+				</div>
+			</div>
+		</div>
+		<?php
+
+	}
+
+	/**
+	 * Render Resume Manager landing page.
+	 *
+	 * @access public
+	 * @since $$next-version$$
+	 */
+	public function resumes_landing_page() {
+
+		wp_enqueue_style( 'job_manager_admin_landing_css' );
+
+		$dismiss_action = 'dismiss_resumes_landing_page';
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Nonce check.
+		if ( isset( $_GET[ $dismiss_action ] ) && wp_verify_nonce( $_GET['_wpnonce'] ?? null, $dismiss_action ) ) {
+			update_option( 'job_manager_addon_upsell_resumes', 'hide' );
+			wp_safe_redirect( admin_url( 'edit.php?post_type=job_listing' ) );
+			exit;
+		}
+
+		?>
+		<div class="wrap">
+			<div class="wpjm-landing__heading">
+				<h1 class="wp-heading-inline">
+					<?php esc_html_e( 'Resume Manager', 'wp-job-manager' ); ?>
+				</h1>
+				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( $dismiss_action, 'true' ), $dismiss_action ) ); ?>">
+					<?php esc_html_e( 'Dismiss', 'wp-job-manager' ); ?>
+				</a>
+			</div>
+			<div class="wpjm-landing">
+				<div class="wpjm-landing__left">
+					<img class="wpjm-landing__addon-logo"
+						alt="<?php esc_html_e( 'Resume Manager add-on logo', 'wp-job-manager' ); ?>"
+						src="https://wpjobmanager.com/wp-content/uploads/2014/02/Resumes.png" />
+					<div class="wpjm-landing__content">
+						<h2 class="wpjm-landing__title">
+							<?php esc_html_e( 'Resume Manager', 'wp-job-manager' ); ?>
+						</h2>
+						<h2 class="wpjm-landing__subtitle">
+							<?php esc_html_e( '$49.00 USD / year (one site)', 'wp-job-manager' ); ?>
+						</h2>
+						<p>
+							<?php esc_html_e( 'Resume Manager is a plugin built on top of WP Job Manager which adds a resume submission form to your site and resume listings, all manageable from WordPress admin.', 'wp-job-manager' ); ?>
+						</p>
+						<ul class="wpjm-list-checkmarks">
+							<li>
+								<?php esc_html_e( 'Post resumes to your site and apply to jobs with the resumes', 'wp-job-manager' ); ?>
+							</li>
+							<li>
+								<?php esc_html_e( 'List resumes, restricting access to certain user roles if you wish', 'wp-job-manager' ); ?>
+							</li>
+							<li>
+								<?php esc_html_e( 'Restrict which user roles can view candidate contact details', 'wp-job-manager' ); ?>
+							</li>
+						</ul>
+
+					</div>
+
+					<div class="wpjm-landing__buttons">
+						<a class="wpjm-button"
+							href="https://wpjobmanager.com/add-ons/resume-manager/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=resumes">
+							<?php esc_html_e( 'Get Resume Manager', 'wp-job-manager' ); ?>
+						</a>
+						<a class="wpjm-button is-link"
+							href="https://wpjobmanager.com/add-ons/resume-manager/?utm_source=plugin_wp-job-manager&utm_medium=upsell&utm_campaign=resumes">
+							<?php esc_html_e( 'See all features', 'wp-job-manager' ); ?>
+						</a>
+					</div>
+				</div>
+
+				<div class="wpjm-landing__right">
+					<img class="wpjm-landing__visual"
+						src="https://wpjobmanager.com/wp-content/uploads/2023/10/ResumeManager-upsell.png" />
+				</div>
+			</div>
+		</div>
+		<?php
+
+	}
+
+
+}

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -60,8 +60,10 @@ class WP_Job_Manager_Admin {
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-settings.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-writepanels.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-setup.php';
+		include_once dirname( __FILE__ ) . '/class-wp-job-manager-addons-landing-page.php';
 
 		$this->settings_page = WP_Job_Manager_Settings::instance();
+		WP_Job_Manager_Addons_Landing_Page::instance();
 
 		add_action( 'admin_init', [ $this, 'admin_init' ] );
 		add_action( 'current_screen', [ $this, 'conditional_includes' ] );
@@ -96,6 +98,8 @@ class WP_Job_Manager_Admin {
 	 */
 	public function admin_enqueue_scripts() {
 		WP_Job_Manager::register_select2_assets();
+
+		WP_Job_Manager::register_style( 'job_manager_brand', 'css/wpjm-brand.css', [] );
 
 		$screen = get_current_screen();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,8 @@ const files = {
 	'js/admin/wpjm-notice-dismiss': 'js/admin/wpjm-notice-dismiss.js',
 	'css/admin': 'css/admin.scss',
 	'css/admin-notices': 'css/admin-notices.scss',
+	'css/admin-landing': 'css/admin-landing.scss',
+	'css/wpjm-brand': 'css/wpjm-brand.scss',
 	'css/frontend': 'css/frontend.scss',
 	'css/job-listings': 'css/job-listings.scss',
 	'css/job-submission': 'css/job-submission.scss',


### PR DESCRIPTION
Fixes: https://github.com/Automattic/WP-Job-Manager/pull/2614
### Changes Proposed in this Pull Request

* Add a new class registering and rendering the new pages
* Add menu items to the Job Manager menu
* Add filter and option to hide the pages (ie when their plugins are installed)
* Add a **job_manager_brand** style that contains some common CSS for the branded parts we are adding, like buttons and colors
* Some tweaks compared to the design:
  * Removed the 'Add New' button as adding applications/resumes on the backend is not really a thing
  * Added dismiss option
  * Simpler copy for the secondary button
  * Resumes → Resume Manager as that's the official name
  * Both buttons link to the product page for now

### Testing Instructions

* Checkout branch, build CSS with npm run start | [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2614-52e83bdf&url=/wp-admin/edit.php?post_type=job_listing)
* Check that menu items are added
* Check their content looks right and all links work
* Check the pages can be dismissed

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Add new info pages for the Applications and Resume Manager extensions.

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* *job_manager_addon_upsell_applications* - set to false to hide Applications info page
* *job_manager_addon_upsell_resumes* - set to false to hide Resumes info page

### Screenshot / Video

![image](https://github.com/Automattic/WP-Job-Manager/assets/176949/4a00fcdd-2d28-4e36-87ca-7717db566c6e)

![image](https://github.com/Automattic/WP-Job-Manager/assets/176949/886c0727-4db4-42dd-b290-437c3ec48977)



<!-- wpjm:plugin-zip -->
----

| Plugin build for 29b83855d5f78bc2b2aa333e88e65ae1972003cd <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2614-29b83855.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2614-29b83855)             |

<!-- /wpjm:plugin-zip -->






