### PR TITLE
Escape menu & post type labels

### DIFF
--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -86,8 +86,8 @@ class WP_Job_Manager_Addons_Landing_Page {
 				__( 'WP Job Manager - Applications', 'wp-job-manager' ),
 				sprintf(
 					'%s <span class="awaiting-mod wpjm-addon-upsell__badge">%s</span>',
-					__( 'Applications', 'wp-job-manager' ),
-					__( 'Pro', 'wp-job-manager' )
+					esc_html__( 'Applications', 'wp-job-manager' ),
+					esc_html__( 'Pro', 'wp-job-manager' )
 				),
 				'manage_options',
 				'job-manager-landing-application',
@@ -120,8 +120,8 @@ class WP_Job_Manager_Addons_Landing_Page {
 				__( 'WP Job Manager - Resumes', 'wp-job-manager' ),
 				sprintf(
 					'%s <span class="awaiting-mod wpjm-addon-upsell__badge">%s</span>',
-					__( 'Resumes', 'wp-job-manager' ),
-					__( 'Pro', 'wp-job-manager' )
+					esc_html__( 'Resumes', 'wp-job-manager' ),
+					esc_html__( 'Pro', 'wp-job-manager' )
 				),
 				'manage_options',
 				'job-manager-landing-resumes',

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -178,11 +178,11 @@ class WP_Job_Manager_Admin {
 		remove_submenu_page( 'edit.php?post_type=job_listing', 'post-new.php?post_type=job_listing' );
 		$item = remove_submenu_page( 'edit.php?post_type=job_listing', 'edit.php?post_type=job_listing' );
 		// change item label to "Job Listings".
-		add_submenu_page( 'edit.php?post_type=job_listing', $item[0], __( 'Job Listings', 'wp-job-manager' ), $item[1], $item[2], '', 0 );
-		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), __( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', [ $this->settings_page, 'output' ] );
+		add_submenu_page( 'edit.php?post_type=job_listing', $item[0], esc_html__( 'Job Listings', 'wp-job-manager' ), $item[1], $item[2], '', 0 );
+		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), esc_html__( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', [ $this->settings_page, 'output' ] );
 
 		if ( WP_Job_Manager_Helper::instance()->has_licensed_products() || apply_filters( 'job_manager_show_addons_page', true ) ) {
-			add_submenu_page( 'edit.php?post_type=job_listing', __( 'WP Job Manager Marketplace', 'wp-job-manager' ), __( 'Marketplace', 'wp-job-manager' ), 'manage_options', 'job-manager-addons', [ $this, 'addons_page' ] );
+			add_submenu_page( 'edit.php?post_type=job_listing', __( 'WP Job Manager Marketplace', 'wp-job-manager' ), esc_html__( 'Marketplace', 'wp-job-manager' ), 'manage_options', 'job-manager-addons', [ $this, 'addons_page' ] );
 		}
 	}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -331,36 +331,36 @@ class WP_Job_Manager_Post_Types {
 					'labels'                => [
 						'name'                  => $plural,
 						'singular_name'         => $singular,
-						'menu_name'             => __( 'Job Manager', 'wp-job-manager' ),
+						'menu_name'             => esc_html__( 'Job Manager', 'wp-job-manager' ),
 						// translators: Placeholder %s is the plural label of the job listing post type.
-						'all_items'             => sprintf( __( 'All %s', 'wp-job-manager' ), $plural ),
-						'add_new'               => __( 'Add New', 'wp-job-manager' ),
+						'all_items'             => sprintf( esc_html__( 'All %s', 'wp-job-manager' ), $plural ),
+						'add_new'               => esc_html__( 'Add New', 'wp-job-manager' ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'add_new_item'          => sprintf( __( 'Add %s', 'wp-job-manager' ), $singular ),
-						'edit'                  => __( 'Edit', 'wp-job-manager' ),
+						'add_new_item'          => sprintf( esc_html__( 'Add %s', 'wp-job-manager' ), $singular ),
+						'edit'                  => esc_html__( 'Edit', 'wp-job-manager' ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'edit_item'             => sprintf( __( 'Edit %s', 'wp-job-manager' ), $singular ),
+						'edit_item'             => sprintf( esc_html__( 'Edit %s', 'wp-job-manager' ), $singular ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'new_item'              => sprintf( __( 'New %s', 'wp-job-manager' ), $singular ),
+						'new_item'              => sprintf( esc_html__( 'New %s', 'wp-job-manager' ), $singular ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'view'                  => sprintf( __( 'View %s', 'wp-job-manager' ), $singular ),
+						'view'                  => sprintf( esc_html__( 'View %s', 'wp-job-manager' ), $singular ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'view_item'             => sprintf( __( 'View %s', 'wp-job-manager' ), $singular ),
+						'view_item'             => sprintf( esc_html__( 'View %s', 'wp-job-manager' ), $singular ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'search_items'          => sprintf( __( 'Search %s', 'wp-job-manager' ), $plural ),
+						'search_items'          => sprintf( esc_html__( 'Search %s', 'wp-job-manager' ), $plural ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'not_found'             => sprintf( __( 'No %s found', 'wp-job-manager' ), $plural ),
+						'not_found'             => sprintf( esc_html__( 'No %s found', 'wp-job-manager' ), $plural ),
 						// translators: Placeholder %s is the plural label of the job listing post type.
-						'not_found_in_trash'    => sprintf( __( 'No %s found in trash', 'wp-job-manager' ), $plural ),
+						'not_found_in_trash'    => sprintf( esc_html__( 'No %s found in trash', 'wp-job-manager' ), $plural ),
 						// translators: Placeholder %s is the singular label of the job listing post type.
-						'parent'                => sprintf( __( 'Parent %s', 'wp-job-manager' ), $singular ),
-						'featured_image'        => __( 'Company Logo', 'wp-job-manager' ),
-						'set_featured_image'    => __( 'Set company logo', 'wp-job-manager' ),
-						'remove_featured_image' => __( 'Remove company logo', 'wp-job-manager' ),
-						'use_featured_image'    => __( 'Use as company logo', 'wp-job-manager' ),
+						'parent'                => sprintf( esc_html__( 'Parent %s', 'wp-job-manager' ), $singular ),
+						'featured_image'        => esc_html__( 'Company Logo', 'wp-job-manager' ),
+						'set_featured_image'    => esc_html__( 'Set company logo', 'wp-job-manager' ),
+						'remove_featured_image' => esc_html__( 'Remove company logo', 'wp-job-manager' ),
+						'use_featured_image'    => esc_html__( 'Use as company logo', 'wp-job-manager' ),
 					],
 					// translators: Placeholder %s is the plural label of the job listing post type.
-					'description'           => sprintf( __( 'This is where you can create and manage %s.', 'wp-job-manager' ), $plural ),
+					'description'           => sprintf( esc_html__( 'This is where you can create and manage %s.', 'wp-job-manager' ), $plural ),
 					'public'                => true,
 					'show_ui'               => true,
 					'capability_type'       => 'job_listing',
@@ -434,7 +434,7 @@ class WP_Job_Manager_Post_Types {
 
 		// Try to pull menu_name from post type object to support themes/plugins that change the menu string.
 		$post_type = get_post_type_object( 'job_listing' );
-		$plural    = isset( $post_type->labels, $post_type->labels->menu_name ) ? $post_type->labels->menu_name : __( 'Job Listings', 'wp-job-manager' );
+		$plural    = isset( $post_type->labels, $post_type->labels->menu_name ) ? $post_type->labels->menu_name : esc_html__( 'Job Listings', 'wp-job-manager' );
 
 		foreach ( $menu as $key => $menu_item ) {
 			if ( strpos( $menu_item[0], $plural ) === 0 ) {


### PR DESCRIPTION

### Changes Proposed in this Pull Request

* Make sure translatable submenu labels are escaped
* Also escape post type labels as some of them are rendered raw by WP core

### Testing Instructions

* Navigate to the Job Manager menu and through the Job listing pages, make sure text is not broken

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix: Escape menu titles and various admin labels



<!-- wpjm:plugin-zip -->
----

| Plugin build for 0ad8bec74c2a6a366ab27b6de96d146dae7e250d <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2630-0ad8bec7.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2630-0ad8bec7)             |

<!-- /wpjm:plugin-zip -->


