### PR TITLE
Add guest sessions

### DIFF
--- a/assets/css/ui.notice.scss
+++ b/assets/css/ui.notice.scss
@@ -8,7 +8,7 @@
 	border: var(--jm-ui-border-size) solid var(--jm-ui-border-light);
 	background: var(--jm-ui-background-color, transparent);
 	color: var(--jm-ui-text-color, inherit);
-	padding: var(--jm-ui-space-m);
+	padding: var(--jm-ui-space-m) var(--jm-ui-space-ml);
 	display: flex;
 	flex-direction: column;
 	gap: var(--jm-ui-space-xs);
@@ -23,8 +23,11 @@
 	margin: var(--jm-ui-space-ml) auto;
 
 	&.has-header {
-		padding: var(--jm-ui-space-ml) var(--jm-ui-space-m);
+		padding: var(--jm-ui-space-ml) var(--jm-ui-space-ml);
 		gap: var(--jm-ui-space-sm);
+	}
+	&.has-header.has-actions {
+		gap: var(--jm-ui-space-m);
 	}
 
 	@each $color in (info, error, success, strong) {
@@ -66,6 +69,23 @@
 		.jm-notice__button,
 		.jm-notice__action, {
 			font-size: 16px;
+		}
+	}
+
+	&.type-dialog {
+		align-items: center;
+
+		padding: var(--jm-ui-space-xxl) var(--jm-ui-space-ml);
+		gap: var(--jm-ui-space-ml);
+
+		.jm-notice__buttons {
+			gap: var(--jm-ui-space-sm);
+		}
+		.jm-notice__button,
+		.jm-notice__button--outline,
+		.jm-notice__button--link,
+		{
+			padding: var(--jm-ui-space-s2) var(--jm-ui-space-sm);
 		}
 	}
 }

--- a/includes/class-guest-session.php
+++ b/includes/class-guest-session.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * File containing the class Guest_Session.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+/**
+ * Manage the guest user session.
+ *
+ * @since $$next-version$$
+ */
+class Guest_Session {
+
+	use Singleton;
+
+	const COOKIE_NAME   = 'jm-guest-user';
+	const COOKIE_EXPIRY = 1 * DAY_IN_SECONDS;
+	const QUERY_VAR     = 'jmtoken';
+
+	/**
+	 * The current guest user.
+	 *
+	 * @var Guest_User|false
+	 */
+	private $user = false;
+
+	/**
+	 * Whether the session has been initialized.
+	 *
+	 * @var bool
+	 */
+	private bool $initialized = false;
+
+	/**
+	 * Get the guest user for the current session.
+	 *
+	 * @return Guest_User|false
+	 */
+	public static function get_current_guest() {
+		$session = self::instance();
+		$session->init();
+
+		return $session->user;
+	}
+
+	/**
+	 * Initialize the guest session based on URL token or session cookie.
+	 * If only a URL token is present, it will be set as a session cookie.
+	 *
+	 * @return void
+	 */
+	private function init() {
+
+		if ( $this->initialized ) {
+			return;
+		}
+
+		$this->initialized = true;
+
+		$token  = $this->get_url_token();
+		$cookie = $this->get_cookie();
+		$token  = $token ?? $cookie;
+
+		if ( ! $token ) {
+			return;
+		}
+
+		$guest = Guest_User::get_by_token( $token );
+
+		$this->user = $guest;
+
+		if ( $guest && $cookie !== $token ) {
+			$this->set_cookie( $token );
+		}
+	}
+
+	/**
+	 * Get the token from a session cookie.
+	 *
+	 * @return string|null
+	 */
+	private function get_cookie() {
+		return isset( $_COOKIE[ self::COOKIE_NAME ] ) ? sanitize_text_field( wp_unslash( $_COOKIE[ self::COOKIE_NAME ] ) ) : null;
+	}
+
+	/**
+	 * Set the token as a session cookie.
+	 *
+	 * @param string $token
+	 */
+	private function set_cookie( $token ) {
+		$secure = 'https' === wp_parse_url( get_option( 'home' ), PHP_URL_SCHEME );
+		$expire = time() + self::COOKIE_EXPIRY;
+		setcookie( self::COOKIE_NAME, $token, $expire, COOKIEPATH, COOKIE_DOMAIN, $secure, true );
+	}
+
+	/**
+	 * Get the token from the URL query string.
+	 *
+	 * @return string|null
+	 */
+	private static function get_url_token() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- URL token-based login action.
+		return isset( $_GET[ self::QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::QUERY_VAR ] ) ) : null;
+	}
+
+}

