### PR TITLE
add directApply if url or email set for application

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -418,7 +418,7 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		}
 	}
 
-	$data['directApply'] = empty( get_the_job_application_method( $post ) ) ? false : true;
+	$data['directApply'] = ! empty( get_the_job_application_method( $post ) );
 
 	$salary   = get_the_job_salary( $post );
 	$currency = get_the_job_salary_currency( $post );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -418,6 +418,8 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		}
 	}
 
+	$data['directApply'] = empty(get_the_job_application_method($post)) ? false : true;
+
 	$salary   = get_the_job_salary( $post );
 	$currency = get_the_job_salary_currency( $post );
 	$unit     = get_the_job_salary_unit( $post );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -418,7 +418,7 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		}
 	}
 
-	$data['directApply'] = empty(get_the_job_application_method($post)) ? false : true;
+	$data['directApply'] = empty( get_the_job_application_method( $post ) ) ? false : true;
 
 	$salary   = get_the_job_salary( $post );
 	$currency = get_the_job_salary_currency( $post );


### PR DESCRIPTION
Fixes #2201

### Changes Proposed in this Pull Request

In 2021 i created a issue for the at that time new value Direct Apply. Idea is that now as soon as the application URL or email is filled out a true value could be passed to the structured data of JobPosting. If there is now application url or email set we will send false to the schema.

### Testing Instructions

* Create a new job with no email or url set -> directApply value should be false
* Create a new job with email set -> directApply value should be true
* Create a new job with url set -> directApply value should be true

Test over https://search.google.com/test/rich-results

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* add schema value directApply true if email or url is set at Application email / url field