### PR TITLE
Improve upsell styles so it is less distracting

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1138,14 +1138,13 @@ h2 .nav-tab-active, nav .nav-tab-active {
 	vertical-align: middle;
 	box-sizing: border-box;
 	margin: 1px 0 -1px 2px;
-	padding: 0 5px;
-	min-width: 18px;
-	height: 18px;
-	border: 2px solid #d63638;
-	border-radius: 9px;
-	background-color: transparent;
+	padding: 0 3px; /* Reduced padding */
+	min-width: 15px; /* Slightly smaller */
+	height: 15px; /* Slightly smaller */
+	border-radius: 5px; /* Less rounded */
+	background-color: #6C737C; /* More neutral color */
 	color: #fff;
-	font-size: 11px;
+	font-size: 10px; /* Smaller font size */
 	line-height: 1.6;
 	text-align: center;
 	z-index: 26;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1129,3 +1129,27 @@ h2 .nav-tab-active, nav .nav-tab-active {
 .jm-logo__wrapper:hover .jm-logo__letters {
 	transform: rotateY(90deg);
 }
+
+/**
+ * Adjust upsells styles
+ */
+.wpjm-addon-upsell__badge {
+	display: inline-block;
+	vertical-align: middle;
+	box-sizing: border-box;
+	margin: 1px 0 -1px 2px;
+	padding: 0 5px;
+	min-width: 18px;
+	height: 18px;
+	border: 2px solid #d63638;
+	border-radius: 9px;
+	background-color: transparent;
+	color: #fff;
+	font-size: 11px;
+	line-height: 1.6;
+	text-align: center;
+	z-index: 26;
+	/* Move upsell to the right */
+	position: absolute;
+	right: 10px;
+}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1138,17 +1138,16 @@ h2 .nav-tab-active, nav .nav-tab-active {
 	vertical-align: middle;
 	box-sizing: border-box;
 	margin: 1px 0 -1px 2px;
-	padding: 0 3px; /* Reduced padding */
-	min-width: 15px; /* Slightly smaller */
-	height: 15px; /* Slightly smaller */
-	border-radius: 5px; /* Less rounded */
-	background-color: #6C737C; /* More neutral color */
+	padding: 0 3px;
+	min-width: 15px;
+	height: 15px;
+	border-radius: 5px;
+	background-color: #6C737C;
 	color: #fff;
-	font-size: 10px; /* Smaller font size */
+	font-size: 10px;
 	line-height: 1.6;
 	text-align: center;
 	z-index: 26;
-	/* Move upsell to the right */
 	position: absolute;
 	right: 10px;
 }

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1130,24 +1130,3 @@ h2 .nav-tab-active, nav .nav-tab-active {
 	transform: rotateY(90deg);
 }
 
-/**
- * Adjust upsells styles
- */
-.wpjm-addon-upsell__badge {
-	display: inline-block;
-	vertical-align: middle;
-	box-sizing: border-box;
-	margin: 1px 0 -1px 2px;
-	padding: 0 3px;
-	min-width: 15px;
-	height: 15px;
-	border-radius: 5px;
-	background-color: #6C737C;
-	color: #fff;
-	font-size: 10px;
-	line-height: 1.6;
-	text-align: center;
-	z-index: 26;
-	position: absolute;
-	right: 10px;
-}

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -40,24 +40,21 @@
 	 * Adjust upsells styles
 	 */
 	.wpjm-addon-upsell__badge {
-		display: flex;
+		border-radius: 16px;
+		color: inherit;
+		font-size: 8px;
+		margin: 0;
+		padding: 4px 8px;
+		text-align: center;
+		height: fit-content;
+		width: fit-content;
+		display: block;
+		line-height: 8px;
 		vertical-align: middle;
 		box-sizing: border-box;
-		margin: auto 0;
-		padding: 0 3px;
 		min-width: 16px;
-		height: 16px;
-		border-radius: 5px;
-		background-color: #6C737C;
-		color: #fff;
-		font-size: 8px;
-		line-height: 1.6;
-		text-align: center;
+		border: 1px solid currentColor;
+		font-weight: 600;
 		z-index: 26;
-		position: absolute;
-		right: 10px;
-		top: 0;
-		bottom: 0;
-		align-items: center;
 	}
 }

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -31,4 +31,27 @@
 		position: relative;
 		top: 1px;
 	}
