### PR TITLE
Update e-mail styles and wrapper

### DIFF
--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -15,16 +15,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
-										</div>
-									</td>
-								</tr>
-							</table>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+
+</div>
+
+<!--[if mso]>
+		</td>
+		<td style="padding:0px;margin:0px;">&nbsp;</td>
+	</tr>
+	<tr><td colspan="3" style="padding:0px;margin:0px;font-size:20px;height:20px;" height="20">&nbsp;</td></tr>
+</table>
+<![endif]-->
+
 </div>
 </body>
 </html>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -15,23 +15,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
+
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=<?php bloginfo( 'charset' ); ?>" />
 	<title><?php echo esc_html( get_bloginfo( 'name' ) ); ?></title>
 </head>
-<body <?php echo is_rtl() ? 'rightmargin' : 'leftmargin'; ?>="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
-<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'?>">
-	<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+<body>
+<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'?>" class="email-wrap">
+
+	<!--[if mso]>
+	<table cellpadding="0" cellspacing="0" border="0" style="padding:0px;margin:0px;width:100%;">
+		<tr><td colspan="3" style="padding:0px;margin:0px;font-size:20px;height:20px;" height="20">&nbsp;</td></tr>
 		<tr>
-			<td align="center" valign="top">
-				<!-- Body -->
-				<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_body">
-					<tr>
-						<td valign="top" id="body_content">
-							<!-- Content -->
-							<table border="0" cellpadding="20" cellspacing="0" width="100%">
-								<tr>
-									<td valign="top">
-										<div id="body_content_inner">
+			<td style="padding:0px;margin:0px;">&nbsp;</td>
+			<td style="padding:0px;margin:0px;" width="560">
+	<![endif]-->
+
+	<div class="content-wrap">

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -11,25 +11,27 @@
  * @version     1.31.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined( "ABSPATH" ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$style_vars                   = [];
-$style_vars['color_bg']       = '#fff';
-$style_vars['color_fg']       = '#000';
-$style_vars['color_light']    = '#eee';
-$style_vars['color_link']     = '#036fa9';
-$style_vars['font_family']    = '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif';
+$style_vars                = [];
+$style_vars["color_bg"]    = "#FFF";
+$style_vars["color_fg"]    = "#000";
+$style_vars["color_light"] = "#F6F7F7";
+$style_vars["color_link"]  = "#0453EB";
+$style_vars["color_button"]  = $style_vars["color_link"];
+$style_vars["color_button_text"]  = "#FFF";
+$style_vars["font_family"] = '-apple-system, "SF Pro Text", BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif';
 
 /**
  * Change the style vars used in email generation stylesheet.
  *
  * @since 1.31.0
  *
- * @param array $style_vars  Variables used in style generation.
+ * @param array $style_vars Variables used in style generation.
  */
-$style_vars = apply_filters( 'job_manager_email_style_vars', $style_vars );
+$style_vars = apply_filters( "job_manager_email_style_vars", $style_vars );
 
 /**
  * Inject styles before the core styles.
@@ -38,24 +40,102 @@ $style_vars = apply_filters( 'job_manager_email_style_vars', $style_vars );
  *
  * @param array $style_vars Variables used in style generation.
  */
-do_action( 'job_manager_email_style_before', $style_vars );
-?>
+do_action( "job_manager_email_style_before", $style_vars );
+
+$color_bg = esc_attr( $style_vars["color_bg"] );
+$color_fg = esc_attr( $style_vars["color_fg"] );
+$color_light = esc_attr( $style_vars["color_light"] );
+$color_link = esc_attr( $style_vars["color_link"] );
+$color_button = esc_attr( $style_vars["color_button"] );
+$color_button_text = esc_attr( $style_vars["color_button_text"] );
+$font_family = ( $style_vars["font_family"] );
+
+echo <<<CSS
+
+body {
+	padding: 0;
+	margin: 0;
+}
 
 #wrapper {
-	background-color: <?php echo esc_attr( $style_vars['color_bg'] ); ?>;
-	color: <?php echo esc_attr( $style_vars['color_fg'] ); ?>;
+	background-color: {$color_light};
+	color: {$color_fg};
 	margin: 0;
-	padding: 70px 0 70px 0;
-	-webkit-text-size-adjust: none !important;
 	width: 100%;
-	font-family: <?php echo esc_attr( $style_vars['font_family'] ); ?>;
+	padding: 0;
+	font-size: initial;
+	font-family: {$font_family};
+}
+
+.content-wrap {
+	max-width: 600px;
+	padding: 32px 12px;
+	background: {$color_bg};
+	border-radius: 2px;
+	line-height: 150%;
+	word-wrap: break-word;
+	margin: 0 auto;
+}
+
+p {
+	margin: 12px 0;
 }
 
 a {
-	color: <?php echo esc_attr( $style_vars['color_link'] ); ?>;
-	font-weight: normal;
+	color: {$color_link};
 	text-decoration: underline;
 }
