### PR TITLE
Double escape parenthesis

### DIFF
--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -211,7 +211,7 @@ function updateVersionInFile( filename ) {
 	// Update version constant.
 	const { constant }    = PLUGINS[ pluginSlug ];
 	newPluginFileContents = newPluginFileContents.replace(
-		new RegExp( `define\( '${constant}', '.*' \);` ),
+		new RegExp( `define\\( '${constant}', '.*' \\);` ),
 		`define( '${ constant }', '${ version }' );`,
 	);
 


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Fixes the release script to update the file constant.
* I had the impression that this was working but it didn't apparently

### Testing Instructions

* if you don't want a release PR to be created you can comment out the following lines:
```
pushBranch();
createPR( changelog );
```
* Run 'npm release 2.1.<whatever>'
* Observe that the constant in `wp-job-manager.php` is updated.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 0d09ae93c7432d602a8b0c40c12aa523510af030 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/11/wp-job-manager-zip-2664-0d09ae93.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/11/2664-0d09ae93)             |

<!-- /wpjm:plugin-zip -->