+
+
+	/**
+	 * Adjust upsells styles
+	 */
+	.wpjm-addon-upsell__badge {
+		display: inline-block;
+		vertical-align: middle;
+		box-sizing: border-box;
+		margin: 1px 0 -1px 2px;
+		padding: 0 3px;
+		min-width: 15px;
+		height: 15px;
+		border-radius: 5px;
+		background-color: #6C737C;
+		color: #fff;
+		font-size: 10px;
+		line-height: 1.6;
+		text-align: center;
+		z-index: 26;
+		position: absolute;
+		right: 10px;
+	}
 }

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -45,16 +45,9 @@
 		font-size: 8px;
 		margin: 0;
 		padding: 4px 8px;
-		text-align: center;
-		height: fit-content;
-		width: fit-content;
-		display: block;
 		line-height: 8px;
-		vertical-align: middle;
-		box-sizing: border-box;
 		min-width: 16px;
 		border: 1px solid currentColor;
 		font-weight: 600;
-		z-index: 26;
 	}
 }

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -21,9 +21,7 @@
 		}
 	}
 
-	li a[href="edit.php?post_type=job_listing&page=job-manager-landing-application"],
-	li a[href="edit.php?post_type=job_listing&page=job-manager-landing-resumes"],
-	{
+	a.wpjm-addon-upsell {
 		border: solid 0 #5D6264;
 		border-width: 1px 0;
 		padding: 8px 12px 8px 12px !important;

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -30,6 +30,9 @@
 		margin-top: -1px;
 		position: relative;
 		top: 1px;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
 	}
 
 

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -37,21 +37,24 @@
 	 * Adjust upsells styles
 	 */
 	.wpjm-addon-upsell__badge {
-		display: inline-block;
+		display: flex;
 		vertical-align: middle;
 		box-sizing: border-box;
-		margin: 1px 0 -1px 2px;
+		margin: auto 0;
 		padding: 0 3px;
 		min-width: 15px;
 		height: 15px;
 		border-radius: 5px;
 		background-color: #6C737C;
 		color: #fff;
-		font-size: 10px;
+		font-size: 8px;
 		line-height: 1.6;
 		text-align: center;
 		z-index: 26;
 		position: absolute;
 		right: 10px;
+		top: 0;
+		bottom: 0;
+		align-items: center;
 	}
 }

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -42,8 +42,8 @@
 		box-sizing: border-box;
 		margin: auto 0;
 		padding: 0 3px;
-		min-width: 15px;
-		height: 15px;
+		min-width: 16px;
+		height: 16px;
 		border-radius: 5px;
 		background-color: #6C737C;
 		color: #fff;

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -30,9 +30,10 @@
 			text-transform: uppercase;
 			border-radius: 16px;
 			color: inherit;
+			opacity: 0.8;
 			font-size: 8px;
 			margin: 0;
-			padding: 4px 8px;
+			padding: 4px 6px;
 			line-height: 8px;
 			border: 1px solid currentColor;
 			font-weight: 600;

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -34,6 +34,7 @@
 		}
 
 		.wpjm-addon-upsell__badge {
+			text-transform: uppercase;
 			border-radius: 16px;
 			color: inherit;
 			font-size: 8px;

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -25,13 +25,6 @@
 		align-items: center;
 		display: flex;
 		justify-content: space-between;
-		margin: -5px -12px;
-		padding: 8px 12px;
-		border-top: solid 1px #5D6264;
-
-		&.resumes {
-			border-bottom: solid 1px #5D6264;
-		}
 
 		.wpjm-addon-upsell__badge {
 			text-transform: uppercase;

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -21,31 +21,27 @@
 		}
 	}
 
-	a.wpjm-addon-upsell {
-		border: solid 0 #5D6264;
-		border-width: 1px 0;
-		padding: 8px 12px 8px 12px !important;
-		margin-top: -1px;
-		position: relative;
-		top: 1px;
+	.wpjm-addon-upsell {
+		align-items: center;
 		display: flex;
 		justify-content: space-between;
-		align-items: center;
-	}
+		margin: -5px -12px;
+		padding: 8px 12px;
+		border-top: solid 1px #5D6264;
 
+		&.resumes {
+			border-bottom: solid 1px #5D6264;
+		}
 
-	/**
-	 * Adjust upsells styles
-	 */
-	.wpjm-addon-upsell__badge {
-		border-radius: 16px;
-		color: inherit;
-		font-size: 8px;
-		margin: 0;
-		padding: 4px 8px;
-		line-height: 8px;
-		min-width: 16px;
-		border: 1px solid currentColor;
-		font-weight: 600;
+		.wpjm-addon-upsell__badge {
+			border-radius: 16px;
+			color: inherit;
+			font-size: 8px;
+			margin: 0;
+			padding: 4px 8px;
+			line-height: 8px;
+			border: 1px solid currentColor;
+			font-weight: 600;
+		}
 	}
 }

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -87,7 +87,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				sprintf(
 					'%s <span class="wpjm-addon-upsell__badge">%s</span>',
 					esc_html__( 'Applications', 'wp-job-manager' ),
-					esc_html__( 'Pro', 'wp-job-manager' )
+					esc_html__( 'PRO', 'wp-job-manager' )
 				),
 				'manage_options',
 				'job-manager-landing-application',
