### PR TITLE
Bound listing duration between 1 and 100 years, or no expiration

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -384,11 +384,14 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 						],
 						[
-							'name'       => 'job_manager_submission_duration',
-							'std'        => '30',
-							'label'      => __( 'Listing Duration', 'wp-job-manager' ),
-							'desc'       => __( 'Listings will display for the set number of days, then expire. Leave this field blank if you don\'t want listings to have an expiration date.', 'wp-job-manager' ),
-							'attributes' => [],
+							'name'              => 'job_manager_submission_duration',
+							'std'               => '30',
+							'label'             => __( 'Listing Duration', 'wp-job-manager' ),
+							'desc'              => __( 'Listings will display for the set number of days, then expire. Leave this field blank if you don\'t want listings to have an expiration date.', 'wp-job-manager' ),
+							'type'              => 'number',
+							'attributes'        => [],
+							'sanitize_callback' => [ $this, 'sanitize_submission_duration' ],
+							'placeholder'       => __( 'No limit', 'wp-job-manager' ),
 						],
 						[
 							'name'       => 'job_manager_renewal_days',
@@ -985,13 +988,19 @@ class WP_Job_Manager_Settings {
 	 * @param string $placeholder
 	 */
 	protected function input_number( $option, $attributes, $value, $placeholder ) {
+		$field_name      = $option['name'] ?? '';
+		$text_class_name = 'small-text';
+		if ( 'job_manager_submission_duration' === $field_name ) {
+			$text_class_name = 'regular-text';
+		}
+
 		echo isset( $option['before'] ) ? wp_kses_post( $option['before'] ) : '';
 		?>
 		<input
-			id="setting-<?php echo esc_attr( $option['name'] ); ?>"
-			class="small-text"
+			id="setting-<?php echo esc_attr( $field_name ); ?>"
+			class="<?php echo esc_attr( $text_class_name ); ?>"
 			type="number"
-			name="<?php echo esc_attr( $option['name'] ); ?>"
+			name="<?php echo esc_attr( $field_name ); ?>"
 			value="<?php echo esc_attr( $value ); ?>"
 			<?php
 			echo implode( ' ', $attributes ) . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -1210,6 +1219,20 @@ class WP_Job_Manager_Settings {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Sanitize the submission duration value between 1 and 100 years
+	 *
+	 * @param string|int $value
+	 * @return int
+	 */
+	public function sanitize_submission_duration( $value ) {
+		if ( ! is_numeric( $value ) ) {
+			return '';
+		}
+
+		return ( $value <= 0 || $value > 36500 ) ? '' : $value;
 	}
 
 	/**

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -1241,17 +1241,37 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
+	 * Internal helper for numeric sanitization.
+	 *
+	 * @param stirng|int $value
+	 * @param int        $min
+	 * @param int        $max
+	 * @param mixed      $default (optional).
+	 * @param bool       $include_min (optional).
+	 * @return string|int
+	 */
+	private function sanitize_numeric_boundaries( $value, $min, $max, $default = '', $include_min = true ) {
+		if ( ! is_numeric( $value ) ) {
+			return $default;
+		}
+
+		if ( ! $include_min && $value <= $min ) {
+			return $default;
+		} elseif ( $value < $min ) {
+			return $default;
+		}
+
+		return $value > $max ? $default : $value;
+	}
+
+	/**
 	 * Sanitize the submission duration value between 1 and MAX_ALLOWED_SUBMISSION_DAYS days
 	 *
 	 * @param string|int $value
 	 * @return string|int
 	 */
 	public function sanitize_submission_duration( $value ) {
-		if ( ! is_numeric( $value ) ) {
-			return '';
-		}
-
-		return ( $value <= 0 || $value > self::MAX_ALLOWED_SUBMISSION_DAYS ) ? '' : $value;
+		return $this->sanitize_numeric_boundaries( $value, 0, self::MAX_ALLOWED_SUBMISSION_DAYS, '', false );
 	}
 
 	/**
@@ -1261,11 +1281,7 @@ class WP_Job_Manager_Settings {
 	 * @return string|int
 	 */
 	public function sanitize_renewal_days( $value ) {
-		if ( ! is_numeric( $value ) ) {
-			return '';
-		}
-
-		return ( $value < 0 || $value > self::MAX_ALLOWED_SUBMISSION_DAYS ) ? '' : $value;
+		return $this->sanitize_numeric_boundaries( $value, 0, self::MAX_ALLOWED_SUBMISSION_DAYS );
 	}
 
 	/**
@@ -1275,11 +1291,7 @@ class WP_Job_Manager_Settings {
 	 * @return string|int
 	 */
 	public function sanitize_submission_limit( $value ) {
-		if ( ! is_numeric( $value ) ) {
-			return '';
-		}
-
-		return ( $value < 0 || $value > self::MAX_ALLOWED_SUBMISSION_LIMIT ) ? '' : $value;
+		return $this->sanitize_numeric_boundaries( $value, 0, self::MAX_ALLOWED_SUBMISSION_LIMIT );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2690

### Changes Proposed in this Pull Request

This PR fixes an issue with the listing duration being a free text setting.
It is now a number, bound from 1 to 100 years.
If a number if below or above, it will be reset to "no expiration".
It's also adding a placeholder "No limit" to the field.

### Testing Instructions

* Don't apply PR
* Follow test steps in #2690 
* Should break
* Apply PR
* Do it again
* ✅ It should be set to "no limit"
* Update limit to a number between 1 and 36500
* ✅ The limit should be properly set
* Update it to a number out of these bounds (eg. 0, -1, 36501)
* ✅ It should be set to "no limit"
* The field should also only accept numbers, you can try manually setting the field to some random text (you'll have to bypass browser submit checks), it should be set to "no limit"





<!-- wpjm:plugin-zip -->
----

| Plugin build for 008c0fbb1105b54c53cac9be799d70300cdb4b08 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2695-008c0fbb.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2695-008c0fbb)             |

<!-- /wpjm:plugin-zip -->




