### PR TITLE
Expand the UI to inline CSS

### DIFF
--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -89,7 +89,7 @@ class UI {
 		$css = ':root{';
 
 		foreach ( $this->css_variables as $name => $value ) {
-			$css .= $name . ': ' . $value . ';';
+			$css .= esc_attr( $name ) . ': ' . esc_attr( $value ) . ';';
 		}
 
 		$css .= '}';

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -76,7 +76,7 @@ class UI {
 	 */
 	public static function ensure_styles( array $css_variables = [] ) {
 		self::instance()->has_ui        = true;
-		self::instance()->css_variables = $css_variables;
+		self::instance()->css_variables = array_merge( self::instance()->css_variables, $css_variables );
 	}
 
 	/**

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -73,7 +73,7 @@ class UI {
 	 *
 	 * @param array $css_variables An array of CSS variables to be enqueued: <variable_name> => <value>.
 	 */
-	public static function ensure_styles( $css_variables = null ) {
+	public static function ensure_styles( array $css_variables = [] ) {
 		self::instance()->has_ui        = true;
 		self::instance()->css_variables = $css_variables;
 	}

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -34,7 +34,7 @@ class UI {
 	 *
 	 * @var bool
 	 */
-	private $has_ui;
+	private bool $has_ui;
 
 	/**
 	 * An array of css variables to be enqueued with the styles.

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -34,12 +34,20 @@ class UI {
 	 *
 	 * @var bool
 	 */
-	private $has_ui = false;
+	private $has_ui;
+
+	/**
+	 * An array of css variables to be enqueued with the styles.
+	 *
+	 * @var array
+	 */
+	private $css_variables;
 
 	/**
 	 * Instance constructor
 	 */
 	private function __construct() {
+		$this->has_ui = false;
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_styles' ] );
 	}
 
@@ -53,14 +61,39 @@ class UI {
 
 		if ( $this->has_ui ) {
 			wp_enqueue_style( 'wp-job-manager-ui' );
+
+			if ( ! empty( $this->css_variables ) ) {
+				wp_add_inline_style( 'wp-job-manager-ui', $this->generate_inline_css() );
+			}
 		}
 	}
 
 	/**
 	 * Request the styles to be loaded for the page.
+	 *
+	 * @param array $css_variables An array of CSS variables to be enqueued: <variable_name> => <value>.
 	 */
-	public static function ensure_styles() {
-		self::instance()->has_ui = true;
+	public static function ensure_styles( $css_variables = null ) {
+		self::instance()->has_ui        = true;
+		self::instance()->css_variables = $css_variables;
+	}
+
+	/**
+	 * Generates CSS to be inlined with the UI styles.
+	 *
+	 * @return string The CSS.
+	 */
+	private function generate_inline_css() {
+
+		$css = ':root{';
+
+		foreach ( $this->css_variables as $name => $value ) {
+			$css .= $name . ': ' . $value . ';';
+		}
+
+		$css .= '}';
+
+		return $css;
 	}
 }
 

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -47,7 +47,8 @@ class UI {
 	 * Instance constructor
 	 */
 	private function __construct() {
-		$this->has_ui = false;
+		$this->has_ui        = false;
+		$this->css_variables = [];
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_styles' ] );
 	}
 

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -41,7 +41,7 @@ class UI {
 	 *
 	 * @var array
 	 */
-	private $css_variables;
+	private array $css_variables;
 
 	/**
 	 * Instance constructor


### PR DESCRIPTION
Needed by: https://github.com/Automattic/wpjm-addons/pull/415/files

### Changes Proposed in this Pull Request

* Adds a way to inline CSS to the WPJM UI

### Testing Instructions

* Should be tested as part of the related PR.








<!-- wpjm:plugin-zip -->
----

| Plugin build for 894f4b2c219d890c5fa9527f7712ccfdd12bc0fe <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2682-894f4b2c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2682-894f4b2c)             |

<!-- /wpjm:plugin-zip -->














