### PR TITLE
Require in Base_Test as bootstrap is not run on addons

### DIFF
--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -100,7 +100,6 @@ class WPJM_Unit_Tests_Bootstrap {
 		require_once $this->includes_dir . '/factories/class-wpjm-factory.php';
 		require_once $this->includes_dir . '/class-wpjm-base-test.php';
 		require_once $this->includes_dir . '/class-wpjm-rest-testcase.php';
-		require_once $this->includes_dir . '/class-function-mocks.php';
 	}
 
 	/**

--- a/tests/php/includes/class-wpjm-base-test.php
+++ b/tests/php/includes/class-wpjm-base-test.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/class-function-mocks.php';
+
 class WPJM_BaseTest extends WP_UnitTestCase {
 	/**
 	 * @var Requests_Transport


### PR DESCRIPTION
Fixes wpjm-addons tests

<!-- wpjm:plugin-zip -->
----

| Plugin build for e08abd3df8ad5d47e000f2e99dd797c79c4ea0f2 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2023/12/wp-job-manager-zip-2691-e08abd3d.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2023/12/2691-e08abd3d)             |

<!-- /wpjm:plugin-zip -->
