### PR TITLE
If the admin menu for Job Manager doesn't exist, don't re-add it anyway

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -177,6 +177,9 @@ class WP_Job_Manager_Admin {
 	public function admin_menu() {
 		remove_submenu_page( 'edit.php?post_type=job_listing', 'post-new.php?post_type=job_listing' );
 		$item = remove_submenu_page( 'edit.php?post_type=job_listing', 'edit.php?post_type=job_listing' );
+		if ( ! $item ) {
+			return;
+		}
 		// change item label to "Job Listings".
 		add_submenu_page( 'edit.php?post_type=job_listing', $item[0], esc_html__( 'Job Listings', 'wp-job-manager' ), $item[1], $item[2], '', 0 );
 		add_submenu_page( 'edit.php?post_type=job_listing', __( 'Settings', 'wp-job-manager' ), esc_html__( 'Settings', 'wp-job-manager' ), 'manage_options', 'job-manager-settings', [ $this->settings_page, 'output' ] );


### PR DESCRIPTION
Fixes #2653

### Changes Proposed in this Pull Request

* Add a condition to not re-add menu entries if the menu entry for Job Manager doesn't exist anyway.

### Testing Instructions

1. Create an `employee` user
2. Log-in with that user
3. Visit `/wp-admin/`
4. Make sure no warnings like the one below appears on the PHP error log:

```
Warning: Trying to access array offset on value of type bool in wp-content/plugins/WP-Job-Manager/includes/admin/class-wp-job-manager-admin.php on line 181
```

5. Now, log-in as an `administrator` user
6. Visit `/wp-admin/` 
7. Make sure the "Job Manager" menu keeps working as usual


<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix: Do not emit warning when user with insufficient access to Job Manager menu tries to access wp-admin

<!-- wpjm:plugin-zip -->
----

| Plugin build for b3ba8ed3b2770f35f87796e5c281fd82d1292528 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2668-b3ba8ed3.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2668-b3ba8ed3)             |

<!-- /wpjm:plugin-zip -->
