### PR TITLE
Replace strings with constants in WP_Job_Manager_Post_Types

### DIFF
--- a/includes/3rd-party/all-in-one-seo-pack.php
+++ b/includes/3rd-party/all-in-one-seo-pack.php
@@ -13,7 +13,7 @@
  */
 function wpjm_aiosp_sitemap_filter_filled_jobs( $posts ) {
 	foreach ( $posts as $index => $post ) {
-		if ( $post instanceof WP_Post && 'job_listing' !== $post->post_type ) {
+		if ( $post instanceof WP_Post && \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 			continue;
 		}
 		if ( is_position_filled( $post ) ) {

--- a/includes/3rd-party/jetpack.php
+++ b/includes/3rd-party/jetpack.php
@@ -13,7 +13,7 @@
  * @return bool
  */
 function wpjm_jetpack_skip_filled_job_listings( $skip_post, $post ) {
-	if ( 'job_listing' !== $post->post_type ) {
+	if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return $skip_post;
 	}
 
@@ -32,7 +32,7 @@ add_action( 'jetpack_sitemap_skip_post', 'wpjm_jetpack_skip_filled_job_listings'
  * @return array
  */
 function wpjm_jetpack_add_post_type( $post_types ) {
-	$post_types[] = 'job_listing';
+	$post_types[] = \WP_Job_Manager_Post_Types::PT_LISTING;
 	return $post_types;
 }
 add_filter( 'jetpack_sitemap_post_types', 'wpjm_jetpack_add_post_type' );

--- a/includes/3rd-party/polylang.php
+++ b/includes/3rd-party/polylang.php
@@ -48,7 +48,7 @@ function polylang_wpjm_get_job_listings_lang( $lang ) {
 	if (
 		function_exists( 'pll_current_language' )
 		&& function_exists( 'pll_is_translated_post_type' )
-		&& pll_is_translated_post_type( 'job_listing' )
+		&& pll_is_translated_post_type( \WP_Job_Manager_Post_Types::PT_LISTING )
 	) {
 		return pll_current_language();
 	}

--- a/includes/3rd-party/rp4wp.php
+++ b/includes/3rd-party/rp4wp.php
@@ -18,7 +18,7 @@ add_filter( 'rp4wp_related_meta_fields_weight', 'wpjm_rp4wp_related_meta_fields_
  * @return string
  */
 function wpjm_rp4wp_template( $located, $template_name, $args ) {
-	if ( 'related-post-default.php' === $template_name && 'job_listing' === $args['related_post']->post_type ) {
+	if ( 'related-post-default.php' === $template_name && \WP_Job_Manager_Post_Types::PT_LISTING === $args['related_post']->post_type ) {
 		return JOB_MANAGER_PLUGIN_DIR . '/templates/content-job_listing.php';
 	}
 	return $located;
@@ -33,7 +33,7 @@ function wpjm_rp4wp_template( $located, $template_name, $args ) {
  * @return array
  */
 function wpjm_rp4wp_related_meta_fields( $meta_fields, $post_id, $post ) {
-	if ( 'job_listing' === $post->post_type ) {
+	if ( \WP_Job_Manager_Post_Types::PT_LISTING === $post->post_type ) {
 		$meta_fields[] = '_company_name';
 		$meta_fields[] = '_job_location';
 	}
@@ -49,7 +49,7 @@ function wpjm_rp4wp_related_meta_fields( $meta_fields, $post_id, $post ) {
  * @return int
  */
 function wpjm_rp4wp_related_meta_fields_weight( $weight, $post, $meta_field ) {
-	if ( 'job_listing' === $post->post_type ) {
+	if ( \WP_Job_Manager_Post_Types::PT_LISTING === $post->post_type ) {
 		$weight = 100;
 	}
 	return $weight;

--- a/includes/3rd-party/wp-all-import.php
+++ b/includes/3rd-party/wp-all-import.php
@@ -13,7 +13,7 @@ add_action( 'pmxi_saved_post', 'wpjm_pmxi_saved_post', 10, 1 );
  * @param  int $post_id
  */
 function wpjm_pmxi_saved_post( $post_id ) {
-	if ( 'job_listing' === get_post_type( $post_id ) ) {
+	if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type( $post_id ) ) {
 		WP_Job_Manager_Post_Types::instance()->maybe_add_default_meta_data( $post_id, get_post( $post_id ) );
 		if ( ! WP_Job_Manager_Geocode::has_location_data( $post_id ) ) {
 			$location = get_post_meta( $post_id, '_job_location', true );

--- a/includes/3rd-party/yoast.php
+++ b/includes/3rd-party/yoast.php
@@ -16,7 +16,7 @@
  * @return string|bool False if we're skipping.
  */
 function wpjm_yoast_skip_filled_job_listings( $url, $type, $post ) {
-	if ( 'job_listing' !== $post->post_type ) {
+	if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return $url;
 	}
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -104,7 +104,7 @@ class WP_Job_Manager_Admin {
 
 		$screen = get_current_screen();
 
-		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', [ 'edit-job_listing', 'plugins', 'job_listing', 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-marketplace', 'edit-job_listing_type' ] ), true ) ) {
+		if ( in_array( $screen->id, apply_filters( 'job_manager_admin_screen_ids', [ 'edit-job_listing', 'plugins', \WP_Job_Manager_Post_Types::PT_LISTING, 'job_listing_page_job-manager-settings', 'job_listing_page_job-manager-marketplace', 'edit-job_listing_type' ] ), true ) ) {
 
 			wp_enqueue_style( 'jquery-ui' );
 			wp_enqueue_style( 'select2' );
@@ -146,7 +146,7 @@ class WP_Job_Manager_Admin {
 			);
 		}
 
-		if ( 'job_listing' === $screen->id && $screen->is_block_editor() ) { // Check if it's block editor in job post.
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING === $screen->id && $screen->is_block_editor() ) { // Check if it's block editor in job post.
 			$post = get_post();
 
 			if ( ! empty( $post ) ) {

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -112,7 +112,7 @@ class WP_Job_Manager_CPT {
 		 *
 		 * @param array $actions_handled {
 		 *     Bulk actions that can be handled, indexed by a unique key name (approve_jobs, expire_jobs, etc). Handlers
-		 *     are responsible for checking abilities (`current_user_can( 'manage_job_listings', $post_id )`) before
+		 *     are responsible for checking abilities (`current_user_can( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $post_id )`) before
 		 *     performing action.
 		 *
 		 *     @type string   $label   Label for the bulk actions dropdown. Passed through sprintf with label name of job listing post type.
@@ -206,7 +206,7 @@ class WP_Job_Manager_CPT {
 			'post_status' => 'expired',
 		];
 		if (
-			current_user_can( 'manage_job_listings', $post_id )
+			current_user_can( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $post_id )
 			&& wp_update_post( $job_data )
 		) {
 			return true;
@@ -223,7 +223,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function bulk_action_handle_mark_job_filled( $post_id ) {
 		if (
-			current_user_can( 'manage_job_listings', $post_id )
+			current_user_can( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $post_id )
 			&& update_post_meta( $post_id, '_filled', 1 )
 		) {
 			return true;
@@ -239,7 +239,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function bulk_action_handle_mark_job_not_filled( $post_id ) {
 		if (
-			current_user_can( 'manage_job_listings', $post_id )
+			current_user_can( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $post_id )
 			&& update_post_meta( $post_id, '_filled', 0 )
 		) {
 			return true;

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -306,14 +306,14 @@ class WP_Job_Manager_CPT {
 	public function jobs_by_category() {
 		global $typenow, $wp_query;
 
-		if ( 'job_listing' !== $typenow || ! taxonomy_exists( 'job_listing_category' ) ) {
+		if ( 'job_listing' !== $typenow || ! taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) {
 			return;
 		}
 
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-category-walker.php';
 
 		$r                 = [];
-		$r['taxonomy']     = 'job_listing_category';
+		$r['taxonomy']     = \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY;
 		$r['pad_counts']   = 1;
 		$r['hierarchical'] = 1;
 		$r['hide_empty']   = 0;
@@ -496,18 +496,18 @@ class WP_Job_Manager_CPT {
 
 		unset( $columns['title'], $columns['date'], $columns['author'] );
 
-		$columns['job_position']         = __( 'Position', 'wp-job-manager' );
-		$columns['job_listing_type']     = __( 'Type', 'wp-job-manager' );
-		$columns['job_location']         = __( 'Location', 'wp-job-manager' );
-		$columns['job_status']           = '<span class="tips" data-tip="' . __( 'Status', 'wp-job-manager' ) . '">' . __( 'Status', 'wp-job-manager' ) . '</span>';
-		$columns['job_posted']           = __( 'Posted', 'wp-job-manager' );
-		$columns['job_expires']          = __( 'Expires', 'wp-job-manager' );
-		$columns['job_listing_category'] = __( 'Categories', 'wp-job-manager' );
-		$columns['featured_job']         = '<span class="tips" data-tip="' . __( 'Featured?', 'wp-job-manager' ) . '">' . __( 'Featured?', 'wp-job-manager' ) . '</span>';
-		$columns['filled']               = '<span class="tips" data-tip="' . __( 'Filled?', 'wp-job-manager' ) . '">' . __( 'Filled?', 'wp-job-manager' ) . '</span>';
+		$columns['job_position']                                     = __( 'Position', 'wp-job-manager' );
+		$columns['job_listing_type']                                 = __( 'Type', 'wp-job-manager' );
+		$columns['job_location']                                     = __( 'Location', 'wp-job-manager' );
+		$columns['job_status']                                       = '<span class="tips" data-tip="' . __( 'Status', 'wp-job-manager' ) . '">' . __( 'Status', 'wp-job-manager' ) . '</span>';
+		$columns['job_posted']                                       = __( 'Posted', 'wp-job-manager' );
+		$columns['job_expires']                                      = __( 'Expires', 'wp-job-manager' );
+		$columns[ \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] = __( 'Categories', 'wp-job-manager' );
+		$columns['featured_job']                                     = '<span class="tips" data-tip="' . __( 'Featured?', 'wp-job-manager' ) . '">' . __( 'Featured?', 'wp-job-manager' ) . '</span>';
+		$columns['filled'] = '<span class="tips" data-tip="' . __( 'Filled?', 'wp-job-manager' ) . '">' . __( 'Filled?', 'wp-job-manager' ) . '</span>';
 
 		if ( ! get_option( 'job_manager_enable_categories' ) ) {
-			unset( $columns['job_listing_category'] );
+			unset( $columns[ \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] );
 		}
 
 		if ( ! get_option( 'job_manager_enable_types' ) ) {
@@ -638,7 +638,7 @@ class WP_Job_Manager_CPT {
 			case 'job_location':
 				the_job_location( true, $post );
 				break;
-			case 'job_listing_category':
+			case \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY:
 				$terms = get_the_term_list( $post->ID, $column, '', ', ', '' );
 				if ( ! $terms ) {
 					echo '<span class="na">&ndash;</span>';

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -134,7 +134,7 @@ class WP_Job_Manager_CPT {
 
 		foreach ( $this->get_bulk_actions() as $key => $bulk_action ) {
 			if ( isset( $bulk_action['label'] ) ) {
-				$bulk_actions[ $key ] = sprintf( $bulk_action['label'], $wp_post_types['job_listing']->labels->name );
+				$bulk_actions[ $key ] = sprintf( $bulk_action['label'], $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->name );
 			}
 		}
 		return $bulk_actions;
@@ -158,7 +158,7 @@ class WP_Job_Manager_CPT {
 			if ( ! empty( $post_ids ) ) {
 				foreach ( $post_ids as $post_id ) {
 					if (
-						'job_listing' === get_post_type( $post_id )
+						\WP_Job_Manager_Post_Types::PT_LISTING === get_post_type( $post_id )
 						&& call_user_func( $actions_handled[ $action ]['handler'], $post_id )
 					) {
 						$handled_jobs[] = $post_id;
@@ -282,7 +282,7 @@ class WP_Job_Manager_CPT {
 
 		if (
 			'edit.php' === $pagenow
-			&& 'job_listing' === $post_type
+			&& \WP_Job_Manager_Post_Types::PT_LISTING === $post_type
 			&& $action
 			&& ! empty( $handled_jobs )
 			&& isset( $actions_handled[ $action ] )
@@ -306,7 +306,7 @@ class WP_Job_Manager_CPT {
 	public function jobs_by_category() {
 		global $typenow, $wp_query;
 
-		if ( 'job_listing' !== $typenow || ! taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $typenow || ! taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) {
 			return;
 		}
 
@@ -350,7 +350,7 @@ class WP_Job_Manager_CPT {
 		global $typenow;
 
 		// Only add the filters for job_listings.
-		if ( 'job_listing' !== $typenow ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $typenow ) {
 			return;
 		}
 
@@ -432,7 +432,7 @@ class WP_Job_Manager_CPT {
 	 * @return string
 	 */
 	public function enter_title_here( $text, $post ) {
-		if ( 'job_listing' === $post->post_type ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING === $post->post_type ) {
 			return esc_html__( 'Position', 'wp-job-manager' );
 		}
 		return $text;
@@ -450,31 +450,31 @@ class WP_Job_Manager_CPT {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes based on input.
 		$revision_title = isset( $_GET['revision'] ) ? wp_post_revision_title( (int) $_GET['revision'], false ) : false;
 
-		$messages['job_listing'] = [
+		$messages[ \WP_Job_Manager_Post_Types::PT_LISTING ] = [
 			0  => '',
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
-			1  => sprintf( __( '%1$s updated. <a href="%2$s">View</a>', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, esc_url( get_permalink( $post_ID ) ) ),
+			1  => sprintf( __( '%1$s updated. <a href="%2$s">View</a>', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name, esc_url( get_permalink( $post_ID ) ) ),
 			2  => __( 'Custom field updated.', 'wp-job-manager' ),
 			3  => __( 'Custom field deleted.', 'wp-job-manager' ),
 			// translators: %s is the singular name of the job listing post type.
-			4  => sprintf( esc_html__( '%s updated.', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name ),
+			4  => sprintf( esc_html__( '%s updated.', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name ),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the revision number.
-			5  => $revision_title ? sprintf( __( '%1$s restored to revision from %2$s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, $revision_title ) : false,
+			5  => $revision_title ? sprintf( __( '%1$s restored to revision from %2$s', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name, $revision_title ) : false,
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
-			6  => sprintf( __( '%1$s published. <a href="%2$s">View</a>', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, esc_url( get_permalink( $post_ID ) ) ),
+			6  => sprintf( __( '%1$s published. <a href="%2$s">View</a>', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name, esc_url( get_permalink( $post_ID ) ) ),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
-			7  => sprintf( esc_html__( '%s saved.', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name ),
+			7  => sprintf( esc_html__( '%s saved.', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name ),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to preview the listing.
-			8  => sprintf( __( '%1$s submitted. <a target="_blank" href="%2$s">Preview</a>', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
+			8  => sprintf( __( '%1$s submitted. <a target="_blank" href="%2$s">Preview</a>', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
 			9  => sprintf(
 				// translators: %1$s is the singular name of the post type; %2$s is the date the post will be published; %3$s is the URL to preview the listing.
 				__( '%1$s scheduled for: <strong>%2$s</strong>. <a target="_blank" href="%3$s">Preview</a>', 'wp-job-manager' ),
-				$wp_post_types['job_listing']->labels->singular_name,
+				$wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name,
 				wp_date( get_option( 'date_format' ) . ' @ ' . get_option( 'time_format' ), get_post_timestamp() ),
 				esc_url( get_permalink( $post_ID ) )
 			),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
-			10 => sprintf( __( '%1$s draft updated. <a target="_blank" href="%2$s">Preview</a>', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
+			10 => sprintf( __( '%1$s draft updated. <a target="_blank" href="%2$s">Preview</a>', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
 		];
 
 		return $messages;
@@ -539,7 +539,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function row_actions( $actions, $post ) {
 
-		if ( 'job_listing' === get_post_type() ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type() ) {
 
 			unset( $actions['inline hide-if-no-js'] );
 			unset( $actions['trash'] );
@@ -732,7 +732,7 @@ class WP_Job_Manager_CPT {
 	public function search_meta( $wp ) {
 		global $pagenow, $wpdb;
 
-		if ( 'edit.php' !== $pagenow || empty( $wp->query_vars['s'] ) || 'job_listing' !== $wp->query_vars['post_type'] ) {
+		if ( 'edit.php' !== $pagenow || empty( $wp->query_vars['s'] ) || \WP_Job_Manager_Post_Types::PT_LISTING !== $wp->query_vars['post_type'] ) {
 			return;
 		}
 
@@ -776,7 +776,7 @@ class WP_Job_Manager_CPT {
 	public function filter_meta( $wp ) {
 		global $pagenow;
 
-		if ( 'edit.php' !== $pagenow || empty( $wp->query_vars['post_type'] ) || 'job_listing' !== $wp->query_vars['post_type'] ) {
+		if ( 'edit.php' !== $pagenow || empty( $wp->query_vars['post_type'] ) || \WP_Job_Manager_Post_Types::PT_LISTING !== $wp->query_vars['post_type'] ) {
 			return;
 		}
 
@@ -822,7 +822,7 @@ class WP_Job_Manager_CPT {
 		global $pagenow, $typenow;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input is used safely.
-		if ( 'edit.php' !== $pagenow || 'job_listing' !== $typenow || ! get_query_var( 'job_listing_search' ) || ! isset( $_GET['s'] ) ) {
+		if ( 'edit.php' !== $pagenow || \WP_Job_Manager_Post_Types::PT_LISTING !== $typenow || ! get_query_var( 'job_listing_search' ) || ! isset( $_GET['s'] ) ) {
 			return $query;
 		}
 
@@ -837,7 +837,7 @@ class WP_Job_Manager_CPT {
 		global $post, $post_type;
 
 		// Abort if we're on the wrong post type, but only if we got a restriction.
-		if ( 'job_listing' !== $post_type ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post_type ) {
 			return;
 		}
 
@@ -876,7 +876,7 @@ class WP_Job_Manager_CPT {
 	 * @return array            Array of post types that support view mode, without job_listing post type.
 	 */
 	public function disable_view_mode( $post_types ) {
-		unset( $post_types['job_listing'] );
+		unset( $post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ] );
 		return $post_types;
 	}
 }

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -494,7 +494,7 @@ class WP_Job_Manager_CPT {
 		unset( $columns['title'], $columns['date'], $columns['author'] );
 
 		$columns['job_position']                                     = __( 'Position', 'wp-job-manager' );
-		$columns['job_listing_type']                                 = __( 'Type', 'wp-job-manager' );
+		$columns[ \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ]     = __( 'Type', 'wp-job-manager' );
 		$columns['job_location']                                     = __( 'Location', 'wp-job-manager' );
 		$columns['job_status']                                       = '<span class="tips" data-tip="' . __( 'Status', 'wp-job-manager' ) . '">' . __( 'Status', 'wp-job-manager' ) . '</span>';
 		$columns['job_posted']                                       = __( 'Posted', 'wp-job-manager' );
@@ -508,7 +508,7 @@ class WP_Job_Manager_CPT {
 		}
 
 		if ( ! get_option( 'job_manager_enable_types' ) ) {
-			unset( $columns['job_listing_type'] );
+			unset( $columns[ \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ] );
 		}
 
 		return $columns;
@@ -595,7 +595,7 @@ class WP_Job_Manager_CPT {
 		global $post;
 
 		switch ( $column ) {
-			case 'job_listing_type':
+			case \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE:
 				$types = wpjm_get_the_job_types( $post );
 
 				if ( $types && ! empty( $types ) ) {

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -318,7 +318,7 @@ class WP_Job_Manager_CPT {
 		$r['hierarchical'] = 1;
 		$r['hide_empty']   = 0;
 		$r['show_count']   = 1;
-		$r['selected']     = ( isset( $wp_query->query['job_listing_category'] ) ) ? $wp_query->query['job_listing_category'] : '';
+		$r['selected']     = ( isset( $wp_query->query[ \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] ) ) ? $wp_query->query[ \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] : '';
 		$r['menu_order']   = false;
 		$terms             = get_terms( $r );
 		$walker            = new WP_Job_Manager_Category_Walker();
@@ -334,11 +334,8 @@ class WP_Job_Manager_CPT {
 				'class'    => [],
 			],
 		];
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes or data exposed based on input.
-		$selected_category = isset( $_GET['job_listing_category'] ) ? sanitize_text_field( wp_unslash( $_GET['job_listing_category'] ) ) : '';
-		echo "<select name='job_listing_category' id='dropdown_job_listing_category'>";
-		echo '<option value="" ' . selected( $selected_category, '', false ) . '>' . esc_html__( 'Select category', 'wp-job-manager' ) . '</option>';
+		echo "<select name='" . esc_attr( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) . "' id='dropdown_job_listing_category'>";
+		echo '<option value="" ' . selected( $r['selected'], '', false ) . '>' . esc_html__( 'Select category', 'wp-job-manager' ) . '</option>';
 		echo wp_kses( $walker->walk( $terms, 0, $r ), $allowed_html );
 		echo '</select>';
 

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -161,7 +161,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			return false;
 		}
 
-		return current_user_can( 'manage_job_listings', $post_id );
+		return current_user_can( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $post_id );
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -109,7 +109,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 				[
 					'action_performed' => 'promotion_deactivated',
 					'handled_jobs'     => [ $post_id ],
-					'post_type'        => 'job_listing',
+					'post_type'        => \WP_Job_Manager_Post_Types::PT_LISTING,
 					'action'           => false,
 					'post_id'          => false,
 					'_wpnonce'         => false,
@@ -130,7 +130,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	public function add_promoted_badge( $post ) {
 		if (
 			is_null( $post )
-			|| 'job_listing' !== $post->post_type
+			|| \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type
 			|| ! WP_Job_Manager_Promoted_Jobs::is_promoted( $post->ID )
 		) {
 			return;
@@ -157,7 +157,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 	 * @return bool Returns true if they can promote a job.
 	 */
 	private function can_manage_job_promotion( int $post_id ) {
-		if ( 'job_listing' !== get_post_type( $post_id ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== get_post_type( $post_id ) ) {
 			return false;
 		}
 
@@ -365,7 +365,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 		$screen = get_current_screen();
 
 		// Job editor.
-		if ( 'job_listing' === $screen->id && ! \WP_Job_Manager_Admin_Notices::is_dismissed( self::JOB_EDITOR_MODAL_NOTICE, true ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING === $screen->id && ! \WP_Job_Manager_Admin_Notices::is_dismissed( self::JOB_EDITOR_MODAL_NOTICE, true ) ) {
 
 			$notice_wrapper_attributes = \WP_Job_Manager_Admin_Notices::get_dismissible_notice_wrapper_attributes( self::JOB_EDITOR_MODAL_NOTICE );
 
@@ -464,7 +464,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 
 		$trash_url = add_query_arg(
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => 'trash',
 			],
 			admin_url( 'edit.php' )

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -152,12 +152,12 @@ class WP_Job_Manager_Writepanels {
 
 		// translators: Placeholder %s is the singular name for a job listing post type.
 		add_meta_box( 'job_listing_data', sprintf( __( '%s Data', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name ), [ $this, 'job_listing_data' ], 'job_listing', 'normal', 'high' );
-		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( 'job_listing_type' ) ) ) {
+		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ) ) ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side' );
 		} elseif ( false === job_manager_multi_job_type() ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side' );
-			$job_listing_type = get_taxonomy( 'job_listing_type' );
-			add_meta_box( 'job_listing_type', $job_listing_type->labels->menu_name, [ $this, 'job_type_single_meta_box' ], 'job_listing', 'side', 'core' );
+			$job_listing_type = get_taxonomy( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
+			add_meta_box( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, $job_listing_type->labels->menu_name, [ $this, 'job_type_single_meta_box' ], 'job_listing', 'side', 'core' );
 		}
 	}
 
@@ -168,7 +168,7 @@ class WP_Job_Manager_Writepanels {
 	 */
 	public function job_type_single_meta_box( $post ) {
 		// Set up the taxonomy object and get terms.
-		$taxonomy_name = 'job_listing_type';
+		$taxonomy_name = \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE;
 
 		// Get all the terms for this taxonomy.
 		$terms     = get_terms(

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -60,7 +60,7 @@ class WP_Job_Manager_Writepanels {
 
 		$fields = [];
 
-		if ( $current_user->has_cap( 'edit_others_job_listings' ) ) {
+		if ( $current_user->has_cap( \WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS ) ) {
 			$fields['_job_author'] = [
 				'label'    => __( 'Posted by', 'wp-job-manager' ),
 				'type'     => 'author',

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -151,13 +151,13 @@ class WP_Job_Manager_Writepanels {
 		global $wp_post_types;
 
 		// translators: Placeholder %s is the singular name for a job listing post type.
-		add_meta_box( 'job_listing_data', sprintf( __( '%s Data', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->singular_name ), [ $this, 'job_listing_data' ], 'job_listing', 'normal', 'high' );
+		add_meta_box( 'job_listing_data', sprintf( __( '%s Data', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name ), [ $this, 'job_listing_data' ], \WP_Job_Manager_Post_Types::PT_LISTING, 'normal', 'high' );
 		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ) ) ) {
-			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side' );
+			remove_meta_box( 'job_listing_typediv', \WP_Job_Manager_Post_Types::PT_LISTING, 'side' );
 		} elseif ( false === job_manager_multi_job_type() ) {
-			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side' );
+			remove_meta_box( 'job_listing_typediv', \WP_Job_Manager_Post_Types::PT_LISTING, 'side' );
 			$job_listing_type = get_taxonomy( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
-			add_meta_box( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, $job_listing_type->labels->menu_name, [ $this, 'job_type_single_meta_box' ], 'job_listing', 'side', 'core' );
+			add_meta_box( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, $job_listing_type->labels->menu_name, [ $this, 'job_type_single_meta_box' ], \WP_Job_Manager_Post_Types::PT_LISTING, 'side', 'core' );
 		}
 	}
 
@@ -617,7 +617,7 @@ class WP_Job_Manager_Writepanels {
 			printf(
 				// translators: %1$s is placeholder for singular name of the job listing post type; %2$s is the intl formatted date the listing was last modified.
 				esc_html__( '%1$s was last modified by the user on %2$s.', 'wp-job-manager' ),
-				esc_html( $wp_post_types['job_listing']->labels->singular_name ),
+				esc_html( $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name ),
 				esc_html( wp_date( get_option( 'date_format' ), (int) $user_edited_timestamp ) )
 			);
 			echo '</em>';
@@ -657,7 +657,7 @@ class WP_Job_Manager_Writepanels {
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
-		if ( 'job_listing' !== $post->post_type ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 			return;
 		}
 

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -264,7 +264,7 @@ class WP_Job_Manager_Ajax {
 		if ( $result['found_jobs'] ) {
 			while ( $jobs->have_posts() ) {
 				$jobs->the_post();
-				get_job_manager_template_part( 'content', 'job_listing' );
+				get_job_manager_template_part( 'content', \WP_Job_Manager_Post_Types::PT_LISTING );
 			}
 		} else {
 			get_job_manager_template_part( 'content', 'no-jobs-found' );

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -335,7 +335,7 @@ class WP_Job_Manager_Ajax {
 		 *
 		 * @param array $user_caps Array of capabilities/roles that are allowed to search for users.
 		 */
-		$allowed_capabilities = apply_filters( 'job_manager_caps_can_search_users', [ 'edit_job_listings' ] );
+		$allowed_capabilities = apply_filters( 'job_manager_caps_can_search_users', [ \WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS ] );
 		foreach ( $allowed_capabilities as $cap ) {
 			if ( current_user_can( $cap ) ) {
 				$user_can_search_users = true;

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -38,7 +38,7 @@ class WP_Job_Manager_Cache_Helper {
 	 * @param int|WP_Post $post_id
 	 */
 	public static function flush_get_job_listings_cache( $post_id ) {
-		if ( 'job_listing' === get_post_type( $post_id ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type( $post_id ) ) {
 			self::get_transient_version( 'get_job_listings', true );
 		}
 	}
@@ -155,7 +155,7 @@ class WP_Job_Manager_Cache_Helper {
 		 * @param string  $old_status Old post status.
 		 * @param WP_Post $post       Post object.
 		 */
-		$post_types = apply_filters( 'wpjm_count_cache_supported_post_types', [ 'job_listing' ], $new_status, $old_status, $post );
+		$post_types = apply_filters( 'wpjm_count_cache_supported_post_types', [ \WP_Job_Manager_Post_Types::PT_LISTING ], $new_status, $old_status, $post );
 
 		// Only proceed when statuses do not match, and post type is supported post type.
 		if ( $new_status === $old_status || ! in_array( $post->post_type, $post_types, true ) ) {
@@ -219,7 +219,7 @@ class WP_Job_Manager_Cache_Helper {
 	 *
 	 * @return int
 	 */
-	public static function get_listings_count( $post_type = 'job_listing', $status = 'pending', $force = false ) {
+	public static function get_listings_count( $post_type = \WP_Job_Manager_Post_Types::PT_LISTING, $status = 'pending', $force = false ) {
 
 		// Get user based cache transient.
 		$user_id   = get_current_user_id();

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require __DIR__ . '/class-wp-job-manager-post-types.php';
 
 /**
  * Methods for cleaning up all plugin data.

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -163,7 +163,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
-		'delete_published_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
 		'delete_others_job_listings',
 		'edit_private_job_listings',
 		'edit_published_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -155,7 +155,7 @@ class WP_Job_Manager_Data_Cleaner {
 	private static $caps = [
 		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
-		'read_job_listing',
+		\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
 		'delete_job_listing',
 		'edit_job_listings',
 		'edit_others_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -154,7 +154,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 */
 	private static $caps = [
 		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS,
-		'edit_job_listing',
+		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
 		'read_job_listing',
 		'delete_job_listing',
 		'edit_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -24,7 +24,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 */
 	private static $custom_post_types = [
 		\WP_Job_Manager_Post_Types::PT_LISTING,
-		'job_guest_user',
+		\WP_Job_Manager_Post_Types::PT_GUEST_USER,
 	];
 
 	/**

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -153,7 +153,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 * @var $caps
 	 */
 	private static $caps = [
-		'manage_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS,
 		'edit_job_listing',
 		'read_job_listing',
 		'delete_job_listing',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -158,7 +158,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
-		'edit_others_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
 		'publish_job_listings',
 		'read_private_job_listings',
 		'delete_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require __DIR__ . '/class-wp-job-manager-post-types.php';
+
 /**
  * Methods for cleaning up all plugin data.
  *

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -170,7 +170,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING_TERMS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING_TERMS,
-		'assign_job_listing_terms',
+		\WP_Job_Manager_Post_Types::CAP_ASSIGN_LISTING_TERMS,
 	];
 
 	/**

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -161,7 +161,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
-		'delete_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
 		'delete_private_job_listings',
 		'delete_published_job_listings',
 		'delete_others_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -165,7 +165,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
-		'edit_private_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
 		'edit_published_job_listings',
 		'manage_job_listing_terms',
 		'edit_job_listing_terms',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -162,7 +162,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
-		'delete_private_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
 		'delete_published_job_listings',
 		'delete_others_job_listings',
 		'edit_private_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -164,7 +164,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
-		'delete_others_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
 		'edit_private_job_listings',
 		'edit_published_job_listings',
 		'manage_job_listing_terms',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -168,7 +168,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
-		'edit_job_listing_terms',
+		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING_TERMS,
 		'delete_job_listing_terms',
 		'assign_job_listing_terms',
 	];

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -169,7 +169,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING_TERMS,
-		'delete_job_listing_terms',
+		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING_TERMS,
 		'assign_job_listing_terms',
 	];
 

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -166,7 +166,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
-		'edit_published_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
 		'manage_job_listing_terms',
 		'edit_job_listing_terms',
 		'delete_job_listing_terms',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -34,7 +34,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 */
 	private static $taxonomies = [
 		\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
-		'job_listing_type',
+		\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 	];
 
 	/** Cron jobs to be unscheduled.

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -157,7 +157,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
 		\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
 		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
-		'edit_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
 		'edit_others_job_listings',
 		'publish_job_listings',
 		'read_private_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -156,7 +156,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
 		\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
-		'delete_job_listing',
+		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
 		'edit_job_listings',
 		'edit_others_job_listings',
 		'publish_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -160,7 +160,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
-		'read_private_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
 		'delete_job_listings',
 		'delete_private_job_listings',
 		'delete_published_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -33,7 +33,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 * @var $taxonomies
 	 */
 	private static $taxonomies = [
-		'job_listing_category',
+		\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
 		'job_listing_type',
 	];
 

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -23,7 +23,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 * @var $custom_post_types
 	 */
 	private static $custom_post_types = [
-		'job_listing',
+		\WP_Job_Manager_Post_Types::PT_LISTING,
 		'job_guest_user',
 	];
 

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -159,7 +159,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
-		'publish_job_listings',
+		\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
 		'read_private_job_listings',
 		'delete_job_listings',
 		'delete_private_job_listings',

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -167,7 +167,7 @@ class WP_Job_Manager_Data_Cleaner {
 		\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
 		\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
-		'manage_job_listing_terms',
+		\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
 		'edit_job_listing_terms',
 		'delete_job_listing_terms',
 		'assign_job_listing_terms',

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -286,7 +286,7 @@ final class WP_Job_Manager_Email_Notifications {
 			}
 		}
 
-		if ( get_option( 'job_manager_enable_categories' ) && wp_count_terms( 'job_listing_category' ) > 0 ) {
+		if ( get_option( 'job_manager_enable_categories' ) && wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) > 0 ) {
 			$job_categories = wpjm_get_the_job_categories( $job );
 			if ( ! empty( $job_categories ) ) {
 				$fields['job_category'] = [

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -276,7 +276,7 @@ final class WP_Job_Manager_Email_Notifications {
 			];
 		}
 
-		if ( get_option( 'job_manager_enable_types' ) && wp_count_terms( 'job_listing_type' ) > 0 ) {
+		if ( get_option( 'job_manager_enable_types' ) && wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ) > 0 ) {
 			$job_types = wpjm_get_the_job_types( $job );
 			if ( ! empty( $job_types ) ) {
 				$fields['job_type'] = [

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -600,7 +600,7 @@ final class WP_Job_Manager_Email_Notifications {
 
 		$job_ids = get_posts(
 			[
-				'post_type'      => 'job_listing',
+				'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => -1,

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -130,7 +130,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
-				'edit_published_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
 				'manage_job_listing_terms',
 				'edit_job_listing_terms',
 				'delete_job_listing_terms',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -171,7 +171,7 @@ class WP_Job_Manager_Install {
 	 */
 	private static function get_default_taxonomy_terms() {
 		return [
-			'job_listing_type' => [
+			\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => [
 				'Full Time'  => [
 					'employment_type' => 'FULL_TIME',
 				],
@@ -196,10 +196,10 @@ class WP_Job_Manager_Install {
 	 */
 	private static function add_employment_types() {
 		$taxonomies = self::get_default_taxonomy_terms();
-		$terms      = $taxonomies['job_listing_type'];
+		$terms      = $taxonomies[ \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ];
 
 		foreach ( $terms as $term => $meta ) {
-			$term = get_term_by( 'slug', sanitize_title( $term ), 'job_listing_type' );
+			$term = get_term_by( 'slug', sanitize_title( $term ), \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 			if ( $term ) {
 				foreach ( $meta as $meta_key => $meta_value ) {
 					if ( ! get_term_meta( (int) $term->term_id, $meta_key, true ) ) {

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -119,7 +119,7 @@ class WP_Job_Manager_Install {
 			],
 			\WP_Job_Manager_Post_Types::PT_LISTING => [
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
-				'read_job_listing',
+				\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
 				'delete_job_listing',
 				'edit_job_listings',
 				'edit_others_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -121,7 +121,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
 				\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
-				'edit_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
 				'edit_others_job_listings',
 				'publish_job_listings',
 				'read_private_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -125,7 +125,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
-				'delete_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
 				'delete_private_job_listings',
 				'delete_published_job_listings',
 				'delete_others_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -128,7 +128,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
-				'delete_others_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
 				'edit_private_job_listings',
 				'edit_published_job_listings',
 				'manage_job_listing_terms',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -114,10 +114,10 @@ class WP_Job_Manager_Install {
 	 */
 	private static function get_core_capabilities() {
 		return [
-			'core'        => [
+			'core'                                 => [
 				\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS,
 			],
-			'job_listing' => [
+			\WP_Job_Manager_Post_Types::PT_LISTING => [
 				'edit_job_listing',
 				'read_job_listing',
 				'delete_job_listing',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -132,7 +132,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
-				'edit_job_listing_terms',
+				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING_TERMS,
 				'delete_job_listing_terms',
 				'assign_job_listing_terms',
 			],

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -123,7 +123,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
-				'publish_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
 				'read_private_job_listings',
 				'delete_job_listings',
 				'delete_private_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -133,7 +133,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING_TERMS,
-				'delete_job_listing_terms',
+				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING_TERMS,
 				'assign_job_listing_terms',
 			],
 		];

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -124,7 +124,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
-				'read_private_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
 				'delete_job_listings',
 				'delete_private_job_listings',
 				'delete_published_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -127,7 +127,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
-				'delete_published_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
 				'delete_others_job_listings',
 				'edit_private_job_listings',
 				'edit_published_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -131,7 +131,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS,
-				'manage_job_listing_terms',
+				\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
 				'edit_job_listing_terms',
 				'delete_job_listing_terms',
 				'assign_job_listing_terms',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -118,7 +118,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS,
 			],
 			\WP_Job_Manager_Post_Types::PT_LISTING => [
-				'edit_job_listing',
+				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
 				'read_job_listing',
 				'delete_job_listing',
 				'edit_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -129,7 +129,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_PUBLISHED_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_OTHERS_LISTINGS,
-				'edit_private_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_EDIT_PRIVATE_LISTINGS,
 				'edit_published_job_listings',
 				'manage_job_listing_terms',
 				'edit_job_listing_terms',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -120,7 +120,7 @@ class WP_Job_Manager_Install {
 			\WP_Job_Manager_Post_Types::PT_LISTING => [
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING,
 				\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
-				'delete_job_listing',
+				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
 				'edit_job_listings',
 				'edit_others_job_listings',
 				'publish_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -115,7 +115,7 @@ class WP_Job_Manager_Install {
 	private static function get_core_capabilities() {
 		return [
 			'core'        => [
-				'manage_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS,
 			],
 			'job_listing' => [
 				'edit_job_listing',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -122,7 +122,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_READ_LISTING,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS,
-				'edit_others_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS,
 				'publish_job_listings',
 				'read_private_job_listings',
 				'delete_job_listings',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -134,7 +134,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTING_TERMS,
 				\WP_Job_Manager_Post_Types::CAP_EDIT_LISTING_TERMS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTING_TERMS,
-				'assign_job_listing_terms',
+				\WP_Job_Manager_Post_Types::CAP_ASSIGN_LISTING_TERMS,
 			],
 		];
 	}

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -126,7 +126,7 @@ class WP_Job_Manager_Install {
 				\WP_Job_Manager_Post_Types::CAP_PUBLISH_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_READ_PRIVATE_LISTINGS,
 				\WP_Job_Manager_Post_Types::CAP_DELETE_LISTINGS,
-				'delete_private_job_listings',
+				\WP_Job_Manager_Post_Types::CAP_DELETE_PRIVATE_LISTINGS,
 				'delete_published_job_listings',
 				'delete_others_job_listings',
 				'edit_private_job_listings',

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -33,6 +33,11 @@ class WP_Job_Manager_Post_Types {
 	/** Capabilities */
 
 	/**
+	 * Constant for the capability name used for managing the job listings.
+	 */
+	public const CAP_MANAGE_LISTINGS = 'manage_job_listings';
+
+	/**
 	 * Constant for the capability name used for the post type used for saving guest user data.
 	 */
 	public const CAP_GUEST_USER = 'job_guest_user';
@@ -183,7 +188,7 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
-		$admin_capability = 'manage_job_listings';
+		$admin_capability = self::CAP_MANAGE_LISTINGS;
 
 		$permalink_structure = self::get_permalink_structure();
 
@@ -1900,7 +1905,7 @@ class WP_Job_Manager_Post_Types {
 			return false;
 		}
 
-		return $user->has_cap( 'manage_job_listings' );
+		return $user->has_cap( self::CAP_MANAGE_LISTINGS );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -2011,7 +2011,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		if ( empty( $post_id ) ) {
-			return current_user_can( 'edit_job_listings' );
+			return current_user_can( self::CAP_EDIT_LISTINGS );
 		}
 
 		return job_manager_user_can_edit_job( $post_id );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -18,10 +18,14 @@ class WP_Job_Manager_Post_Types {
 
 	const PERMALINK_OPTION_NAME = 'job_manager_permalinks';
 
+	/** Post Types */
+
 	/**
 	 * Constant for the post type name used for saving guest user data.
 	 */
 	public const PT_GUEST_USER = 'job_guest_user';
+
+	/** Capabilities */
 
 	/**
 	 * Constant for the capability name used for the post type used for saving guest user data.

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -2034,7 +2034,7 @@ class WP_Job_Manager_Post_Types {
 			return false;
 		}
 
-		return $user->has_cap( 'edit_others_job_listings' );
+		return $user->has_cap( self::CAP_EDIT_OTHERS_LISTINGS );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -40,6 +40,11 @@ class WP_Job_Manager_Post_Types {
 	public const TAX_LISTING_CATEGORY = 'job_listing_category';
 
 	/**
+	 * Constant for the job listing type taxonomy name.
+	 */
+	public const TAX_LISTING_TYPE = 'job_listing_type';
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var self
@@ -157,7 +162,7 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function hide_job_type_block_editor_selector( $response, $taxonomy, $request ) {
 		if (
-			'job_listing_type' === $taxonomy->name
+			self::TAX_LISTING_TYPE === $taxonomy->name
 			&& 'edit' === $request->get_param( 'context' )
 		) {
 			$response->data['visibility']['show_ui'] = false;
@@ -261,7 +266,7 @@ class WP_Job_Manager_Post_Types {
 			}
 
 			register_taxonomy(
-				'job_listing_type',
+				self::TAX_LISTING_TYPE,
 				apply_filters( 'register_taxonomy_job_listing_type_object_type', [ 'job_listing' ] ),
 				apply_filters(
 					'register_taxonomy_job_listing_type_args',
@@ -310,7 +315,7 @@ class WP_Job_Manager_Post_Types {
 					'term',
 					'employment_type',
 					[
-						'object_subtype'    => 'job_listing_type',
+						'object_subtype'    => self::TAX_LISTING_TYPE,
 						'show_in_rest'      => true,
 						'type'              => 'string',
 						'single'            => true,
@@ -671,7 +676,7 @@ class WP_Job_Manager_Post_Types {
 
 		if ( ! empty( $input_job_types ) ) {
 			$query_args['tax_query'][] = [
-				'taxonomy' => 'job_listing_type',
+				'taxonomy' => self::TAX_LISTING_TYPE,
 				'field'    => 'slug',
 				'terms'    => $input_job_types + [ 0 ],
 			];

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -32,6 +32,13 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public const CAP_GUEST_USER = 'job_guest_user';
 
+	/** Taxonomies */
+
+	/**
+	 * Constant for the job listing category taxonomy name.
+	 */
+	public const TAX_LISTING_CATEGORY = 'job_listing_category';
+
 	/**
 	 * The single instance of the class.
 	 *
@@ -190,7 +197,7 @@ class WP_Job_Manager_Post_Types {
 			}
 
 			register_taxonomy(
-				'job_listing_category',
+				self::TAX_LISTING_CATEGORY,
 				apply_filters( 'register_taxonomy_job_listing_category_object_type', [ 'job_listing' ] ),
 				apply_filters(
 					'register_taxonomy_job_listing_category_args',
@@ -675,7 +682,7 @@ class WP_Job_Manager_Post_Types {
 			$field                     = is_numeric( $cats ) ? 'term_id' : 'slug';
 			$operator                  = 'all' === get_option( 'job_manager_category_filter_type', 'all' ) && count( $cats ) > 1 ? 'AND' : 'IN';
 			$query_args['tax_query'][] = [
-				'taxonomy'         => 'job_listing_category',
+				'taxonomy'         => self::TAX_LISTING_CATEGORY,
 				'field'            => $field,
 				'terms'            => $cats,
 				'include_children' => 'AND' !== $operator,

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -21,6 +21,11 @@ class WP_Job_Manager_Post_Types {
 	/** Post Types */
 
 	/**
+	 * Constant for the post type name used for job listings.
+	 */
+	public const PT_LISTING = 'job_listing';
+
+	/**
 	 * Constant for the post type name used for saving guest user data.
 	 */
 	public const PT_GUEST_USER = 'job_guest_user';
@@ -143,7 +148,7 @@ class WP_Job_Manager_Post_Types {
 	public function force_classic_block( $allowed_block_types, $post ) {
 		_deprecated_function( __METHOD__, '1.35.2' );
 
-		if ( 'job_listing' === $post->post_type ) {
+		if ( self::PT_LISTING === $post->post_type ) {
 			return [ 'core/freeform' ];
 		}
 		return $allowed_block_types;
@@ -174,7 +179,7 @@ class WP_Job_Manager_Post_Types {
 	 * Registers the custom post type and taxonomies.
 	 */
 	public function register_post_types() {
-		if ( post_type_exists( 'job_listing' ) ) {
+		if ( post_type_exists( self::PT_LISTING ) ) {
 			return;
 		}
 
@@ -203,7 +208,7 @@ class WP_Job_Manager_Post_Types {
 
 			register_taxonomy(
 				self::TAX_LISTING_CATEGORY,
-				apply_filters( 'register_taxonomy_job_listing_category_object_type', [ 'job_listing' ] ),
+				apply_filters( 'register_taxonomy_job_listing_category_object_type', [ self::PT_LISTING ] ),
 				apply_filters(
 					'register_taxonomy_job_listing_category_args',
 					[
@@ -267,7 +272,7 @@ class WP_Job_Manager_Post_Types {
 
 			register_taxonomy(
 				self::TAX_LISTING_TYPE,
-				apply_filters( 'register_taxonomy_job_listing_type_object_type', [ 'job_listing' ] ),
+				apply_filters( 'register_taxonomy_job_listing_type_object_type', [ self::PT_LISTING ] ),
 				apply_filters(
 					'register_taxonomy_job_listing_type_args',
 					[
@@ -353,7 +358,7 @@ class WP_Job_Manager_Post_Types {
 		];
 
 		register_post_type(
-			'job_listing',
+			self::PT_LISTING,
 			apply_filters(
 				'register_post_type_job_listing',
 				[
@@ -392,7 +397,7 @@ class WP_Job_Manager_Post_Types {
 					'description'           => sprintf( esc_html__( 'This is where you can create and manage %s.', 'wp-job-manager' ), $plural ),
 					'public'                => true,
 					'show_ui'               => true,
-					'capability_type'       => 'job_listing',
+					'capability_type'       => self::PT_LISTING,
 					'map_meta_cap'          => true,
 					'publicly_queryable'    => true,
 					'exclude_from_search'   => false,
@@ -490,7 +495,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		// Try to pull menu_name from post type object to support themes/plugins that change the menu string.
-		$post_type = get_post_type_object( 'job_listing' );
+		$post_type = get_post_type_object( self::PT_LISTING );
 		$plural    = isset( $post_type->labels, $post_type->labels->menu_name ) ? $post_type->labels->menu_name : esc_html__( 'Job Listings', 'wp-job-manager' );
 
 		foreach ( $menu as $key => $menu_item ) {
@@ -585,9 +590,9 @@ class WP_Job_Manager_Post_Types {
 		global $post;
 
 		if (
-			! is_singular( 'job_listing' ) ||
+			! is_singular( self::PT_LISTING ) ||
 			! in_the_loop() ||
-			'job_listing' !== $post->post_type ||
+			self::PT_LISTING !== $post->post_type ||
 			( post_password_required() && ! is_super_admin() )
 		) {
 			return $content;
@@ -599,7 +604,7 @@ class WP_Job_Manager_Post_Types {
 
 		do_action( 'job_content_start' );
 
-		get_job_manager_template_part( 'content-single', 'job_listing' );
+		get_job_manager_template_part( 'content-single', self::PT_LISTING );
 
 		do_action( 'job_content_end' );
 
@@ -636,7 +641,7 @@ class WP_Job_Manager_Post_Types {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$query_args = [
-			'post_type'           => 'job_listing',
+			'post_type'           => self::PT_LISTING,
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
 			'posts_per_page'      => $input_posts_per_page,
@@ -738,7 +743,7 @@ class WP_Job_Manager_Post_Types {
 			return;
 		}
 
-		$wp->query_vars['post_type'] = 'job_listing';
+		$wp->query_vars['post_type'] = self::PT_LISTING;
 	}
 
 	/**
@@ -792,7 +797,7 @@ class WP_Job_Manager_Post_Types {
 		// Change status to expired.
 		$job_ids = get_posts(
 			[
-				'post_type'      => 'job_listing',
+				'post_type'      => self::PT_LISTING,
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => -1,
@@ -843,7 +848,7 @@ class WP_Job_Manager_Post_Types {
 			$date_cutoff = current_datetime()->sub( new DateInterval( 'P' . $delete_expired_jobs_days . 'D' ) );
 			$job_ids     = get_posts(
 				[
-					'post_type'      => 'job_listing',
+					'post_type'      => self::PT_LISTING,
 					'post_status'    => 'expired',
 					'fields'         => 'ids',
 					'date_query'     => [
@@ -872,7 +877,7 @@ class WP_Job_Manager_Post_Types {
 		$date_cutoff = current_datetime()->sub( new DateInterval( 'P30D' ) );
 		$job_ids     = get_posts(
 			[
-				'post_type'      => 'job_listing',
+				'post_type'      => self::PT_LISTING,
 				'post_status'    => 'preview',
 				'fields'         => 'ids',
 				'date_query'     => [
@@ -914,7 +919,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param WP_Post $post       The post object.
 	 */
 	public function transition_post_status( $new_status, $old_status, $post ) {
-		if ( 'job_listing' !== $post->post_type ) {
+		if ( self::PT_LISTING !== $post->post_type ) {
 			return;
 		}
 
@@ -967,7 +972,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param WP_Post $post
 	 */
 	public function set_expiry( $post ) {
-		if ( 'job_listing' !== $post->post_type ) {
+		if ( self::PT_LISTING !== $post->post_type ) {
 			return;
 		}
 
@@ -1010,7 +1015,7 @@ class WP_Job_Manager_Post_Types {
 	public function set_job_expiration( $job, $date_expires ) {
 		$job = get_post( $job );
 
-		if ( 'job_listing' !== $job->post_type ) {
+		if ( self::PT_LISTING !== $job->post_type ) {
 			return false;
 		}
 
@@ -1033,7 +1038,7 @@ class WP_Job_Manager_Post_Types {
 	public function get_job_expiration( $job ) {
 		$job = get_post( $job );
 
-		if ( 'job_listing' !== $job->post_type ) {
+		if ( self::PT_LISTING !== $job->post_type ) {
 			return false;
 		}
 
@@ -1126,7 +1131,7 @@ class WP_Job_Manager_Post_Types {
 	 * @return array
 	 */
 	public function fix_post_name( $data, $postarr ) {
-		if ( 'job_listing' === $data['post_type']
+		if ( self::PT_LISTING === $data['post_type']
 			&& 'pending' === $data['post_status']
 			&& ! current_user_can( 'publish_posts' )
 			&& isset( $postarr['post_name'] )
@@ -1261,7 +1266,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param mixed  $meta_value
 	 */
 	public function maybe_add_geolocation_data( $object_id, $meta_key, $meta_value ) {
-		if ( '_job_location' !== $meta_key || 'job_listing' !== get_post_type( $object_id ) ) {
+		if ( '_job_location' !== $meta_key || self::PT_LISTING !== get_post_type( $object_id ) ) {
 			return;
 		}
 		do_action( 'job_manager_job_location_edited', $object_id, $meta_value );
@@ -1276,7 +1281,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param mixed  $meta_value
 	 */
 	public function update_post_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
-		if ( 'job_listing' !== get_post_type( $object_id ) ) {
+		if ( self::PT_LISTING !== get_post_type( $object_id ) ) {
 			return;
 		}
 
@@ -1356,7 +1361,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param WP_Post $post    Post object.
 	 */
 	public function maybe_add_default_meta_data( $post_id, $post ) {
-		if ( empty( $post ) || 'job_listing' === $post->post_type ) {
+		if ( empty( $post ) || self::PT_LISTING === $post->post_type ) {
 			add_post_meta( $post_id, '_filled', 0, true );
 			add_post_meta( $post_id, '_featured', 0, true );
 		}
@@ -1370,7 +1375,7 @@ class WP_Job_Manager_Post_Types {
 	 * @param WP_Post $post        Post object.
 	 */
 	public function track_job_submission( $new_status, $old_status, $post ) {
-		if ( empty( $post ) || 'job_listing' !== get_post_type( $post ) ) {
+		if ( empty( $post ) || self::PT_LISTING !== get_post_type( $post ) ) {
 			return;
 		}
 
@@ -1420,7 +1425,7 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function sitemaps_maybe_hide_filled( $query_args, $post_type ) {
 		if (
-			'job_listing' !== $post_type
+			self::PT_LISTING !== $post_type
 			|| 1 !== absint( get_option( 'job_manager_hide_filled_positions' ) )
 		) {
 			return $query_args;
@@ -1447,7 +1452,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		$post = get_post();
-		if ( ! $post || 'job_listing' !== $post->post_type ) {
+		if ( ! $post || self::PT_LISTING !== $post->post_type ) {
 			return;
 		}
 
@@ -1512,7 +1517,7 @@ class WP_Job_Manager_Post_Types {
 					'sanitize_callback' => $field['sanitize_callback'],
 					'auth_callback'     => $field['auth_edit_callback'],
 					'single'            => true,
-					'object_subtype'    => 'job_listing',
+					'object_subtype'    => self::PT_LISTING,
 				]
 			);
 		}
@@ -1951,7 +1956,7 @@ class WP_Job_Manager_Post_Types {
 	 * @return array
 	 */
 	public function delete_user_add_job_listings_post_type( $types ) {
-		$types[] = 'job_listing';
+		$types[] = self::PT_LISTING;
 
 		return $types;
 	}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -38,6 +38,91 @@ class WP_Job_Manager_Post_Types {
 	public const CAP_MANAGE_LISTINGS = 'manage_job_listings';
 
 	/**
+	 * Constant for the capability name used for editing a job listing.
+	 */
+	public const CAP_EDIT_LISTING = 'edit_job_listing';
+
+	/**
+	 * Constant for the capability name used for reading job listings.
+	 */
+	public const CAP_READ_LISTING = 'read_job_listing';
+
+	/**
+	 * Constant for the capability name used for deleting job listings.
+	 */
+	public const CAP_DELETE_LISTING = 'delete_job_listing';
+
+	/**
+	 * Constant for the capability name used for editing job listings.
+	 */
+	public const CAP_EDIT_LISTINGS = 'edit_job_listings';
+
+	/**
+	 * Constant for the capability name used for editing others job listings.
+	 */
+	public const CAP_EDIT_OTHERS_LISTINGS = 'edit_others_job_listings';
+
+	/**
+	 * Constant for the capability name used for publishing job listings.
+	 */
+	public const CAP_PUBLISH_LISTINGS = 'publish_job_listings';
+
+	/**
+	 * Constant for the capability name used for reading private job listings.
+	 */
+	public const CAP_READ_PRIVATE_LISTINGS = 'read_private_job_listings';
+
+	/**
+	 * Constant for the capability name used for deleting job listings.
+	 */
+	public const CAP_DELETE_LISTINGS = 'delete_job_listings';
+
+	/**
+	 * Constant for the capability name used for deleting private job listings.
+	 */
+	public const CAP_DELETE_PRIVATE_LISTINGS = 'delete_private_job_listings';
+
+	/**
+	 * Constant for the capability name used for deleting published job listings.
+	 */
+	public const CAP_DELETE_PUBLISHED_LISTINGS = 'delete_published_job_listings';
+
+	/**
+	 * Constant for the capability name used for deleting others job listings.
+	 */
+	public const CAP_DELETE_OTHERS_LISTINGS = 'delete_others_job_listings';
+
+	/**
+	 * Constant for the capability name used for editing private job listings.
+	 */
+	public const CAP_EDIT_PRIVATE_LISTINGS = 'edit_private_job_listings';
+
+	/**
+	 * Constant for the capability name used for editing published job listings.
+	 */
+	public const CAP_EDIT_PUBLISHED_LISTINGS = 'edit_published_job_listings';
+
+	/**
+	 * Constant for the capability name used for managing job listing terms.
+	 */
+	public const CAP_MANAGE_LISTING_TERMS = 'manage_job_listing_terms';
+
+	/**
+	 * Constant for the capability name used for editing job listing terms.
+	 */
+	public const CAP_EDIT_LISTING_TERMS = 'edit_job_listing_terms';
+
+	/**
+	 * Constant for the capability name used for deleting job listing terms.
+	 */
+	public const CAP_DELETE_LISTING_TERMS = 'delete_job_listing_terms';
+
+	/**
+	 * Constant for the capability name used for assigning job listing terms.
+	 */
+	public const CAP_ASSIGN_LISTING_TERMS = 'assign_job_listing_terms';
+
+	/**
 	 * Constant for the capability name used for the post type used for saving guest user data.
 	 */
 	public const CAP_GUEST_USER = 'job_guest_user';

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -198,7 +198,7 @@ class WP_Job_Manager_Shortcodes {
 			}
 
 			try {
-				if ( empty( $job ) || 'job_listing' !== $job->post_type || ! job_manager_user_can_edit_job( $job_id ) ) {
+				if ( empty( $job ) || \WP_Job_Manager_Post_Types::PT_LISTING !== $job->post_type || ! job_manager_user_can_edit_job( $job_id ) ) {
 					throw new Exception( __( 'Invalid ID', 'wp-job-manager' ) );
 				}
 
@@ -327,7 +327,7 @@ class WP_Job_Manager_Shortcodes {
 	 */
 	private function get_job_dashboard_query_args( $posts_per_page = -1 ) {
 		$job_dashboard_args = [
-			'post_type'           => 'job_listing',
+			'post_type'           => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status'         => [ 'publish', 'expired', 'pending', 'draft', 'preview' ],
 			'ignore_sticky_posts' => 1,
 			'posts_per_page'      => $posts_per_page,
@@ -434,7 +434,7 @@ class WP_Job_Manager_Shortcodes {
 		if (
 			! get_current_user_id()
 			|| ! $job instanceof WP_Post
-			|| 'job_listing' !== $job->post_type
+			|| \WP_Job_Manager_Post_Types::PT_LISTING !== $job->post_type
 			|| ! $this->is_job_available_on_dashboard( $job )
 		) {
 			return [];
@@ -738,7 +738,7 @@ class WP_Job_Manager_Shortcodes {
 				get_job_manager_template( 'job-listings-start.php' );
 				while ( $jobs->have_posts() ) {
 					$jobs->the_post();
-					get_job_manager_template_part( 'content', 'job_listing' );
+					get_job_manager_template_part( 'content', \WP_Job_Manager_Post_Types::PT_LISTING );
 				}
 				get_job_manager_template( 'job-listings-end.php' );
 				if ( $jobs->found_posts > $atts['per_page'] && $atts['show_more'] ) {
@@ -859,7 +859,7 @@ class WP_Job_Manager_Shortcodes {
 		ob_start();
 
 		$args = [
-			'post_type'   => 'job_listing',
+			'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status' => 'publish',
 			'p'           => $atts['id'],
 		];
@@ -870,7 +870,7 @@ class WP_Job_Manager_Shortcodes {
 			while ( $jobs->have_posts() ) {
 				$jobs->the_post();
 				echo '<h1>' . wp_kses_post( wpjm_get_the_job_title() ) . '</h1>';
-				get_job_manager_template_part( 'content-single', 'job_listing' );
+				get_job_manager_template_part( 'content-single', \WP_Job_Manager_Post_Types::PT_LISTING );
 			}
 		}
 
@@ -900,7 +900,7 @@ class WP_Job_Manager_Shortcodes {
 		ob_start();
 
 		$args = [
-			'post_type'   => 'job_listing',
+			'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status' => 'publish',
 		];
 
@@ -928,7 +928,7 @@ class WP_Job_Manager_Shortcodes {
 				$jobs->the_post();
 				$width = $atts['width'] ? $atts['width'] : 'auto';
 				echo '<div class="job_summary_shortcode align' . esc_attr( $atts['align'] ) . '" style="width: ' . esc_attr( $width ) . '">';
-				get_job_manager_template_part( 'content-summary', 'job_listing' );
+				get_job_manager_template_part( 'content-summary', \WP_Job_Manager_Post_Types::PT_LISTING );
 				echo '</div>';
 			}
 		}
@@ -956,7 +956,7 @@ class WP_Job_Manager_Shortcodes {
 		ob_start();
 
 		$args = [
-			'post_type'   => 'job_listing',
+			'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status' => 'publish',
 		];
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -662,7 +662,7 @@ class WP_Job_Manager_Shortcodes {
 		if ( ! empty( $atts['selected_category'] ) ) {
 			foreach ( $atts['selected_category'] as $cat_index => $category ) {
 				if ( ! is_numeric( $category ) ) {
-					$term = get_term_by( 'slug', $category, 'job_listing_category' );
+					$term = get_term_by( 'slug', $category, \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 
 					if ( $term ) {
 						$atts['selected_category'][ $cat_index ] = $term->term_id;

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -26,8 +26,8 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		$categories  = 0;
 		$count_posts = wp_count_posts( 'job_listing' );
 
-		if ( taxonomy_exists( 'job_listing_category' ) ) {
-			$categories = wp_count_terms( 'job_listing_category', [ 'hide_empty' => false ] );
+		if ( taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) {
+			$categories = wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY, [ 'hide_empty' => false ] );
 		}
 
 		$usage_data = [
@@ -99,14 +99,14 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 * @return int Number of job categories with a description.
 	 **/
 	private static function get_job_category_has_description_count() {
-		if ( ! taxonomy_exists( 'job_listing_category' ) ) {
+		if ( ! taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) {
 			return 0;
 		}
 
 		$count = 0;
 		$terms = get_terms(
 			[
-				'taxonomy'   => 'job_listing_category',
+				'taxonomy'   => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
 				'hide_empty' => false,
 			]
 		);

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -24,7 +24,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 **/
 	public static function get_usage_data() {
 		$categories  = 0;
-		$count_posts = wp_count_posts( 'job_listing' );
+		$count_posts = wp_count_posts( \WP_Job_Manager_Post_Types::PT_LISTING );
 
 		if ( taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) {
 			$categories = wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY, [ 'hide_empty' => false ] );
@@ -188,7 +188,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_jobs_by_type_count( $job_type ) {
 		$query = new WP_Query(
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
 				'tax_query'   => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Used in production with no issues.
@@ -214,7 +214,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_company_logo_count() {
 		$query = new WP_Query(
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
 				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
@@ -239,7 +239,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_job_type_count() {
 		$query = new WP_Query(
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => [ 'expired', 'publish' ],
 				'fields'      => 'ids',
 				'tax_query'   => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Used in production with no issues.
@@ -264,7 +264,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_jobs_count_with_meta( $meta_key ) {
 		$query = new WP_Query(
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
 				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
@@ -291,7 +291,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_jobs_count_with_checked_meta( $meta_key ) {
 		$query = new WP_Query(
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
 				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
@@ -314,7 +314,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	private static function get_jobs_by_guests() {
 		$query = new WP_Query(
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => [ 'publish', 'expired' ],
 				'fields'      => 'ids',
 				'author__in'  => [ 0 ],
@@ -375,7 +375,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 	 */
 	public static function get_event_logging_base_fields() {
 		$base_fields = [
-			'job_listings' => wp_count_posts( 'job_listing' )->publish,
+			'job_listings' => wp_count_posts( \WP_Job_Manager_Post_Types::PT_LISTING )->publish,
 			'paid'         => self::has_paid_extensions() ? 1 : 0,
 		];
 

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -34,7 +34,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'employers'                   => self::get_employer_count(),
 			'job_categories'              => $categories,
 			'job_categories_desc'         => self::get_job_category_has_description_count(),
-			'job_types'                   => wp_count_terms( 'job_listing_type', [ 'hide_empty' => false ] ),
+			'job_types'                   => wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, [ 'hide_empty' => false ] ),
 			'job_types_desc'              => self::get_job_type_has_description_count(),
 			'job_types_emp_type'          => self::get_job_type_has_employment_type_count(),
 			'jobs_type'                   => self::get_job_type_count(),
@@ -133,7 +133,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		$count = 0;
 		$terms = get_terms(
 			[
-				'taxonomy'   => 'job_listing_type',
+				'taxonomy'   => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 				'hide_empty' => false,
 			]
 		);
@@ -160,7 +160,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 		$count = 0;
 		$terms = get_terms(
 			[
-				'taxonomy'   => 'job_listing_type',
+				'taxonomy'   => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 				'hide_empty' => false,
 			]
 		);
@@ -194,7 +194,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				'tax_query'   => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Used in production with no issues.
 					[
 						'field'    => 'slug',
-						'taxonomy' => 'job_listing_type',
+						'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 						'terms'    => $job_type,
 					],
 				],
@@ -244,7 +244,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 				'fields'      => 'ids',
 				'tax_query'   => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Used in production with no issues.
 					[
-						'taxonomy' => 'job_listing_type',
+						'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 						'operator' => 'EXISTS',
 					],
 				],

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -142,7 +142,7 @@ class WP_Job_Manager {
 	 */
 	public function activate() {
 		WP_Job_Manager_Ajax::add_endpoint();
-		unregister_post_type( 'job_listing' );
+		unregister_post_type( \WP_Job_Manager_Post_Types::PT_LISTING );
 		add_filter( 'pre_option_job_manager_enable_types', '__return_true' );
 		$this->post_types->register_post_types();
 		remove_filter( 'pre_option_job_manager_enable_types', '__return_true' );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -259,7 +259,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => '',
 						'priority'    => 5,
 						'default'     => '',
-						'taxonomy'    => 'job_listing_category',
+						'taxonomy'    => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
 					],
 					'job_description'     => [
 						'label'    => __( 'Description', 'wp-job-manager' ),
@@ -357,7 +357,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			]
 		);
 
-		if ( ! get_option( 'job_manager_enable_categories' ) || 0 === intval( wp_count_terms( 'job_listing_category' ) ) ) {
+		if ( ! get_option( 'job_manager_enable_categories' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) ) {
 			unset( $this->fields['job']['job_category'] );
 		}
 		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( 'job_listing_type' ) ) ) {
@@ -634,7 +634,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 							}
 							break;
 						case 'job_category':
-							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_category', [ 'fields' => 'ids' ] );
+							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY, [ 'fields' => 'ids' ] );
 							break;
 						case 'company_logo':
 							$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_thumbnail_id( $job->ID ) : get_post_meta( $job->ID, '_' . $key, true );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -250,7 +250,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'Choose job type&hellip;', 'wp-job-manager' ),
 						'priority'    => 4,
 						'default'     => 'full-time',
-						'taxonomy'    => 'job_listing_type',
+						'taxonomy'    => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 					],
 					'job_category'        => [
 						'label'       => __( 'Job category', 'wp-job-manager' ),
@@ -360,7 +360,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( ! get_option( 'job_manager_enable_categories' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) ) {
 			unset( $this->fields['job']['job_category'] );
 		}
-		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( 'job_listing_type' ) ) ) {
+		if ( ! get_option( 'job_manager_enable_types' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ) ) ) {
 			unset( $this->fields['job']['job_type'] );
 		}
 		if ( get_option( 'job_manager_enable_salary' ) ) {
@@ -628,7 +628,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 							$this->fields[ $group_key ][ $key ]['value'] = $job->post_content;
 							break;
 						case 'job_type':
-							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, 'job_listing_type', [ 'fields' => 'ids' ] );
+							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, [ 'fields' => 'ids' ] );
 							if ( ! job_manager_multi_job_type() ) {
 								$this->fields[ $group_key ][ $key ]['value'] = current( $this->fields[ $group_key ][ $key ]['value'] );
 							}
@@ -865,7 +865,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					$terms = $values['job']['job_type'];
 
 					foreach ( $terms as $term ) {
-						$term = get_term_by( 'id', intval( $term ), 'job_listing_type' );
+						$term = get_term_by( 'id', intval( $term ), \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 
 						if ( $term ) {
 							$job_slug[] = $term->slug;

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -840,7 +840,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$job_data = [
 			'post_title'     => $post_title,
 			'post_content'   => $post_content,
-			'post_type'      => 'job_listing',
+			'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'comment_status' => 'closed',
 		];
 

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -304,7 +304,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		$verified = false;
 		// We only verify the token if the job_id exists and user has access to it.
 		if ( 'job_listing' === get_post_type( $job_id ) ) {
-			if ( user_can( $user_id, 'manage_job_listings', $job_id ) ) {
+			if ( user_can( $user_id, \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $job_id ) ) {
 				$verified = WP_Job_Manager_Site_Trust_Token::instance()->validate( 'user', $user_id, $token );
 			}
 		}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -162,7 +162,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		global $wpdb;
 
 		$args = [
-			'post_type'           => 'job_listing',
+			'post_type'           => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status'         => array_merge( array_keys( get_job_listing_post_statuses() ), [ 'trash' ] ),
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
@@ -270,10 +270,10 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	public function get_job_data( $request ) {
 		$job_id = $request->get_param( 'job_id' );
 		$post   = get_post( $job_id );
-		if ( 'job_listing' !== get_post_type( $post ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== get_post_type( $post ) ) {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
-		$controller = get_post_type_object( 'job_listing' )->get_rest_controller();
+		$controller = get_post_type_object( \WP_Job_Manager_Post_Types::PT_LISTING )->get_rest_controller();
 		if ( ! ( $controller instanceof WP_REST_Posts_Controller ) || ! $controller->check_read_permission( $post ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to view this job.', 'wp-job-manager' ), [ 'status' => rest_authorization_required_code() ] );
 		}
@@ -303,7 +303,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		$verified = false;
 		// We only verify the token if the job_id exists and user has access to it.
-		if ( 'job_listing' === get_post_type( $job_id ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type( $job_id ) ) {
 			if ( user_can( $user_id, \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $job_id ) ) {
 				$verified = WP_Job_Manager_Site_Trust_Token::instance()->validate( 'user', $user_id, $token );
 			}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-notifications.php
@@ -134,7 +134,7 @@ class WP_Job_Manager_Promoted_Jobs_Notifications {
 	public function deleted_meta( $meta_ids, $post_id, $meta_key ) {
 		if (
 			WP_Job_Manager_Promoted_Jobs::PROMOTED_META_KEY === $meta_key
-			&& 'job_listing' === get_post_type( $post_id )
+			&& \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type( $post_id )
 		) {
 			$this->watched_fields_changed = true;
 		}

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php
@@ -100,7 +100,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 */
 	private function register_post_metas() {
 		register_post_meta(
-			'job_listing',
+			\WP_Job_Manager_Post_Types::PT_LISTING,
 			self::PROMOTED_META_KEY,
 			[
 				'show_in_rest'  => true,
@@ -139,7 +139,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return boolean
 	 */
 	public static function is_promoted( $post_id ) {
-		if ( 'job_listing' !== get_post_type( $post_id ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== get_post_type( $post_id ) ) {
 			return false;
 		}
 
@@ -187,7 +187,7 @@ class WP_Job_Manager_Promoted_Jobs {
 	 * @return boolean Whether pre change passed correctly.
 	 */
 	private static function pre_change_promotion( $post_id ) {
-		if ( 'job_listing' !== get_post_type( $post_id ) ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== get_post_type( $post_id ) ) {
 			return false;
 		}
 
@@ -209,7 +209,7 @@ class WP_Job_Manager_Promoted_Jobs {
 		$args = wp_parse_args(
 			$args,
 			[
-				'post_type'      => 'job_listing',
+				'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status'    => 'any',
 				'posts_per_page' => 1,
 				'fields'         => 'ids',

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -24,7 +24,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 		global $wp_post_types;
 
 		// translators: Placeholder %s is the plural label for the job listing post type.
-		$this->widget_name        = sprintf( __( 'Featured %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name );
+		$this->widget_name        = sprintf( __( 'Featured %s', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->name );
 		$this->widget_cssclass    = 'job_manager widget_featured_jobs';
 		$this->widget_description = __( 'Display a list of featured listings on your site.', 'wp-job-manager' );
 		$this->widget_id          = 'widget_featured_jobs';
@@ -32,7 +32,7 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 			'title'     => [
 				'type'  => 'text',
 				// translators: Placeholder %s is the plural label for the job listing post type.
-				'std'   => sprintf( __( 'Featured %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name ),
+				'std'   => sprintf( __( 'Featured %s', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->name ),
 				'label' => __( 'Title', 'wp-job-manager' ),
 			],
 			'number'    => [

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -24,7 +24,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 		global $wp_post_types;
 
 		// translators: Placeholder %s is the plural label for the job listing post type.
-		$this->widget_name        = sprintf( __( 'Recent %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name );
+		$this->widget_name        = sprintf( __( 'Recent %s', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->name );
 		$this->widget_cssclass    = 'job_manager widget_recent_jobs';
 		$this->widget_description = __( 'Display a list of recent listings on your site, optionally matching a keyword and location.', 'wp-job-manager' );
 		$this->widget_id          = 'widget_recent_jobs';
@@ -32,7 +32,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 			'title'           => [
 				'type'  => 'text',
 				// translators: Placeholder %s is the plural label for the job listing post type.
-				'std'   => sprintf( __( 'Recent %s', 'wp-job-manager' ), $wp_post_types['job_listing']->labels->name ),
+				'std'   => sprintf( __( 'Recent %s', 'wp-job-manager' ), $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->name ),
 				'label' => __( 'Title', 'wp-job-manager' ),
 			],
 			'keyword'         => [

--- a/templates/job-filter-job-types.php
+++ b/templates/job-filter-job-types.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
-<?php if ( ! is_tax( 'job_listing_type' ) && empty( $job_types ) ) : ?>
+<?php if ( ! is_tax( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ) && empty( $job_types ) ) : ?>
 	<ul class="job_types">
 		<?php foreach ( get_job_listing_types() as $type ) : ?>
 			<li><label for="job_type_<?php echo esc_attr( $type->slug ); ?>" class="<?php echo esc_attr( sanitize_title( $type->name ) ); ?>"><input type="checkbox" name="filter_job_type[]" value="<?php echo esc_attr( $type->slug ); ?>" <?php checked( in_array( $type->slug, $selected_job_types ), true ); ?> id="job_type_<?php echo esc_attr( $type->slug ); ?>" /> <?php echo esc_html( $type->name ); ?></label></li>

--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -49,13 +49,13 @@ do_action( 'job_manager_job_filters_before', $atts );
 			<?php foreach ( $categories as $category ) : ?>
 				<input type="hidden" name="search_categories[]" value="<?php echo esc_attr( sanitize_title( $category ) ); ?>" />
 			<?php endforeach; ?>
-		<?php elseif ( $show_categories && ! is_tax( 'job_listing_category' ) && get_terms( [ 'taxonomy' => 'job_listing_category' ] ) ) : ?>
+		<?php elseif ( $show_categories && ! is_tax( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) && get_terms( [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] ) ) : ?>
 			<div class="search_categories">
 				<label for="search_categories"><?php esc_html_e( 'Category', 'wp-job-manager' ); ?></label>
 				<?php if ( $show_category_multiselect ) : ?>
-					<?php job_manager_dropdown_categories( [ 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'hide_empty' => true ] ); ?>
+					<?php job_manager_dropdown_categories( [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY, 'hierarchical' => 1, 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'hide_empty' => true ] ); ?>
 				<?php else : ?>
-					<?php job_manager_dropdown_categories( [ 'taxonomy' => 'job_listing_category', 'hierarchical' => 1, 'show_option_all' => __( 'Any category', 'wp-job-manager' ), 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'multiple' => false, 'hide_empty' => true ] ); ?>
+					<?php job_manager_dropdown_categories( [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY, 'hierarchical' => 1, 'show_option_all' => __( 'Any category', 'wp-job-manager' ), 'name' => 'search_categories', 'orderby' => 'name', 'selected' => $selected_category, 'multiple' => false, 'hide_empty' => true ] ); ?>
 				<?php endif; ?>
 			</div>
 		<?php endif; ?>

--- a/templates/job-preview.php
+++ b/templates/job-preview.php
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="job_listing_preview single_job_listing">
 		<h1><?php wpjm_the_job_title(); ?></h1>
 
-		<?php get_job_manager_template_part( 'content-single', 'job_listing' ); ?>
+		<?php get_job_manager_template_part( 'content-single', \WP_Job_Manager_Post_Types::PT_LISTING ); ?>
 
 		<input type="hidden" name="job_id" value="<?php echo esc_attr( $form->get_job_id() ); ?>" />
 		<input type="hidden" name="step" value="<?php echo esc_attr( $form->get_step() ); ?>" />

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -34,7 +34,7 @@ switch ( $job->post_status ) :
 			sprintf(
 				// translators: %1$s is the job listing post type name, %2$s is the job listing URL.
 				__( '%1$s listed successfully. To view your listing <a href="%2$s">click here</a>.', 'wp-job-manager' ),
-				esc_html( $wp_post_types['job_listing']->labels->singular_name ),
+				esc_html( $wp_post_types[\WP_Job_Manager_Post_Types::PT_LISTING]->labels->singular_name ),
 				get_permalink( $job->ID )
 			)
 		) . '</div>';
@@ -45,7 +45,7 @@ switch ( $job->post_status ) :
 			sprintf(
 				// translators: Placeholder %s is the job listing post type name.
 				esc_html__( '%s submitted successfully. Your listing will be visible once approved.', 'wp-job-manager' ),
-				esc_html( $wp_post_types['job_listing']->labels->singular_name )
+				esc_html( $wp_post_types[\WP_Job_Manager_Post_Types::PT_LISTING]->labels->singular_name )
 			)
 		);
 
@@ -60,7 +60,7 @@ switch ( $job->post_status ) :
 					// the plural name of the job listing post type
 					__( '  <a href="%1$s"> View your %2$s</a>', 'wp-job-manager' ),
 					$job_dashboard_link,
-					esc_html( $wp_post_types['job_listing' ]->labels->name )
+					esc_html( $wp_post_types[\WP_Job_Manager_Post_Types::PT_LISTING ]->labels->name )
 				)
 			);
 		} elseif ( $job_dashboard_link && $job_dashboard_title ) { // If there is both a job_dashboard page and a title on the page
@@ -90,7 +90,7 @@ switch ( $job->post_status ) :
 			sprintf(
 			// translators: %1$s is the job listing post type name.
 				__( '%1$s submitted successfully.', 'wp-job-manager' ),
-				esc_html( $wp_post_types['job_listing']->labels->singular_name )
+				esc_html( $wp_post_types[\WP_Job_Manager_Post_Types::PT_LISTING]->labels->singular_name )
 			)
 		) . '</div>';
 

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -111,7 +111,7 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	 * Helper to add capability for `user_has_cap` filter.
 	 */
 	public function add_manage_job_listing_cap( $caps ) {
-		$caps['manage_job_listings'] = 1;
+		$caps[\WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS] = 1;
 		return $caps;
 	}
 

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -46,7 +46,7 @@ class WPJM_BaseTest extends WP_UnitTestCase {
 	 * When needed, this allows you to re-register post type.
 	 */
 	protected function reregister_post_type() {
-		unregister_post_type( 'job_listing' );
+		unregister_post_type( \WP_Job_Manager_Post_Types::PT_LISTING );
 		WP_Job_Manager_Post_Types::instance()->register_post_types();
 	}
 

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -23,7 +23,7 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Job Listing title %s' ),
 			'post_content' => new WP_UnitTest_Generator_Sequence( 'Job Listing content %s' ),
 			'post_excerpt' => new WP_UnitTest_Generator_Sequence( 'Job Listing excerpt %s' ),
-			'post_type'    => 'job_listing',
+			'post_type'    => \WP_Job_Manager_Post_Types::PT_LISTING,
 		];
 	}
 

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
@@ -52,7 +52,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		// When no filters are given.
 		$query = new WP_Query(
 			[
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'fields'    => 'ids',
 			]
 		);
@@ -65,7 +65,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		$_GET['job_listing_filled'] = '1';
 		$query                      = new WP_Query(
 			[
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'fields'    => 'ids',
 			]
 		);
@@ -79,7 +79,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		$_GET['job_listing_featured'] = '0';
 		$query                        = new WP_Query(
 			[
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'fields'    => 'ids',
 			]
 		);
@@ -101,7 +101,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 
 		// Create some listings.
 		$listing_id = $this->factory->post->create(
-			[ 'post_type' => 'job_listing' ]
+			[ 'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING ]
 		);
 
 		// Simulate viewing some other page.
@@ -112,7 +112,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		$_GET['job_listing_featured'] = '1';
 		$query                        = new WP_Query(
 			[
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'fields'    => 'ids',
 			]
 		);
@@ -123,7 +123,7 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 
 	private function create_listing_with_meta( $meta ) {
 		$id = $this->factory->post->create(
-			[ 'post_type' => 'job_listing' ]
+			[ 'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING ]
 		);
 
 		foreach ( $meta as $meta_key => $meta_value ) {

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-categories.php
@@ -186,6 +186,6 @@ class WP_Test_WP_Job_Manager_Job_Categories_Test extends WPJM_REST_TestCase {
 	}
 
 	protected function get_job_category() {
-		return $this->factory->term->create( [ 'taxonomy' => 'job_listing_category' ] );
+		return $this->factory->term->create( [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] );
 	}
 }

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -431,7 +431,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	private function reset_meta_keys() {
 		global $wp_meta_keys;
 
-		unset( $wp_meta_keys['post']['job_listing'] );
+		unset( $wp_meta_keys['post'][\WP_Job_Manager_Post_Types::PT_LISTING] );
 
 		WP_Job_Manager_Post_Types::instance()->register_meta_fields();
 	}

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-types.php
@@ -193,6 +193,6 @@ class WP_Test_WP_Job_Manager_Job_Types_Test extends WPJM_REST_TestCase {
 	}
 
 	protected function get_job_type() {
-		return $this->factory->term->create( [ 'taxonomy' => 'job_listing_type' ] );
+		return $this->factory->term->create( [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ] );
 	}
 }

--- a/tests/php/tests/includes/test_class.wp-job-manager-cache-helper.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-cache-helper.php
@@ -277,8 +277,8 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 		$posts_expired   = $this->factory->job_listing->create_many( 5, [ 'post_status' => 'expired' ] );
 		$posts_shifted   = [];
 
-		$expired_count   = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'expired' );
-		$published_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'publish' );
+		$expired_count   = WP_Job_Manager_Cache_Helper::get_listings_count( \WP_Job_Manager_Post_Types::PT_LISTING, 'expired' );
+		$published_count = WP_Job_Manager_Cache_Helper::get_listings_count( \WP_Job_Manager_Post_Types::PT_LISTING, 'publish' );
 		$initial_count   = WP_Job_Manager_Cache_Helper::get_listings_count();
 		$this->assertEquals( count( $posts_pending ), $initial_count );
 
@@ -295,13 +295,13 @@ class WP_Test_WP_Job_Manager_Cache_Helper extends WPJM_BaseTest {
 
 		// Unhandled status.
 		WP_Job_Manager_Cache_Helper::maybe_clear_count_transients( 'expired', 'publish', get_post( $published_post_id ) );
-		$middle_expired_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'expired' );
+		$middle_expired_count = WP_Job_Manager_Cache_Helper::get_listings_count( \WP_Job_Manager_Post_Types::PT_LISTING, 'expired' );
 		$this->assertEquals( $expired_count, $middle_expired_count );
 
 		add_filter( 'wpjm_count_cache_supported_statuses', [ $this, 'helper_add_expired_status' ] );
 
 		WP_Job_Manager_Cache_Helper::maybe_clear_count_transients( 'expired', 'publish', get_post( $published_post_id ) );
-		$second_middle_expired_count = WP_Job_Manager_Cache_Helper::get_listings_count( 'job_listing', 'expired' );
+		$second_middle_expired_count = WP_Job_Manager_Cache_Helper::get_listings_count( \WP_Job_Manager_Post_Types::PT_LISTING, 'expired' );
 		$this->assertLessThan( $second_middle_expired_count, $middle_expired_count );
 
 		// Legit call for method.

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -210,13 +210,13 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		$this->regular_user_id = $this->factory->user->create( [ 'role' => 'author' ] );
 		$regular_user          = get_user_by( 'id', $this->regular_user_id );
 		$regular_user->add_cap( 'edit_others_posts' );
-		$regular_user->add_cap( 'manage_job_listings' );
+		$regular_user->add_cap( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS );
 
 		// Create a teacher user and assign some caps.
 		$this->employer_user_id = $this->factory->user->create( [ 'role' => 'employer' ] );
 		$employer_user          = get_user_by( 'id', $this->employer_user_id );
 		$employer_user->add_cap( 'edit_others_posts' );
-		$employer_user->add_cap( 'manage_job_listings' );
+		$employer_user->add_cap( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS );
 
 		// Add a WPJM cap to an existing role.
 		$role = get_role( 'editor' );
@@ -476,16 +476,16 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		$regular_user = get_user_by( 'id', $this->regular_user_id );
 		$this->assertTrue( in_array( 'author', $regular_user->roles, true ), 'Author role should not be removed' );
 		$this->assertTrue( $regular_user->has_cap( 'edit_others_posts' ), 'Non-WPJM cap should not be removed from user' );
-		$this->assertFalse( $regular_user->has_cap( 'manage_job_listings' ), 'WPJM cap should be removed from user' );
+		$this->assertFalse( $regular_user->has_cap( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS ), 'WPJM cap should be removed from user' );
 
 		$employer_user = get_user_by( 'id', $this->employer_user_id );
 		$this->assertFalse( in_array( 'employer', $employer_user->roles, true ), 'Employer role should be removed from user' );
 		$this->assertFalse( array_key_exists( 'employer', $employer_user->caps ), 'Employer role should be removed from user caps' );
 		$this->assertTrue( $employer_user->has_cap( 'edit_others_posts' ), 'Non-WPJM cap should not be removed from employer' );
-		$this->assertFalse( $employer_user->has_cap( 'manage_job_listings' ), 'WPJM cap should be removed from employer' );
+		$this->assertFalse( $employer_user->has_cap( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS ), 'WPJM cap should be removed from employer' );
 
 		$role = get_role( 'editor' );
-		$this->assertFalse( $role->has_cap( 'manage_job_listings' ), 'WPJM cap should be removed from role' );
+		$this->assertFalse( $role->has_cap( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS ), 'WPJM cap should be removed from role' );
 
 		$role = get_role( 'employer' );
 		$this->assertNull( $role, 'Employer role should be removed overall' );

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -59,7 +59,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 			8,
 			[
 				'post_status' => 'publish',
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 			]
 		);
 	}

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -73,7 +73,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 		$this->job_listing_types = [];
 
 		for ( $i = 1; $i <= 3; $i++ ) {
-			$this->job_listing_types[] = wp_insert_term( 'Job Type ' . $i, 'job_listing_type' );
+			$this->job_listing_types[] = wp_insert_term( 'Job Type ' . $i, \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 		}
 
 		wp_set_object_terms(
@@ -82,7 +82,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 				$this->job_listing_types[0]['term_id'],
 				$this->job_listing_types[1]['term_id'],
 			],
-			'job_listing_type'
+			\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE
 		);
 		wp_set_object_terms(
 			$this->job_listing_ids[1],
@@ -90,7 +90,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 				$this->job_listing_types[1]['term_id'],
 				$this->job_listing_types[2]['term_id'],
 			],
-			'job_listing_type'
+			\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE
 		);
 		wp_set_object_terms(
 			$this->job_listing_ids[2],
@@ -99,7 +99,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 				$this->job_listing_types[1]['term_id'],
 				$this->job_listing_types[2]['term_id'],
 			],
-			'job_listing_type'
+			\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE
 		);
 
 		// Setup some categories.

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -495,7 +495,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 
 	protected function get_valid_job() {
 		$full_time_term = wp_create_term( 'Full Time', 'job_listing_type' );
-		$weird_cat_term = wp_create_term( 'Weird', 'job_listing_category' );
+		$weird_cat_term = wp_create_term( 'Weird', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 		$job_args       = [
 			'post_title'   => 'Job Post-' . md5( microtime( true ) ),
 			'post_content' => 'Job Description-' . md5( microtime( true ) ),
@@ -506,7 +506,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 			],
 			'tax_input'    => [
 				'job_listing_type'     => $full_time_term['term_id'],
-				'job_listing_category' => $weird_cat_term['term_id'],
+				\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY => $weird_cat_term['term_id'],
 			],
 		];
 		return get_post( $this->factory->job_listing->create( $job_args ) );

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -494,7 +494,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 	}
 
 	protected function get_valid_job() {
-		$full_time_term = wp_create_term( 'Full Time', 'job_listing_type' );
+		$full_time_term = wp_create_term( 'Full Time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 		$weird_cat_term = wp_create_term( 'Weird', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 		$job_args       = [
 			'post_title'   => 'Job Post-' . md5( microtime( true ) ),
@@ -505,7 +505,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 				'_company_website' => 'http://' . md5( microtime( true ) ) . '.com',
 			],
 			'tax_input'    => [
-				'job_listing_type'     => $full_time_term['term_id'],
+				\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE     => $full_time_term['term_id'],
 				\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY => $weird_cat_term['term_id'],
 			],
 		];

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -85,7 +85,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$jobs = $wp_query = new WP_Query(
 			[
 				'p'         => $job_id,
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
@@ -99,9 +99,9 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		while ( $jobs->have_posts() ) {
 			$jobs->the_post();
 			$post = get_post();
-			$this->assertTrue( is_singular( 'job_listing' ), 'Is singular === true' );
+			$this->assertTrue( is_singular( \WP_Job_Manager_Post_Types::PT_LISTING ), 'Is singular === true' );
 			$this->assertTrue( in_the_loop(), 'In the loop' );
-			$this->assertEquals( 'job_listing', $post->post_type, 'Result is a job listing' );
+			$this->assertEquals( \WP_Job_Manager_Post_Types::PT_LISTING, $post->post_type, 'Result is a job listing' );
 
 			$post_content_filtered = $instance->job_content( $post->post_content );
 			$this->assertNotEquals( $post->post_content, $post_content_filtered );
@@ -234,7 +234,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$instance->add_feed_query_args( $wp );
 		$this->assertCount( 2, $wp->query_vars );
 		$this->assertArrayHasKey( 'post_type', $wp->query_vars );
-		$this->assertEquals( 'job_listing', $wp->query_vars['post_type'] );
+		$this->assertEquals( \WP_Job_Manager_Post_Types::PT_LISTING, $wp->query_vars['post_type'] );
 	}
 
 	/**
@@ -313,7 +313,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$new_jobs[]     = $this->factory->job_listing->create( $new_job_args[2] );
 		$jobs           = $wp_query = new WP_Query(
 			[
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'orderby'   => 'ID',
 				'order'     => 'ASC',
 			]
@@ -689,7 +689,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		// Legit.
 		$data                 = [
-			'post_type'   => 'job_listing',
+			'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status' => 'pending',
 			'post_name'   => 'Bad ABC',
 		];
@@ -711,7 +711,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 
 		// Bad Post Status.
 		$data                 = [
-			'post_type'   => 'job_listing',
+			'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status' => 'publish',
 			'post_name'   => 'Bad ABC',
 		];
@@ -840,7 +840,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$instance = WP_Job_Manager_Post_Types::instance();
 		$post     = wp_insert_post(
 			[
-				'post_type'  => 'job_listing',
+				'post_type'  => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_title' => 'Hello A',
 			]
 		);
@@ -887,7 +887,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$jobs = $wp_query = new WP_Query(
 			[
 				'p'         => $job_id,
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
@@ -916,7 +916,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$jobs = $wp_query = new WP_Query(
 			[
 				'p'         => $job_id,
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
@@ -954,7 +954,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$jobs = $wp_query = new WP_Query(
 			[
 				'p'         => $job_id,
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );
@@ -985,7 +985,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$jobs = $wp_query = new WP_Query(
 			[
 				'p'         => $job_id,
-				'post_type' => 'job_listing',
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
 			]
 		);
 		$this->assertEquals( 1, $jobs->post_count );

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -281,15 +281,15 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	public function test_job_feed_item() {
 		$instance       = WP_Job_Manager_Post_Types::instance();
 		$new_jobs       = [];
-		$type_a         = wp_create_term( 'Job Type A', 'job_listing_type' );
-		$type_b         = wp_create_term( 'Job Type B', 'job_listing_type' );
+		$type_a         = wp_create_term( 'Job Type A', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
+		$type_b         = wp_create_term( 'Job Type B', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 		$new_job_args   = [];
 		$new_job_args[] = [
 			'meta_input' => [
 				'_company_name' => 'Custom Company A',
 			],
 			'tax_input'  => [
-				'job_listing_type' => $type_a['term_id'],
+				\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => $type_a['term_id'],
 			],
 		];
 		$new_job_args[] = [
@@ -298,7 +298,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				'_company_name' => '',
 			],
 			'tax_input'  => [
-				'job_listing_type' => $type_b['term_id'],
+				\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => $type_b['term_id'],
 			],
 		];
 		$new_job_args[] = [
@@ -324,7 +324,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		while ( $jobs->have_posts() ) {
 			$has_location = ! empty( $new_job_args[ $index ]['meta_input']['_job_location'] );
 			$has_company  = ! empty( $new_job_args[ $index ]['meta_input']['_company_name'] );
-			$has_job_type = ! empty( $new_job_args[ $index ]['tax_input']['job_listing_type'] );
+			$has_job_type = ! empty( $new_job_args[ $index ]['tax_input'][\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE] );
 			$index++;
 
 			$jobs->the_post();

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -195,7 +195,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_job_types_count() {
-		$terms = $this->factory->term->create_many( 14, [ 'taxonomy' => 'job_listing_type' ] );
+		$terms = $this->factory->term->create_many( 14, [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ] );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -214,13 +214,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$valid   = $this->factory->term->create_many(
 			2,
 			[
-				'taxonomy'    => 'job_listing_type',
+				'taxonomy'    => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 				'description' => ' Valid description ',
 			]
 		);
 		$invalid = $this->factory->term->create(
 			[
-				'taxonomy'    => 'job_listing_type',
+				'taxonomy'    => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 				'description' => "\t\n",
 			]
 		);
@@ -238,7 +238,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_job_type_has_employment_type_count
 	 */
 	public function test_get_job_type_has_employment_type_count() {
-		$terms = $this->factory->term->create_many( 5, [ 'taxonomy' => 'job_listing_type' ] );
+		$terms = $this->factory->term->create_many( 5, [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ] );
 
 		// Set the employment type for some terms.
 		add_term_meta( $terms[1], 'employment_type', 'FULL_TIME' );
@@ -260,12 +260,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_freelance_jobs_count() {
 		$this->create_default_job_listings();
 
-		wp_set_object_terms( $this->draft[0], 'freelance', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[5], 'freelance', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[6], 'freelance', 'job_listing_type', false );
-		wp_set_object_terms( $this->preview[0], 'freelance', 'job_listing_type', false );
-		wp_set_object_terms( $this->pending[3], 'freelance', 'job_listing_type', false );
-		wp_set_object_terms( $this->publish[9], 'freelance', 'job_listing_type', false );
+		wp_set_object_terms( $this->draft[0], 'freelance', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[5], 'freelance', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[6], 'freelance', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->preview[0], 'freelance', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->pending[3], 'freelance', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->publish[9], 'freelance', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -282,12 +282,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_full_time_jobs_count() {
 		$this->create_default_job_listings();
 
-		wp_set_object_terms( $this->draft[0], 'full-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[5], 'full-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[6], 'full-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->preview[0], 'full-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->pending[3], 'full-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->publish[9], 'full-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->draft[0], 'full-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[5], 'full-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[6], 'full-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->preview[0], 'full-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->pending[3], 'full-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->publish[9], 'full-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -304,12 +304,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_internship_jobs_count() {
 		$this->create_default_job_listings();
 
-		wp_set_object_terms( $this->draft[0], 'internship', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[5], 'internship', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[6], 'internship', 'job_listing_type', false );
-		wp_set_object_terms( $this->preview[0], 'internship', 'job_listing_type', false );
-		wp_set_object_terms( $this->pending[3], 'internship', 'job_listing_type', false );
-		wp_set_object_terms( $this->publish[9], 'internship', 'job_listing_type', false );
+		wp_set_object_terms( $this->draft[0], 'internship', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[5], 'internship', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[6], 'internship', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->preview[0], 'internship', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->pending[3], 'internship', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->publish[9], 'internship', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -326,12 +326,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_part_time_jobs_count() {
 		$this->create_default_job_listings();
 
-		wp_set_object_terms( $this->draft[0], 'part-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[5], 'part-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[6], 'part-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->preview[0], 'part-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->pending[3], 'part-time', 'job_listing_type', false );
-		wp_set_object_terms( $this->publish[9], 'part-time', 'job_listing_type', false );
+		wp_set_object_terms( $this->draft[0], 'part-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[5], 'part-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[6], 'part-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->preview[0], 'part-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->pending[3], 'part-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->publish[9], 'part-time', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -348,12 +348,12 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	public function test_get_temporary_jobs_count() {
 		$this->create_default_job_listings();
 
-		wp_set_object_terms( $this->draft[0], 'temporary', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[5], 'temporary', 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[6], 'temporary', 'job_listing_type', false );
-		wp_set_object_terms( $this->preview[0], 'temporary', 'job_listing_type', false );
-		wp_set_object_terms( $this->pending[3], 'temporary', 'job_listing_type', false );
-		wp_set_object_terms( $this->publish[9], 'temporary', 'job_listing_type', false );
+		wp_set_object_terms( $this->draft[0], 'temporary', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[5], 'temporary', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[6], 'temporary', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->preview[0], 'temporary', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->pending[3], 'temporary', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->publish[9], 'temporary', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -467,15 +467,15 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 */
 	public function test_get_job_type_count() {
 		$this->create_default_job_listings();
-		$terms = $this->factory->term->create_many( 6, [ 'taxonomy' => 'job_listing_type' ] );
+		$terms = $this->factory->term->create_many( 6, [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ] );
 
 		// Assign job types to some jobs.
-		wp_set_object_terms( $this->draft[0], $terms[0], 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[5], $terms[1], 'job_listing_type', false );
-		wp_set_object_terms( $this->expired[6], $terms[2], 'job_listing_type', false );
-		wp_set_object_terms( $this->preview[0], $terms[3], 'job_listing_type', false );
-		wp_set_object_terms( $this->pending[3], $terms[4], 'job_listing_type', false );
-		wp_set_object_terms( $this->publish[9], $terms[5], 'job_listing_type', false );
+		wp_set_object_terms( $this->draft[0], $terms[0], \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[5], $terms[1], \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->expired[6], $terms[2], \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->preview[0], $terms[3], \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->pending[3], $terms[4], \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
+		wp_set_object_terms( $this->publish[9], $terms[5], \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, false );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -128,7 +128,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_job_categories_count() {
-		$terms = $this->factory->term->create_many( 14, [ 'taxonomy' => 'job_listing_category' ] );
+		$terms = $this->factory->term->create_many( 14, [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] );
 
 		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
 
@@ -159,13 +159,13 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$valid   = $this->factory->term->create_many(
 			2,
 			[
-				'taxonomy'    => 'job_listing_category',
+				'taxonomy'    => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
 				'description' => ' Valid description ',
 			]
 		);
 		$invalid = $this->factory->term->create(
 			[
-				'taxonomy'    => 'job_listing_category',
+				'taxonomy'    => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
 				'description' => "\t\n",
 			]
 		);

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -62,7 +62,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		// Ensure job categories and types are enabled.
 		update_option( 'job_manager_enable_categories', 1 );
 		update_option( 'job_manager_enable_types', 1 );
-		unregister_post_type( 'job_listing' );
+		unregister_post_type( \WP_Job_Manager_Post_Types::PT_LISTING );
 		$post_type_instance = WP_Job_Manager_Post_Types::instance();
 		$post_type_instance->register_post_types();
 	}
@@ -439,7 +439,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$media = $this->factory->attachment->create_many(
 			6,
 			[
-				'post_type'   => 'job_listing',
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status' => 'publish',
 			]
 		);

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -891,7 +891,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	protected function set_up_request_page() {
-		$this->go_to( get_post_type_archive_link( 'job_listing' ) );
+		$this->go_to( get_post_type_archive_link( \WP_Job_Manager_Post_Types::PT_LISTING ) );
 	}
 
 	protected function set_up_request_shortcode( $tag = 'jobs' ) {

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -233,8 +233,8 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_categories() {
-		$this->assertTrue( taxonomy_exists( 'job_listing_category' ) );
-		$this->assertTrue( current_user_can( get_taxonomy( 'job_listing_category' )->cap->assign_terms ) );
+		$this->assertTrue( taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) );
+		$this->assertTrue( current_user_can( get_taxonomy( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY )->cap->assign_terms ) );
 		$categories      = [
 			'main'  => [],
 			'weird' => [],
@@ -243,11 +243,11 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			'none'  => [],
 		];
 		$terms           = [];
-		$terms['jazz']   = $categories['main'][] = $categories['all'][] = wp_create_term( 'jazz', 'job_listing_category' );
-		$terms['swim']   = $categories['main'][] = $categories['all'][] = wp_create_term( 'swim', 'job_listing_category' );
-		$terms['dev']    = $categories['main'][] = $categories['all'][] = wp_create_term( 'dev', 'job_listing_category' );
-		$terms['potato'] = $categories['weird'][] = $categories['all'][] = wp_create_term( 'potato', 'job_listing_category' );
-		$terms['coffee'] = $categories['happy'][] = $categories['all'][] = wp_create_term( 'coffee', 'job_listing_category' );
+		$terms['jazz']   = $categories['main'][] = $categories['all'][] = wp_create_term( 'jazz', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
+		$terms['swim']   = $categories['main'][] = $categories['all'][] = wp_create_term( 'swim', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
+		$terms['dev']    = $categories['main'][] = $categories['all'][] = wp_create_term( 'dev', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
+		$terms['potato'] = $categories['weird'][] = $categories['all'][] = wp_create_term( 'potato', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
+		$terms['coffee'] = $categories['happy'][] = $categories['all'][] = wp_create_term( 'coffee', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 		foreach ( $categories as $k => $category ) {
 			$categories[ $k ] = wp_list_pluck( $category, 'term_id' );
 		}
@@ -263,7 +263,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			3,
 			[
 				'tax_input' => [
-					'job_listing_category' => $categories['main'],
+					\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY => $categories['main'],
 				],
 			]
 		);
@@ -271,7 +271,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			2,
 			[
 				'tax_input' => [
-					'job_listing_category' => $categories['weird'],
+					\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY => $categories['weird'],
 				],
 			]
 		);
@@ -279,7 +279,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			2,
 			[
 				'tax_input' => [
-					'job_listing_category' => $categories['happy'],
+					\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY => $categories['happy'],
 				],
 			]
 		);
@@ -781,8 +781,8 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	public function test_is_wpjm_taxonomy_success() {
 		$this->assertFalse( is_wpjm_taxonomy() );
 		$this->assertFalse( is_wpjm() );
-		$this->assertTrue( taxonomy_exists( 'job_listing_category' ) );
-		$this->assertTrue( current_user_can( get_taxonomy( 'job_listing_category' )->cap->assign_terms ) );
+		$this->assertTrue( taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) );
+		$this->assertTrue( current_user_can( get_taxonomy( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY )->cap->assign_terms ) );
 		$this->set_up_request_taxonomy();
 		$this->assertTrue( is_wpjm_taxonomy() );
 		$this->assertTrue( is_wpjm() );
@@ -839,7 +839,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::wpjm_get_categories_by_slug
 	 */
 	public function test_get_categories_by_slug() {
-		$taxonomy_name = 'job_listing_category';
+		$taxonomy_name = \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY;
 		$default_args  = [
 			'orderby' => 'slug',
 			'order'   => 'ASC',
@@ -867,7 +867,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::wpjm_get_categories_by_slug
 	 */
 	public function test_get_categories_by_slug_excluding_categories() {
-		$taxonomy_name = 'job_listing_category';
+		$taxonomy_name = \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY;
 		$default_args  = [
 			'orderby' => 'slug',
 			'order'   => 'ASC',
@@ -922,7 +922,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	protected function set_up_request_taxonomy() {
-		$term = wp_create_term( 'jazz', 'job_listing_category' );
+		$term = wp_create_term( 'jazz', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 		$this->go_to( get_term_link( $term['term_id'] ) );
 	}
 

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -352,8 +352,8 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_job_types() {
-		$this->assertTrue( taxonomy_exists( 'job_listing_type' ) );
-		$this->assertTrue( current_user_can( get_taxonomy( 'job_listing_type' )->cap->assign_terms ) );
+		$this->assertTrue( taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ) );
+		$this->assertTrue( current_user_can( get_taxonomy( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE )->cap->assign_terms ) );
 		$tags            = [
 			'main'  => [],
 			'weird' => [],
@@ -362,11 +362,11 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			'none'  => [],
 		];
 		$terms           = [];
-		$terms['jazz']   = $tags['main'][] = $tags['all'][] = wp_create_term( 'jazz', 'job_listing_type' );
-		$terms['swim']   = $tags['main'][] = $tags['all'][] = wp_create_term( 'swim', 'job_listing_type' );
-		$terms['dev']    = $tags['main'][] = $tags['all'][] = wp_create_term( 'dev', 'job_listing_type' );
-		$terms['potato'] = $tags['weird'][] = $tags['all'][] = wp_create_term( 'potato', 'job_listing_type' );
-		$terms['coffee'] = $tags['happy'][] = $tags['all'][] = wp_create_term( 'coffee', 'job_listing_type' );
+		$terms['jazz']   = $tags['main'][] = $tags['all'][] = wp_create_term( 'jazz', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
+		$terms['swim']   = $tags['main'][] = $tags['all'][] = wp_create_term( 'swim', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
+		$terms['dev']    = $tags['main'][] = $tags['all'][] = wp_create_term( 'dev', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
+		$terms['potato'] = $tags['weird'][] = $tags['all'][] = wp_create_term( 'potato', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
+		$terms['coffee'] = $tags['happy'][] = $tags['all'][] = wp_create_term( 'coffee', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 		foreach ( $tags as $k => $category ) {
 			$tags[ $k ] = wp_list_pluck( $category, 'term_id' );
 		}
@@ -382,7 +382,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			3,
 			[
 				'tax_input' => [
-					'job_listing_type' => $tags['main'],
+					\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => $tags['main'],
 				],
 			]
 		);
@@ -390,7 +390,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			2,
 			[
 				'tax_input' => [
-					'job_listing_type' => $tags['weird'],
+					\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => $tags['weird'],
 				],
 			]
 		);
@@ -398,7 +398,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 			2,
 			[
 				'tax_input' => [
-					'job_listing_type' => $tags['happy'],
+					\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => $tags['happy'],
 				],
 			]
 		);

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,6 +10,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 // Cleanup all data.
+require 'includes/class-wp-job-manager-post-types.php';
 require 'includes/class-wp-job-manager-data-cleaner.php';
 
 if ( ! is_multisite() ) {

--- a/wp-job-manager-deprecated.php
+++ b/wp-job-manager-deprecated.php
@@ -60,7 +60,7 @@ if ( ! function_exists( 'get_the_job_type' ) ) :
 		_deprecated_function( __FUNCTION__, '1.27.0', 'wpjm_get_the_job_types' );
 
 		$post = get_post( $post );
-		if ( 'job_listing' !== $post->post_type ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 			return;
 		}
 

--- a/wp-job-manager-deprecated.php
+++ b/wp-job-manager-deprecated.php
@@ -64,7 +64,7 @@ if ( ! function_exists( 'get_the_job_type' ) ) :
 			return;
 		}
 
-		$types = wp_get_post_terms( $post->ID, 'job_listing_type' );
+		$types = wp_get_post_terms( $post->ID, \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 
 		if ( $types ) {
 			$type = current( $types );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -148,7 +148,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		if ( ! empty( $args['job_types'] ) ) {
 			$query_args['tax_query'][] = [
-				'taxonomy' => 'job_listing_type',
+				'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE,
 				'field'    => 'slug',
 				'terms'    => $args['job_types'],
 			];
@@ -428,7 +428,7 @@ if ( ! function_exists( 'get_job_listing_types' ) ) :
 			$args = apply_filters( 'get_job_listing_types_args', $args );
 
 			// Prevent users from filtering the taxonomy.
-			$args['taxonomy'] = 'job_listing_type';
+			$args['taxonomy'] = \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE;
 
 			return get_terms( $args );
 		}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -56,7 +56,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		}
 
 		$query_args = [
-			'post_type'              => 'job_listing',
+			'post_type'              => \WP_Job_Manager_Post_Types::PT_LISTING,
 			'post_status'            => $post_status,
 			'ignore_sticky_posts'    => 1,
 			'offset'                 => absint( $args['offset'] ),
@@ -396,7 +396,7 @@ if ( ! function_exists( 'get_featured_job_ids' ) ) :
 			[
 				'posts_per_page'   => -1,
 				'suppress_filters' => false,
-				'post_type'        => 'job_listing',
+				'post_type'        => \WP_Job_Manager_Post_Types::PT_LISTING,
 				'post_status'      => 'publish',
 				'meta_key'         => '_featured', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Used in production with no issues.
 				'meta_value'       => '1', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Used in production with no issues.
@@ -760,7 +760,7 @@ function job_manager_user_can_edit_job( $job_id ) {
 	} else {
 		$job = get_post( $job_id );
 
-		if ( ! $job || 'job_listing' !== $job->post_type || ( absint( $job->post_author ) !== get_current_user_id() && ! current_user_can( 'edit_post', $job_id ) ) ) {
+		if ( ! $job || \WP_Job_Manager_Post_Types::PT_LISTING !== $job->post_type || ( absint( $job->post_author ) !== get_current_user_id() && ! current_user_can( 'edit_post', $job_id ) ) ) {
 			$can_edit = false;
 		}
 	}
@@ -794,7 +794,7 @@ function is_wpjm() {
  * @return bool
  */
 function is_wpjm_page() {
-	$is_wpjm_page = is_post_type_archive( 'job_listing' );
+	$is_wpjm_page = is_post_type_archive( \WP_Job_Manager_Post_Types::PT_LISTING );
 
 	if ( ! $is_wpjm_page ) {
 		$wpjm_page_ids = array_filter(
@@ -890,7 +890,7 @@ function has_wpjm_shortcode( $content = null, $tag = null ) {
  * @return bool
  */
 function is_wpjm_job_listing() {
-	return is_singular( [ 'job_listing' ] );
+	return is_singular( [ \WP_Job_Manager_Post_Types::PT_LISTING ] );
 }
 
 /**
@@ -901,7 +901,7 @@ function is_wpjm_job_listing() {
  * @return bool
  */
 function is_wpjm_taxonomy() {
-	return is_tax( get_object_taxonomies( 'job_listing' ) );
+	return is_tax( get_object_taxonomies( \WP_Job_Manager_Post_Types::PT_LISTING ) );
 }
 
 /**
@@ -1521,7 +1521,7 @@ function job_manager_duplicate_listing( $post_id ) {
 	}
 
 	$post = get_post( $post_id );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return 0;
 	}
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -158,7 +158,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$field                     = is_numeric( $args['search_categories'][0] ) ? 'term_id' : 'slug';
 			$operator                  = 'all' === get_option( 'job_manager_category_filter_type', 'all' ) && count( $args['search_categories'] ) > 1 ? 'AND' : 'IN';
 			$query_args['tax_query'][] = [
-				'taxonomy'         => 'job_listing_category',
+				'taxonomy'         => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
 				'field'            => $field,
 				'terms'            => array_values( $args['search_categories'] ),
 				'include_children' => 'AND' !== $operator,
@@ -463,7 +463,7 @@ if ( ! function_exists( 'get_job_listing_categories' ) ) :
 		$args = apply_filters( 'get_job_listing_category_args', $args );
 
 		// Prevent users from filtering the taxonomy.
-		$args['taxonomy'] = 'job_listing_category';
+		$args['taxonomy'] = \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY;
 
 		return get_terms( $args );
 	}
@@ -485,7 +485,7 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 		if ( $args['search_categories'] ) {
 			foreach ( $args['search_categories'] as $category ) {
 				if ( is_numeric( $category ) ) {
-					$category_object = get_term_by( 'id', $category, 'job_listing_category' );
+					$category_object = get_term_by( 'id', $category, \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 					if ( ! is_wp_error( $category_object ) ) {
 						$job_categories[] = $category_object->slug;
 					}
@@ -1169,7 +1169,7 @@ function job_manager_dropdown_categories( $args = '' ) {
 		'id'              => '',
 		'class'           => 'job-manager-category-dropdown ' . ( is_rtl() ? 'chosen-rtl' : '' ),
 		'depth'           => 0,
-		'taxonomy'        => 'job_listing_category',
+		'taxonomy'        => \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY,
 		'value'           => 'id',
 		'multiple'        => true,
 		'show_option_all' => false,

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -229,7 +229,7 @@ function get_the_job_permalink( $post = null ) {
 function get_the_job_application_method( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return;
 	}
 
@@ -304,7 +304,7 @@ function wpjm_get_job_employment_types( $post = null ) {
 function wpjm_allow_indexing_job_listing( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return true;
 	}
 
@@ -333,7 +333,7 @@ function wpjm_allow_indexing_job_listing( $post = null ) {
 function wpjm_output_job_listing_structured_data( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return false;
 	}
 
@@ -363,7 +363,7 @@ function wpjm_output_job_listing_structured_data( $post = null ) {
 function wpjm_get_job_listing_structured_data( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return false;
 	}
 
@@ -454,7 +454,7 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 function wpjm_get_job_listing_location_structured_data( $post ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return false;
 	}
 
@@ -523,7 +523,7 @@ function wpjm_the_job_title( $post = null ) {
  */
 function wpjm_get_the_job_title( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return null;
 	}
 
@@ -561,7 +561,7 @@ function wpjm_the_job_description( $post = null ) {
  */
 function wpjm_get_the_job_description( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return null;
 	}
 
@@ -610,7 +610,7 @@ function wpjm_the_job_types( $post = null, $separator = ', ' ) {
 function wpjm_get_the_job_types( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return false;
 	}
 
@@ -669,7 +669,7 @@ function wpjm_the_job_categories( $post = null, $separator = ', ' ) {
 function wpjm_get_the_job_categories( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return false;
 	}
 
@@ -837,7 +837,7 @@ function the_job_location( $map_link = true, $post = null ) {
  */
 function get_the_job_location( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return null;
 	}
 
@@ -1006,7 +1006,7 @@ function the_company_video( $post = null ) {
  */
 function get_the_company_video( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return null;
 	}
 	return apply_filters( 'the_company_video', $post->_company_video, $post );
@@ -1049,7 +1049,7 @@ function the_company_name( $before = '', $after = '', $echo = true, $post = null
  */
 function get_the_company_name( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return '';
 	}
 
@@ -1066,7 +1066,7 @@ function get_the_company_name( $post = null ) {
 function get_the_company_website( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return;
 	}
 
@@ -1116,7 +1116,7 @@ function the_company_tagline( $before = '', $after = '', $echo = true, $post = n
 function get_the_company_tagline( $post = null ) {
 	$post = get_post( $post );
 
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return null;
 	}
 
@@ -1158,7 +1158,7 @@ function the_company_twitter( $before = '', $after = '', $echo = true, $post = n
  */
 function get_the_company_twitter( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return null;
 	}
 
@@ -1198,7 +1198,7 @@ function job_listing_class( $class = '', $post_id = null ) {
 function get_job_listing_class( $class = '', $post_id = null ) {
 	$post = get_post( $post_id );
 
-	if ( empty( $post ) || 'job_listing' !== $post->post_type ) {
+	if ( empty( $post ) || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return [];
 	}
 
@@ -1227,11 +1227,11 @@ function get_job_listing_class( $class = '', $post_id = null ) {
 function wpjm_add_post_class( $classes, $class, $post_id ) {
 	$post = get_post( $post_id );
 
-	if ( empty( $post ) || 'job_listing' !== $post->post_type ) {
+	if ( empty( $post ) || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return $classes;
 	}
 
-	$classes[] = 'job_listing';
+	$classes[] = \WP_Job_Manager_Post_Types::PT_LISTING;
 
 	if ( get_option( 'job_manager_enable_types' ) ) {
 		$job_types = wpjm_get_the_job_types( $post );
@@ -1283,7 +1283,7 @@ add_action( 'single_job_listing_start', 'job_listing_company_display', 30 );
  */
 function get_the_job_salary( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return;
 	}
 
@@ -1356,7 +1356,7 @@ function the_job_salary( $before = '', $after = '', $echo = true, $post = null )
  */
 function get_the_job_salary_currency( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return;
 	}
 
@@ -1385,7 +1385,7 @@ function get_the_job_salary_currency( $post = null ) {
  */
 function get_the_job_salary_unit( $post = null ) {
 	$post = get_post( $post );
-	if ( ! $post || 'job_listing' !== $post->post_type ) {
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
 		return;
 	}
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -673,7 +673,7 @@ function wpjm_get_the_job_categories( $post = null ) {
 		return false;
 	}
 
-	$categories = get_the_terms( $post->ID, 'job_listing_category' );
+	$categories = get_the_terms( $post->ID, \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 
 	if ( empty( $categories ) || is_wp_error( $categories ) ) {
 		$categories = [];

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -614,7 +614,7 @@ function wpjm_get_the_job_types( $post = null ) {
 		return false;
 	}
 
-	$types = get_the_terms( $post->ID, 'job_listing_type' );
+	$types = get_the_terms( $post->ID, \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 
 	if ( empty( $types ) || is_wp_error( $types ) ) {
 		$types = [];


### PR DESCRIPTION
Fixes #2663

### Changes Proposed in this Pull Request

* Replace strings with constants in `WP_Job_Manager_Post_Types`

### Testing Instructions

Test if the plugin is generally work. Some examples:

1. Create a Job Type
2. Create job categories
3. Create job listings using the data created above
4. Update/delete job categories, types and listings
5. Try to uninstall the plugin
6. etc.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

- [New] Add constants to refer to IDs of post types, capabilities and taxonomies






<!-- wpjm:plugin-zip -->
----

| Plugin build for df7b39fdeac43846b95aed26e4e6c35ec689df17 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2687-df7b39fd.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2687-df7b39fd)             |

<!-- /wpjm:plugin-zip -->










