### PR TITLE
Add access tokens

### DIFF
--- a/includes/class-access-token.php
+++ b/includes/class-access-token.php
@@ -31,6 +31,7 @@ class Access_Token {
 	 */
 	public function __construct( array $metadata ) {
 		$this->metadata = $metadata;
+		ksort( $this->metadata );
 	}
 
 	/**

--- a/includes/class-access-token.php
+++ b/includes/class-access-token.php
@@ -74,7 +74,7 @@ class Access_Token {
 	 * @return bool True if the token is correct.
 	 */
 	public function verify( string $token ) : bool {
-		$token_data = $this->lood_token_data( $this->payload );
+		$token_data = $this->load_token_data( $this->payload );
 
 		if ( true === $this->check_token_expiry( $token_data['payload'] ) ) {
 			return false;
@@ -89,7 +89,7 @@ class Access_Token {
 	 * @return bool
 	 */
 	public function is_expired() : bool {
-		$token_data = $this->lood_token_data( $this->payload );
+		$token_data = $this->load_token_data( $this->payload );
 
 		return $this->check_token_expiry( $token_data['payload'] );
 	}
@@ -116,7 +116,7 @@ class Access_Token {
 	 * @type string $payload    The token payload.
 	 * }
 	 */
-	protected function lood_token_data( array $payload ): array {
+	protected function load_token_data( array $payload ): array {
 		$token_hash = get_user_meta( $payload['user_id'], 'job_manager_alerts_secret_key', true );
 		$payload    = get_user_meta( $payload['user_id'], 'job_manager_alerts_token_payload', true );
 

--- a/includes/class-access-token.php
+++ b/includes/class-access-token.php
@@ -17,14 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since $$next-version$$
  */
 class Access_Token {
-
-	/**
-	 * An expiry timestamp.
-	 *
-	 * @var int|null
-	 */
-	private ?int $expiry;
-
 	/**
 	 * Token's metadata. They are hashed together with the token.
 	 *
@@ -35,12 +27,10 @@ class Access_Token {
 	/**
 	 * Constructor.
 	 *
-	 * @param array    $metadata Metadata to be hashed together with the token.
-	 * @param int|null $expiry Expiry timestamp.
+	 * @param array $metadata Metadata to be hashed together with the token.
 	 */
-	public function __construct( array $metadata, int $expiry = null ) {
+	public function __construct( array $metadata ) {
 		$this->metadata = $metadata;
-		$this->expiry   = $expiry;
 	}
 
 	/**
@@ -49,94 +39,43 @@ class Access_Token {
 	 * @return string The token.
 	 */
 	public function create() : string {
-		// Create a random token, rtrim and strtr converts the base64 to a url-friendly format.
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Method used safely.
-		$token = rtrim( strtr( base64_encode( openssl_random_pseudo_bytes( 18 ) ), '+/', '-_' ), '=' );
+		$tick = wp_nonce_tick();
 
+		return $this->generate_token( $tick );
+	}
+
+	/**
+	 * Generates a token for a tick.
+	 *
+	 * @param float $tick
+	 *
+	 * @return false|string
+	 */
+	private function generate_token( float $tick ) {
 		$metadata_json = wp_json_encode( $this->metadata );
-		$token_hash    = password_hash( $metadata_json . $token, PASSWORD_DEFAULT );
 
-		$this->store_token_data( $this->metadata, $token_hash, $this->expiry );
-
-		return $token;
+		return substr( wp_hash( $tick . '|' . $metadata_json, 'nonce' ), -12, 10 );
 	}
 
 	/**
 	 * Verifies that a token is correct.
 	 *
 	 * @param string $token The token to verify.
+	 * @param int    $duration_days Days that the token should be valid.
 	 *
 	 * @return bool True if the token is correct.
 	 */
-	public function verify( string $token ) : bool {
-		$stored_data = $this->load_token_data( $this->metadata );
+	public function verify( string $token, int $duration_days ) : bool {
+		$duration_ticks = $duration_days * 2;
+		$tick           = wp_nonce_tick();
 
-		if ( true === $this->check_token_expiry( $stored_data['expiry'] ) ) {
-			return false;
+		for ( $i = 0; $i < $duration_ticks; $i++ ) {
+			if ( hash_equals( $this->generate_token( $tick - $i ), $token ) ) {
+				return true;
+			}
 		}
 
-		return password_verify( wp_json_encode( $this->metadata ) . $token, $stored_data['token_hash'] );
-	}
-
-	/**
-	 * Whether the token is expired.
-	 *
-	 * @return bool
-	 */
-	public function is_expired() : bool {
-		$stored_data = $this->load_token_data( $this->metadata );
-
-		return $this->check_token_expiry( $stored_data['expiry'] );
-	}
-
-	/**
-	 * Checks if a token is expired.
-	 *
-	 * @param int $expiry The token expiry.
-	 *
-	 * @return bool
-	 */
-	private function check_token_expiry( int $expiry ) : bool {
-		return ! empty( $expiry ) && time() > $expiry;
-	}
-
-	/**
-	 * Load the token data from storage.
-	 *
-	 * @param array $metadata The metadata of the token.
-	 *
-	 * @return array $stored_data {
-	 *
-	 * @type string $token_hash The token hash. Used for verification.
-	 * @type string $metadata The stored token metadata.
-	 * @type int    $expiry The expiry timestamp.
-	 * }
-	 */
-	protected function load_token_data( array $metadata ): array {
-		$token_hash      = get_user_meta( $metadata['user_id'], 'job_manager_alerts_secret_key', true );
-		$stored_metadata = get_user_meta( $metadata['user_id'], 'job_manager_alerts_token_metadata', true );
-		$expiry          = (int) get_user_meta( $metadata['user_id'], 'job_manager_alerts_token_expiry', true );
-
-		return [
-			'token_hash' => $token_hash,
-			'metadata'   => $stored_metadata ?: [],
-			'expiry'     => $expiry,
-		];
-	}
-
-	/**
-	 * Store the token data.
-	 *
-	 * @param array    $metadata   The token metadata.
-	 * @param string   $token_hash The token hash that will be used for the verification.
-	 * @param int|null $expiry The token expiry.
-	 *
-	 * @return void
-	 */
-	protected function store_token_data( array $metadata, string $token_hash, ?int $expiry ): void {
-		update_user_meta( $metadata['user_id'], 'job_manager_alerts_secret_key', $token_hash );
-		update_user_meta( $metadata['user_id'], 'job_manager_alerts_token_metadata', $metadata );
-		update_user_meta( $metadata['user_id'], 'job_manager_alerts_token_expiry', $expiry );
+		return false;
 	}
 }
 

--- a/includes/class-access-token.php
+++ b/includes/class-access-token.php
@@ -55,7 +55,7 @@ class Access_Token {
 	private function generate_token( float $tick ) {
 		$metadata_json = wp_json_encode( $this->metadata );
 
-		return substr( wp_hash( $tick . '|' . $metadata_json, 'nonce' ), -12, 10 );
+		return substr( wp_hash( $tick . '|' . $metadata_json, 'nonce' ), -18, 16 );
 	}
 
 	/**

--- a/includes/class-access-token.php
+++ b/includes/class-access-token.php
@@ -40,7 +40,7 @@ class Access_Token {
 	 * @return string The token.
 	 */
 	public function create() : string {
-		$tick = wp_nonce_tick();
+		$tick = $this->token_tick();
 
 		return $this->generate_token( $tick );
 	}
@@ -67,10 +67,9 @@ class Access_Token {
 	 * @return bool True if the token is correct.
 	 */
 	public function verify( string $token, int $duration_days ) : bool {
-		$duration_ticks = $duration_days * 2;
-		$tick           = wp_nonce_tick();
+		$tick = $this->token_tick();
 
-		for ( $i = 0; $i < $duration_ticks; $i++ ) {
+		for ( $i = 0; $i < $duration_days; $i++ ) {
 			if ( hash_equals( $this->generate_token( $tick - $i ), $token ) ) {
 				return true;
 			}
@@ -78,6 +77,14 @@ class Access_Token {
 
 		return false;
 	}
+
+	/**
+	 * The tick controls how often the token is going to be rotated. Copied from wp_nonce_tick to avoid the nonce_life
+	 * filter.
+	 *
+	 * @return false|float
+	 */
+	private function token_tick() {
+		return ceil( time() / DAY_IN_SECONDS );
+	}
 }
-
-

--- a/includes/class-access-token.php
+++ b/includes/class-access-token.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * File containing the class Access_Token.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * A token that provides access to a private resource.
+ *
+ * @since $$next-version$$
+ */
+class Access_Token {
+
+	/**
+	 * An expiry timestamp.
+	 *
+	 * @var int|null
+	 */
+	private ?int $expiry;
+
+	/**
+	 * Token's payload. It is hashed together with the token.
+	 *
+	 * @var array
+	 */
+	private array $payload;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array    $payload A payload to be hashed together with the token.
+	 * @param int|null $expiry Expiry timestamp.
+	 */
+	public function __construct( array $payload, int $expiry = null ) {
+		$this->payload = $payload;
+		$this->expiry  = $expiry;
+	}
+
+	/**
+	 * Creates a new token.
+	 *
+	 * @return string The token.
+	 */
+	public function create() : string {
+		$payload_json = wp_json_encode( $this->payload );
+		// Create a random token, rtrim and strtr converts the base64 to a url-friendly format.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Method used safely.
+		$token = rtrim( strtr( base64_encode( openssl_random_pseudo_bytes( 18 ) ), '+/', '-_' ), '=' );
+
+		$payload = $this->payload;
+		if ( ! empty( $this->expiry ) ) {
+			$payload['expiry'] = $this->expiry;
+		}
+
+		$token_hash = password_hash( $payload_json . $token, PASSWORD_DEFAULT );
+
+		$this->store_token_data( $payload, $token_hash );
+
+		return $token;
+	}
+
+	/**
+	 * Verifies that a token is correct.
+	 *
+	 * @param string $token The token to verify.
+	 *
+	 * @return bool True if the token is correct.
+	 */
+	public function verify( string $token ) : bool {
+		$token_data = $this->lood_token_data( $this->payload );
+
+		if ( true === $this->check_token_expiry( $token_data['payload'] ) ) {
+			return false;
+		}
+
+		return password_verify( wp_json_encode( $this->payload ) . $token, $token_data['token_hash'] );
+	}
+
+	/**
+	 * Whether the token is expired.
+	 *
+	 * @return bool
+	 */
+	public function is_expired() : bool {
+		$token_data = $this->lood_token_data( $this->payload );
+
+		return $this->check_token_expiry( $token_data['payload'] );
+	}
+
+	/**
+	 * Checks if a token is expired.
+	 *
+	 * @param array $payload The token payload.
+	 *
+	 * @return bool
+	 */
+	private function check_token_expiry( array $payload ) : bool {
+		return ! empty( $payload['expiry'] ) && time() > $payload['expiry'];
+	}
+
+	/**
+	 * Load the token data from storage.
+	 *
+	 * @param array $payload The payload of the token.
+	 *
+	 * @return array $token_data {
+	 *
+	 * @type string $token_hash The token hash. Used for verification.
+	 * @type string $payload    The token payload.
+	 * }
+	 */
+	protected function lood_token_data( array $payload ): array {
+		$token_hash = get_user_meta( $payload['user_id'], 'job_manager_alerts_secret_key', true );
+		$payload    = get_user_meta( $payload['user_id'], 'job_manager_alerts_token_payload', true );
+
+		return [
+			'token_hash' => $token_hash,
+			'payload'    => $payload ?: [],
+		];
+	}
+
+	/**
+	 * Store the token data.
+	 *
+	 * @param array  $payload    The token payload.
+	 * @param string $token_hash The token hash that will be used for the verification.
+	 *
+	 * @return void
+	 */
+	protected function store_token_data( array $payload, string $token_hash ): void {
+		update_user_meta( $payload['user_id'], 'job_manager_alerts_secret_key', $token_hash );
+		update_user_meta( $payload['user_id'], 'job_manager_alerts_token_payload', $payload );
+	}
+}
+
+

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -76,6 +76,7 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-data-exporter.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-com-api.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-access-token.php';
 
 		if ( is_admin() ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-admin.php';

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,6 +29,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
 	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,4 +1,26 @@
 <?php /** @noinspection PhpCSValidationInspection */
+function log7( ...$val ) {
+	if ( is_array( $val ) ) {
+		foreach ( $val as $v ) {
+			error_log(print_r($v,true));
+		}
+	} else {
+		error_log(print_r($val,true));
+	}
+
+}
+
+function log8( ...$val ){
+	ob_start();
+	if ( is_array( $val ) ) {
+		foreach ( $val as $v ) {
+			var_dump($v);
+		}
+	} else {
+		var_dump($val);
+	}
+	error_log(ob_get_clean());
+}
 
 /**
  * WPJM Unit Tests Bootstrap

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,26 +1,4 @@
 <?php /** @noinspection PhpCSValidationInspection */
-function log7( ...$val ) {
-	if ( is_array( $val ) ) {
-		foreach ( $val as $v ) {
-			error_log(print_r($v,true));
-		}
-	} else {
-		error_log(print_r($val,true));
-	}
-
-}
-
-function log8( ...$val ){
-	ob_start();
-	if ( is_array( $val ) ) {
-		foreach ( $val as $v ) {
-			var_dump($v);
-		}
-	} else {
-		var_dump($val);
-	}
-	error_log(ob_get_clean());
-}
 
 /**
  * WPJM Unit Tests Bootstrap

--- a/tests/php/tests/includes/test_class.access-token.php
+++ b/tests/php/tests/includes/test_class.access-token.php
@@ -14,7 +14,7 @@ function time() : int {
 }
 class WP_Test_Access_Token extends WP_UnitTestCase {
 
-	public static ?int $time;
+	public static ?int $time = null;
 
 	protected function tearDown() : void {
 		self::$time = null;

--- a/tests/php/tests/includes/test_class.access-token.php
+++ b/tests/php/tests/includes/test_class.access-token.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WP_Job_Manager;
+
+use WP_UnitTestCase;
+
+class WP_Test_Access_Token extends WP_UnitTestCase {
+
+	public function test_correct_token_verified_succesfully() {
+		$access_token = new Access_Token( [ 'user_id' => 10 ] );
+		$token = $access_token->create();
+
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( 'aRandomString' ) );
+	}
+
+	public function test_expired_token_not_verified() {
+		$access_token = new Access_Token( [ 'user_id' => 10 ], time() - 1000 );
+		$token = $access_token->create();
+
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token ) );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->is_expired() );
+	}
+
+	public function test_incorrect_payload_not_verified() {
+		$access_token = new Access_Token( [ 'user_id' => 10 ], time() + 1000 );
+		$token = $access_token->create();
+
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10 ] ) )->is_expired() );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10 ] ))->verify( $token ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 110 ] ) )->verify( $token ) );
+	}
+}

--- a/tests/php/tests/includes/test_class.access-token.php
+++ b/tests/php/tests/includes/test_class.access-token.php
@@ -4,15 +4,21 @@ namespace WP_Job_Manager;
 
 use WP_UnitTestCase;
 
-function time() {
+/**
+ * Mocks global time().
+ *
+ * @return int
+ */
+function time() : int {
 	return WP_Test_Access_Token::$time ?: \time();
 }
 class WP_Test_Access_Token extends WP_UnitTestCase {
 
-	public static $time;
+	public static ?int $time;
+
 	protected function tearDown() : void {
 		self::$time = null;
-	    parent::tearDown();
+		parent::tearDown();
 	}
 
 	public function test_correct_token_verified_succesfully() {
@@ -51,5 +57,4 @@ class WP_Test_Access_Token extends WP_UnitTestCase {
 		self::assertTrue( ( new Access_Token( [ 'user_id' => 10 ] ) )->verify( $token ) );
 		self::assertFalse( ( new Access_Token( [ 'user_id' => 10 ] ) )->verify( $token_with_expiry ) );
 	}
-
 }

--- a/tests/php/tests/includes/test_class.access-token.php
+++ b/tests/php/tests/includes/test_class.access-token.php
@@ -2,44 +2,54 @@
 
 namespace WP_Job_Manager;
 
-use ReflectionObject;
 use WP_UnitTestCase;
 
+function time() {
+	return WP_Test_Access_Token::$time ?: \time();
+}
 class WP_Test_Access_Token extends WP_UnitTestCase {
+
+	public static $time;
+	protected function tearDown() : void {
+		self::$time = null;
+	    parent::tearDown();
+	}
 
 	public function test_correct_token_verified_succesfully() {
 		$access_token = new Access_Token( [ 'user_id' => 10 ] );
 		$token = $access_token->create();
 
-		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token, 1 ) );
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( 'aRandomString', 1 ) );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ) )->verify( $token ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ) )->verify( 'aRandomString' ) );
 	}
 
 	public function test_expired_token_not_verified() {
 		$access_token = new Access_Token( [ 'user_id' => 10 ] );
-		$token = $access_token->create();
+		$token = $access_token->create( time() + 200 );
 
-		$reflection_object = new ReflectionObject( $access_token );
-		$tick_method = $reflection_object->getMethod( 'token_tick' );
-		$tick_method->setAccessible(true);
-		$tick = $tick_method->invoke( $access_token );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ) )->verify( $token ) );
 
-		$generate_token_method = ( new ReflectionObject( $access_token ) )->getMethod( 'generate_token' );
-		$generate_token_method->setAccessible( true );
+		self::$time = time() + 500;
 
-		$token_previous_day = $generate_token_method->invoke( $access_token, $tick - 1 );
-		$token_2_days_ago   = $generate_token_method->invoke( $access_token, $tick - 2 );
-
-		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token, 2 ) );
-		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token_previous_day, 2 ) );
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token_2_days_ago, 2 ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ) )->verify( $token ) );
 	}
 
 	public function test_incorrect_payload_not_verified() {
 		$access_token = new Access_Token( [ 'user_id' => 10, 'email' => 'email@email.com' ] );
 		$token = $access_token->create();
 
-		self::assertTrue( ( new Access_Token( [ 'email' => 'email@email.com', 'user_id' => 10 ] ))->verify( $token, 1 ) );
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 110, 'email' => 'email@email.com' ] ) )->verify( $token, 1 ) );
+		self::assertTrue( ( new Access_Token( [ 'email' => 'email@email.com', 'user_id' => 10 ] ) )->verify( $token ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 110, 'email' => 'email@email.com' ] ) )->verify( $token ) );
 	}
