### PR TITLE
Remove public update endpoint and add nonce check

### DIFF
--- a/includes/admin/class-wp-job-manager-permalink-settings.php
+++ b/includes/admin/class-wp-job-manager-permalink-settings.php
@@ -141,13 +141,14 @@ class WP_Job_Manager_Permalink_Settings {
 			return;
 		}
 
+		check_admin_referer( 'update-permalink' );
+
 		if ( function_exists( 'switch_to_locale' ) ) {
 			switch_to_locale( get_locale() );
 		}
 
 		$permalink_settings = WP_Job_Manager_Post_Types::get_raw_permalink_settings();
 
-		// phpcs:disable WordPress.Security.NonceVerification.Missing -- WP core handles nonce check for settings save.
 		$permalink_settings['job_base']      = isset( $_POST['wpjm_job_base_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_base_slug'] ) ) : '';
 		$permalink_settings['category_base'] = isset( $_POST['wpjm_job_category_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_category_slug'] ) ) : '';
 		$permalink_settings['type_base']     = isset( $_POST['wpjm_job_type_slug'] ) ? sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_type_slug'] ) ) : '';
@@ -155,7 +156,6 @@ class WP_Job_Manager_Permalink_Settings {
 		if ( isset( $_POST['wpjm_job_listings_archive_slug'] ) ) {
 			$permalink_settings['jobs_archive'] = sanitize_title_with_dashes( wp_unslash( $_POST['wpjm_job_listings_archive_slug'] ) );
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		update_option( WP_Job_Manager_Post_Types::PERMALINK_OPTION_NAME, wp_json_encode( $permalink_settings ) );
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -239,7 +239,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	 * @return WP_Error|WP_REST_Response The response, or WP_Error on failure.
 	 */
 	public function update_job_status( $request ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager_Helper_API::bulk_update_check' );
+		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager_Promoted_Jobs_API::refresh_status' );
 
 		$post_id = $request->get_param( 'id' );
 		$status  = $request->get_param( 'status' );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -69,27 +69,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 				],
 			]
 		);
-		register_rest_route(
-			self::NAMESPACE,
-			self::REST_BASE . '/(?P<id>[\d]+)',
-			[
-				[
-					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => [ $this, 'update_job_status' ],
-					'permission_callback' => '__return_true',
-					'args'                => [
-						'id'     => [
-							'type'     => 'integer',
-							'required' => true,
-						],
-						'status' => [
-							'type'     => 'boolean',
-							'required' => true,
-						],
-					],
-				],
-			]
-		);
+
 		register_rest_route(
 			self::NAMESPACE,
 			self::REST_BASE . '/(?P<job_id>[\d]+)',
@@ -252,11 +232,15 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	/**
 	 * Update the promoted job status.
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response The response, or WP_Error on failure.
 	 */
 	public function update_job_status( $request ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager_Helper_API::bulk_update_check' );
+
 		$post_id = $request->get_param( 'id' );
 		$status  = $request->get_param( 'status' );
 		$post    = get_post( $post_id );


### PR DESCRIPTION
More information in:
https://github.com/Automattic/WP-Job-Manager-Private/pull/26
https://github.com/Automattic/WP-Job-Manager-Private/pull/25

<!-- wpjm:plugin-zip -->
----

| Plugin build for 98e33a45da7ed6626b5726192ce738552da175d3 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2642-98e33a45.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2642-98e33a45)             |

<!-- /wpjm:plugin-zip -->
