### PR TITLE
Add color input setting type

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -19,6 +19,11 @@
 		margin: 12px 0;
 		font-size: 12px;
 	}
+
+	input.job-alerts-color-picker {
+		width: 30px;
+		height: 30px;
+	}
 }
 
 .job-manager-settings-header-wrap {

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -812,6 +812,29 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
+	 * Color input field.
+	 *
+	 * @param array  $option
+	 * @param array  $ignored_attributes
+	 * @param mixed  $value
+	 * @param string $ignored_placeholder
+	 */
+	protected function input_color( $option, $ignored_attributes, $value, $ignored_placeholder ) {
+		?>
+		<input
+			id="setting-<?php echo esc_attr( $option['name'] ); ?>"
+			class="job-alerts-color-picker"
+			type="color"
+			name="<?php echo esc_attr( $option['name'] ); ?>"
+			value="<?php echo esc_attr( $value ); ?>"
+		/>
+		<?php
+		if ( ! empty( $option['desc'] ) ) {
+			echo ' <p class="description">' . wp_kses_post( $option['desc'] ) . '</p>';
+		}
+	}
+
+	/**
 	 * Radio input field.
 	 *
 	 * @param array  $option


### PR DESCRIPTION
Part of https://github.com/Automattic/wpjm-addons/issues/154

### Changes Proposed in this Pull Request

* Add a `color` setting type

### Testing Instructions

* You need to add a setting like this to be able to see it in action:

```
array(
		'name'     => 'job_manager_alerts_brand_color',
		'label'    => __( 'Brand Color', 'wp-job-manager-alerts' ),
		'std'      => '#0453EB',
		'type'     => 'color',
		'desc'     => __( 'Set the color used for links and buttons in e-mails and shortcodes.', 'wp-job-manager-alerts' ),
),
```

### Screenshot / Video
![So8gEsxrDcJ2zn0fKspB4ih3qtI9ZNsOKGMZ6DyL.jpg](https://github.com/Automattic/WP-Job-Manager/assets/3220162/30f96b8b-3980-43db-b105-53057022da63)

<!-- wpjm:plugin-zip -->
----

| Plugin build for 2de3427d6e5e4f8db9c0e46304d2581fdf79ce1b <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2670-2de3427d.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2670-2de3427d)             |

<!-- /wpjm:plugin-zip -->