+
+	public function test_token_no_expiration_always_verified() {
+		$access_token = new Access_Token( [ 'user_id' => 10 ] );
+		$token = $access_token->create();
+		$token_with_expiry = $access_token->create( time() + 1000 );
+
+		self::$time = time() + 10000000;
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10 ] ) )->verify( $token ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10 ] ) )->verify( $token_with_expiry ) );
+	}
+
 }

--- a/tests/php/tests/includes/test_class.access-token.php
+++ b/tests/php/tests/includes/test_class.access-token.php
@@ -2,6 +2,7 @@
 
 namespace WP_Job_Manager;
 
+use ReflectionObject;
 use WP_UnitTestCase;
 
 class WP_Test_Access_Token extends WP_UnitTestCase {
@@ -10,24 +11,37 @@ class WP_Test_Access_Token extends WP_UnitTestCase {
 		$access_token = new Access_Token( [ 'user_id' => 10 ] );
 		$token = $access_token->create();
 
-		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token ) );
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( 'aRandomString' ) );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token, 1 ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( 'aRandomString', 1 ) );
 	}
 
 	public function test_expired_token_not_verified() {
-		$access_token = new Access_Token( [ 'user_id' => 10 ], time() - 1000 );
+		$access_token = new Access_Token( [ 'user_id' => 10 ] );
 		$token = $access_token->create();
 
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token ) );
-		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->is_expired() );
+		$generate_token = ( new ReflectionObject( $access_token ) )->getMethod( 'generate_token' );
+		$generate_token->setAccessible( true );
+		$tick = wp_nonce_tick();
+
+		$token_12_hours = $generate_token->invoke( $access_token, $tick - 1 );
+		$token_24_hours = $generate_token->invoke( $access_token, $tick - 2 );
+		$token_36_hours = $generate_token->invoke( $access_token, $tick - 3 );
+		$token_48_hours = $generate_token->invoke( $access_token, $tick - 4 );
+		$token_60_hours = $generate_token->invoke( $access_token, $tick - 5 );
+
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token, 2 ) );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token_12_hours, 2 ) );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token_24_hours, 2 ) );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token_36_hours, 2 ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token_48_hours, 2 ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 10] ))->verify( $token_60_hours, 2 ) );
 	}
 
 	public function test_incorrect_payload_not_verified() {
 		$access_token = new Access_Token( [ 'user_id' => 10 ], time() + 1000 );
 		$token = $access_token->create();
 
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 10 ] ) )->is_expired() );
-		self::assertTrue( ( new Access_Token( [ 'user_id' => 10 ] ))->verify( $token ) );
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 110 ] ) )->verify( $token ) );
+		self::assertTrue( ( new Access_Token( [ 'user_id' => 10 ] ))->verify( $token, 1 ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 110 ] ) )->verify( $token, 1 ) );
 	}
 }

