### PR TITLE
Fix Incorrectly duplicated string in settings

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -272,7 +272,7 @@ class WP_Job_Manager_Settings {
 							'std'        => '0',
 							'label'      => __( 'Salary Unit', 'wp-job-manager' ),
 							'cb_label'   => __( 'Enable Job Salary Unit Customization', 'wp-job-manager' ),
-							'desc'       => __( 'This lets users add a salary currency when submitting a job.', 'wp-job-manager' ),
+							'desc'       => __( 'This lets users add a salary unit when submitting a job.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
 						],


### PR DESCRIPTION
Fixes #2609

### Changes Proposed in this Pull Request
* Fixes incorrectly duplicated string in settings and adjust it to a text that matches the setting

### Testing Instructions

1. Go to /wp-admin/edit.php?post_type=job_listing&page=job-manager-settings#settings-job_listings
2. Scroll down to Salary Currency / Salary Unit
3. see if the description text for salary currency and salary unit is now different

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes
* Fixes incorrectly duplicated string in settings

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video
