### PR TITLE
Release WP Job Manager 2.1.0

### DIFF
--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -34,7 +34,7 @@ if ( ! empty( $categories ) ) {
 ?>
 <form class="extension-search" method="get" action="<?php esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons' ) ); ?>">
 	<input type="hidden" name="post_type" value="job_listing" />
-	<input type="hidden" name="page" value="job-manager-addons" />
+	<input type="hidden" name="page" value="job-manager-marketplace" />
 	<input class="wpjm-extension-search-input" type="text" name="search" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php echo esc_attr__( 'Search', 'wp-job-manager' ); ?>" />
 	<input class="wpjm-extension-search-button button" type="submit" value="<?php echo esc_attr__( 'Search', 'wp-job-manager' ); ?>" />
 </form>

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -232,14 +232,14 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	/**
 	 * Update the promoted job status.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 2.1.0
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response The response, or WP_Error on failure.
 	 */
 	public function update_job_status( $request ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager_Promoted_Jobs_API::refresh_status' );
+		_deprecated_function( __METHOD__, '2.1.0', 'WP_Job_Manager_Promoted_Jobs_API::refresh_status' );
 
 		$post_id = $request->get_param( 'id' );
 		$status  = $request->get_param( 'status' );

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 2.0.0\n"
+"Project-Id-Version: WP Job Manager 2.1.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-11-17T10:41:37+00:00\n"
+"POT-Creation-Date: 2023-11-17T13:34:50+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: wp-job-manager\n"
@@ -2380,12 +2380,12 @@ msgstr ""
 msgid "No plugins are activated that have licenses managed by WP Job Manager."
 msgstr ""
 
-#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:265
-#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:290
+#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:249
+#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:274
 msgid "The promoted job was not found"
 msgstr ""
 
-#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:294
+#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:278
 msgid "Sorry, you are not allowed to view this job."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: job manager, job listing, job board, job management, job lists, job list, 
 Requires at least: 6.1
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '2.0.0' );
+define( 'JOB_MANAGER_VERSION', '2.1.0' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 2.0.0
+ * Version: 2.1.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.1


### PR DESCRIPTION

> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## WP Job Manager 2.1.0

> [!NOTE]
> These release notes between the two  lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Fix: Remove public update endpoint and add nonce check (#2642)
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org





<!-- wpjm:plugin-zip -->
----

| Plugin build for 6a1fc4b3e1895c3d5b4af1cd9d0ebbac7d9b50dc <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2643-6a1fc4b3.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2643-6a1fc4b3)             |

<!-- /wpjm:plugin-zip -->






