### PR TITLE
Guard against fatal caused by possibly unset/invalid setting value.

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -1086,6 +1086,10 @@ class WP_Job_Manager_Settings {
 	 * @param string $placeholder
 	 */
 	protected function input_multi_enable_expand( $option, $attributes, $values, $placeholder ) {
+		if ( empty( $values ) ) {
+			$values = [];
+		}
+
 		echo '<div class="setting-enable-expand">';
 		$enable_option               = $option['enable_field'];
 		$enable_option['name']       = $option['name'] . '[' . $enable_option['name'] . ']';
@@ -1103,7 +1107,9 @@ class WP_Job_Manager_Settings {
 			$enable_option['attributes'][] = 'disabled="disabled"';
 		}
 
-		$this->input_checkbox( $enable_option, $enable_option['attributes'], $values[ $option['enable_field']['name'] ], null );
+		$value = $values[ $option['enable_field']['name'] ] ?? '';
+
+		$this->input_checkbox( $enable_option, $enable_option['attributes'], $value, null );
 
 		echo '<div class="sub-settings-expandable">';
 		$this->input_multi( $option, $attributes, $values, $placeholder );


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Guard against invalid setting values on input_multi_enable_expand.

### Testing Instructions

* Try it on a fresh wpjm/addons install.
* Open settings, and navigate to Email Notifications.
* No fatals.
* Tweak email notification settings and check that they are saved.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Guard against invalid/unset input_multi_enable_expand value.

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* none

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video


<!-- wpjm:plugin-zip -->
----

| Plugin build for b5fc6726e0df0848c7d2dd5b35b30a41e94d3c88 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2688-b5fc6726.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2688-b5fc6726)             |

<!-- /wpjm:plugin-zip -->
