### PR TITLE
Add support to display messages after a redirect

### DIFF
--- a/includes/ui/RedirectMessage.php
+++ b/includes/ui/RedirectMessage.php
@@ -62,15 +62,15 @@ class RedirectMessage {
 
 		$content = self::get_transient_message( $key );
 
-		if ( $content ) {
-			$content .= self::add_inline_script( $query_var );
-
-			UI::ensure_styles();
-
-			return $content;
+		if ( ! $content ) {
+			return null;
 		}
 
-		return null;
+		$content .= self::add_inline_script( $query_var );
+
+		UI::ensure_styles();
+
+		return $content;
 	}
 
 	/**
@@ -99,15 +99,15 @@ class RedirectMessage {
 	private static function get_transient_message( $key, $delete = true ) {
 		$content = get_transient( self::TRANSIENT_PREFIX . $key );
 
-		if ( is_string( $content ) ) {
-			if ( $delete ) {
-				delete_transient( self::TRANSIENT_PREFIX . $key );
-			}
-
-			return $content;
+		if ( ! is_string( $content ) ) {
+			return null;
 		}
 
-		return null;
+		if ( $delete ) {
+			delete_transient( self::TRANSIENT_PREFIX . $key );
+		}
+
+		return $content;
 	}
 
 	/**

--- a/includes/ui/RedirectMessage.php
+++ b/includes/ui/RedirectMessage.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Frontend redirect messages.
+ *
+ * @package wp-job-manager
+ * @since $$next-version$$
+ */
+
+namespace WP_Job_Manager\UI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Redirect after an action is finished and make sure a message can displayed on the next page load.
+ *
+ * Stores the messages in a transient with an ID, and passes along the ID as a query string to the redirected URL.
+ *
+ * @since $$next-version$$
+ *
+ * @internal This API is still under development and subject to change.
+ * @access private
+ */
+class RedirectMessage {
+
+	const DEFAULT_QUERY_VAR = 'message';
+	const TRANSIENT_PREFIX  = 'wpjm_message_';
+
+	/**
+	 * Redirect to a URL with a message to be displayed on the next page load.
+	 *
+	 * @param string $url URL to redirect to.
+	 * @param string $message Optional message to be displayed on the next page load.
+	 * @param string $query_var A query variable added to the redirect URL, referencing the message transient.
+	 */
+	public static function redirect( $url, $message = null, $query_var = '' ) {
+		if ( ! empty( $message ) ) {
+			$url = add_query_arg( [ $query_var ?? self::DEFAULT_QUERY_VAR => self::set_transient_message( $message ) ], $url );
+		}
+		wp_safe_redirect( $url );
+		exit;
+	}
+
+	/**
+	 * Get a message set during the previous redirect.
+	 *
+	 * @param string $query_var Optional namespace for the message.
+	 *
+	 * @return string|null Message content if there is one.
+	 */
+	public static function get_message( $query_var = '' ) {
+
+		$query_var = $query_var ?? self::DEFAULT_QUERY_VAR;
+
+		//phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action is performed.
+		$key = sanitize_key( wp_unslash( $_GET[ $query_var ] ?? null ) );
+
+		if ( ! $key ) {
+			return null;
+		}
+
+		$content = self::get_transient_message( $key );
+
+		if ( $content ) {
+			$content .= self::add_inline_script( $query_var );
+
+			UI::ensure_styles();
+
+			return $content;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Add a message for the next page load.
+	 *
+	 * @param string $message Message to be displayed on the next page load.
+	 *
+	 * @return string Transient key.
+	 */
+	private static function set_transient_message( $message ) {
+		$key = uniqid();
+
+		set_transient( self::TRANSIENT_PREFIX . $key, $message, 10 * MINUTE_IN_SECONDS );
+
+		return $key;
+	}
+
+	/**
+	 * Get a message for the given transient key, and optionally delete the transient.
+	 *
+	 * @param string $key Transient key.
+	 * @param bool   $delete Whether to delete the message after retrieving it.
+	 *
+	 * @return string|null Message to be displayed on the next page load.
+	 */
+	private static function get_transient_message( $key, $delete = true ) {
+		$content = get_transient( self::TRANSIENT_PREFIX . $key );
+
+		if ( is_string( $content ) ) {
+			if ( $delete ) {
+				delete_transient( self::TRANSIENT_PREFIX . $key );
+			}
+
+			return $content;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Add a small script to remove the redirect message query var from the URL upon page load.
+	 *
+	 * @param string $query_var Query var to remove.
+	 *
+	 * @return string Script HTML.
+	 */
+	private static function add_inline_script( $query_var ) {
+		return '
+			<script>
+				const url = new URL( location.href );
+				url.searchParams.delete(\'' . esc_js( $query_var ) . '\');
+				history.replaceState(null, \'\', url)
+
+			</script>
+		';
+	}
+
+}

--- a/includes/ui/RedirectMessage.php
+++ b/includes/ui/RedirectMessage.php
@@ -35,8 +35,12 @@ class RedirectMessage {
 	 * @param string $query_var A query variable added to the redirect URL, referencing the message transient.
 	 */
 	public static function redirect( $url, $message = null, $query_var = '' ) {
+		if ( empty( $query_var ) ) {
+			$query_var = self::DEFAULT_QUERY_VAR;
+		}
+
 		if ( ! empty( $message ) ) {
-			$url = add_query_arg( [ $query_var ?? self::DEFAULT_QUERY_VAR => self::set_transient_message( $message ) ], $url );
+			$url = add_query_arg( [ $query_var => self::set_transient_message( $message ) ], $url );
 		}
 		wp_safe_redirect( $url );
 		exit;
@@ -51,7 +55,9 @@ class RedirectMessage {
 	 */
 	public static function get_message( $query_var = '' ) {
 
-		$query_var = $query_var ?? self::DEFAULT_QUERY_VAR;
+		if ( empty( $query_var ) ) {
+			$query_var = self::DEFAULT_QUERY_VAR;
+		}
 
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action is performed.
 		$key = sanitize_key( wp_unslash( $_GET[ $query_var ] ?? null ) );

--- a/includes/ui/class-redirect-message.php
+++ b/includes/ui/class-redirect-message.php
@@ -124,14 +124,15 @@ class Redirect_Message {
 	 * @return string Script HTML.
 	 */
 	private static function add_inline_script( $query_var ) {
-		return '
+		$query_var = esc_js( $query_var );
+		return <<<HTML
 			<script>
 				const url = new URL( location.href );
-				url.searchParams.delete(\'' . esc_js( $query_var ) . '\');
-				history.replaceState(null, \'\', url)
+				url.searchParams.delete('{$query_var}');
+				history.replaceState(null, '', url)
 
 			</script>
-		';
+HTML;
 	}
 
 }

--- a/includes/ui/class-redirect-message.php
+++ b/includes/ui/class-redirect-message.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @internal This API is still under development and subject to change.
  * @access private
  */
-class RedirectMessage {
+class Redirect_Message {
 
 	const DEFAULT_QUERY_VAR = 'message';
 	const TRANSIENT_PREFIX  = 'wpjm_message_';

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-notice.php';
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/RedirectMessage.php';
 
 /**
  * Frontend UI elements of Job Manager.

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-notice.php';
-require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/RedirectMessage.php';
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-redirect-message.php';
 
 /**
  * Frontend UI elements of Job Manager.


### PR DESCRIPTION
Based on https://github.com/Automattic/WP-Job-Manager/pull/2659

### Changes Proposed in this Pull Request

* Add a helper that lets you set a message, redirect the page, and show the message
* This serves a common pattern used when serving a POST/GET action like saving a form or changing a setting: we redirect the page after the action is done so it's not triggered again on page reload or a link share.
* Stores the message in a transient with an ID, and passes along the ID as a query string argument to the redirected URL, like `?message=234d72af2`
* Includes a small JS script to remove that query argument

### Testing Instructions

* See 393-gh-Automattic/wpjm-addons for testing

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Add support to display messages after a redirect 





<!-- wpjm:plugin-zip -->
----

| Plugin build for fbdf0d056e2881bf2dd99f856f295c3952b13d28 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2667-fbdf0d05.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2667-fbdf0d05)             |

<!-- /wpjm:plugin-zip -->







