### PR TITLE
Add multiple checkbox input fields

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -812,13 +812,13 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
-	 * Radio and Checkbox Outputs.
+	 * Multiple Choice field output (radio or checkbox).
 	 *
 	 * @param array  $option Option data.
 	 * @param mixed  $value  Current value.
 	 * @param string $type   'radio' or 'checkbox'.
 	 */
-	protected function radio_checkbox_outputs( $option, $value, $type ) {
+	protected function multiple_choice_output( $option, $value, $type ) {
 		?>
 		<fieldset>
 		<legend class="screen-reader-text">
@@ -851,7 +851,7 @@ class WP_Job_Manager_Settings {
 	 * @param string $ignored_placeholder
 	 */
 	protected function input_radio( $option, $ignored_attributes, $value, $ignored_placeholder ) {
-		$this->radio_checkbox_outputs( $option, $value, 'radio' );
+		$this->multiple_choice_output( $option, $value, 'radio' );
 	}
 
 	/**
@@ -863,7 +863,7 @@ class WP_Job_Manager_Settings {
 	 * @param string $ignored_placeholder
 	 */
 	protected function input_multi_checkbox( $option, $ignored_attributes, $value, $ignored_placeholder ) {
-		$this->radio_checkbox_outputs( $option, $value, 'checkbox' );
+		$this->multiple_choice_output( $option, $value, 'checkbox' );
 	}
 	/**
 	 * Page input field.

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -828,15 +828,16 @@ class WP_Job_Manager_Settings {
 		if ( ! empty( $option['desc'] ) ) {
 			echo ' <p class="description">' . wp_kses_post( $option['desc'] ) . '</p>';
 		}
-		if ( 'checkbox' === $type ) {
-			foreach ( $option['options'] as $key => $name ) {
-				$value = (array) $value;
-				echo '<label><input name="' . esc_attr( $option['name'] . '[fields][]' ) . '" type="' . esc_attr( $type ) . '" value="' . esc_attr( strtolower( $name ) ) . '" ' . checked( isset( $value['fields'] ) && is_array( $value['fields'] ) && in_array( strtolower( $name ), $value['fields'], true ), true, 0 ) . '/>' . esc_html( $name ) . '</label><br>';
-			}
-		} else {
-			foreach ( $option['options'] as $key => $name ) {
-				echo '<label><input name="' . esc_attr( $option['name'] ) . '" type="radio" value="' . esc_attr( $key ) . '" ' . checked( $value, $key, false ) . ' />' . esc_html( $name ) . '</label><br>';
-			}
+		foreach ( $option['options'] as $key => $name ) {
+			$input_name  = esc_attr( 'checkbox' === $type ? $option['name'] . '[fields][]' : $option['name'] );
+			$input_type  = esc_attr( $type );
+			$input_value = esc_attr( 'checkbox' === $type ? strtolower( $name ) : $key );
+			$is_checked  = 'checkbox' === $type
+				? checked( isset( $value['fields'] ) && is_array( $value['fields'] ) && in_array( strtolower( $name ), $value['fields'], true ), true, 0 )
+				: checked( $value, $key, false );
+			$label       = esc_html( $name );
+
+			echo "<label><input name='{$input_name}' type='{$input_type}' value='{$input_value}' {$is_checked} />{$label}</label><br>"; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 		?>
 		</fieldset>

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -834,7 +834,7 @@ class WP_Job_Manager_Settings {
 		}
 	}
 
-  /**
+	/**
 	 * Multiple Choice field output (radio or checkbox).
 	 *
 	 * @param array  $option Option data.

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -812,14 +812,13 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
-	 * Radio input field.
+	 * Radio and Checkbox Outputs.
 	 *
-	 * @param array  $option
-	 * @param array  $ignored_attributes
-	 * @param mixed  $value
-	 * @param string $ignored_placeholder
+	 * @param array  $option Option data.
+	 * @param mixed  $value  Current value.
+	 * @param string $type   'radio' or 'checkbox'.
 	 */
-	protected function input_radio( $option, $ignored_attributes, $value, $ignored_placeholder ) {
+	protected function radio_checkbox_outputs( $option, $value, $type ) {
 		?>
 		<fieldset>
 		<legend class="screen-reader-text">
@@ -829,15 +828,43 @@ class WP_Job_Manager_Settings {
 		if ( ! empty( $option['desc'] ) ) {
 			echo ' <p class="description">' . wp_kses_post( $option['desc'] ) . '</p>';
 		}
-
-		foreach ( $option['options'] as $key => $name ) {
-			echo '<label><input name="' . esc_attr( $option['name'] ) . '" type="radio" value="' . esc_attr( $key ) . '" ' . checked( $value, $key, false ) . ' />' . esc_html( $name ) . '</label><br>';
+		if ( 'checkbox' === $type ) {
+			foreach ( $option['options'] as $key => $name ) {
+				$value = (array) $value;
+				echo '<label><input name="' . esc_attr( $option['name'] . '[fields][]' ) . '" type="' . esc_attr( $type ) . '" value="' . esc_attr( strtolower( $name ) ) . '" ' . checked( isset( $value['fields'] ) && is_array( $value['fields'] ) && in_array( strtolower( $name ), $value['fields'], true ), true, 0 ) . '/>' . esc_html( $name ) . '</label><br>';
+			}
+		} else {
+			foreach ( $option['options'] as $key => $name ) {
+				echo '<label><input name="' . esc_attr( $option['name'] ) . '" type="radio" value="' . esc_attr( $key ) . '" ' . checked( $value, $key, false ) . ' />' . esc_html( $name ) . '</label><br>';
+			}
 		}
 		?>
 		</fieldset>
 		<?php
 	}
+	/**
+	 * Radio input field.
+	 *
+	 * @param array  $option
+	 * @param array  $ignored_attributes
+	 * @param mixed  $value
+	 * @param string $ignored_placeholder
+	 */
+	protected function input_radio( $option, $ignored_attributes, $value, $ignored_placeholder ) {
+		$this->radio_checkbox_outputs( $option, $value, 'radio' );
+	}
 
+	/**
+	 * Multiple Checkbox input field.
+	 *
+	 * @param array  $option
+	 * @param array  $ignored_attributes
+	 * @param mixed  $value
+	 * @param string $ignored_placeholder
+	 */
+	protected function input_multi_checkbox( $option, $ignored_attributes, $value, $ignored_placeholder ) {
+		$this->radio_checkbox_outputs( $option, $value, 'checkbox' );
+	}
 	/**
 	 * Page input field.
 	 *


### PR DESCRIPTION
Needed for https://github.com/Automattic/wpjm-addons/issues/152

### Changes Proposed in this Pull Request

* Add a new type of setting which is `multiple checkboxes` for a single setting.  

### Testing Instructions

* Check this PR out to have a setting to test https://github.com/Automattic/wpjm-addons/pull/394
* Verify that the setting shows up properly

### Screenshot / Video

![kEg7doEO8EfOflam7RdHFR4uOktNV4k9IaeWKoYt.jpg](https://github.com/Automattic/wpjm-addons/assets/3220162/e497fd5c-2a9a-44ac-b9e8-2c6e38eb22db)



<!-- wpjm:plugin-zip -->
----

| Plugin build for c136d942384655076d9c6545c2e21046c7f95078 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2669-c136d942.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2669-c136d942)             |

<!-- /wpjm:plugin-zip -->




