### PR TITLE
Fix plugin zip workflow

### DIFF
--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -83,7 +83,7 @@ async function uploadZip() {
 
 	const headers  = `"Content-Disposition: attachment; filename=\"wp-job-manager-zip-${ id }.zip\""`;
 	const url      = `${ MEDIA_LIBRARY_ENDPOINT }?title=wp-job-manager-zip-${ id }`;
-	const response = await $`curl -u ${ login } --http1.1 --data-binary @wp-job-manager.zip -H ${ headers } ${ url }`.quiet();
+	const response = await $`curl -s -u ${ login } --http1.1 --data-binary @wp-job-manager.zip -H ${ headers } ${ url }`.quiet();
 
 	const uploadedFileUrl = JSON.parse( response.toString() )?.source_url?.replaceAll( '"', '' ).trim();
 	if ( ! uploadedFileUrl ) {

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -1,4 +1,7 @@
-import chalk from 'chalk';
+#!/usr/bin/env zx
+
+import 'zx/globals'
+
 import { execSync } from "node:child_process";
 import process from "node:process";
 import { parseArgs } from "node:util";
@@ -17,44 +20,43 @@ const MEDIA_LIBRARY_ENDPOINT = "https://wpjobmanager.com/wp-json/wp/v2/media"
 
 const login = env.WPJMCOM_API_LOGIN;
 
-( function main() {
+if ( ! login ) {
+	console.log( 'WPJobManager.com secrets not available, exiting.' );
+	process.exit( 0 );
+}
 
-	if ( ! login ) {
-		console.log( 'WPJobManager.com secrets not available, exiting.' );
-		process.exit( 0 );
-	}
+try {
+	await deleteOldZips();
+} catch ( error ) {
+	console.log( 'Failed to delete old plugin zips.' );
+	console.log( error.message );
+	console.log( error.stack );
+	process.exit( 1 );
+}
 
-	try {
-		deleteOldZips();
-	} catch ( error ) {
-		console.log( 'Failed to delete old plugin zips.' );
-		console.log( error.message );
-		console.log( error.stack );
-		process.exit( 1 );
-	}
+if ( merged ) {
+	return;
+}
 
-	if ( merged ) {
-		return;
-	}
-
-	try {
-		const zip = uploadZip();
-		addLinksToPR( zip );
-	} catch ( error ) {
-		console.log( 'Failed to upload plugin zip.' );
-		console.log( error.message );
-		console.log( error.stack );
-		process.exit( 1 );
-	}
-
-} )();
+try {
+	const zip = await uploadZip();
+	await addLinksToPR( zip );
+} catch ( error ) {
+	console.log( 'Failed to upload plugin zip.' );
+	console.log( error.message );
+	console.log( error.stack );
+	process.exit( 1 );
+}
 
 /**
  * Remove previously uploaded plugin zip files for the PR.
  */
-function deleteOldZips() {
+async function deleteOldZips() {
 
-	const oldZips = JSON.parse( execSync( `curl -s -u "${ login }" "${ MEDIA_LIBRARY_ENDPOINT }?mime_type=application/zip&_fields=id,date,title,source_url"` ).toString() );
+	const url      = `${ MEDIA_LIBRARY_ENDPOINT }?mime_type=application/zip&_fields=id,date,title,source_url`;
+	const response = await $`curl -s -u ${ login } ${ url }`;
+
+	const oldZips = JSON.parse( response.toString() );
 	if ( oldZips?.code || ! Array.isArray( oldZips ) ) {
 		console.log( `[${ oldZips.code }]`, oldZips.message );
 		return;
@@ -62,9 +64,10 @@ function deleteOldZips() {
 	oldZips?.forEach( ( zip ) => {
 		const
 			title = zip.title.rendered;
-		if ( title.startsWith( `wp-job-manager-zip-${pr}-`  ) ) {
+		if ( title.startsWith( `wp-job-manager-zip-${ pr }-` ) ) {
 			console.log( `Deleting old plugin build ${ title }.zip` );
-			execSync( `curl -s -u "${ login }" -X DELETE "${ MEDIA_LIBRARY_ENDPOINT }/${ zip.id }?force=true"` );
+			const deleteUrl = `${ MEDIA_LIBRARY_ENDPOINT }/${ zip.id }?force=true`;
+			$`curl -s -u ${ login } -X DELETE ${ deleteUrl }`;
 		}
 	} )
 }
@@ -72,21 +75,23 @@ function deleteOldZips() {
 /**
  * Upload plugin zip to media library.
  *
- * @returns {string} URL to plugin zip file.
+ * @returns {Promise<string>} URL to plugin zip file.
  */
-function uploadZip() {
+async function uploadZip() {
 
 	const id = `${ pr }-${ commit.substring( 0, 8 ) }`;
 
-	const response = execSync( `curl -u "${ login }" --http1.1 --data-binary @wp-job-manager.zip -H "Content-Disposition: attachment; filename=\"wp-job-manager-zip-${ id }.zip\"" ${ MEDIA_LIBRARY_ENDPOINT }?title=wp-job-manager-zip-${ id }` ).toString();
+	const headers  = `"Content-Disposition: attachment; filename=\"wp-job-manager-zip-${ id }.zip\""`;
+	const url      = `${ MEDIA_LIBRARY_ENDPOINT }?title=wp-job-manager-zip-${ id }`;
+	const response = await $`curl -u ${ login } --http1.1 --data-binary @wp-job-manager.zip -H ${ headers } ${ url }`;
 
-	const zip = JSON.parse( response )?.source_url?.replaceAll( '"', '' ).trim();
-	if ( ! zip ) {
+	const uploadedFileUrl = JSON.parse( response.toString() )?.source_url?.replaceAll( '"', '' ).trim();
+	if ( ! uploadedFileUrl ) {
 		throw new Error( response );
 	}
-	console.log( chalk.green( '✓' ), `Plugin file uploaded to ${ zip }` )
+	console.log( chalk.green( '✓' ), `Plugin file uploaded to ${ uploadedFileUrl }` )
 
-	return zip;
+	return uploadedFileUrl;
 }
 
 /**
@@ -94,7 +99,7 @@ function uploadZip() {
  *
  * @param {string} zip URL to plugin zip file.
  */
-function addLinksToPR( zip ) {
+async function addLinksToPR( zip ) {
 
 	const [ , path, id ] = zip.match( 'wp-content/uploads/(.*)/wp-job-manager-zip-(.*).zip' );
 	const playgroundLink = `https://wpjobmanager.com/playground/?core=${ path }/${ id }`
@@ -111,10 +116,10 @@ function addLinksToPR( zip ) {
 <!-- /wpjm:plugin-zip -->
 `;
 
-	let body = execSync( `gh pr view ${ pr } --json body --jq .body` ).toString();
+	let body = await $`gh pr view ${ pr } --json body --jq .body`;
 
-	body = body.replace( /((<!-- wpjm:plugin-zip -->([\s\S]*)<!-- \/wpjm:plugin-zip -->)|$)/, links );
+	body = body.toString().replace( /((<!-- wpjm:plugin-zip -->([\s\S]*)<!-- \/wpjm:plugin-zip -->)|$)/, links );
 
-	execSync( `gh pr edit ${ pr } --body "${ body.replaceAll( '"', '\\"' ) }"`, { stdio: 'inherit' } )
+	await $`gh pr edit ${ pr } --body ${ body }`;
 	console.log( chalk.green( '✓' ), 'Plugin build links added to PR.' );
 }

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -35,7 +35,7 @@ try {
 }
 
 if ( merged ) {
-	return;
+	process.exit( 0 );
 }
 
 try {

--- a/scripts/upload-and-link-plugin-zip.mjs
+++ b/scripts/upload-and-link-plugin-zip.mjs
@@ -81,7 +81,7 @@ async function uploadZip() {
 
 	const id = `${ pr }-${ commit.substring( 0, 8 ) }`;
 
-	const headers  = `"Content-Disposition: attachment; filename=\"wp-job-manager-zip-${ id }.zip\""`;
+	const headers  = `Content-Disposition: attachment; filename="wp-job-manager-zip-${ id }.zip"`;
 	const url      = `${ MEDIA_LIBRARY_ENDPOINT }?title=wp-job-manager-zip-${ id }`;
 	const response = await $`curl -s -u ${ login } --http1.1 --data-binary @wp-job-manager.zip -H ${ headers } ${ url }`.quiet();
 


### PR DESCRIPTION

### Changes Proposed in this Pull Request

* Use zx to escape shell commands better

### Testing Instructions

* Add `code` and hope it doesn't break
* See Plugin Build / Plugin Build (pull_request) check


<!-- wpjm:plugin-zip -->
----

| Plugin build for 027ab53c0fc1c39339d28fde3b7c3e2e7e11fa5e <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2615-027ab53c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2615-027ab53c)             |

<!-- /wpjm:plugin-zip -->
