### PR TITLE
Add support for custom settings page logos

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -54,7 +54,7 @@
 }
 
 .job-manager-settings-logo {
-	width: 177px;
+	height: 40px;
 }
 .job-manager-settings-footer-mobile {
 	display: none;

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -554,7 +554,9 @@ class WP_Job_Manager_Settings {
 	 */
 	public function output() {
 		$this->init_settings();
+
 		?>
+
 		<div class="wrap job-manager-settings-wrap">
 			<form class="job-manager-options" method="post" action="options.php">
 
@@ -564,9 +566,10 @@ class WP_Job_Manager_Settings {
 					<div class="job-manager-settings-header">
 						<div class="job-manager-settings-header-row">
 							<div class="job-manager-settings-logo-wrap">
-								<img class="job-manager-settings-logo"
-									src="<?php echo esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/jm-full-logo.png' ); ?>"
-									alt="<?php esc_attr_e( 'Job Manager', 'wp-job-manager' ); ?>" />
+								<?php
+								// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in method.
+								echo $this->get_logo();
+								?>
 							</div>
 							<input type="submit" class="job-manager-settings-submit wpjm-button is-outline" value="<?php esc_attr_e( 'Save Changes', 'wp-job-manager' ); ?>" />
 						</div>
@@ -1226,5 +1229,16 @@ class WP_Job_Manager_Settings {
 		}
 
 		return $capabilities_and_roles;
+	}
+
+	/**
+	 * Get the logo for the page.
+	 *
+	 * @return string
+	 */
+	protected function get_logo(): string {
+		return '<img class="job-manager-settings-logo"
+					src="' . esc_url( JOB_MANAGER_PLUGIN_URL . '/assets/images/jm-full-logo.png' ) . '"
+					alt="' . esc_attr__( 'Job Manager', 'wp-job-manager' ) . '" />';
 	}
 }


### PR DESCRIPTION
Core PR for 403-gh-Automattic/wpjm-addons

### Changes Proposed in this Pull Request

* In the settings page, move the logo to a method that can be overriden by derived classes (used in addons)

### Testing Instructions

* See 403-gh-Automattic/wpjm-addons


<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes




<!-- wpjm:plugin-zip -->
----

| Plugin build for d3937c8d168e2f7e6d14686cc21f993e8e7215b0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2671-d3937c8d.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2671-d3937c8d)             |

<!-- /wpjm:plugin-zip -->
