### PR TITLE
Safeguard array in WP_Job_Manager_Settings::input_capabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "squizlabs/php_codesniffer": "3.7.2",
     "wp-coding-standards/wpcs": "2.3.0",
     "sirbrillig/phpcs-variable-analysis": "^2.6",
-    "yoast/phpunit-polyfills": "1.0.2"
+    "yoast/phpunit-polyfills": "^1.0.2"
   },
   "archive": {
     "exclude": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ad1aa9c624a2f0d31d5a060bf9e19a6",
+    "content-hash": "1cd3fe71485fe28c6a5db70db65239f2",
     "packages": [],
     "packages-dev": [
         {
@@ -2158,16 +2158,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
-                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2175,13 +2175,12 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "yoast/yoastcs": "^2.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -2215,7 +2214,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-10-03T08:40:26+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -2230,5 +2229,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -1073,6 +1073,10 @@ class WP_Job_Manager_Settings {
 	 * @param string   $ignored_placeholder We set the placeholder in the method. This is ignored.
 	 */
 	protected function input_capabilities( $option, $attributes, $value, $ignored_placeholder ) {
+		if ( ! is_array( $value ) ) {
+			$value = [ $value ];
+		}
+
 		$option['options']     = self::get_capabilities_and_roles( $value );
 		$option['placeholder'] = esc_html__( 'Everyone (Public)', 'wp-job-manager' );
 
@@ -1131,17 +1135,16 @@ class WP_Job_Manager_Settings {
 	 * @param array $caps Selected capabilities to ensure they show up in the list.
 	 * @return array
 	 */
-	private static function get_capabilities_and_roles( $caps = [] ) {
+	private static function get_capabilities_and_roles( array $caps = [] ) {
 		$capabilities_and_roles = [];
 		$roles                  = get_editable_roles();
 
 		foreach ( $roles as $key => $role ) {
 			$capabilities_and_roles[ $key ] = $role['name'];
 		}
-
 		// Go through custom user selected capabilities and add them to the list.
 		foreach ( $caps as $value ) {
-			if ( isset( $capabilities_and_roles[ $value ] ) ) {
+			if ( ! is_string( $value ) || empty( $value ) || isset( $capabilities_and_roles[ $value ] ) ) {
 				continue;
 			}
 			$capabilities_and_roles[ $value ] = $value;

--- a/tests/php/includes/stubs/class-wp-job-manager-admin-settings-stub.php
+++ b/tests/php/includes/stubs/class-wp-job-manager-admin-settings-stub.php
@@ -1,0 +1,17 @@
+<?php
+
+class WP_Job_Manager_Admin_Settings_Stub extends WP_Job_Manager_Settings {
+	private static $instance = null;
+
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	public function test_input_capabilities( $option, $attributes, $value ) {
+		return $this->input_capabilities( $option, $attributes, $value, '' );
+	}
+}
+

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-settings.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-settings.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-settings.php';
+require_once WPJM_Unit_Tests_Bootstrap::instance()->includes_dir . '/stubs/class-wp-job-manager-admin-settings-stub.php';
+
+class WP_Test_WP_Job_Manager_Settings extends WPJM_BaseTest {
+
+	public function test_input_capabilities_should_not_fail_on_invalid_capabilities_provided() {
+		$stub = WP_Job_Manager_Admin_Settings_Stub::instance();
+
+		$values_to_test = array(
+			null,
+			0,
+			'',
+			'invalid',
+			array(),
+			new stdClass(),
+		);
+
+		$this->setOutputCallback( function() {} );
+		$this->expectNotToPerformAssertions();
+
+		foreach ( $values_to_test as $value ) {
+			$stub->test_input_capabilities( [ 'name' => 'test' ], [], $value );
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes #2625 

### Changes Proposed in this Pull Request

This PR adds safeguard in input_capabilities to avoid invalid capabilities to be passed to get_capabilities_and_roles.
It also adds data type safeguard in get_capabilities_and_roles in order to avoid invalid array access.
Lastly, it also updates yoast/phpunit-polyfills in composer.json/lock in order to make the tests compatible with the latest PHPUnit version.

### Testing Instructions

* Install the test suite as described in tests/README.md
* Run isolated test `vendor/bin/phpunit --filter WP_Test_WP_Job_Manager_Settings`
* ✅ The test should pass
* Also run full test suite `vendor/bin/phpunit`
* ✅ All tests should pass
* Go to the settings page `wp-admin/edit.php?post_type=job_listing&page=job-manager-settings#settings-general`
* ✅ Make sure the settings are still displayed properly and that no new errors appear in the logs


<!-- wpjm:plugin-zip -->
----

| Plugin build for eb532dcedd200b53d07ee7b67d8bf9716a39a3a4 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2631-eb532dce.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2631-eb532dce)             |

<!-- /wpjm:plugin-zip -->


