### PR TITLE
Add/featured first argument

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -309,6 +309,7 @@ jQuery( document ).ready( function( $ ) {
 			var $results = $target.find( '.job_listings' );
 			var per_page = $target.data( 'per_page' );
 			var orderby = $target.data( 'orderby' );
+			var featured_first = $target.data( 'featured_first' );
 			var order = $target.data( 'order' );
 			var featured = $target.data( 'featured' );
 			var filled = $target.data( 'filled' );
@@ -380,6 +381,7 @@ jQuery( document ).ready( function( $ ) {
 					filter_post_status: post_status,
 					per_page: per_page,
 					orderby: orderby,
+					featured_first: featured_first,
 					order: order,
 					page: page,
 					featured: featured,

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -135,6 +135,7 @@ class WP_Job_Manager_Ajax {
 		$featured           = isset( $_REQUEST['featured'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured'] ) ) : null;
 		$remote_position    = isset( $_REQUEST['remote_position'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['remote_position'] ) ) : null;
 		$show_pagination    = isset( $_REQUEST['show_pagination'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['show_pagination'] ) ) : null;
+		$featured_first     = isset( $_REQUEST['featured_first'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured_first'] ) ) : null;
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( is_array( $search_categories ) ) {
@@ -154,6 +155,7 @@ class WP_Job_Manager_Ajax {
 			'post_status'       => $filter_post_status,
 			'orderby'           => $orderby,
 			'order'             => $order,
+			'featured_first'    => $featured_first,
 			'offset'            => ( $page - 1 ) * $per_page,
 			'posts_per_page'    => max( 1, $per_page ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Known slow query.
 		];

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -769,9 +769,6 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $atts['post_status'] ) ) {
 			$data_attributes['post_status'] = implode( ',', $atts['post_status'] );
 		}
-		if ( ! empty( $atts['featured_first'] ) ) {
-			$data_attributes['featured_first'] = $atts['featured_first'] ? 'true' : 'false';
-		}
 
 		$data_attributes['post_id'] = isset( $GLOBALS['post'] ) ? $GLOBALS['post']->ID : 0;
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -627,9 +627,6 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! is_null( $atts['remote_position'] ) ) {
 			$atts['remote_position'] = ( is_bool( $atts['remote_position'] ) && $atts['remote_position'] ) || in_array( $atts['remote_position'], [ 1, '1', 'true', 'yes' ], true );
 		}
-		if ( ! is_null( $atts['featured_first'] ) ) {
-			$atts['featured_first'] = ( is_bool( $atts['featured_first'] ) && $atts['featured_first'] ) || in_array( $atts['featured_first'], [ 1, '1', 'true', 'yes' ], true );
-		}
 
 		// By default, use client-side state to populate form fields.
 		$disable_client_state = false;

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -592,6 +592,7 @@ class WP_Job_Manager_Shortcodes {
 					'featured'                  => null, // True to show only featured, false to hide featured, leave null to show both.
 					'filled'                    => null, // True to show only filled, false to hide filled, leave null to show both/use the settings.
 					'remote_position'           => null, // True to show only remote, false to hide remote, leave null to show both.
+					'featured_first'            => false, // True to show featured first, false to show in default order.
 
 					// Default values for filters.
 					'location'                  => '',
@@ -613,6 +614,7 @@ class WP_Job_Manager_Shortcodes {
 		$atts['show_category_multiselect'] = $this->string_to_bool( $atts['show_category_multiselect'] );
 		$atts['show_more']                 = $this->string_to_bool( $atts['show_more'] );
 		$atts['show_pagination']           = $this->string_to_bool( $atts['show_pagination'] );
+		$atts['featured_first']            = $this->string_to_bool( $atts['featured_first'] );
 
 		if ( ! is_null( $atts['featured'] ) ) {
 			$atts['featured'] = ( is_bool( $atts['featured'] ) && $atts['featured'] ) || in_array( $atts['featured'], [ 1, '1', 'true', 'yes' ], true );
@@ -624,6 +626,9 @@ class WP_Job_Manager_Shortcodes {
 
 		if ( ! is_null( $atts['remote_position'] ) ) {
 			$atts['remote_position'] = ( is_bool( $atts['remote_position'] ) && $atts['remote_position'] ) || in_array( $atts['remote_position'], [ 1, '1', 'true', 'yes' ], true );
+		}
+		if ( ! is_null( $atts['featured_first'] ) ) {
+			$atts['featured_first'] = ( is_bool( $atts['featured_first'] ) && $atts['featured_first'] ) || in_array( $atts['featured_first'], [ 1, '1', 'true', 'yes' ], true );
 		}
 
 		// By default, use client-side state to populate form fields.
@@ -679,6 +684,7 @@ class WP_Job_Manager_Shortcodes {
 			'order'                      => $atts['order'],
 			'categories'                 => implode( ',', $atts['categories'] ),
 			'disable-form-state-storage' => $disable_client_state,
+			'featured_first'             => $atts['featured_first'] ? 'true' : 'false',
 		];
 
 		if ( $atts['show_filters'] ) {
@@ -765,6 +771,9 @@ class WP_Job_Manager_Shortcodes {
 		}
 		if ( ! empty( $atts['post_status'] ) ) {
 			$data_attributes['post_status'] = implode( ',', $atts['post_status'] );
+		}
+		if ( ! empty( $atts['featured_first'] ) ) {
+			$data_attributes['featured_first'] = $atts['featured_first'] ? 'true' : 'false';
 		}
 
 		$data_attributes['post_id'] = isset( $GLOBALS['post'] ) ? $GLOBALS['post']->ID : 0;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -181,7 +181,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			];
 		}
 
-		if ( 'true' === $args['featured_first'] ) {
+		if ( 'true' === $args['featured_first'] && 'featured' !== $args['orderby'] && 'rand_featured' !== $args['orderby'] ) {
 			$query_args['orderby'] = [
 				'menu_order'           => 'ASC',
 				$query_args['orderby'] => $query_args['order'],

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -34,6 +34,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 				'filled'            => null,
 				'remote_position'   => null,
 				'fields'            => 'all',
+				'featured_first'    => 0,
 			]
 		);
 
@@ -177,6 +178,13 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$query_args['orderby'] = [
 				'menu_order' => 'ASC',
 				'rand'       => 'ASC',
+			];
+		}
+
+		if ( 'true' === $args['featured_first'] ) {
+			$query_args['orderby'] = [
+				'menu_order'           => 'ASC',
+				$query_args['orderby'] => $query_args['order'],
 			];
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/1487

### Changes Proposed in this Pull Request

* Add a new `featured_first` argument to the `[jobs]` shortcode
* This ensures that now regardless of the order, featured jobs will be first!

### Testing Instructions

* There are a lot of combinations to test for the jobs!

```
[jobs orderby="featured" featured_first="true" order="desc"]
[jobs orderby="title" featured_first="true" order="desc"]
[jobs orderby="ID" featured_first="true" order="desc"]
[jobs orderby="name" featured_first="true" order="desc"]
[jobs orderby="date" featured_first="true" order="desc"]
[jobs orderby="modified" featured_first="true" order="desc"]
[jobs orderby="rand" featured_first="true" order="desc"]
[jobs orderby="rand_featured" featured_first="true" order="desc"]
[jobs orderby="featured" featured_first="true" order="asc"]
[jobs orderby="rand_featured" featured_first="true" order="asc"]
[jobs orderby="title" featured_first="true" order="asc"]
[jobs orderby="ID" featured_first="true" order="asc"]
[jobs orderby="name" featured_first="true" order="asc"]
[jobs orderby="date" featured_first="true" order="asc"]
[jobs orderby="modified" featured_first="true" order="asc"]
[jobs orderby="rand" featured_first="true" order="asc"]
[jobs orderby="rand_featured" featured_first="true" order="asc"]
[jobs orderby="featured" featured_first="true" order="asc"]
```

I would also make sure to try at least a few `featured_first="false"` to ensure that works as well.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Add new shortcode parameter, "featured_first" so you can ensure featured listings always show up on top.




<!-- wpjm:plugin-zip -->
----

| Plugin build for c3b858a88193136c708f9508ab0ea779707195b0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2675-c3b858a8.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2675-c3b858a8)             |

<!-- /wpjm:plugin-zip -->




