### PR TITLE
Rename "addons" to "marketplace" on the UI and URL

### DIFF
--- a/includes/admin/class-notices-conditions-checker.php
+++ b/includes/admin/class-notices-conditions-checker.php
@@ -25,7 +25,7 @@ class Notices_Conditions_Checker {
 		'edit-job_listing',
 		'edit-job_listing_category',
 		'edit-job_listing_type',
-		'job_listing_page_job-manager-addons',
+		'job_listing_page_job-manager-marketplace',
 		'job_listing_page_job-manager-settings',
 	];
 

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -125,7 +125,7 @@ class WP_Job_Manager_Addons {
 		?>
 		<div class="wrap wp_job_manager wp_job_manager_add_ons_wrap">
 			<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons' ) ); ?>" class="nav-tab
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace' ) ); ?>" class="nav-tab
 									<?php
 									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 									if ( ! isset( $_GET['section'] ) || 'helper' !== $_GET['section'] ) {
@@ -134,7 +134,7 @@ class WP_Job_Manager_Addons {
 									?>
 				"><?php esc_html_e( 'WP Job Manager Marketplace', 'wp-job-manager' ); ?></a>
 				<?php if ( current_user_can( 'update_plugins' ) ) : ?>
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper' ) ); ?>" class="nav-tab
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace&section=helper' ) ); ?>" class="nav-tab
 									<?php
 									// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
 									if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {

--- a/includes/admin/class-wp-job-manager-addons.php
+++ b/includes/admin/class-wp-job-manager-addons.php
@@ -191,7 +191,7 @@ class WP_Job_Manager_Addons {
 					}
 					?>
 				">
-					<?php esc_html_e( 'WP Job Manager Marketplace', 'wp-job-manager' ); ?>
+					<?php esc_html_e( 'Marketplace', 'wp-job-manager' ); ?>
 				</a>
 				<?php if ( current_user_can( 'update_plugins' ) ) : ?>
 					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace&section=helper' ) ); ?>"

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -365,7 +365,7 @@ class WP_Job_Manager_Admin_Notices {
 				'edit-job_listing',
 				'edit-job_listing_category',
 				'edit-job_listing_type',
-				'job_listing_page_job-manager-addons',
+				'job_listing_page_job-manager-marketplace',
 				'job_listing_page_job-manager-settings',
 			],
 			$additional_screens

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -182,12 +182,12 @@ class WP_Job_Manager_Admin {
 		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), __( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', [ $this->settings_page, 'output' ] );
 
 		if ( WP_Job_Manager_Helper::instance()->has_licensed_products() || apply_filters( 'job_manager_show_addons_page', true ) ) {
-			add_submenu_page( 'edit.php?post_type=job_listing', __( 'WP Job Manager Marketplace', 'wp-job-manager' ), __( 'Marketplace', 'wp-job-manager' ), 'manage_options', 'job-manager-addons', [ $this, 'addons_page' ] );
+			add_submenu_page( 'edit.php?post_type=job_listing', __( 'WP Job Manager Marketplace', 'wp-job-manager' ), __( 'Marketplace', 'wp-job-manager' ), 'manage_options', 'job-manager-marketplace', [ $this, 'addons_page' ] );
 		}
 	}
 
 	/**
-	 * Displays addons page.
+	 * Displays marketplace page.
 	 */
 	public function addons_page() {
 		$addons = include 'class-wp-job-manager-addons.php';

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -103,7 +103,7 @@ class WP_Job_Manager_Admin {
 
 		$screen = get_current_screen();
 
-		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', [ 'edit-job_listing', 'plugins', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-addons', 'edit-job_listing_type' ] ), true ) ) {
+		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', [ 'edit-job_listing', 'plugins', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-marketplace', 'edit-job_listing_type' ] ), true ) ) {
 
 			wp_enqueue_style( 'jquery-ui' );
 			wp_enqueue_style( 'select2' );

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -23,7 +23,7 @@ if ( ! empty( $categories ) ) {
 		?>
 		<li>
 			<a class="<?php echo $current_category === $category->slug ? 'current' : ''; ?>"
-				href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&category=' . esc_attr( $category->slug ) ) ); ?>">
+				href="<?php echo esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace&category=' . esc_attr( $category->slug ) ) ); ?>">
 				<?php echo esc_html( $category->label ); ?>
 			</a>
 		</li>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the view for displaying the list of add-ons available to extend WP Job Manager.
+ * File containing the view for displaying the list of extensions available to extend WP Job Manager.
  *
  * @package wp-job-manager
  */
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo '<h1 class="screen-reader-text">' . esc_html__( 'WP Job Manager Add-ons', 'wp-job-manager' ) . '</h1>';
+echo '<h1 class="screen-reader-text">' . esc_html__( 'WP Job Manager Marketplace', 'wp-job-manager' ) . '</h1>';
 echo '<div class="wpjm-extensions-filter-search">';
 if ( ! empty( $categories ) ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -44,7 +44,7 @@ echo '</div>';
 echo '<br class="clear" />';
 
 if ( empty( $add_ons ) ) {
-	echo '<div class="notice notice-warning below-h2"><p><strong>' . esc_html__( 'No add-ons were found.', 'wp-job-manager' ) . '</strong></p></div>';
+	echo '<div class="notice notice-warning below-h2"><p><strong>' . esc_html__( 'No extensions were found.', 'wp-job-manager' ) . '</strong></p></div>';
 } else {
 	echo '<ul class="products">';
 	foreach ( $add_ons as $add_on ) {

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -487,7 +487,7 @@ class WP_Job_Manager_Helper {
 			$manage_license_label = __( 'Activate License', 'wp-job-manager' );
 			$css_class            = 'wpjm-activate-license-link';
 		}
-		$actions[] = '<a class="' . esc_attr( $css_class ) . '" href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper' ) ) . '">' . esc_html( $manage_license_label ) . '</a>';
+		$actions[] = '<a class="' . esc_attr( $css_class ) . '" href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace&section=helper' ) ) . '">' . esc_html( $manage_license_label ) . '</a>';
 
 		return $actions;
 	}
