### PR TITLE
Add custom post type for storing guest user data

### DIFF
--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -24,6 +24,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 */
 	private static $custom_post_types = [
 		'job_listing',
+		'job_guest_user',
 	];
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -417,6 +417,34 @@ class WP_Job_Manager_Post_Types {
 				'label_count'               => _n_noop( 'Preview <span class="count">(%s)</span>', 'Preview <span class="count">(%s)</span>', 'wp-job-manager' ),
 			]
 		);
+
+		/**
+		 * Custom post type used to store guest user data.
+		 */
+		register_post_type(
+			'job_guest_user',
+			[
+				apply_filters(
+					'register_post_type_job_guest_user',
+					[
+						'description'         => esc_html__( 'This is where guest user data is stored.', 'wp-job-manager' ),
+						'public'              => false,
+						'show_ui'             => false,
+						'capability_type'     => 'job_guest_user',
+						'map_meta_cap'        => false,
+						'publicly_queryable'  => false,
+						'exclude_from_search' => true,
+						'hierarchical'        => false,
+						'rewrite'             => false,
+						'query_var'           => false,
+						'supports'            => [ 'title', 'custom-fields', 'thumbnail' ],
+						'has_archive'         => false,
+						'show_in_nav_menus'   => false,
+						'show_in_rest'        => false,
+					]
+				),
+			]
+		);
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -19,6 +19,16 @@ class WP_Job_Manager_Post_Types {
 	const PERMALINK_OPTION_NAME = 'job_manager_permalinks';
 
 	/**
+	 * Constant for the post type name used for saving guest user data.
+	 */
+	public const PT_GUEST_USER = 'job_guest_user';
+
+	/**
+	 * Constant for the capability name used for the post type used for saving guest user data.
+	 */
+	public const CAP_GUEST_USER = 'job_guest_user';
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var self
@@ -422,7 +432,7 @@ class WP_Job_Manager_Post_Types {
 		 * Custom post type used to store guest user data.
 		 */
 		register_post_type(
-			'job_guest_user',
+			self::PT_GUEST_USER,
 			[
 				apply_filters(
 					'register_post_type_job_guest_user',
@@ -430,7 +440,7 @@ class WP_Job_Manager_Post_Types {
 						'description'         => esc_html__( 'This is where guest user data is stored.', 'wp-job-manager' ),
 						'public'              => false,
 						'show_ui'             => false,
-						'capability_type'     => 'job_guest_user',
+						'capability_type'     => self::CAP_GUEST_USER,
 						'map_meta_cap'        => false,
 						'publicly_queryable'  => false,
 						'exclude_from_search' => true,

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -437,7 +437,7 @@ class WP_Job_Manager_Post_Types {
 						'hierarchical'        => false,
 						'rewrite'             => false,
 						'query_var'           => false,
-						'supports'            => [ 'title', 'custom-fields', 'thumbnail' ],
+						'supports'            => [ 'title', 'custom-fields' ],
 						'has_archive'         => false,
 						'show_in_nav_menus'   => false,
 						'show_in_rest'        => false,


### PR DESCRIPTION
Fixes #2660 

### Changes Proposed in this Pull Request

* Add custom post type for storing guest user data

### Testing Instructions

Just check if the code makes sense, considering the purpose for this CPT and also the parameters of the `register_post_type` function. 





<!-- wpjm:plugin-zip -->
----

| Plugin build for 72adc4783d5912aad2990a3ea98e540f1f66ee20 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2661-72adc478.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2661-72adc478)             |

<!-- /wpjm:plugin-zip -->






