### PR TITLE
Add filter to allow Polylang to translate our job listing categories

### DIFF
--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -83,3 +83,23 @@ function polylang_wpjm_doing_ajax( $is_ajax ) {
 	return isset( $_SERVER['REQUEST_URI'] ) && false === strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/jm-ajax/' ) ? $is_ajax : true;
 }
 add_filter( 'pll_is_ajax_on_front', 'polylang_wpjm_doing_ajax' );
+
+/**
+ * Set Job Listings Categories to be translatable.
+ * This is needed because Polylang doesn't support custom taxonomies by default.
+ *
+ * @since $$next_version$$
+ * @param array $taxonomies
+ * @param bool  $is_settings
+ * @return array
+ */
+function add_job_listing_category_to_pll_taxonomies( $taxonomies, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $taxonomies['job_listing_category'] );
+	} else {
+		$taxonomies['job_listing_category'] = 'job_listing_category';
+	}
+	return $taxonomies;
+
+}
+add_filter( 'pll_get_taxonomies', 'add_job_listing_category_to_pll_taxonomies', 10, 2 );

--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -83,23 +83,3 @@ function polylang_wpjm_doing_ajax( $is_ajax ) {
 	return isset( $_SERVER['REQUEST_URI'] ) && false === strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/jm-ajax/' ) ? $is_ajax : true;
 }
 add_filter( 'pll_is_ajax_on_front', 'polylang_wpjm_doing_ajax' );
-
-/**
- * Set Job Listings Categories to be translatable.
- * This is needed because Polylang doesn't support custom taxonomies by default.
- *
- * @since $$next_version$$
- * @param array $taxonomies
- * @param bool  $is_settings
- * @return array
- */
-function add_job_listing_category_to_pll_taxonomies( $taxonomies, $is_settings ) {
-	if ( $is_settings ) {
-		unset( $taxonomies['job_listing_category'] );
-	} else {
-		$taxonomies['job_listing_category'] = 'job_listing_category';
-	}
-	return $taxonomies;
-
-}
-add_filter( 'pll_get_taxonomies', 'add_job_listing_category_to_pll_taxonomies', 10, 2 );

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -4,6 +4,7 @@
   </custom-types>
   <taxonomies>
     <taxonomy translate="1">job_listing_type</taxonomy>
+	<taxonomy translate="1">job_listing_category</taxonomy>
   </taxonomies>
   <custom-fields>
     <custom-field action="copy">_filled</custom-field>


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Polylang by default won't translate custom taxonomies - this adds a filter to make them translatable

### Testing Instructions

* Install Polylang
* Set a few languages
* Apply this patch!
* Go to Job Manager -> Categories, you should see this:
![uOodlMoDjfW85nmUVAKBSVg2yr80tmf32c3odEBy.jpg](https://github.com/Automattic/WP-Job-Manager/assets/3220162/be7388f1-97c8-4f30-8f9f-04ebd08d7de9)

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

*Set our Job Listings Category to be translatable by Polylang by default


<!-- wpjm:plugin-zip -->
----

| Plugin build for 48b85c4a7eeb5b3d0bce52872acd980f8bd224de <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2657-48b85c4a.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2657-48b85c4a)             |

<!-- /wpjm:plugin-zip -->