@@ -1074,7 +1074,7 @@ class WP_Job_Manager_Helper {
 				// translators: %1$s is the URL to the license key page, %2$s is the plugin name.
 					__( '<a href="%1$s">Please enter your license key</a> to get updates for "%2$s".', 'wp-job-manager' )
 				),
-				esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) ),
+				esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace&section=helper#' . sanitize_title( $product_slug . '_row' ) ) ),
 				esc_html( $plugin_data['Name'] )
 			),
 		];
@@ -1107,7 +1107,7 @@ class WP_Job_Manager_Helper {
 					__( 'There is a problem with the license for "%1$s". Please <a href="%2$s">manage the license</a> to check for a solution and continue receiving updates.', 'wp-job-manager' )
 				),
 				esc_html( $plugin_data['Name'] ),
-				esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons&section=helper#' . sanitize_title( $product_slug . '_row' ) ) )
+				esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace&section=helper#' . sanitize_title( $product_slug . '_row' ) ) )
 			),
 		];
 		$notices[ 'wpjm_license_error_notice_' . $product_slug ] = $notice;

--- a/readme.txt
+++ b/readme.txt
@@ -31,15 +31,15 @@ The plugin comes with several shortcodes to output jobs in various formats, and 
 
 = Documentation =
 
-Documentation for the core plugin and add-ons can be found [on the docs site here](https://wpjobmanager.com/documentation/). Please take a look before requesting support because it covers all frequently asked questions!
+Documentation for the core plugin and extensions can be found [on the docs site here](https://wpjobmanager.com/documentation/). Please take a look before requesting support because it covers all frequently asked questions!
 
-= Add-ons =
+= Extensions =
 
 The core WP Job Manager plugin is free and always will be. It covers all functionality we consider 'core' to running a simple job board site.
 
-Additional, advanced functionality is available through add-ons. Not only do these extend the usefulness of the core plugin, they also help fund the development and support of core.
+Additional, advanced functionality is available through extensions. Not only do these extend the usefulness of the core plugin, they also help fund the development and support of core.
 
-You can browse available add-ons after installing the plugin by going to `Job Listings > Add-ons`. Our popular add-ons include:
+You can browse available extensions after installing the plugin by going to `WP Job Manager > Marketplace`. Our popular extensions include:
 
 **[Applications](https://wpjobmanager.com/add-ons/applications/)**
 
@@ -57,9 +57,9 @@ Resume Manager is a plugin built on top of WP Job Manager which adds a resume su
 
 Allow registered users to save their job searches and create alerts which send new jobs via email daily, weekly or fortnightly.
 
-**[Core add-on bundle](https://wpjobmanager.com/add-ons/bundle/)**
+**[WPJM Pro Bundle](https://wpjobmanager.com/add-ons/bundle/)**
 
-You can get the above add-ons and several others at discount with our [Core Add-on Bundle](https://wpjobmanager.com/add-ons/bundle/). Take a look!
+You can get the above extensions and several others at discount with our [WPJM Pro Bundle](https://wpjobmanager.com/add-ons/bundle/). Take a look!
 
 = Contributing and reporting bugs =
 
@@ -71,7 +71,7 @@ Thanks to all of our contributors.
 
 Use the WordPress.org forums for community support where we try to help all users. If you spot a bug, you can log it (or fix it) on [Github](https://github.com/Automattic/WP-Job-Manager) where we can act upon them more efficiently.
 
-If you need help with one of our add-ons, [please raise a ticket in our help desk](https://wpjobmanager.com/support/).
+If you need help with one of our extensions, [please raise a ticket in our help desk](https://wpjobmanager.com/support/).
 
 If you want help with a customization, please consider hiring a developer! [http://jobs.wordpress.net/](http://jobs.wordpress.net/) is a good place to start.
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ Resume Manager is a plugin built on top of WP Job Manager which adds a resume su
 
 Allow registered users to save their job searches and create alerts which send new jobs via email daily, weekly or fortnightly.
 
-**[WPJM Pro Bundle](https://wpjobmanager.com/add-ons/bundle/)**
+**[Job Manager Pro Bundle](https://wpjobmanager.com/add-ons/bundle/)**
 
 You can get the above extensions and several others at discount with our [WPJM Pro Bundle](https://wpjobmanager.com/add-ons/bundle/). Take a look!
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ The core WP Job Manager plugin is free and always will be. It covers all functio
 
 Additional, advanced functionality is available through extensions. Not only do these extend the usefulness of the core plugin, they also help fund the development and support of core.
 
-You can browse available extensions after installing the plugin by going to `WP Job Manager > Marketplace`. Our popular extensions include:
+You can browse available extensions after installing the plugin by going to `Job Manager > Marketplace`. Our popular extensions include:
 
 **[Applications](https://wpjobmanager.com/add-ons/applications/)**
 


### PR DESCRIPTION
Fixes #2616

### Changes Proposed in this Pull Request

* Change every URL and UI reference from "add-ons"  to "marketplace" (or "extensions", where appropriate)
  * This change doesn't change any filenames, classes, method, functions or hook names

### Testing Instructions

Navigate WPJM and make sure all links to the previous addons page still works correctly. Check notices and various possible references to the pages.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

- Use "extensions" instead of "add-ons" on the URLs and UI

### Screenshot / Video






<!-- wpjm:plugin-zip -->
----

| Plugin build for 67a7b6f8d1d96474704eaff86f6e819e50c38bf0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/10/wp-job-manager-zip-2622-67a7b6f8.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/10/2622-67a7b6f8)             |

<!-- /wpjm:plugin-zip -->








