### PR TITLE
Add array initialization to avoid warning

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -547,6 +547,8 @@ class WP_Job_Manager_CPT {
 			unset( $actions['inline hide-if-no-js'] );
 			unset( $actions['trash'] );
 
+			$admin_actions = [];
+
 			if ( in_array( $post->post_status, [ 'pending', 'pending_payment' ], true ) && current_user_can( 'publish_post', $post->ID ) ) {
 				$admin_actions['approve'] = [
 					'action' => 'approved',


### PR DESCRIPTION
Reported here: p1697436278049289-slack-C6GGX896G

When you display trashed listings in admin, a warning is displayed.

### Changes Proposed in this Pull Request

* Add array initialization.

### Testing Instructions

* Trash a listing and visit the listings in admin.
* Observe that a warning is not displayed.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 026cf295c3b009182f93ba2a52e86830cd358b5a <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2619-026cf295.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2619-026cf295)             |

<!-- /wpjm:plugin-zip -->
