### PR TITLE
Add Salary Range Field & JobSchema to WPJM

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1618,7 +1618,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => (bool) get_option( 'job_manager_enable_salary' ),
 				'show_in_rest'  => true,
 			],
-			'_job_salary_max'          => [
+			'_job_salary_max'	=> [
 				'label'         => __( 'Salary (max)', 'wp-job-manager' ),
 				'type'          => 'text',
 				'placeholder'   => __( 'e.g. 25000', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1618,7 +1618,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => (bool) get_option( 'job_manager_enable_salary' ),
 				'show_in_rest'  => true,
 			],
-			'_job_salary_max'	=> [
+			'_job_salary_max'      => [
 				'label'         => __( 'Salary (max)', 'wp-job-manager' ),
 				'type'          => 'text',
 				'placeholder'   => __( 'e.g. 25000', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -700,6 +700,7 @@ class WP_Job_Manager_Post_Types {
 		$company   = get_the_company_name( $post_id );
 		$job_types = wpjm_get_the_job_types( $post_id );
 		$salary    = get_the_job_salary( $post_id );
+		$salarymax = get_the_job_salary_max( $post_id );
 
 		if ( $location ) {
 			echo '<job_listing:location><![CDATA[' . esc_html( $location ) . "]]></job_listing:location>\n";
@@ -713,6 +714,9 @@ class WP_Job_Manager_Post_Types {
 		}
 		if ( $salary ) {
 			echo '<job_listing:salary><![CDATA[' . esc_html( $salary ) . "]]></job_listing:salary>\n";
+		}
+		if ( $salarymax ) {
+			echo '<job_listing:salarymax><![CDATA[' . esc_html( $salarymax ) . "]]></job_listing:salarymax>\n";
 		}
 
 		/**
@@ -1605,11 +1609,21 @@ class WP_Job_Manager_Post_Types {
 				'show_in_rest'  => true,
 			],
 			'_job_salary'          => [
-				'label'         => __( 'Salary', 'wp-job-manager' ),
+				'label'         => __( 'Salary / Salary (min)', 'wp-job-manager' ),
 				'type'          => 'text',
 				'placeholder'   => __( 'e.g. 20000', 'wp-job-manager' ),
 				'priority'      => 13,
 				'description'   => __( 'Add a salary field, this field is optional.', 'wp-job-manager' ),
+				'data_type'     => 'string',
+				'show_in_admin' => (bool) get_option( 'job_manager_enable_salary' ),
+				'show_in_rest'  => true,
+			],
+			'_job_salary_max'          => [
+				'label'         => __( 'Salary (max)', 'wp-job-manager' ),
+				'type'          => 'text',
+				'placeholder'   => __( 'e.g. 25000', 'wp-job-manager' ),
+				'priority'      => 14,
+				'description'   => __( 'Add a max salary field, this field is optional.', 'wp-job-manager' ),
 				'data_type'     => 'string',
 				'show_in_admin' => (bool) get_option( 'job_manager_enable_salary' ),
 				'show_in_rest'  => true,
@@ -1619,7 +1633,7 @@ class WP_Job_Manager_Post_Types {
 				'type'          => 'text',
 				'data_type'     => 'string',
 				'placeholder'   => __( 'e.g. USD', 'wp-job-manager' ),
-				'priority'      => 14,
+				'priority'      => 15,
 				'description'   => __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency.', 'wp-job-manager' ),
 				'default'       => '',
 				'show_in_admin' => get_option( 'job_manager_enable_salary' ) && get_option( 'job_manager_enable_salary_currency' ),
@@ -1630,7 +1644,7 @@ class WP_Job_Manager_Post_Types {
 				'type'          => 'select',
 				'data_type'     => 'string',
 				'options'       => job_manager_get_salary_unit_options(),
-				'priority'      => 15,
+				'priority'      => 16,
 				'description'   => __( 'Add a salary period unit, this field is optional. Leave it empty to use the default salary unit, if one is defined.', 'wp-job-manager' ),
 				'default'       => '',
 				'show_in_admin' => get_option( 'job_manager_enable_salary' ) && get_option( 'job_manager_enable_salary_unit' ),

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -371,7 +371,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				unset( $this->fields['job']['job_salary_unit'] );
 			}
 		} else {
-			unset( $this->fields['job']['job_salary'], $this->fields['job']['job_salary_currency'], $this->fields['job']['job_salary_unit'] );
+			unset( $this->fields['job']['job_salary'], $this->fields['job']['job_salary_max'], $this->fields['job']['job_salary_currency'], $this->fields['job']['job_salary_unit'] );
 		}
 		if ( ! get_option( 'job_manager_enable_remote_position' ) ) {
 			unset( $this->fields['job']['remote_position'] );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -282,12 +282,12 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'e.g. 20000', 'wp-job-manager' ),
 						'priority'    => 8,
 					],
-					'job_salary_max'          => [
-						'label'         => __( 'Salary (max)', 'wp-job-manager' ),
-						'type'          => 'text',
-						'required'    => false,
-						'placeholder'   => __( 'e.g. 25000', 'wp-job-manager' ),
-						'priority'      => 9,
+					'job_salary_max'	=> [
+						'label'			=> __( 'Salary (max)', 'wp-job-manager' ),
+						'type'			=> 'text',
+						'required'		=> false,
+						'placeholder'	=> __( 'e.g. 25000', 'wp-job-manager' ),
+						'priority'		=> 9,
 					],
 					'job_salary_currency' => [
 						'label'       => __( 'Salary Currency', 'wp-job-manager' ),

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -282,12 +282,12 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'e.g. 20000', 'wp-job-manager' ),
 						'priority'    => 8,
 					],
-					'job_salary_max'	=> [
-						'label'			=> __( 'Salary (max)', 'wp-job-manager' ),
-						'type'			=> 'text',
-						'required'		=> false,
-						'placeholder'	=> __( 'e.g. 25000', 'wp-job-manager' ),
-						'priority'		=> 9,
+					'job_salary_max'      => [
+						'label'       => __( 'Salary (max)', 'wp-job-manager' ),
+						'type'        => 'text',
+						'required'    => false,
+						'placeholder' => __( 'e.g. 25000', 'wp-job-manager' ),
+						'priority'    => 9,
 					],
 					'job_salary_currency' => [
 						'label'       => __( 'Salary Currency', 'wp-job-manager' ),

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -276,11 +276,18 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'priority'    => 7,
 					],
 					'job_salary'          => [
-						'label'       => __( 'Salary', 'wp-job-manager' ),
+						'label'       => __( 'Salary / Salary (min)', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
 						'placeholder' => __( 'e.g. 20000', 'wp-job-manager' ),
 						'priority'    => 8,
+					],
+					'job_salary_max'          => [
+						'label'         => __( 'Salary (max)', 'wp-job-manager' ),
+						'type'          => 'text',
+						'required'    => false,
+						'placeholder'   => __( 'e.g. 25000', 'wp-job-manager' ),
+						'priority'      => 9,
 					],
 					'job_salary_currency' => [
 						'label'       => __( 'Salary Currency', 'wp-job-manager' ),
@@ -288,7 +295,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'required'    => false,
 						'placeholder' => __( 'e.g. USD', 'wp-job-manager' ),
 						'description' => __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency.', 'wp-job-manager' ),
-						'priority'    => 9,
+						'priority'    => 10,
 					],
 					'job_salary_unit'     => [
 						'label'       => __( 'Salary Unit', 'wp-job-manager' ),
@@ -296,7 +303,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'options'     => job_manager_get_salary_unit_options(),
 						'description' => __( 'Add a salary period unit, this field is optional. Leave it empty to use the default salary unit, if one is defined.', 'wp-job-manager' ),
 						'required'    => false,
-						'priority'    => 10,
+						'priority'    => 11,
 					],
 				],
 				'company' => [

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -242,10 +242,10 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'is_remote'    => (bool) get_post_meta( $item->ID, '_remote_position', true ),
 			'job_type'     => $terms_array,
 			'salary'       => [
-				'amount'   => get_post_meta( $item->ID, '_job_salary', true ),
-				'amountmax'=> get_post_meta( $item->ID, '_job_salary_max', true ),
-				'currency' => get_the_job_salary_currency( $item ),
-				'unit'     => get_the_job_salary_unit_display_text( $item ),
+				'amount'	=> get_post_meta( $item->ID, '_job_salary', true ),
+				'amountmax'	=> get_post_meta( $item->ID, '_job_salary_max', true ),
+				'currency'	=> get_the_job_salary_currency( $item ),
+				'unit'		=> get_the_job_salary_unit_display_text( $item ),
 			],
 		];
 	}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -243,6 +243,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'job_type'     => $terms_array,
 			'salary'       => [
 				'amount'   => get_post_meta( $item->ID, '_job_salary', true ),
+				'amountmax'=> get_post_meta( $item->ID, '_job_salary_max', true ),
 				'currency' => get_the_job_salary_currency( $item ),
 				'unit'     => get_the_job_salary_unit_display_text( $item ),
 			],

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -242,10 +242,10 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'is_remote'    => (bool) get_post_meta( $item->ID, '_remote_position', true ),
 			'job_type'     => $terms_array,
 			'salary'       => [
-				'amount'	=> get_post_meta( $item->ID, '_job_salary', true ),
-				'amountmax'	=> get_post_meta( $item->ID, '_job_salary_max', true ),
-				'currency'	=> get_the_job_salary_currency( $item ),
-				'unit'		=> get_the_job_salary_unit_display_text( $item ),
+				'amount'      => get_post_meta( $item->ID, '_job_salary', true ),
+				'amountmax'   => get_post_meta( $item->ID, '_job_salary_max', true ),
+				'currency'    => get_the_job_salary_currency( $item ),
+				'unit'        => get_the_job_salary_unit_display_text( $item ),
 			],
 		];
 	}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -242,10 +242,10 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'is_remote'    => (bool) get_post_meta( $item->ID, '_remote_position', true ),
 			'job_type'     => $terms_array,
 			'salary'       => [
-				'amount'      => get_post_meta( $item->ID, '_job_salary', true ),
-				'amountmax'   => get_post_meta( $item->ID, '_job_salary_max', true ),
-				'currency'    => get_the_job_salary_currency( $item ),
-				'unit'        => get_the_job_salary_unit_display_text( $item ),
+				'amount'    => get_post_meta( $item->ID, '_job_salary', true ),
+				'amountmax' => get_post_meta( $item->ID, '_job_salary_max', true ),
+				'currency'  => get_the_job_salary_currency( $item ),
+				'unit'      => get_the_job_salary_unit_display_text( $item ),
 			],
 		];
 	}

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -171,7 +171,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	 * Tests to make sure public meta fields are exposed to guest users and private meta fields are hidden.
 	 */
 	public function test_guest_can_read_only_public_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_max', '_job_salary_currency', '_job_salary_unit'  ];
 		$private_fields = [ '_job_expires' ];
 		$this->logout();
 		$post_id = $this->get_job_listing();
@@ -192,7 +192,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_same_employer_read_access_to_private_meta_fields() {
-		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
+		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires', '_remote_position', '_job_salary', '_job_salary_max', '_job_salary_currency', '_job_salary_unit'  ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();
 
@@ -207,7 +207,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_different_employer_read_access_to_private_meta_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit' ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_max', '_job_salary_currency', '_job_salary_unit' ];
 		$private_fields = [ '_job_expires' ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1377,7 +1377,7 @@ function the_job_salary( $before = '', $after = '', $echo = true, $post = null )
 	 * @param string  $unit
 	 * @param string  $after
 	 */
-	$job_salary = apply_filters( 'the_job_salary_message', $job_salary, $post, $before, $salary, $currency, $salarymax, $unit, $after );
+	$job_salary = apply_filters( 'the_job_salary_message', $job_salary, $post, $before, $salary, $currency, $unit, $after, $salarymax );
 
 	if ( $echo ) {
 		echo esc_html( $job_salary );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -418,10 +418,10 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		}
 	}
 
-	$salary       = get_the_job_salary( $post );
-	$salary_max   = get_the_job_salary_max( $post );
-	$currency     = get_the_job_salary_currency( $post );
-	$unit         = get_the_job_salary_unit( $post );
+	$salary     = get_the_job_salary( $post );
+	$salary_max = get_the_job_salary_max( $post );
+	$currency   = get_the_job_salary_currency( $post );
+	$unit       = get_the_job_salary_unit( $post );
 	if ( ! empty( $salary_max ) ) {
 		$data['baseSalary']                      = [];
 		$data['baseSalary']['@type']             = 'MonetaryAmount';
@@ -1345,11 +1345,11 @@ function get_the_job_salary_max( $post = null ) {
  * @return string|void
  */
 function the_job_salary( $before = '', $after = '', $echo = true, $post = null ) {
-	$post     = get_post( $post );
-	$salary   = get_the_job_salary( $post );
+	$post      = get_post( $post );
+	$salary    = get_the_job_salary( $post );
 	$salarymax = get_the_job_salary_max( $post );
-	$currency = get_the_job_salary_currency( $post );
-	$unit     = get_the_job_salary_unit_display_text( $post );
+	$currency  = get_the_job_salary_currency( $post );
+	$unit      = get_the_job_salary_unit_display_text( $post );
 
 	if ( strlen( $salary ) === 0 ) {
 		return;

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1323,11 +1323,11 @@ function get_the_job_salary_max( $post = null ) {
 	$job_salary_max = $post->_job_salary_max;
 
 	/**
-	 * Filter the returned job salary.
+	 * Filter the returned max job salary.
 	 *
 	 * @since 1.36.0
 	 *
-	 * @param string  $job_salary
+	 * @param string  $job_salary_max
 	 * @param WP_Post $post
 	 */
 	return apply_filters( 'the_job_salary_max', $job_salary_max, $post );
@@ -1372,11 +1372,12 @@ function the_job_salary( $before = '', $after = '', $echo = true, $post = null )
 	 * @param WP_Post $post
 	 * @param string  $before
 	 * @param string  $salary
+	 * @param string  $salarymax
 	 * @param string  $currency
 	 * @param string  $unit
 	 * @param string  $after
 	 */
-	$job_salary = apply_filters( 'the_job_salary_message', $job_salary, $post, $before, $salary, $currency, $unit, $after );
+	$job_salary = apply_filters( 'the_job_salary_message', $job_salary, $post, $before, $salary, $currency, $salarymax, $unit, $after );
 
 	if ( $echo ) {
 		echo esc_html( $job_salary );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -418,10 +418,19 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		}
 	}
 
-	$salary   = get_the_job_salary( $post );
-	$currency = get_the_job_salary_currency( $post );
-	$unit     = get_the_job_salary_unit( $post );
-	if ( ! empty( $salary ) ) {
+	$salary       = get_the_job_salary( $post );
+	$salary_max   = get_the_job_salary_max( $post );
+	$currency     = get_the_job_salary_currency( $post );
+	$unit         = get_the_job_salary_unit( $post );
+	if ( ! empty( $salary_max ) ) {
+		$data['baseSalary']                      = [];
+		$data['baseSalary']['@type']             = 'MonetaryAmount';
+		$data['baseSalary']['currency']          = $currency;
+		$data['baseSalary']['value']['@type']    = 'QuantitativeValue';
+		$data['baseSalary']['value']['minValue'] = $salary;
+		$data['baseSalary']['value']['maxValue'] = $salary_max;
+		$data['baseSalary']['value']['unitText'] = $unit;
+	} elseif ( ! empty( $salary ) ) {
 		$data['baseSalary']                      = [];
 		$data['baseSalary']['@type']             = 'MonetaryAmount';
 		$data['baseSalary']['currency']          = $currency;
@@ -1299,6 +1308,33 @@ function get_the_job_salary( $post = null ) {
 }
 
 /**
+ * Gets the max job salary.
+ *
+ * @since 1.37.0
+ * @param int|WP_Post|null $post (default: null).
+ * @return string|null
+ */
+function get_the_job_salary_max( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || 'job_listing' !== $post->post_type ) {
+		return;
+	}
+
+	$job_salary_max = $post->_job_salary_max;
+
+	/**
+	 * Filter the returned job salary.
+	 *
+	 * @since 1.36.0
+	 *
+	 * @param string  $job_salary
+	 * @param WP_Post $post
+	 */
+	return apply_filters( 'the_job_salary_max', $job_salary_max, $post );
+}
+
+
+/**
  * Displays or retrieves the job salary with optional content.
  *
  * @since 1.36.0
@@ -1311,6 +1347,7 @@ function get_the_job_salary( $post = null ) {
 function the_job_salary( $before = '', $after = '', $echo = true, $post = null ) {
 	$post     = get_post( $post );
 	$salary   = get_the_job_salary( $post );
+	$salarymax = get_the_job_salary_max( $post );
 	$currency = get_the_job_salary_currency( $post );
 	$unit     = get_the_job_salary_unit_display_text( $post );
 
@@ -1319,6 +1356,9 @@ function the_job_salary( $before = '', $after = '', $echo = true, $post = null )
 	}
 
 	$job_salary = $before . $salary . ' ' . $currency;
+	if ( ! empty( $salarymax ) ) {
+		$job_salary .= ' - ' . $salarymax . ' ' . $currency;
+	}
 	if ( ! empty( $unit ) ) {
 		$job_salary .= ' / ' . $unit;
 	}


### PR DESCRIPTION
Fixes #2629

### Changes Proposed in this Pull Request

* Adds a max salary field to the frontend and admin forms.
* Adds a max salary information to Google's Job Search Structured Data

### Testing Instructions

* Create/Edit Job Listing and add salary
  * 1) add only one salary number (in min field)
  * 2) add both min salary and max salary
* View the salary on the frontend
* Copy the output HTML and paste here - https://search.google.com/test/rich-results

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Add: WPJM now supportes Salary Ranges and includes them into the job schema