### PR TITLE
Release WP Job Manager 3.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Plugin Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get npm cache directory
         id: npm-cache
         run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: WPJM Release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
      - name: Checkout
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
 
      - name: Setup Node
        uses: actions/setup-node@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get cached composer directories
         uses: actions/cache@v3

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -14,7 +14,7 @@ jobs:
     name: WPJM release checklist
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Checklist
         uses: automattic/contextual-qa-checklist-action@master
         with:

--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -11,7 +11,7 @@ jobs:
         name: Report Plugin Build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Publish commit status with the link to download the plugin 
               id: plugin_artifact
               uses: Automattic/github-action-report-artifact@v0

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 2.1.0\n"
+"Project-Id-Version: WP Job Manager 3.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-11-17T13:34:50+00:00\n"
+"POT-Creation-Date: 2023-11-23T16:49:01+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0\n"
+"X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: wp-job-manager\n"
 
 #. Plugin Name of the plugin
@@ -375,7 +375,6 @@ msgstr ""
 msgid "%1$s updated. <a href=\"%2$s\">View</a>"
 msgstr ""
 
-#. translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 #: includes/admin/class-wp-job-manager-cpt.php:460
 msgid "Custom field updated."
 msgstr ""
@@ -471,7 +470,6 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/admin/class-wp-job-manager-cpt.php:570
 #: includes/class-wp-job-manager-post-types.php:340
 #: includes/class-wp-job-manager-shortcodes.php:450
@@ -1470,7 +1468,6 @@ msgstr[1] ""
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
-#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/class-wp-job-manager-data-exporter.php:51
 #: includes/class-wp-job-manager-post-types.php:357
 msgid "Company Logo"
@@ -1687,7 +1684,6 @@ msgstr ""
 msgid "Job Manager"
 msgstr ""
 
-#. translators: Placeholder %s is the plural label of the job listing post type.
 #: includes/class-wp-job-manager-post-types.php:337
 msgid "Add New"
 msgstr ""
@@ -1901,7 +1897,6 @@ msgstr ""
 msgid "Missing submission page."
 msgstr ""
 
-#. translators: Placeholder %s is the plural label for the job listing post type.
 #: includes/class-wp-job-manager-shortcodes.php:401
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:36
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:52
@@ -2259,7 +2254,6 @@ msgstr ""
 #: includes/helper/class-wp-job-manager-helper.php:490
 #: includes/helper/views/html-licenses.php:44
 #: includes/helper/views/html-licenses.php:170
-#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:155
 msgid "Activate License"
 msgstr ""
 
@@ -2756,7 +2750,6 @@ msgstr ""
 msgid "%s submitted successfully. Your listing will be visible once approved."
 msgstr ""
 
-#. translators: %1$s is the URL to view the listing; %2$s is
 #: templates/job-submitted.php:61
 msgid "  <a href=\"%1$s\"> View your %2$s</a>"
 msgstr ""
@@ -2768,10 +2761,6 @@ msgstr ""
 #. translators: %1$s is the job listing post type name.
 #: templates/job-submitted.php:92
 msgid "%1$s submitted successfully."
-msgstr ""
-
-#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:122
-msgid "Requires Attention"
 msgstr ""
 
 #: wp-job-manager-functions.php:368

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: job manager, job listing, job board, job management, job lists, job list, 
 Requires at least: 6.1
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 2.1.0
+Stable tag: 3.0.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -276,26 +276,30 @@ function buildReleaseNotes() {
 	let prs = execSync( `${ ghPrs }  --json number,title,body,labels` );
 	prs     = JSON.parse( prs );
 
-	const changelogs = prs.map( ( pr ) => {
+	let changelog = prs.map( ( pr ) => {
 		const body              = pr.body;
 		const changelogSections = body.match( /### Release Notes([\S\s]*?)(?:###|<!--|$)/ );
 
 		if ( ! changelogSections ) {
 			return `* ${ pr.title } (#${ pr.number })`;
 		}
-		const changelog = changelogSections[ 1 ].trim();
+		const prChangelog = changelogSections[ 1 ].trim();
 
-		if ( ! changelog.match( /\w/ ) ) {
+		if ( ! prChangelog.match( /\w/ ) ) {
 			return '';
 		}
 
-		return changelog;
-	} );
+		return prChangelog;
+	} ).join( "\n" );
+
+	if ( changelog.trim().length === 0 ) {
+		changelog = '* Updated plugin headers';
+	}
 
 	console.log( 'Proposed changelog: ' );
-	console.log( changelogs.join( "\n" ) );
+	console.log( changelog );
 
-	return changelogs.join( "\n" );
+	return changelog;
 }
 
 /**

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 2.1.0
+ * Version: 3.0.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.1


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## WP Job Manager 3.0.0

> [!NOTE]
> These release notes between the two  lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Updated plugin headers
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org
