### PR TITLE
Release WP Job Manager 2.0.0

### DIFF
--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -3,7 +3,7 @@
  * File WP_Job_Manager_Addons_Landing_Page class.
  *
  * @package wp-job-manager
- * @since $$next-version$$
+ * @since 2.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Landing pages for Applications and Resumes add-ons.
  *
- * @since $$next-version$$
+ * @since 2.0.0
  */
 class WP_Job_Manager_Addons_Landing_Page {
 
@@ -21,14 +21,14 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 * The single instance of the class.
 	 *
 	 * @var self
-	 * @since  $$next-version$$
+	 * @since  2.0.0
 	 */
 	private static $instance = null;
 
 	/**
 	 * Singleton accessor.
 	 *
-	 * @since  $$next-version$$
+	 * @since  2.0.0
 	 * @static
 	 * @return self Main instance.
 	 */
@@ -43,7 +43,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	/**
 	 * Initialize class for landing pages.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_applications_menu_item' ], 12 );
@@ -55,7 +55,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 * Register styles for landing pages.
 	 *
 	 * @access private
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 */
 	public function register_styles() {
 		WP_Job_Manager::register_style( 'job_manager_admin_landing_css', 'css/admin-landing.css', [ 'job_manager_brand' ] );
@@ -66,7 +66,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 * Add Applications add-on menu item if needed.
 	 *
 	 * @access private
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 */
 	public function add_applications_menu_item() {
 		$was_addon_installed = (bool) get_option( 'wp_job_manager_applications_version', false );
@@ -75,7 +75,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 		/**
 		 * Filters whether the 'Applications' landing page should be added to the Job Manager menu.
 		 *
-		 * @since $$next-version$$
+		 * @since 2.0.0
 		 *
 		 * @param bool $show True if the menu should be added.
 		 */
@@ -100,7 +100,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 * Add Resumes add-on menu item if needed.
 	 *
 	 * @access private
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 */
 	public function add_resumes_menu_item() {
 		$was_addon_installed = ! ! get_option( 'wp_resume_manager_version', false );
@@ -109,7 +109,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 		/**
 		 * Filters whether the 'Resumes' landing page should be added to the Job Manager menu.
 		 *
-		 * @since $$next-version$$
+		 * @since 2.0.0
 		 *
 		 * @param bool $show True if the menu should be added.
 		 */
@@ -134,7 +134,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 * Render Applications landing page.
 	 *
 	 * @access private
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 */
 	public function applications_landing_page() {
 
@@ -217,7 +217,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 * Render Resume Manager landing page.
 	 *
 	 * @access private
-	 * @since $$next-version$$
+	 * @since 2.0.0
 	 */
 	public function resumes_landing_page() {
 

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -152,12 +152,12 @@ class WP_Job_Manager_Admin_Notices {
 	/**
 	 * Set up filters for core admin notices.
 	 *
-	 * @deprecated since $$next-version$$. See maybe_add_core_setup_notice
+	 * @deprecated since 2.0.0. See maybe_add_core_setup_notice
 	 *
 	 * Note: For internal use only. Do not call manually.
 	 */
 	public static function init_core_notices() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager_Admin_Notices::maybe_add_core_setup_notice' );
+		_deprecated_function( __METHOD__, '2.0.0', 'WP_Job_Manager_Admin_Notices::maybe_add_core_setup_notice' );
 	}
 
 	/**
@@ -386,7 +386,7 @@ class WP_Job_Manager_Admin_Notices {
 	 */
 	public static function is_admin_on_standard_job_manager_screen( $additional_screens = [] ) {
 
-		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\Admin\Notices_Conditions_Checker::check' );
+		_deprecated_function( __METHOD__, '2.0.0', 'WP_Job_Manager\Admin\Notices_Conditions_Checker::check' );
 
 		$screen          = get_current_screen();
 		$screen_id       = $screen ? $screen->id : '';
@@ -415,12 +415,12 @@ class WP_Job_Manager_Admin_Notices {
 	/**
 	 * Displays the setup wizard notice when WPJM is first activated.
 	 *
-	 * @deprecated since $$next-version$$. See maybe_add_core_setup_notice
+	 * @deprecated since 2.0.0. See maybe_add_core_setup_notice
 	 *
 	 * Note: For internal use only. Do not call manually.
 	 */
 	public static function display_core_setup() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager_Admin_Notices::maybe_add_core_setup_notice' );
+		_deprecated_function( __METHOD__, '2.0.0', 'WP_Job_Manager_Admin_Notices::maybe_add_core_setup_notice' );
 	}
 
 	/**

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 1.42.0\n"
+"Project-Id-Version: WP Job Manager 2.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-10-04T13:26:49+00:00\n"
+"POT-Creation-Date: 2023-11-17T10:41:37+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.7.1\n"
+"X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: wp-job-manager\n"
 
 #. Plugin Name of the plugin
@@ -65,105 +65,236 @@ msgstr ""
 msgid "Terms and Conditions is a required field"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-addons.php:96
-#: includes/admin/class-wp-job-manager-admin.php:172
-#: includes/admin/views/html-admin-page-addons.php:12
-msgid "WP Job Manager Add-ons"
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:86
+msgid "WP Job Manager - Applications"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-addons.php:104
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:89
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:157
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:170
+msgid "Applications"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:90
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:124
+msgid "Pro"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:120
+msgid "WP Job Manager - Resumes"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:123
+msgid "Resumes"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:160
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:243
+msgid "Dismiss"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:166
+msgid "Applications add-on logo"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:173
+msgid "$79.00 USD / year (one site)"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:176
+msgid "Allow candidates to apply to jobs using a form &amp; employers to view and manage the applications from their job dashboard."
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:180
+msgid "Apply to jobs via forms and save applications"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:183
+msgid "List applications in the employer job and admin dashboard"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:186
+msgid "Privately rate and comment on applications"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:196
+msgid "Get Applications"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:201
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:284
+msgid "See all features"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:240
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:253
+msgid "Resume Manager"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:249
+msgid "Resume Manager add-on logo"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:256
+msgid "$49.00 USD / year (one site)"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:259
+msgid "Resume Manager is a plugin built on top of WP Job Manager which adds a resume submission form to your site and resume listings, all manageable from WordPress admin."
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:263
+msgid "Post resumes to your site and apply to jobs with the resumes"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:266
+msgid "List resumes, restricting access to certain user roles if you wish"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:269
+msgid "Restrict which user roles can view candidate contact details"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons-landing-page.php:279
+msgid "Get Resume Manager"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons.php:194
+#: includes/admin/class-wp-job-manager-admin.php:185
+msgid "Marketplace"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-addons.php:206
 #: includes/helper/views/html-licenses.php:14
 msgid "Licenses"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:159
+#: includes/admin/class-wp-job-manager-admin-notices.php:169
 msgid "Action failed. Please refresh the page and retry."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:163
+#: includes/admin/class-wp-job-manager-admin-notices.php:173
 msgid "You don&#8217;t have permission to do this."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:463
-msgid "Update"
+#: includes/admin/class-wp-job-manager-admin-notices.php:446
+msgid "You are nearly ready to start listing jobs with Job Manager"
 msgstr ""
 
-#. translators: %s is the name of the wpjm addon to be updated.
-#: includes/admin/class-wp-job-manager-admin-notices.php:466
-msgid "Good news, reminder to update to the latest version of %s."
+#: includes/admin/class-wp-job-manager-admin-notices.php:451
+#: includes/admin/views/html-admin-notice-core-setup.php:19
+msgid "Run Setup Wizard"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:470
-msgid "View release notes"
+#: includes/admin/class-wp-job-manager-admin-notices.php:457
+msgid "Skip Setup*"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:478
-msgid "Good news, reminder to update these plugins to their latest versions."
-msgstr ""
+#: includes/admin/class-wp-job-manager-admin-notices.php:544
+msgid "Job Manager: Plugin update available"
+msgid_plural "Job Manager: Plugin updates available"
+msgstr[0] ""
+msgstr[1] ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:479
-msgid "Update All"
-msgstr ""
+#: includes/admin/class-wp-job-manager-admin-notices.php:545
+msgid "Good news, you can update the following extension to its latest version:"
+msgid_plural "Good news, you can update the following extensions to their latest versions:"
+msgstr[0] ""
+msgstr[1] ""
 
 #. translators: %s is the new version number for the addon.
-#: includes/admin/class-wp-job-manager-admin-notices.php:488
+#: includes/admin/class-wp-job-manager-admin-notices.php:560
 msgid "New Version: %s"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:613
+#: includes/admin/class-wp-job-manager-admin-notices.php:567
+msgid "Update"
+msgid_plural "Update All"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/class-wp-job-manager-admin-notices.php:651
+msgid "Dismiss this notice"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-admin-notices.php:707
 msgid "Listing renewals require the latest version of WC Paid Listings. Please update the plugin to enable the feature."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin-notices.php:622
+#: includes/admin/class-wp-job-manager-admin-notices.php:716
 msgid "Listing renewals require the latest version of Simple Paid Listings. Please update the plugin to enable the feature."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:121
+#: includes/admin/class-wp-job-manager-admin-notices.php:739
+msgid "Did you know?"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-admin-notices.php:740
+msgid " You can upgrade your job listings with Job Manager extensions and add applications, resumes, alerts, and more!"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-admin-notices.php:743
+msgid "View Extensions"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-admin.php:131
 msgctxt "user selection"
 msgid "No matches found"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:122
+#: includes/admin/class-wp-job-manager-admin.php:132
 msgctxt "user selection"
 msgid "Loading failed"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:123
+#: includes/admin/class-wp-job-manager-admin.php:133
 msgctxt "user selection"
 msgid "Please enter 1 or more characters"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:124
+#: includes/admin/class-wp-job-manager-admin.php:134
 msgctxt "user selection"
 msgid "Please enter %qty% or more characters"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:125
+#: includes/admin/class-wp-job-manager-admin.php:135
 msgctxt "user selection"
 msgid "Loading more results&hellip;"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:126
+#: includes/admin/class-wp-job-manager-admin.php:136
 msgctxt "user selection"
 msgid "Searching&hellip;"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:129
+#: includes/admin/class-wp-job-manager-admin.php:139
 msgctxt "job promotion"
 msgid "Promote your job"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:130
+#: includes/admin/class-wp-job-manager-admin.php:140
 msgctxt "job promotion"
 msgid "Learn More"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:169
+#: includes/admin/class-wp-job-manager-admin.php:141
+msgctxt "job promotion"
+msgid "Don't show this again"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-admin.php:181
+#: includes/admin/class-wp-job-manager-settings.php:138
+#: includes/class-wp-job-manager-post-types.php:437
+msgid "Job Listings"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-admin.php:182
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-admin.php:172
-msgid "Add-ons"
+#: includes/admin/class-wp-job-manager-admin.php:185
+#: includes/admin/views/html-admin-page-addons.php:12
+msgid "WP Job Manager Marketplace"
 msgstr ""
 
 #. translators: Placeholder (%s) is the plural name of the job listings post type.
@@ -244,6 +375,7 @@ msgstr ""
 msgid "%1$s updated. <a href=\"%2$s\">View</a>"
 msgstr ""
 
+#. translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 #: includes/admin/class-wp-job-manager-cpt.php:460
 msgid "Custom field updated."
 msgstr ""
@@ -316,6 +448,7 @@ msgstr ""
 
 #: includes/admin/class-wp-job-manager-cpt.php:505
 #: includes/admin/class-wp-job-manager-settings.php:189
+#: includes/class-wp-job-manager-post-types.php:187
 msgid "Categories"
 msgstr ""
 
@@ -328,44 +461,45 @@ msgstr ""
 msgid "Filled?"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-cpt.php:553
+#: includes/admin/class-wp-job-manager-cpt.php:555
 msgid "Approve"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-cpt.php:561
+#: includes/admin/class-wp-job-manager-cpt.php:563
 #: includes/admin/class-wp-job-manager-writepanels.php:244
 #: includes/admin/class-wp-job-manager-writepanels.php:294
 msgid "View"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-cpt.php:568
+#. translators: Placeholder %s is the singular label of the job listing post type.
+#: includes/admin/class-wp-job-manager-cpt.php:570
 #: includes/class-wp-job-manager-post-types.php:340
 #: includes/class-wp-job-manager-shortcodes.php:450
 #: includes/class-wp-job-manager-shortcodes.php:494
 msgid "Edit"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-cpt.php:575
+#: includes/admin/class-wp-job-manager-cpt.php:577
 #: includes/class-wp-job-manager-shortcodes.php:509
 msgid "Delete"
 msgstr ""
 
 #. translators: %d is the post ID for the job listing.
-#: includes/admin/class-wp-job-manager-cpt.php:611
+#: includes/admin/class-wp-job-manager-cpt.php:613
 msgid "ID: %d"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-cpt.php:634
+#: includes/admin/class-wp-job-manager-cpt.php:636
 msgid "Show more details"
 msgstr ""
 
 #. translators: %s placeholder is the username of the user.
-#: includes/admin/class-wp-job-manager-cpt.php:664
+#: includes/admin/class-wp-job-manager-cpt.php:666
 msgid "by a guest"
 msgstr ""
 
 #. translators: %s placeholder is the username of the user.
-#: includes/admin/class-wp-job-manager-cpt.php:664
+#: includes/admin/class-wp-job-manager-cpt.php:666
 msgid "by %s"
 msgstr ""
 
@@ -403,96 +537,96 @@ msgctxt "Job type slug - resave permalinks after changing this"
 msgid "job-type"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:78
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:264
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:267
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:85
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:271
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:274
 msgid "Promote"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:91
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:98
 msgid "No job listing ID provided for deactivation of the promotion."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:95
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:102
 msgid "You do not have permission to deactivate the promotion for this job listing."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:136
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:143
 msgid "Your job is promoted and being exposed through API but it's not published in your site. You can fix it by publishing it again or deactivating the promotion."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:139
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:146
 msgid "This job has been promoted to external job boards."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:142
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:256
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:149
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:263
 msgid "Promoted"
 msgstr ""
 
 #. translators: Placeholder (%s) is the name of the job listing affected.
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:170
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:177
 msgid "Promotion for %s deactivated"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:185
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:192
 msgid "No job listing ID provided for promotion."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:192
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:199
 msgid "You do not have permission to edit this job listing."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:196
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:203
 msgid "You do not have permission to promote this job listing."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:258
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:265
 msgid "Manage"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:260
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:387
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:267
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:411
 msgid "Deactivate"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:266
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:273
 msgid "The job needs to be published in order to be promoted."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:376
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:400
 msgid "Are you sure you want to deactivate promotion for this job?"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:379
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:403
 msgid "If you still have time until the promotion expires, this time will be lost and the promotion of the job will be canceled."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:384
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:408
 msgid "Cancel"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:413
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:437
 msgid "Congratulations! Your first job has been successfully promoted."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:414
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:438
 msgid "To manage your promoted job, use the <em>Edit</em> and <em>Deactivate</em> links beside the job listing under the <strong>Promote</strong> column. Unpublishing a job listing will not deactivate the promotion."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:453
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:477
 msgid "You have promoted jobs in the trash."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:454
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:478
 msgid "Trashed jobs are not be available to your applicants. Deactivate the promotion or publish the job again to fix this."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:463
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:487
 msgid "Check the trash"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:486
+#: includes/admin/class-wp-job-manager-promoted-jobs-admin.php:535
 msgid "You need to deactivate the promotion before deleting the job."
 msgstr ""
 
@@ -541,12 +675,6 @@ msgstr ""
 msgid "If checked, when the plugin is uninstalled, job listings will be permanently deleted immediately."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:138
-#: includes/class-wp-job-manager-post-types.php:334
-#: includes/class-wp-job-manager-post-types.php:437
-msgid "Job Listings"
-msgstr ""
-
 #: includes/admin/class-wp-job-manager-settings.php:144
 msgid "Listings Per Page"
 msgstr ""
@@ -572,27 +700,27 @@ msgid "Page numbered links"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:162
-msgid "Filled Positions"
+msgid "Filled Listings"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:163
-msgid "Hide filled positions"
+msgid "Hide filled listings"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:164
-msgid "Filled positions will not display in your archives."
+msgid "Filled job listings will not be included in search results, sitemap and feeds."
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:171
-msgid "Hide Expired Listings"
+msgid "Expired Listings"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:172
-msgid "Hide expired listings in job archives/search"
+msgid "Hide expired listings"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:173
-msgid "Expired job listings will not be searchable."
+msgid "Expired job listings will not be shown to the users on the job board."
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:180
@@ -644,6 +772,7 @@ msgid "Jobs will be shown if within ALL selected categories"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:218
+#: includes/class-wp-job-manager-post-types.php:250
 msgid "Types"
 msgstr ""
 
@@ -706,7 +835,6 @@ msgid "Enable Job Salary Currency Customization"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:256
-#: includes/admin/class-wp-job-manager-settings.php:275
 msgid "This lets users add a salary currency when submitting a job."
 msgstr ""
 
@@ -736,6 +864,10 @@ msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:274
 msgid "Enable Job Salary Unit Customization"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-settings.php:275
+msgid "This lets users add a salary unit when submitting a job."
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:282
@@ -1050,7 +1182,7 @@ msgstr ""
 msgid "Select a page&hellip;"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:1077
+#: includes/admin/class-wp-job-manager-settings.php:1081
 msgid "Everyone (Public)"
 msgstr ""
 
@@ -1120,16 +1252,35 @@ msgstr ""
 msgid "You are nearly ready to start listing jobs with <strong>WP Job Manager</strong>."
 msgstr ""
 
-#: includes/admin/views/html-admin-notice-core-setup.php:19
-msgid "Run Setup Wizard"
-msgstr ""
-
 #: includes/admin/views/html-admin-notice-core-setup.php:20
 msgid "Skip Setup"
 msgstr ""
 
-#: includes/admin/views/html-admin-page-addons.php:33
-msgid "No add-ons were found."
+#: includes/admin/views/html-admin-page-addons.php:38
+#: includes/admin/views/html-admin-page-addons.php:39
+#: includes/helper/views/html-licenses.php:54
+#: includes/helper/views/html-licenses.php:55
+msgid "Search"
+msgstr ""
+
+#: includes/admin/views/html-admin-page-addons.php:47
+msgid "No extensions were found."
+msgstr ""
+
+#: includes/admin/views/html-admin-page-addons.php:78
+msgid "By"
+msgstr ""
+
+#: includes/admin/views/html-admin-page-addons.php:82
+msgid "Get Extension"
+msgstr ""
+
+#: includes/admin/views/html-admin-page-addons.php:91
+msgid "Paid Add-on"
+msgstr ""
+
+#: includes/admin/views/html-admin-page-addons.php:95
+msgid "More details"
 msgstr ""
 
 #: includes/admin/views/html-admin-setup-header.php:13
@@ -1319,6 +1470,7 @@ msgstr[1] ""
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
+#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/class-wp-job-manager-data-exporter.php:51
 #: includes/class-wp-job-manager-post-types.php:357
 msgid "Company Logo"
@@ -1531,6 +1683,11 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
+#: includes/class-wp-job-manager-post-types.php:334
+msgid "Job Manager"
+msgstr ""
+
+#. translators: Placeholder %s is the plural label of the job listing post type.
 #: includes/class-wp-job-manager-post-types.php:337
 msgid "Add New"
 msgstr ""
@@ -1744,6 +1901,7 @@ msgstr ""
 msgid "Missing submission page."
 msgstr ""
 
+#. translators: Placeholder %s is the plural label for the job listing post type.
 #: includes/class-wp-job-manager-shortcodes.php:401
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:36
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:52
@@ -1791,9 +1949,9 @@ msgstr ""
 #. translators: Placeholder %s is a URL to the document on wpjobmanager.com with info on usage tracking.
 #: includes/class-wp-job-manager-usage-tracking.php:230
 msgid ""
-"We'd love if you helped us make WP Job Manager better by allowing us to collect\n"
-"\t\t\t\t<a target=\"_blank\" href=\"%s\">usage tracking data</a>. No sensitive information is\n"
-"\t\t\t\tcollected, and you can opt out at any time."
+"<p>We'd love if you helped us make WP Job Manager better by allowing us to collect\n"
+"\t\t\t\t<a target=\"_blank\" href=\"%s\">usage tracking data</a>.</p><p>No sensitive information is\n"
+"\t\t\t\tcollected, and you can opt out at any time.</p>"
 msgstr ""
 
 #. translators: the href tag contains the URL for the page telling users what data WPJM tracks.
@@ -2066,89 +2224,98 @@ msgstr ""
 msgid "Renew Listing &rarr;"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:356
+#: includes/helper/class-wp-job-manager-helper.php:362
 msgid "your WP Job Manager plugin"
 msgstr ""
 
 #. translators: First placeholder is the plugin name, second placeholder is the My Account URL.
-#: includes/helper/class-wp-job-manager-helper.php:382
+#: includes/helper/class-wp-job-manager-helper.php:388
 msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> is not activated on this website and has been removed. Manage your activations on your <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">My Account page</a>."
 msgstr ""
 
 #. translators: First placeholder is the plugin name; second placeholder is the URL to purchase the plugin.
-#: includes/helper/class-wp-job-manager-helper.php:387
+#: includes/helper/class-wp-job-manager-helper.php:393
 msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> is not valid and has been removed. <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">Purchase a new license</a> to receive updates and support."
 msgstr ""
 
 #. translators: First placeholder is the plugin name, second placeholder is the My Account URL.
-#: includes/helper/class-wp-job-manager-helper.php:392
+#: includes/helper/class-wp-job-manager-helper.php:398
 msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> has expired. You must <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">renew your license</a> to receive updates and support."
 msgstr ""
 
 #. translators: First placeholder is the plugin name, second placeholder is the My Account URL.
-#: includes/helper/class-wp-job-manager-helper.php:395
+#: includes/helper/class-wp-job-manager-helper.php:401
 msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> is expiring soon. Please <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">renew your license</a> to continue receiving updates and support."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:477
+#: includes/helper/class-wp-job-manager-helper.php:484
 msgid "Manage License (Requires Attention)"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:480
+#: includes/helper/class-wp-job-manager-helper.php:487
 msgid "Manage License"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:483
+#: includes/helper/class-wp-job-manager-helper.php:490
 #: includes/helper/views/html-licenses.php:44
 #: includes/helper/views/html-licenses.php:170
 #: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:155
 msgid "Activate License"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:789
+#: includes/helper/class-wp-job-manager-helper.php:804
 msgid "Please enter a valid license key in order to activate this plugin's license."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:819
+#: includes/helper/class-wp-job-manager-helper.php:834
 msgid "Please enter a valid license key in order to activate the licenses of the plugins."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:846
+#: includes/helper/class-wp-job-manager-helper.php:863
 msgid "There was an error activating your license key. Please try again later."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:901
+#: includes/helper/class-wp-job-manager-helper.php:919
 msgid "license is not active."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:913
+#: includes/helper/class-wp-job-manager-helper.php:932
 msgid "There was an error while deactivating the plugin."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:925
+#: includes/helper/class-wp-job-manager-helper.php:945
 msgid "Plugin license has been deactivated."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1020
+#: includes/helper/class-wp-job-manager-helper.php:1042
 msgid "Connection failed to the License Key API server - possible server issue."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1029
+#: includes/helper/class-wp-job-manager-helper.php:1051
 msgid "Plugin license has been activated."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1033
+#: includes/helper/class-wp-job-manager-helper.php:1055
 msgid "An unknown error occurred while attempting to activate the license"
 msgstr ""
 
-#. translators: %1$s is the URL to the license key page, %2$s is the plugin name.
-#: includes/helper/class-wp-job-manager-helper.php:1071
-msgid "<a href=\"%1$s\">Please enter your license key</a> to get updates for \"%2$s\"."
+#: includes/helper/class-wp-job-manager-helper.php:1093
+msgid "Job Manager: License required"
+msgid_plural "Job Manager: Licenses required"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %1$s is the URL to the license key page.
+#: includes/helper/class-wp-job-manager-helper.php:1097
+msgid "<a href=\"%1$s\">Please add or review your license keys</a> to get updates for the following extensions:"
 msgstr ""
 
-#. translators: %1$s is the plugin name, %2$s is the URL to the license key page.
-#: includes/helper/class-wp-job-manager-helper.php:1103
-msgid "There is a problem with the license for \"%1$s\". Please <a href=\"%2$s\">manage the license</a> to check for a solution and continue receiving updates."
+#: includes/helper/class-wp-job-manager-helper.php:1104
+msgid "Manage Licenses"
+msgstr ""
+
+#: includes/helper/class-wp-job-manager-helper.php:1109
+msgid "My Account"
 msgstr ""
 
 #: includes/helper/class-wp-job-manager-site-trust-token.php:67
@@ -2173,11 +2340,6 @@ msgstr ""
 
 #: includes/helper/views/html-licenses.php:43
 msgid "ENTER YOUR LICENSE KEY"
-msgstr ""
-
-#: includes/helper/views/html-licenses.php:54
-#: includes/helper/views/html-licenses.php:55
-msgid "Search"
 msgstr ""
 
 #. translators: placeholder is the number of active addons, which will never be zero.
@@ -2594,6 +2756,7 @@ msgstr ""
 msgid "%s submitted successfully. Your listing will be visible once approved."
 msgstr ""
 
+#. translators: %1$s is the URL to view the listing; %2$s is
 #: templates/job-submitted.php:61
 msgid "  <a href=\"%1$s\"> View your %2$s</a>"
 msgstr ""
@@ -2729,40 +2892,40 @@ msgstr ""
 msgid "Application via %1$s listing on %2$s"
 msgstr ""
 
-#: wp-job-manager-template.php:707
+#: wp-job-manager-template.php:709
 msgid "Your email"
 msgstr ""
 
-#: wp-job-manager-template.php:708
+#: wp-job-manager-template.php:710
 msgid "you@yourdomain.com"
 msgstr ""
 
-#: wp-job-manager-template.php:716
+#: wp-job-manager-template.php:718
 msgid "Username"
 msgstr ""
 
-#: wp-job-manager-template.php:725
+#: wp-job-manager-template.php:727
 msgid "Password"
 msgstr ""
 
-#: wp-job-manager-template.php:735
+#: wp-job-manager-template.php:737
 msgid "Verify Password"
 msgstr ""
 
-#: wp-job-manager-template.php:762
+#: wp-job-manager-template.php:764
 msgid "Posted on "
 msgstr ""
 
 #. translators: Placeholder %s is the relative, human readable time since the job listing was posted.
-#: wp-job-manager-template.php:765
-#: wp-job-manager-template.php:786
+#: wp-job-manager-template.php:767
+#: wp-job-manager-template.php:788
 msgid "Posted %s ago"
 msgstr ""
 
-#: wp-job-manager-template.php:801
+#: wp-job-manager-template.php:803
 msgid "Remote"
 msgstr ""
 
-#: wp-job-manager-template.php:825
+#: wp-job-manager-template.php:827
 msgid "Anywhere"
 msgstr ""

--- a/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
+++ b/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
@@ -563,7 +563,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * Ensure that jQuery has been enqueued since the opt-in dialog JS depends
 	 * on it. Should not be called externally.
 	 *
-	 * @deprecated since $$next-version$$
+	 * @deprecated since 2.0.0
 	 **/
 	public function enqueue_script_deps() {
 		_deprecated_function( __METHOD__, '$$next-version' );
@@ -573,7 +573,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * Output the JS code to handle the opt-in dialog. Should not be called
 	 * externally.
 	 *
-	 * @deprecated since $$next-version$$
+	 * @deprecated since 2.0.0
 	 **/
 	public function output_opt_in_js() {
 		_deprecated_function( __METHOD__, '$$next-version' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "1.42.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "1.42.0",
+      "version": "2.0.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "1.42.0",
+  "version": "2.0.0",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mikejolley, automattic, adamkheckler, alexsanford1, annezazu, cena, chaselivingston, csonnek, davor.altman, donnapep, donncha, drawmyface, erania-pinnera, fjorgemota, jacobshere, jakeom, jeherve, jenhooks, jgs, jonryan, kraftbj, lamdayap, lschuyler, macmanx, nancythanki, orangesareorange, rachelsquirrel, renathoc, ryancowles, richardmtl, scarstocea
 Tags: job manager, job listing, job board, job management, job lists, job list, job, jobs, company, hiring, employment, employer, employees, candidate, freelance, internship, job listings, positions, board, application, hiring, listing, manager, recruiting, recruitment, talent
 Requires at least: 6.1
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 7.2
 Stable tag: 2.0.0
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: job manager, job listing, job board, job management, job lists, job list, 
 Requires at least: 6.1
 Tested up to: 6.3
 Requires PHP: 7.2
-Stable tag: 1.42.0
+Stable tag: 2.0.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -6,8 +6,8 @@
  * Version: 2.0.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
- * Requires at least: 6.0
- * Tested up to: 6.2
+ * Requires at least: 6.1
+ * Tested up to: 6.4
  * Requires PHP: 7.4
  * Text Domain: wp-job-manager
  * Domain Path: /languages/
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '1.41.0-dev' );
+define( 'JOB_MANAGER_VERSION', '2.0.0' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.42.0
+ * Version: 2.0.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.0


### PR DESCRIPTION

> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## WP Job Manager 2.0.0

> [!NOTE]
> These release notes between the two  lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Enhancement: Improve settings descriptions (#2639)
* Enhancement: Add directApply in Google job schema (#2635)
* Enhancement: Add 'Don't show this again' link to dismiss promote job modal in the editor (#2632)
* Enhancement: Add landing pages for Applications and Resumes extensions (#2621)
* Fix: Align actions in notices in the center (#2637)
* Fix: Safeguard array in WP_Job_Manager_Settings::input_capabilities (#2631)
* Fix: Escape menu titles and various admin labels (#2630)
* Fix: Incorrectly duplicated string in settings (#2628)
* Fix: Add array initialization to avoid warning (#2619)
* Fix: Do not check for plugin updates when there are no plugins (#2605)
* Change: Reorganize administration menu (#2621)
* Change: Update naming from Add-ons to Extensions, Marketplace (#2621)


---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org



<!-- wpjm:plugin-zip -->
----

| Plugin build for e97a5413d2ce069c1f09c657a66b6a3c7e95820c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2640-e97a5413.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2640-e97a5413)             |

<!-- /wpjm:plugin-zip -->


