### PR TITLE
Add error when invalid file type used for company logo

### DIFF
--- a/assets/js/ajax-file-upload.js
+++ b/assets/js/ajax-file-upload.js
@@ -52,6 +52,8 @@ jQuery(function($) {
 
 				if ( uploadErrors.length > 0 ) {
 					this.validation_errors = this.validation_errors.concat( uploadErrors );
+					data.context = $('<progress value="" max="100"></progress>').appendTo( $uploaded_files );
+					data.submit();
 				} else {
 					if ( false !== fileLimitLeft ) {
 						$file_field.data( 'file_limit_left', fileLimitLeft - 1 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2233

### Changes Proposed in this Pull Request

* Show error message when invalid file type used when adding a company logo

### Testing Instructions

* Go to post a job
* Use an invalid file type when trying to add a company logo
* Verify that the error alert window pops up

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Added an error message if you use an invalid file type when uploading a company logo

### Screenshot / Video

https://github.com/Automattic/WP-Job-Manager/assets/3220162/44f2fd2b-67df-4c38-bbf7-9b6d06a7a0b2

<!-- wpjm:plugin-zip -->
----

| Plugin build for dce409e21ac29c94d4353914ae8391137e104a43 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2678-dce409e2.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2678-dce409e2)             |

<!-- /wpjm:plugin-zip -->