@@ -121,7 +121,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				sprintf(
 					'%s <span class="wpjm-addon-upsell__badge">%s</span>',
 					esc_html__( 'Resumes', 'wp-job-manager' ),
-					esc_html__( 'Pro', 'wp-job-manager' )
+					esc_html__( 'PRO', 'wp-job-manager' )
 				),
 				'manage_options',
 				'job-manager-landing-resumes',

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -48,6 +48,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_applications_menu_item' ], 12 );
 		add_action( 'admin_menu', [ $this, 'add_resumes_menu_item' ], 12 );
+		add_action( 'admin_init', [ $this, 'add_css_class' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_styles' ] );
 	}
 
@@ -59,6 +60,29 @@ class WP_Job_Manager_Addons_Landing_Page {
 	 */
 	public function register_styles() {
 		WP_Job_Manager::register_style( 'job_manager_admin_landing_css', 'css/admin-landing.css', [ 'job_manager_brand' ] );
+	}
+
+	/**
+	 * Add CSS class to the menu items with the upsells.
+	 *
+	 * @access private
+	 * @since $$next-version$$
+	 */
+	public function add_css_class() {
+		global $submenu;
+		if ( ! isset( $submenu['edit.php?post_type=job_listing'] ) ) {
+			return;
+		}
+		foreach ( $submenu['edit.php?post_type=job_listing'] as $key => $menu ) {
+			if ( in_array( $menu[2], [ 'job-manager-landing-application', 'job-manager-landing-resumes' ], true ) ) {
+				if ( ! isset( $menu[4] ) ) {
+					$menu[4] = '';
+				}
+				$menu[4] .= add_cssclass( 'wpjm-addon-upsell', $menu[4] );
+			}
+			//phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- This is the only way to add the CSS class to the menu.
+			$submenu['edit.php?post_type=job_listing'][ $key ] = $menu;
+		}
 	}
 
 

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -85,7 +85,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				'edit.php?post_type=job_listing',
 				__( 'WP Job Manager - Applications', 'wp-job-manager' ),
 				sprintf(
-					'%s <span class="awaiting-mod wpjm-addon-upsell__badge">%s</span>',
+					'%s <span class="wpjm-addon-upsell__badge">%s</span>',
 					esc_html__( 'Applications', 'wp-job-manager' ),
 					esc_html__( 'Pro', 'wp-job-manager' )
 				),
@@ -119,7 +119,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				'edit.php?post_type=job_listing',
 				__( 'WP Job Manager - Resumes', 'wp-job-manager' ),
 				sprintf(
-					'%s <span class="awaiting-mod wpjm-addon-upsell__badge">%s</span>',
+					'%s <span class="wpjm-addon-upsell__badge">%s</span>',
 					esc_html__( 'Resumes', 'wp-job-manager' ),
 					esc_html__( 'Pro', 'wp-job-manager' )
 				),

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -48,7 +48,6 @@ class WP_Job_Manager_Addons_Landing_Page {
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_applications_menu_item' ], 12 );
 		add_action( 'admin_menu', [ $this, 'add_resumes_menu_item' ], 12 );
-		add_action( 'admin_init', [ $this, 'add_css_class' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_styles' ] );
 	}
 
@@ -61,30 +60,6 @@ class WP_Job_Manager_Addons_Landing_Page {
 	public function register_styles() {
 		WP_Job_Manager::register_style( 'job_manager_admin_landing_css', 'css/admin-landing.css', [ 'job_manager_brand' ] );
 	}
-
-	/**
-	 * Add CSS class to the menu items with the upsells.
-	 *
-	 * @access private
-	 * @since $$next-version$$
-	 */
-	public function add_css_class() {
-		global $submenu;
-		if ( ! isset( $submenu['edit.php?post_type=job_listing'] ) ) {
-			return;
-		}
-		foreach ( $submenu['edit.php?post_type=job_listing'] as $key => $menu ) {
-			if ( in_array( $menu[2], [ 'job-manager-landing-application', 'job-manager-landing-resumes' ], true ) ) {
-				if ( ! isset( $menu[4] ) ) {
-					$menu[4] = '';
-				}
-				$menu[4] .= add_cssclass( 'wpjm-addon-upsell', $menu[4] );
-			}
-			//phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- This is the only way to add the CSS class to the menu.
-			$submenu['edit.php?post_type=job_listing'][ $key ] = $menu;
-		}
-	}
-
 
 	/**
 	 * Add Applications add-on menu item if needed.
@@ -109,7 +84,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				'edit.php?post_type=job_listing',
 				__( 'WP Job Manager - Applications', 'wp-job-manager' ),
 				sprintf(
-					'%s <span class="wpjm-addon-upsell__badge">%s</span>',
+					'<div class="wpjm-addon-upsell">%s <span class="wpjm-addon-upsell__badge">%s</span></div>',
 					esc_html__( 'Applications', 'wp-job-manager' ),
 					esc_html__( 'PRO', 'wp-job-manager' )
 				),
@@ -143,7 +118,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				'edit.php?post_type=job_listing',
 				__( 'WP Job Manager - Resumes', 'wp-job-manager' ),
 				sprintf(
-					'%s <span class="wpjm-addon-upsell__badge">%s</span>',
+					'<div class="wpjm-addon-upsell resumes">%s <span class="wpjm-addon-upsell__badge">%s</span></div>',
 					esc_html__( 'Resumes', 'wp-job-manager' ),
 					esc_html__( 'PRO', 'wp-job-manager' )
 				),

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -118,7 +118,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				'edit.php?post_type=job_listing',
 				__( 'WP Job Manager - Resumes', 'wp-job-manager' ),
 				sprintf(
-					'<div class="wpjm-addon-upsell resumes">%s <span class="wpjm-addon-upsell__badge">%s</span></div>',
+					'<div class="wpjm-addon-upsell">%s <span class="wpjm-addon-upsell__badge">%s</span></div>',
 					esc_html__( 'Resumes', 'wp-job-manager' ),
 					esc_html__( 'Pro', 'wp-job-manager' )
 				),

--- a/includes/admin/class-wp-job-manager-addons-landing-page.php
+++ b/includes/admin/class-wp-job-manager-addons-landing-page.php
@@ -86,7 +86,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				sprintf(
 					'<div class="wpjm-addon-upsell">%s <span class="wpjm-addon-upsell__badge">%s</span></div>',
 					esc_html__( 'Applications', 'wp-job-manager' ),
-					esc_html__( 'PRO', 'wp-job-manager' )
+					esc_html__( 'Pro', 'wp-job-manager' )
 				),
 				'manage_options',
 				'job-manager-landing-application',
@@ -120,7 +120,7 @@ class WP_Job_Manager_Addons_Landing_Page {
 				sprintf(
 					'<div class="wpjm-addon-upsell resumes">%s <span class="wpjm-addon-upsell__badge">%s</span></div>',
 					esc_html__( 'Resumes', 'wp-job-manager' ),
-					esc_html__( 'PRO', 'wp-job-manager' )
+					esc_html__( 'Pro', 'wp-job-manager' )
 				),
 				'manage_options',
 				'job-manager-landing-resumes',


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Change styles of the upsells for Applications and Resumes so it is less distracting

### Testing Instructions

On a WP installation running this branch of the plugin:

* Run `npm start` to compile assets
* Access `/wp-admin` on your WP installation
* Check if the styles of the upsells look less distracting compared to the previous red background
* Also make sure to check how the style looks when testing different admin color schemes on your profile in WordPress:

![Option to change admin color scheme on WP](https://github.com/Automattic/WP-Job-Manager/assets/529864/ff2b2787-9685-4ee7-836b-88a725c560e9)

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Make upsells for Applications and Resumes less distracting

### Screenshot / Video

![Screenshot of the new layout for upsells](https://github.com/Automattic/WP-Job-Manager/assets/529864/4b48acdc-f4f2-4f19-acd9-6677b7e9cc92)

### Context

Experiment started after discussion on Slack: p1700490939485889-slack-C9W0QF6KA










<!-- wpjm:plugin-zip -->
----

| Plugin build for e5d951a9281d0ecc94912a11da31850ea7637dfd <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2651-e5d951a9.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2651-e5d951a9)             |

<!-- /wpjm:plugin-zip -->


















