### PR TITLE
Fix link to extensions page

### DIFF
--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -741,7 +741,7 @@ class WP_Job_Manager_Admin_Notices {
 			'actions'     => [
 				[
 					'label' => __( 'View Extensions', 'wp-job-manager' ),
-					'url'   => admin_url( 'edit.php?post_type=job_listing&page=job-manager-addons' ),
+					'url'   => admin_url( 'edit.php?post_type=job_listing&page=job-manager-marketplace' ),
 				],
 			],
 		];


### PR DESCRIPTION
Fixes link to extensions page

<!-- wpjm:plugin-zip -->
----

| Plugin build for 175b3ae9e1402409987332f6bfc7c26ba5103bc7 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2650-175b3ae9.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2650-175b3ae9)             |

<!-- /wpjm:plugin-zip -->
