### PR TITLE
Hide the 'Add new' menu with CSS

### DIFF
--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -10,6 +10,10 @@
 			@include jm-icon();
 			content: "\e830";
 		}
+
+		a[href="post-new.php?post_type=job_listing"] {
+			display: none;
+		}
 	}
 
 	#menu-posts-resume {

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -175,7 +175,6 @@ class WP_Job_Manager_Admin {
 	 * Adds pages to admin menu.
 	 */
 	public function admin_menu() {
-		remove_submenu_page( 'edit.php?post_type=job_listing', 'post-new.php?post_type=job_listing' );
 		$item = remove_submenu_page( 'edit.php?post_type=job_listing', 'edit.php?post_type=job_listing' );
 		if ( ! $item ) {
 			return;


### PR DESCRIPTION
Fixes #2673

### Changes Proposed in this Pull Request

* It seems that Core WP expects the 'Add New' menu to exist in order to check if the user has the capabilities to add a new post.
* This happens in `user_can_access_admin_page` if you want to take a look. For our case, the 'Add New' page should have a parent page for the appropriate capability to be checked in line 2178
* I think that the only viable option is to re-add the menu and hide it with CSS.

### Testing Instructions

* Follow the steps in the linked ticket and ensure that the user can access the 'Add new' job listing page.
* The user needs to have only the job listing related rights.
* WooCommerce should not be active as Woo redirects the user to the 'My account' page if he doesn't have 'edit_posts' rights.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 3a72581fb398c9facbf9228286678381e9d738f3 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2689-3a72581f.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2689-3a72581f)             |

<!-- /wpjm:plugin-zip -->
