### PR TITLE
Fix email multipart boundary

### DIFF
--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -976,6 +976,15 @@ final class WP_Job_Manager_Email_Notifications {
 	private static function get_multipart_body( string $content_html, string $content_plain ): string {
 		$multipart_body = '';
 
+		if ( ! empty( $content_plain ) ) {
+
+			$multipart_body .= '
+--' . self::MULTIPART_BOUNDARY . '
+Content-Type: text/plain; charset="utf-8"
+
+' . $content_plain;
+		}
+
 		if ( ! empty( $content_html ) ) {
 			$multipart_body .= '
 --' . self::MULTIPART_BOUNDARY . '
@@ -984,13 +993,10 @@ Content-Type: text/html; charset="utf-8"
 ' . $content_html;
 		}
 
-		if ( ! empty( $content_plain ) ) {
-
+		if ( ! empty( $multipart_body ) ) {
 			$multipart_body .= '
---' . self::MULTIPART_BOUNDARY . '
-Content-Type: text/plain; charset="utf-8"
-
-' . $content_plain;
+--' . self::MULTIPART_BOUNDARY . '--
+';
 		}
 
 		return $multipart_body;

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -18,7 +18,7 @@ final class WP_Job_Manager_Email_Notifications {
 	const EMAIL_SETTING_PREFIX     = 'job_manager_email_';
 	const EMAIL_SETTING_ENABLED    = 'enabled';
 	const EMAIL_SETTING_PLAIN_TEXT = 'plain_text';
-	const MULTIPART_BOUNDARY       = '--jm-boundary';
+	const MULTIPART_BOUNDARY       = 'jm-boundary';
 
 	/**
 	 * Notifications to be scheduled.


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/pull/2684#discussion_r1432548658

### Changes Proposed in this Pull Request

* Remove the `--` prefix so it's not included in the Content-Type header
* Add `--jm-boundary--` to the end
* Move plain text part first

### Testing Instructions

* Send e-mails and check that HTML / plain text versions work. See #2684 

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes





<!-- wpjm:plugin-zip -->
----

| Plugin build for 14e2f09bcb8e137b38db42b4f6304a8850affcd0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2693-14e2f09b.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2693-14e2f09b)             |

<!-- /wpjm:plugin-zip -->


