### PR TITLE
Align actions in notices in the center

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -39,7 +39,7 @@ $notice-success: #43af99;
 	&__top {
 		display: flex;
 		flex-direction: row;
-		align-items: flex-start;
+		align-items: center;
 		flex-wrap: wrap;
 		gap: 20px;
 	}

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -25,6 +25,7 @@ $notice-success: #43af99;
 
 	gap: 10px;
 	padding: 20px 24px;
+	padding-right: calc(48px + 24px);
 	transform-origin: top center;
 	overflow: hidden;
 
@@ -95,6 +96,7 @@ $notice-success: #43af99;
 	&__extra_details {
 		font-size: 14px;
 		border-radius: 2px;
+		padding-right: 48px;
 	}
 
 	a:where(:not(.wpjm-button)) {

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -33,7 +33,7 @@ $notice-success: #43af99;
 	}
 
 	.wp-core-ui &.is-dismissible {
-		padding-right: calc(52px + 24px);
+		padding-right: 24px;
 	}
 
 	&__top {
@@ -79,9 +79,7 @@ $notice-success: #43af99;
 	button.notice-dismiss {
 		padding: 6px;
 		color: inherit;
-		position: absolute;
-		top: 20px;
-		right: 24px;
+		position: static;
 
 		&::before {
 			color: inherit;


### PR DESCRIPTION
Before
![Screenshot 2023-11-13 at 15 32 39](https://github.com/Automattic/WP-Job-Manager/assets/53191348/da7c6a8c-f20b-40ac-9c17-f42adb17c13f)

After
![Screenshot 2023-11-13 at 15 31 37](https://github.com/Automattic/WP-Job-Manager/assets/53191348/db922a44-415b-41c4-b101-375c80b05624)


### Changes Proposed in this Pull Request

* A small fix which aligns in the center the actions in admin notices

### Testing Instructions

* Load a notice and observe that the actions in the notice are now center-aligned.



<!-- wpjm:plugin-zip -->
----

| Plugin build for b3e0505f8532f3d11bc9743d9c2c8f86c69480a0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2637-b3e0505f.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2637-b3e0505f)             |

<!-- /wpjm:plugin-zip -->




