### PR TITLE
Set dateFormat if there is none set from core

### DIFF
--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -19,6 +19,7 @@ jQuery(document).ready( function() {
 			}
 		} );
 		$target.datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
+		$target.datepicker("option", "dateFormat", $target.datepicker("option", "dateFormat") || "MM d, yy");
 		if ( $target.val() ) {
 			var dateParts = $target.val().split('-');
 			if ( 3 === dateParts.length ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-job-manager-application-deadline/issues/60

### Changes Proposed in this Pull Request

* If there is no Date Format set from core General Settings, we'll set the default of `MM d, yy` so that the date picker works.  Previosuly, if the date format was empty, the datepicker wouldn't work at all.
* If Date Format is set in core, then we'll respect that.

### Testing Instructions

* Enable Application Deadline
* Go to Settings > General and go to Date Format
* Select "Custom" and make sure it's blank.  Save!
* <img src="https://github.com/Automattic/WP-Job-Manager/assets/3220162/97e924d6-1fde-4e15-b9f5-3866546a5928" width="400" >
* Go to post a job, and select a Closing date
* See that the date still shows up, in `MM d, yy` format
* Change the Date Format to something else, like `Y-m-d` and see that it respects the new date format.

### Release Notes

* Fix: Add fallback for date format if it's not set in General Settings.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 526e25a90982f2d147f9a1f065d7779fee6ddc2c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2645-526e25a9.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2645-526e25a9)             |

<!-- /wpjm:plugin-zip -->
