### PR TITLE
Flush cache on job listing post meta updates

### DIFF
--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -22,6 +22,7 @@ class WP_Job_Manager_Cache_Helper {
 	 */
 	public static function init() {
 		add_action( 'save_post', [ __CLASS__, 'flush_get_job_listings_cache' ] );
+		add_action( 'update_post_meta', [ __CLASS__, 'maybe_flush_get_job_listings_cache_on_meta_update' ], 10, 2 );
 		add_action( 'delete_post', [ __CLASS__, 'flush_get_job_listings_cache' ] );
 		add_action( 'trash_post', [ __CLASS__, 'flush_get_job_listings_cache' ] );
 		add_action( 'job_manager_my_job_do_action', [ __CLASS__, 'job_manager_my_job_do_action' ] );
@@ -41,6 +42,16 @@ class WP_Job_Manager_Cache_Helper {
 		if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type( $post_id ) ) {
 			self::get_transient_version( 'get_job_listings', true );
 		}
+	}
+
+	/**
+	 * Flush the cache on updates to job listing meta.
+	 *
+	 * @param int $meta_id
+	 * @param int $post_id
+	 */
+	public static function maybe_flush_get_job_listings_cache_on_meta_update( $meta_id, $post_id ) {
+		self::flush_get_job_listings_cache( $post_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2697

### Changes Proposed in this Pull Request

* Make sure job listing cache is flushed when post meta is updated for job listings

### Testing Instructions

* See #2697 

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix cache issue when marking jobs as filled/not filled via bulk actions



<!-- wpjm:plugin-zip -->
----

| Plugin build for 86366069ca495ff6400e0b8d39c1f61f4fb3487b <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2698-86366069.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2698-86366069)             |

<!-- /wpjm:plugin-zip -->