--- a/includes/class-guest-user.php
+++ b/includes/class-guest-user.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * File containing the class Guest_User.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * A guest user is a site visitors without a full account, identified by their email address.
+ *
+ * @since $$next-version$$
+ */
+class Guest_User {
+	const TOKEN_EXPIRY    = 35 * DAY_IN_SECONDS;
+	const TOKEN_PREFIX    = 'jm';
+	const TOKEN_SEPARATOR = '-';
+
+	/**
+	 * The post object for the guest user.
+	 *
+	 * @var \WP_Post
+	 */
+	private $post;
+
+	/**
+	 * The post ID.
+	 *
+	 * @readonly
+	 * @var int
+	 */
+	public int $ID;
+
+	/**
+	 * The user email address.
+	 *
+	 * @readonly
+	 * @var string
+	 */
+	public string $user_email;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \WP_Post $guest The guest user post object.
+	 */
+	public function __construct( \WP_Post $guest ) {
+		$this->post       = $guest;
+		$this->ID         = $guest->ID;
+		$this->user_email = $guest->post_title;
+	}
+
+	/**
+	 * The post object for the guest user.
+	 *
+	 * @param int|string $guest_id Post ID of guest user, or their email.
+	 *
+	 * @return self|false
+	 */
+	public static function load( $guest_id ) {
+
+		if ( is_numeric( $guest_id ) ) {
+			$guest = get_post( $guest_id );
+		} elseif ( is_email( $guest_id ) ) {
+			$email = sanitize_email( $guest_id );
+			$guest = get_posts(
+				[
+					'post_type' => \WP_Job_Manager_Post_Types::PT_GUEST_USER,
+					'title'     => $email,
+				]
+			);
+			$guest = empty( $guest ) ? false : $guest[0];
+		}
+
+		if ( empty( $guest ) ) {
+			return false;
+		}
+
+		return new self( $guest );
+	}
+
+	/**
+	 * Create a new guest user for the given email. Returns existing guest user if one exists for the email.
+	 *
+	 * @param string $email
+	 *
+	 * @return self|false
+	 */
+	public static function create( string $email ) {
+
+		$email = sanitize_email( $email );
+
+		if ( ! is_email( $email ) ) {
+			return false;
+		}
+
+		$existing = self::load( $email );
+
+		if ( $existing ) {
+			return $existing;
+		}
+
+		$guest_id = wp_insert_post(
+			[
+				'post_title'  => $email,
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_GUEST_USER,
+				'post_status' => 'publish',
+			]
+		);
+
+		return self::load( $guest_id );
+
+	}
+
+	/**
+	 * Get a URL token for the guest user. Includes the guest user ID and an access token.
+	 *
+	 * @return string
+	 */
+	public function create_token() {
+
+		$at           = new Access_Token( [ 'guest_id' => $this->ID ] );
+		$access_token = $at->create( time() + self::TOKEN_EXPIRY );
+
+		return implode( self::TOKEN_SEPARATOR, [ self::TOKEN_PREFIX, $this->ID, $access_token ] );
+
+	}
+
+	/**
+	 * Verify a URL token and return the guest user if valid.
+	 *
+	 * @param string $token URL token.
+	 *
+	 * @return Guest_User|false
+	 */
+	public static function get_by_token( $token ) {
+
+		if ( ! is_string( $token ) ) {
+			return false;
+		}
+
+		$token_parts = explode( self::TOKEN_SEPARATOR, $token );
+		if ( count( $token_parts ) !== 3 ) {
+			return false;
+		}
+
+		[ $prefix, $guest_id, $access_token ] = $token_parts;
+
+		if ( self::TOKEN_PREFIX !== $prefix ) {
+			return false;
+		}
+
+		$at = new Access_Token( [ 'guest_id' => (int) $guest_id ] );
+
+		if ( ! $at->verify( $access_token ) ) {
+			return false;
+		}
+
+		return self::load( $guest_id );
+	}
+}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -60,6 +60,7 @@ class WP_Job_Manager {
 	 */
 	public function __construct() {
 		// Includes.
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/trait-singleton.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-install.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-post-types.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-ajax.php';
@@ -77,9 +78,8 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-com-api.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-access-token.php';
-
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/trait-singleton.php';
-
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-guest-user.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-guest-session.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-ui.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-ui-settings.php';
 

--- a/includes/ui/class-notice.php
+++ b/includes/ui/class-notice.php
@@ -60,6 +60,42 @@ class Notice {
 	}
 
 	/**
+	 * A permanent informational message.
+	 *
+	 * @param string|array $args A message, or an array of options accepted by Notice::render.
+	 */
+	public static function hint( $args ) {
+		$args = is_array( $args ) ? $args : [ 'message' => $args ];
+
+		return self::render(
+			array_merge(
+				[
+					'classes' => array_merge( [ 'type-hint' ], $args['classes'] ?? [] ),
+				],
+				$args
+			)
+		);
+	}
+
+	/**
+	 * A permanent message that requires action to proceed.
+	 *
+	 * @param string|array $args
+	 */
+	public static function dialog( $args ) {
+		$args = is_array( $args ) ? $args : [ 'message' => $args ];
+
+		return self::render(
+			array_merge(
+				[
+					'classes' => array_merge( [ 'type-dialog' ], $args['classes'] ?? [] ),
+				],
+				$args
+			)
+		);
+	}
+
+	/**
 	 * Notice element.
 	 *
 	 * @param array $options {
@@ -150,7 +186,7 @@ class Notice {
 
 		if ( ! empty( $options['id'] ) ) {
 			/**
-			 * Filters an individual notice.Return false to disable the notice.
+			 * Filters an individual notice. Return false to disable the notice.
 			 *
 			 * @since $$next-version$$
 			 *
@@ -219,7 +255,7 @@ class Notice {
 			]
 		);
 
-		return '<a href="' . esc_url( $args['url'] ) . '" class="' . esc_attr( $class ) . '"><span>' . esc_html( $args['text'] ) . '</span></a>';
+		return '<a href="' . esc_url( $args['url'] ) . '" class="' . esc_attr( $class ) . '"><span>' . esc_html( $args['label'] ) . '</span></a>';
 
 	}
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -100,6 +100,7 @@ class WPJM_Unit_Tests_Bootstrap {
 		require_once $this->includes_dir . '/factories/class-wpjm-factory.php';
 		require_once $this->includes_dir . '/class-wpjm-base-test.php';
 		require_once $this->includes_dir . '/class-wpjm-rest-testcase.php';
+		require_once $this->includes_dir . '/class-function-mocks.php';
 	}
 
 	/**

--- a/tests/php/includes/class-function-mocks.php
+++ b/tests/php/includes/class-function-mocks.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Helper to mock global PHP or WordPress functions.
+ *
+ * Caller code should be in the WP_Job_Manager namespace.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+class Function_Mocks {
+	public static $active_mocks = [];
+
+	public static function mock( $name, $mock_function ) {
+		self::$active_mocks[ $name ] = $mock_function;
+	}
+
+	public static function tearDown() {
+		self::$active_mocks = [];
+	}
+
+	public static function run( $name, $args, $fallback ) {
+		if ( ! empty( self::$active_mocks[ $name ] ) ) {
+			return call_user_func_array( self::$active_mocks[ $name ], $args );
+		} else {
+			return call_user_func_array( $fallback, $args );
+		}
+	}
+}
+
+/**
+ * Mocks global time().
+ *
+ * @return int
+ */
+function time(): int {
+	return Function_Mocks::run( 'time', [], '\time' );
+}
+
+/**
+ * Mocks setcookie().
+ */
+function setcookie( ...$args ) {
+	return Function_Mocks::run( 'setcookie', $args, '\setcookie' );
+
+}
+

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -30,6 +30,7 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		parent::tearDown();
+		\WP_Job_Manager\Function_Mocks::tearDown();
 		$this->disable_manage_job_listings_cap();
 		$this->logout();
 	}

--- a/tests/php/tests/includes/test_class.access-token.php
+++ b/tests/php/tests/includes/test_class.access-token.php
@@ -2,21 +2,16 @@
 
 namespace WP_Job_Manager;
 
-use WP_UnitTestCase;
-
-/**
- * Mocks global time().
- *
- * @return int
- */
-function time() : int {
-	return WP_Test_Access_Token::$time ?: \time();
-}
-class WP_Test_Access_Token extends WP_UnitTestCase {
+class WP_Test_Access_Token extends \WPJM_BaseTest {
 
 	public static ?int $time = null;
 
-	protected function tearDown() : void {
+	public function setUp() : void {
+		parent::setUp();
+		Function_Mocks::mock( 'time', fn() => self::$time ?? \time() );
+	}
+
+	public function tearDown() : void {
 		self::$time = null;
 		parent::tearDown();
 	}

--- a/tests/php/tests/includes/test_class.guest-session.php
+++ b/tests/php/tests/includes/test_class.guest-session.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace WP_Job_Manager;
+
+class WP_Test_Guest_Session extends \WPJM_BaseTest {
+
+	public static ?int $time    = null;
+	public static      $cookies = [];
+
+	//setup
+	public function setUp(): void {
+		parent::setUp();
+		Function_Mocks::mock( 'setcookie', fn( $name, $value ) => self::$cookies[ $name ] = $value );
+		Function_Mocks::mock( 'time', fn() => self::$time ?? \time() );
+		$_COOKIE = self::$cookies;
+		$_GET    = [];
+	}
+
+	public function tearDown(): void {
+		self::$time = null;
+		parent::tearDown();
+
+		$reflection = new \ReflectionClass( Guest_Session::class );
+		$instance   = $reflection->getProperty( 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+		$instance->setAccessible( false );
+
+	}
+
+	/**
+	 * Test that a guest user is found if there is a valid URL token.
+	 */
+	public function test_resolve_user_from_url_token() {
+		// Arrange: Create a guest user and add token to the request.
+		$email                            = 'test@example.com';
+		$guest_user                       = Guest_User::create( $email );
+		$_GET[ Guest_Session::QUERY_VAR ] = $guest_user->create_token();
+
+		// Act: Get the current guest user.
+		$current_guest = Guest_Session::get_current_guest();
+
+		// Assert: Check that the current guest user is the same as the created guest user.
+		$this->assertInstanceOf( Guest_User::class, $current_guest );
+		$this->assertEquals( $email, $current_guest->user_email );
+	}
+
+	/**
+	 * Test that a guest user is found if there is a valid cookie token.
+	 */
+	public function test_resolve_user_from_cookie() {
+		// Arrange: Create a guest user and add token to a cookie.
+		$email                                 = 'test@example.com';
+		$guest_user                            = Guest_User::create( $email );
+		$_COOKIE[ Guest_Session::COOKIE_NAME ] = $guest_user->create_token();
+
+		// Act: Get the current guest user.
+		$current_guest = Guest_Session::get_current_guest();
+
+		// Assert: Check that the current guest user is the same as the created guest user.
+		$this->assertInstanceOf( Guest_User::class, $current_guest );
+		$this->assertEquals( $email, $current_guest->user_email );
+	}
+
+	/**
+	 * Test that a guest user is not returned if there is no token.
+	 */
+	public function test_get_current_guest_no_session() {
+		// Act: Get the current guest user.
+		$current_guest = Guest_Session::get_current_guest();
+
+		// Assert: Check that there is no current guest user.
+		$this->assertFalse( $current_guest );
+	}
+
+	/**
+	 * Test that a guest user is not returned if the token is invalid.
+	 */
+	public function test_get_current_guest_invalid_token() {
+		// Arrange: Set an invalid token in the session.
+		$_COOKIE[ Guest_Session::COOKIE_NAME ] = 'invalid_token';
+
+		// Act: Get the current guest user.
+		$current_guest = Guest_Session::get_current_guest();
+
+		// Assert: Check that there is no current guest user.
+		$this->assertFalse( $current_guest );
+	}
+
+	/**
+	 * Test that a guest user is not returned if the user has been deleted.
+	 */
+	public function test_get_current_guest_non_existent_user() {
+		// Arrange: Create a guest user and get a token for it, then delete the guest user.
+		$email      = 'test@example.com';
+		$guest_user = Guest_User::create( $email );
+		$token      = $guest_user->create_token();
+		wp_delete_post( $guest_user->ID );
+		$_COOKIE[ Guest_Session::COOKIE_NAME ] = $token;
+
+		// Act: Get the current guest user.
+		$current_guest = Guest_Session::get_current_guest();
+
+		// Assert: Check that there is no current guest user.
+		$this->assertFalse( $current_guest );
+	}
+
+	/**
+	 * Test that a guest user is not returned if the token has expired.
+	 */
+	public function test_get_current_guest_expired_token() {
+		// Arrange: Create a guest user and get a token for it, then set the time to after the token's expiry.
+		$email                                 = 'test@example.com';
+		$guest_user                            = Guest_User::create( $email );
+		$token                                 = $guest_user->create_token();
+		self::$time                            = time() + 50 * DAY_IN_SECONDS;
+		$_COOKIE[ Guest_Session::COOKIE_NAME ] = $token;
+
+		// Act: Get the current guest user.
+		$current_guest = Guest_Session::get_current_guest();
+
+		// Assert: Check that there is no current guest user.
+		$this->assertFalse( $current_guest );
+	}
+
+
+}

--- a/tests/php/tests/includes/test_class.guest-user.php
+++ b/tests/php/tests/includes/test_class.guest-user.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace WP_Job_Manager;
+
+class WP_Test_Guest_User extends \WPJM_BaseTest {
+
+	public static ?int $time = null;
+
+	public function setUp() : void {
+		parent::setUp();
+		Function_Mocks::mock( 'time', fn() =>
+			self::$time ?? \time()
+		);
+	}
+
+	public function tearDown() : void {
+		self::$time = null;
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that a guest user can be created.
+	 */
+	public function test_create() {
+		// Arrange: Prepare the necessary objects and values.
+		$email = 'test@example.com';
+
+		// Act: Call the method being tested.
+		$guest_user = Guest_User::create( $email );
+
+		// Assert: Check that the method's output is as expected.
+		$this->assertInstanceOf( Guest_User::class, $guest_user );
+		$this->assertEquals( $email, $guest_user->user_email );
+	}
+
+	/**
+	 * Test that guest user creation fails with invalid email.
+	 */
+	public function test_create_with_invalid_email() {
+		// Arrange.
+		$email = 'testexample.com';
+
+		// Act.
+		$guest_user = Guest_User::create( $email );
+
+		// Assert.
+		$this->assertfalse( $guest_user );
+	}
+
+	/**
+	 * Test that a guest user can be looked up by a valid token.
+	 */
+	public function test_get_by_token() {
+		// Arrange: Create a guest user and get a token for it.
+		$email      = 'test@example.com';
+		$guest_user = Guest_User::create( $email );
+		$token      = $guest_user->create_token();
+
+		// Act: Get the guest user by token.
+		$retrieved_guest_user = Guest_User::get_by_token( $token );
+
+		// Assert: Check that the guest user is found.
+		$this->assertInstanceOf( Guest_User::class, $retrieved_guest_user );
+		$this->assertEquals( $email, $retrieved_guest_user->user_email );
+	}
+
+	/**
+	 * Test invalid token not returning the guest user.
+	 */
+	public function test_invalid_token() {
+		$guest_user = Guest_User::create( 'test@example.com' );
+		$token      = $guest_user->create_token();
+
+		$token = substr( $token, 0, -5 ) . 'aaaaa';
+
+		// Act: Get the guest user by token.
+		$retrieved_guest_user = Guest_User::get_by_token( $token );
+
+		// Assert: Check that the guest user is found.
+		$this->assertFalse( $retrieved_guest_user );
+	}
+
+	/**
+	 * Test valid token of a deleted user returns false.
+	 */
+	public function test_token_of_deleted_user() {
+		$guest_user = Guest_User::create( 'test@example.com' );
+		$token      = $guest_user->create_token();
+
+		wp_delete_post( $guest_user->ID );
+
+		// Act: Get the guest user by token.
+		$retrieved_guest_user = Guest_User::get_by_token( $token );
+
+		// Assert: Check that the guest user is found.
+		$this->assertFalse( $retrieved_guest_user );
+	}
+
+	/**
+	 * Test expired token not returning the guest user.
+	 */
+	public function test_expired_token() {
+		$guest_user = Guest_User::create( 'test@example.com' );
+		$token      = $guest_user->create_token();
+
+		self::$time = time() + 50 * DAY_IN_SECONDS;
+
+		// Act: Get the guest user by token.
+		$retrieved_guest_user = Guest_User::get_by_token( $token );
+
+		// Assert: Check that the guest user is found.
+		$this->assertFalse( $retrieved_guest_user );
+	}
+
+	/**
+	 * Test that a guest user can be looked up by ID.
+	 */
+	public function test_load_by_id() {
+		// Arrange: Create a guest user.
+		$email    = 'test@example.com';
+		$guest_id = Guest_User::create( $email )->ID;
+
+		// Act: Load the guest user by ID.
+		$loaded_guest_user = Guest_User::load( $guest_id );
+
+		// Assert: Check that the loaded guest user is the same as the created guest user.
+		$this->assertInstanceOf( Guest_User::class, $loaded_guest_user );
+		$this->assertEquals( $guest_id, $loaded_guest_user->ID );
+	}
+
+	/**
+	 * Test that a guest user can be looked up by email.
+	 */
+	public function test_load_by_email() {
+		// Arrange: Create a guest user.
+		$email = 'test@example.com';
+		Guest_User::create( $email );
+
+		// Act: Load the guest user by email.
+		$loaded_guest_user = Guest_User::load( $email );
+
+		// Assert: Check that the loaded guest user is the same as the created guest user.
+		$this->assertInstanceOf( Guest_User::class, $loaded_guest_user );
+		$this->assertEquals( $email, $loaded_guest_user->user_email );
+	}
+
+	/**
+	 * Test that a guest user can be looked up by ID.
+	 */
+	public function test_load_with_invalid_email() {
+		// Arrange.
+		$email    = 'nosuchuser@example.com';
+
+		// Act.
+		$guest_user = Guest_User::load( $email );
+
+		// Assert.
+		$this->assertFalse( $guest_user );
+	}
+
+}


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Add a `Guest_User` class to manage creation and lookup of guest users
* Add `Guest_Session` to 'log in' guest users

Works like this:

`Guest_User( $id/$email )->create_token()`
- Creates a token — this joins together the guest user id and their access token into an URL token so it's just one thing. 

*[ link with token gets sent out, user clicks it ]*

`Guest_Session::get_current_guest()`:
- Checks if there is a token in the URL or in a cookie
- Verifies the token, sets the guest user if it checks out
- Sets a cookie if it's a new session
- Returns the guest user object

Cookie is the same as the URL token, which keeps things simple.

### Testing Instructions

* See 420-gh-Automattic/wpjm-addons for the whole flow

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Add support for user sessions without a full account



<!-- wpjm:plugin-zip -->
----

| Plugin build for c1bac6971c264d913e6f8516a0ebe013d83c3638 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2686-c1bac697.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2686-c1bac697)             |

<!-- /wpjm:plugin-zip -->