--- a/tests/php/tests/includes/test_class.access-token.php
+++ b/tests/php/tests/includes/test_class.access-token.php
@@ -38,10 +38,10 @@ class WP_Test_Access_Token extends WP_UnitTestCase {
 	}
 
 	public function test_incorrect_payload_not_verified() {
-		$access_token = new Access_Token( [ 'user_id' => 10 ], time() + 1000 );
+		$access_token = new Access_Token( [ 'user_id' => 10, 'email' => 'email@email.com' ] );
 		$token = $access_token->create();
 
-		self::assertTrue( ( new Access_Token( [ 'user_id' => 10 ] ))->verify( $token, 1 ) );
-		self::assertFalse( ( new Access_Token( [ 'user_id' => 110 ] ) )->verify( $token, 1 ) );
+		self::assertTrue( ( new Access_Token( [ 'email' => 'email@email.com', 'user_id' => 10 ] ))->verify( $token, 1 ) );
+		self::assertFalse( ( new Access_Token( [ 'user_id' => 110, 'email' => 'email@email.com' ] ) )->verify( $token, 1 ) );
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wpjm-addons/issues/161, https://github.com/Automattic/wpjm-addons/issues/160

This meant to be be an initial approach to get some early feedback. Main points:
- The tokens support expiry. I think that we should use this for guest accounts.
- The code will be in WPJM core to be able to be used by all plugins.
- The current implementation is meant to be a replacement for the unsusbscribe links. The next iteration will save data in post meta for guest accounts.
- I based my solution in an [existing approach ](https://github.com/Automattic/wpjm-addons/blob/e46bef58903934ef6fb91873e9823e5c97334440/src/alerts/wp-job-manager-alerts.php#L412C2-L412C2)that we had in alerts for unsusbscribe links. I think that this approach is a bit more secure as:
	* It doesn't use DES
	* It stores only hashed values.
- If we agree on the approach I will also request a review from our security team.
- I am thinking that we should replace [these methods](https://github.com/Automattic/wpjm-addons/blob/e46bef58903934ef6fb91873e9823e5c97334440/src/alerts/wp-job-manager-alerts.php#L412C2-L412C2) with this class. We could potentially use both methods for some time to not break backward compatibility.

### Changes Proposed in this Pull Request

* Adds a token class which can be used to create and verify tokens.
* It's possible for tokens to have an expiry date.

### Testing Instructions

* Just check the approach and make sure that the tests pass.











<!-- wpjm:plugin-zip -->
----

| Plugin build for 622323363e98e89303675956a6524c01f640887b <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2666-62232336.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2666-62232336)             |

<!-- /wpjm:plugin-zip -->




