+
+a:hover {
+	color: inherit !important;
+}
+
+.button-single {
+	margin: 24px 0;
+	text-align: center;
+	padding: 12px 24px;
+	background: {$color_button};
+	color: {$color_button_text};
+	cursor: pointer;
+	font-style: normal;
+	font-weight: 600;
+	line-height: 180%;
+	text-decoration: unset;
+	display: block;
+	border-radius: 2px;
+}
+.button-single:hover {
+	background: {$color_fg};
+	color: {$color_bg};
+}
+
+.footer {
+	margin: 24px 0;
+}
+
+.small-separator {
+	margin: 24px 0;
+	width: 80px;
+	height: 1px;
+	background: {$color_light};
+}
+
+.actions {
+	margin: 24px 0;
+	text-align: center;
+	padding: 18px 24px;
+	background: {$color_light};
+}
+
+.action {
+	color: {$color_link};
+	text-decoration: underline;
+}
+
+.footer__content {
+	margin: 24px 0;
+}
+
 
 .email-container {
 	margin-bottom: 10px;
@@ -64,7 +144,7 @@ a {
 td.detail-label,
 td.detail-value {
 	vertical-align: middle;
-	border: 1px solid  <?php echo esc_attr( $style_vars['color_light'] ); ?>;
+	border: 1px solid {$color_light};
 }
 
 td.detail-label {
@@ -72,7 +152,32 @@ td.detail-label {
 	width: 40%;
 }
 
-<?php
+
+@media screen and (min-width: 600px) {
+	.email-wrap {
+		padding: 24px !important;
+	}
+
+	.content-wrap {
+		padding: 48px 32px !important;
+	}
+}
+
+@media screen and (max-width: 325px) {
+	.actions .action {
+		display: block !important;
+		line-height: 32px;
+	}
+
+	.actions .action-separator {
+		display: none !important;
+	}
+}
+
+
+CSS;
+
+
 /**
  * Inject styles after the core styles.
  *
@@ -80,4 +185,4 @@ td.detail-label {
  *
  * @param array $style_vars Variables used in style generation.
  */
-do_action( 'job_manager_email_style_after', $style_vars );
+do_action( "job_manager_email_style_after", $style_vars );

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -11,19 +11,19 @@
  * @version     1.31.0
  */
 
-if ( ! defined( "ABSPATH" ) ) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$style_vars                  = [];
-$style_vars["color_bg"]      = "#FFF";
-$style_vars["color_fg"]      = "#000";
-$style_vars["color_light"]   = "#F6F7F7";
-$style_vars["color_stroke"]  = "#E6E6E6";
-$style_vars["color_link"]    = "#0453EB";
-$style_vars["color_button"]  = $style_vars["color_link"];
-$style_vars["color_button_text"]  = "#FFF";
-$style_vars["font_family"]   = "-apple-system, 'SF Pro Text', BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif";
+$style_vars                      = [];
+$style_vars['color_bg']          = '#FFF';
+$style_vars['color_fg']          = '#000';
+$style_vars['color_light']       = '#F6F7F7';
+$style_vars['color_stroke']      = '#E6E6E6';
+$style_vars['color_link']        = '#0453EB';
+$style_vars['color_button']      = $style_vars['color_link'];
+$style_vars['color_button_text'] = '#FFF';
+$style_vars['font_family']       = '-apple-system, "SF Pro Text", BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif';
 
 /**
  * Change the style vars used in email generation stylesheet.
@@ -32,7 +32,7 @@ $style_vars["font_family"]   = "-apple-system, 'SF Pro Text', BlinkMacSystemFont
  *
  * @param array $style_vars Variables used in style generation.
  */
-$style_vars = apply_filters( "job_manager_email_style_vars", $style_vars );
+$style_vars = apply_filters( 'job_manager_email_style_vars', $style_vars );
 
 /**
  * Inject styles before the core styles.
@@ -41,16 +41,16 @@ $style_vars = apply_filters( "job_manager_email_style_vars", $style_vars );
  *
  * @param array $style_vars Variables used in style generation.
  */
-do_action( "job_manager_email_style_before", $style_vars );
+do_action( 'job_manager_email_style_before', $style_vars );
 
-$color_bg = esc_attr( $style_vars["color_bg"] );
-$color_fg = esc_attr( $style_vars["color_fg"] );
-$color_light = esc_attr( $style_vars["color_light"] );
-$color_stroke = esc_attr( $style_vars["color_stroke"] );
-$color_link = esc_attr( $style_vars["color_link"] );
-$color_button = esc_attr( $style_vars["color_button"] );
-$color_button_text = esc_attr( $style_vars["color_button_text"] );
-$font_family = strip_tags( $style_vars["font_family"] );
+$color_bg          = esc_attr( $style_vars['color_bg'] );
+$color_fg          = esc_attr( $style_vars['color_fg'] );
+$color_light       = esc_attr( $style_vars['color_light'] );
+$color_stroke      = esc_attr( $style_vars['color_stroke'] );
+$color_link        = esc_attr( $style_vars['color_link'] );
+$color_button      = esc_attr( $style_vars['color_button'] );
+$color_button_text = esc_attr( $style_vars['color_button_text'] );
+$font_family       = wp_strip_all_tags( $style_vars['font_family'] );
 
 echo <<<CSS
 
@@ -183,9 +183,7 @@ td.detail-label {
 	}
 }
 
-
 CSS;
-
 
 /**
  * Inject styles after the core styles.
@@ -194,4 +192,4 @@ CSS;
  *
  * @param array $style_vars Variables used in style generation.
  */
-do_action( "job_manager_email_style_after", $style_vars );
+do_action( 'job_manager_email_style_after', $style_vars );

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -15,14 +15,15 @@ if ( ! defined( "ABSPATH" ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$style_vars                = [];
-$style_vars["color_bg"]    = "#FFF";
-$style_vars["color_fg"]    = "#000";
-$style_vars["color_light"] = "#F6F7F7";
-$style_vars["color_link"]  = "#0453EB";
+$style_vars                  = [];
+$style_vars["color_bg"]      = "#FFF";
+$style_vars["color_fg"]      = "#000";
+$style_vars["color_light"]   = "#F6F7F7";
+$style_vars["color_stroke"]  = "#E6E6E6";
+$style_vars["color_link"]    = "#0453EB";
 $style_vars["color_button"]  = $style_vars["color_link"];
 $style_vars["color_button_text"]  = "#FFF";
-$style_vars["font_family"] = '-apple-system, "SF Pro Text", BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif';
+$style_vars["font_family"]   = "-apple-system, 'SF Pro Text', BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif";
 
 /**
  * Change the style vars used in email generation stylesheet.
@@ -45,10 +46,11 @@ do_action( "job_manager_email_style_before", $style_vars );
 $color_bg = esc_attr( $style_vars["color_bg"] );
 $color_fg = esc_attr( $style_vars["color_fg"] );
 $color_light = esc_attr( $style_vars["color_light"] );
+$color_stroke = esc_attr( $style_vars["color_stroke"] );
 $color_link = esc_attr( $style_vars["color_link"] );
 $color_button = esc_attr( $style_vars["color_button"] );
 $color_button_text = esc_attr( $style_vars["color_button_text"] );
-$font_family = ( $style_vars["font_family"] );
+$font_family = strip_tags( $style_vars["font_family"] );
 
 echo <<<CSS
 
@@ -104,9 +106,16 @@ a:hover {
 	display: block;
 	border-radius: 2px;
 }
+
 .button-single:hover {
 	background: {$color_fg};
 	color: {$color_bg};
+}
+
+.box {
+	border: 1px solid {$color_stroke};
+	padding: 24px;
+	margin: 24px 0;
 }
 
 .footer {

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -116,7 +116,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		$this->assertEmpty( $sent_email->cc );
 		$this->assertEmpty( $sent_email->bcc );
 		$this->assertEquals( 'Test Subject', $sent_email->subject );
-		$this->assertStringContainsString( "<p><strong>test</strong></p>", $sent_email->body );
+		$this->assertStringContainsString( '<strong>test</strong>', $sent_email->body );
 		$this->assertStringContainsString( 'From: From Name <from@example.com>', $sent_email->header );
 		$this->assertStringContainsString( 'Content-Type: text/html;', $sent_email->header );
 	}


### PR DESCRIPTION
Part of 396-gh-Automattic/wpjm-addons

### Changes Proposed in this Pull Request

* Update the e-mail header and footer with new layout built for Alert e-mails
* Fix font family not working in e-mails
* Update styling

### Testing Instructions

* Set up mail capture / a way to view outgoing e-mails
* Make sure e-mails are enabled and set to rich text in Job Manager -> Settings -> E-mail Notifications
* Do an action that triggers an e-mail: submit a new job on the frontend, edit a job on the frontend, submit a resume
* View the e-mail

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Change: Improve styling for rich text e-mails

### Screenshot / Video

<img width="1038" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/75f5c5c2-702c-4baa-83ca-29b8e6c970bd">






<!-- wpjm:plugin-zip -->
----

| Plugin build for 9a0645507ddc9ad00607dfd2ae43268c89e5e15a <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2672-9a064550.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2672-9a064550)             |

<!-- /wpjm:plugin-zip -->






