### PR TITLE
Small fixes to actions and release script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Plugin Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get npm cache directory
         id: npm-cache
         run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: WPJM Release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
      - name: Checkout
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
 
      - name: Setup Node
        uses: actions/setup-node@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get cached composer directories
         uses: actions/cache@v3

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -14,7 +14,7 @@ jobs:
     name: WPJM release checklist
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Checklist
         uses: automattic/contextual-qa-checklist-action@master
         with:

--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -11,7 +11,7 @@ jobs:
         name: Report Plugin Build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Publish commit status with the link to download the plugin 
               id: plugin_artifact
               uses: Automattic/github-action-report-artifact@v0

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -276,26 +276,30 @@ function buildReleaseNotes() {
 	let prs = execSync( `${ ghPrs }  --json number,title,body,labels` );
 	prs     = JSON.parse( prs );
 
-	const changelogs = prs.map( ( pr ) => {
+	let changelog = prs.map( ( pr ) => {
 		const body              = pr.body;
 		const changelogSections = body.match( /### Release Notes([\S\s]*?)(?:###|<!--|$)/ );
 
 		if ( ! changelogSections ) {
 			return `* ${ pr.title } (#${ pr.number })`;
 		}
-		const changelog = changelogSections[ 1 ].trim();
+		const prChangelog = changelogSections[ 1 ].trim();
 
-		if ( ! changelog.match( /\w/ ) ) {
+		if ( ! prChangelog.match( /\w/ ) ) {
 			return '';
 		}
 
-		return changelog;
-	} );
+		return prChangelog;
+	} ).join( "\n" );
+
+	if ( changelog.trim().length === 0 ) {
+		changelog = '* Updated plugin headers';
+	}
 
 	console.log( 'Proposed changelog: ' );
-	console.log( changelogs.join( "\n" ) );
+	console.log( changelog );
 
-	return changelogs.join( "\n" );
+	return changelog;
 }
 
 /**


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Updates actions/checkout to v4 to avoid some warnings
* Adds a default release note 'Updated plugin headers' when the release notes are empty.

### Testing Instructions

* You can run the script locally to test
* Or alternatively you can check https://github.com/Automattic/WP-Job-Manager/pull/2648 to see for the result of running the script.