### PR TITLE
Fix warnings when priority not set in form field.

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -296,10 +296,12 @@ abstract class WP_Job_Manager_Form {
 	 * @return int
 	 */
 	protected function sort_by_priority( $a, $b ) {
-		if ( floatval( $a['priority'] ) === floatval( $b['priority'] ) ) {
+		$a_priority = isset( $a['priority'] ) ? $a['priority'] : 100000;
+		$b_priority = isset( $b['priority'] ) ? $b['priority'] : 100000;
+		if ( floatval( $a_priority ) === floatval( $b_priority ) ) {
 			return 0;
 		}
-		return ( floatval( $a['priority'] ) < floatval( $b['priority'] ) ) ? -1 : 1;
+		return ( floatval( $a_priority ) < floatval( $b_priority ) ) ? -1 : 1;
 	}
 
 	/**


### PR DESCRIPTION
The following php 8 warnings were reported

```
PHP Warning: Undefined array key "priority" in wp-job-manager/includes/abstracts/abstract-wp-job-manager-form.php on line 302
PHP Warning: Undefined array key "priority" in wp-job-manager/includes/abstracts/abstract-wp-job-manager-form.php on line 299
```

### Changes Proposed in this Pull Request

* Fixes warnings by ensuring that the priority key exists, otherwise "punishes" the fields that have no priority.

### Testing Instructions

* On a php8 setup remove one priority key from a form field. I did it in the forms used in add-a-job.
* Test that warnings do not show.
* The field should go to the bottom of the form.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* 

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video



<!-- wpjm:plugin-zip -->
----

| Plugin build for 74e76c0f498803fcd42f1640d96c7a5af24797b3 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2696-74e76c0f.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2696-74e76c0f)             |

<!-- /wpjm:plugin-zip -->


