### PR TITLE
Save previous license upon deactivation

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-options.php
+++ b/includes/helper/class-wp-job-manager-helper-options.php
@@ -85,6 +85,18 @@ class WP_Job_Manager_Helper_Options {
 	}
 
 	/**
+	 * Save the previous license key for a product.
+	 *
+	 * @param string $product_slug
+	 * @param string $key
+	 *
+	 * @return void
+	 */
+	public static function set_previous_license_key( $product_slug, $key ) {
+		update_option( 'job_manager_previous_license_' . $product_slug, $key );
+	}
+
+	/**
 	 * Attempt to retrieve license data from legacy storage.
 	 *
 	 * @param string $product_slug

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -934,6 +934,7 @@ class WP_Job_Manager_Helper {
 			return;
 		}
 
+		WP_Job_Manager_Helper_Options::set_previous_license_key( $product_slug, $license['license_key'] );
 		WP_Job_Manager_Helper_Options::delete( $product_slug, 'license_key' );
 		WP_Job_Manager_Helper_Options::delete( $product_slug, 'email' );
 		WP_Job_Manager_Helper_Options::delete( $product_slug, 'errors' );

--- a/includes/helper/views/html-licenses.php
+++ b/includes/helper/views/html-licenses.php
@@ -160,7 +160,7 @@ $plugin_section_first = 'plugin-license-section--first';
 						}
 						if ( apply_filters( 'wpjm_display_license_form_for_addon', true, $product_slug ) ) {
 							$has_error            = in_array( 'error', array_column( $notices, 'type' ), true );
-							$previous_license_key = get_option( 'job_manager_previous_license_' . $product_slug ) ? get_option( 'job_manager_previous_license_' . $product_slug ) : '';
+							$previous_license_key = get_option( 'job_manager_previous_license_' . $product_slug, null ) ?? '';
 							?>
 							<form method="post" class='plugin-license-form'>
 								<?php wp_nonce_field( 'wpjm-manage-license' ); ?>

--- a/includes/helper/views/html-licenses.php
+++ b/includes/helper/views/html-licenses.php
@@ -159,14 +159,15 @@ $plugin_section_first = 'plugin-license-section--first';
 							}
 						}
 						if ( apply_filters( 'wpjm_display_license_form_for_addon', true, $product_slug ) ) {
-							$has_error = in_array( 'error', array_column( $notices, 'type' ), true );
+							$has_error            = in_array( 'error', array_column( $notices, 'type' ), true );
+							$previous_license_key = get_option( 'job_manager_previous_license_' . $product_slug ) ? get_option( 'job_manager_previous_license_' . $product_slug ) : '';
 							?>
 							<form method="post" class='plugin-license-form'>
 								<?php wp_nonce_field( 'wpjm-manage-license' ); ?>
 								<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_action" name="action" value="activate"/>
 								<input type="hidden" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_plugin" name="product_slug" value="<?php echo esc_attr( $product_slug ); ?>"/>
 								<label for="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_license_key" class="plugin-license-label"><?php esc_html_e( 'LICENSE', 'wp-job-manager' ); ?></label>
-								<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_license_key" class="plugin-license-field<?php echo $has_error ? ' plugin-license-field--error' : ''; ?>" name="license_key" placeholder="XXXX-XXXX-XXXX-XXXX"/>
+								<input type="text" id="<?php echo esc_attr( sanitize_title( $product_slug ) ); ?>_license_key" class="plugin-license-field<?php echo $has_error ? ' plugin-license-field--error' : ''; ?>" name="license_key" placeholder="XXXX-XXXX-XXXX-XXXX" value="<?php echo esc_attr( $previous_license_key ); ?>"/>
 								<input type="submit" class="button plugin-license-button" name="submit" value="<?php esc_attr_e( 'Activate License', 'wp-job-manager' ); ?>" />
 							</form>
 							<?php


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2493

### Changes Proposed in this Pull Request

* When you deactivate a plugin, we'll now store the license in an option!
* That way, if you decide to activate the plugin again, it will show up in the license box pre-filled so you can activate it easily without needing to find it again.

### Testing Instructions

* Install a plugin separately (not wpjm-addons monorepo)
* Go to wpjobmanager.com and get a license for it
* Activate the license in Job Manager > Marketplace > Licenses
* Deactivate the plugin now!
* Go back to the Licenses page, see that your license is not active but the old license key is there!
* Profit.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Store previous license when plugin is deactivated for easier reactivation later.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 19f909b1296b1e1b37a172dd1b1b0de796340c21 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2676-19f909b1.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2676-19f909b1)             |

<!-- /wpjm:plugin-zip -->


