### PR TITLE
Allow employers to schedule job listings from the frontend.

### DIFF
--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -497,7 +497,7 @@ class WP_Job_Manager_CPT {
 		$columns[ \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ]     = __( 'Type', 'wp-job-manager' );
 		$columns['job_location']                                     = __( 'Location', 'wp-job-manager' );
 		$columns['job_status']                                       = '<span class="tips" data-tip="' . __( 'Status', 'wp-job-manager' ) . '">' . __( 'Status', 'wp-job-manager' ) . '</span>';
-		$columns['job_posted']                                       = __( 'Posted', 'wp-job-manager' );
+		$columns['job_posted']                                       = __( 'Date', 'wp-job-manager' );
 		$columns['job_expires']                                      = __( 'Expires', 'wp-job-manager' );
 		$columns[ \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ] = __( 'Categories', 'wp-job-manager' );
 		$columns['featured_job']                                     = '<span class="tips" data-tip="' . __( 'Featured?', 'wp-job-manager' ) . '">' . __( 'Featured?', 'wp-job-manager' ) . '</span>';

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -339,8 +339,8 @@ class WP_Job_Manager_Settings {
 
 							'name'       => 'job_manager_enable_scheduled_listings',
 							'std'        => '0',
-							'label'      => __( 'Scheduled listings', 'wp-job-manager' ),
-							'cb_label'   => __( 'Enable Scheduled listings', 'wp-job-manager' ),
+							'label'      => __( 'Scheduled Listings', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable scheduled listings', 'wp-job-manager' ),
 							'desc'       => __( 'Allow employers to set a date in the future for the listing to publish.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -336,6 +336,16 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 						],
 						[
+
+							'name'       => 'job_manager_enable_scheduled_listings',
+							'std'        => '0',
+							'label'      => __( 'Scheduled listings', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable Scheduled listings', 'wp-job-manager' ),
+							'desc'       => __( 'Allow employers to set a date in the future for the listing to publish.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+						],
+						[
 							'name'       => 'job_manager_generate_username_from_email',
 							'std'        => '1',
 							'label'      => __( 'Account Username', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -404,7 +404,7 @@ class WP_Job_Manager_Shortcodes {
 			[
 				'job_title' => __( 'Title', 'wp-job-manager' ),
 				'filled'    => __( 'Filled?', 'wp-job-manager' ),
-				'date'      => __( 'Date Posted', 'wp-job-manager' ),
+				'date'      => __( 'Date', 'wp-job-manager' ),
 				'expires'   => __( 'Listing Expires', 'wp-job-manager' ),
 			]
 		);

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -336,6 +336,10 @@ class WP_Job_Manager_Shortcodes {
 			'author'              => get_current_user_id(),
 		];
 
+		if ( get_option( 'job_manager_enable_scheduled_listings' ) ) {
+			$job_dashboard_args['post_status'][] = 'future';
+		}
+
 		if ( $posts_per_page > 0 ) {
 			$job_dashboard_args['offset'] = ( max( 1, get_query_var( 'paged' ) ) - 1 ) * $posts_per_page;
 		}

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -197,9 +197,9 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 
 			update_post_meta( $this->job_id, '_job_edited', time() );
 
-			if ( 'publish' === $post_status ) {
+			if ( in_array( $post_status, [ 'future', 'publish' ], true ) ) {
 				$save_message = $save_message . ' <a href="' . get_permalink( $this->job_id ) . '">' . __( 'View &rarr;', 'wp-job-manager' ) . '</a>';
-			} elseif ( 'publish' === $original_post_status && 'pending' === $post_status ) {
+			} elseif ( in_array( $original_post_status, [ 'future', 'publish' ], true ) && 'pending' === $post_status ) {
 				$save_message = __( 'Your changes have been submitted and your listing will be visible again once approved.', 'wp-job-manager' );
 
 				/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -376,12 +376,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( ! get_option( 'job_manager_enable_remote_position' ) ) {
 			unset( $this->fields['job']['remote_position'] );
 		}
-		if ( true || get_option( 'job_manager_enable_scheduled_listings' ) ) {
+
+		if ( ! get_option( 'job_manager_disable_scheduled_listings' ) ) {
 			$field_type = version_compare( JOB_MANAGER_VERSION, '1.30.0', '>=' ) ? 'date' : 'text';
 
 			$this->fields['job']['job_schedule_listing'] = [
 				'label'       => __( 'Schedule date', 'wp-job-manager' ),
-				'description' => __( 'schedule a date for this listing to go public. leave empty if you want to publish now.', 'wp-job-manager' ),
+				'description' => __( 'Optionally schedule a date for this listing to go public.', 'wp-job-manager' ),
 				'type'        => $field_type,
 				'required'    => false,
 				'placeholder' => '',

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -859,7 +859,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		];
 
 		if ( ! empty( $values['job']['job_schedule_listing'] ) ) {
-			$maybe_formatted_date = $this->maybe_format_datetime_if_valid( $values['job']['job_schedule_listing'] );
+			$maybe_formatted_date = $this->maybe_format_future_datetime( $values['job']['job_schedule_listing'] );
 
 			if ( false !== $maybe_formatted_date ) {
 				$job_data['post_date']     = $maybe_formatted_date;
@@ -1088,19 +1088,23 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
-	 * Checks that a string is a valid datetime. Formats datetime for post date.
+	 * Checks that a string is a valid future datetime. Formats datetime for post date.
 	 *
 	 * @param string $maybe_date_string The date to format.
 	 *
 	 * @return false|mixed
 	 */
-	private function maybe_format_datetime_if_valid( string $maybe_date_string ): mixed {
+	private function maybe_format_future_datetime( string $maybe_date_string ): mixed {
 		if ( empty( $maybe_date_string ) ) {
 			return false;
 		}
 
 		$time = strtotime( $maybe_date_string );
 		if ( false === $time ) {
+			return false;
+		}
+
+		if ( $time < time() ) {
 			return false;
 		}
 
@@ -1136,7 +1140,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				$post_date_gmt = current_time( 'mysql', 1 );
 
 				$job_schedule_listing_date = get_post_meta( $job->ID, '_job_schedule_listing', true );
-				$maybe_formatted_date      = $this->maybe_format_datetime_if_valid( $job_schedule_listing_date );
+				$maybe_formatted_date      = $this->maybe_format_future_datetime( $job_schedule_listing_date );
 
 				if ( false !== $maybe_formatted_date ) {
 					$post_date     = $maybe_formatted_date;

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -377,7 +377,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			unset( $this->fields['job']['remote_position'] );
 		}
 
-		if ( ! get_option( 'job_manager_disable_scheduled_listings' ) ) {
+		if ( get_option( 'job_manager_enable_scheduled_listings' ) ) {
 			$field_type = version_compare( JOB_MANAGER_VERSION, '1.30.0', '>=' ) ? 'date' : 'text';
 
 			$this->fields['job']['job_schedule_listing'] = [

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -381,8 +381,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$field_type = version_compare( JOB_MANAGER_VERSION, '1.30.0', '>=' ) ? 'date' : 'text';
 
 			$this->fields['job']['job_schedule_listing'] = [
-				'label'       => __( 'Schedule date', 'wp-job-manager' ),
-				'description' => __( 'Optionally schedule a date for this listing to go public.', 'wp-job-manager' ),
+				'label'       => __( 'Scheduled Date', 'wp-job-manager' ),
+				'description' => __( 'Optionally set the date when this listing will be published.', 'wp-job-manager' ),
 				'type'        => $field_type,
 				'required'    => false,
 				'placeholder' => '',

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -378,12 +378,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		if ( get_option( 'job_manager_enable_scheduled_listings' ) ) {
-			$field_type = version_compare( JOB_MANAGER_VERSION, '1.30.0', '>=' ) ? 'date' : 'text';
-
 			$this->fields['job']['job_schedule_listing'] = [
 				'label'       => __( 'Scheduled Date', 'wp-job-manager' ),
 				'description' => __( 'Optionally set the date when this listing will be published.', 'wp-job-manager' ),
-				'type'        => $field_type,
+				'type'        => 'date',
 				'required'    => false,
 				'placeholder' => '',
 				'priority'    => '6.5',

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -379,6 +379,7 @@ if ( ! function_exists( 'get_job_listing_post_statuses' ) ) :
 				'pending'         => _x( 'Pending approval', 'post status', 'wp-job-manager' ),
 				'pending_payment' => _x( 'Pending payment', 'post status', 'wp-job-manager' ),
 				'publish'         => _x( 'Active', 'post status', 'wp-job-manager' ),
+				'future'          => _x( 'Scheduled', 'post status', 'wp-job-manager' ),
 			]
 		);
 	}

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -763,8 +763,15 @@ function the_job_publish_date( $post = null ) {
 	if ( 'default' === $date_format ) {
 		$display_date = esc_html__( 'Posted on ', 'wp-job-manager' ) . wp_date( get_option( 'date_format' ), get_post_timestamp( $post ) );
 	} else {
+		$post_timestamp = get_post_timestamp( $post );
+		$current_time   = time();
+
 		// translators: Placeholder %s is the relative, human readable time since the job listing was posted.
-		$display_date = sprintf( esc_html__( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( get_post_timestamp( $post ), time() ) );
+		$display_date = sprintf( esc_html__( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( $post_timestamp, $current_time ) );
+		if ( $post_timestamp > $current_time ) {
+			// translators: Placeholder %s is the relative, human readable time the job listing is scheduled to be published.
+			$display_date = sprintf( esc_html__( 'Scheduled to publish in %s', 'wp-job-manager' ), human_time_diff( $post_timestamp, $current_time ) );
+		}
 	}
 
 	echo '<time datetime="' . esc_attr( get_post_datetime( $post )->format( 'Y-m-d' ) ) . '">' . wp_kses_post( $display_date ) . '</time>';


### PR DESCRIPTION
Fixes #1901 

### Changes Proposed in this Pull Request

* Introduces a new form field for scheduling a listing date.

### Testing Instructions

* Enable scheduled listings. Under settings > Job Submission.
* Go to an Add-A-Job page. The form contains a schedule listing field.
* Create a new listing and leave the field empty. Listing is published as before.
* Create another listing and select a date in the future. Listing is set to publish on a future date.
* Check on wp-admin, the listing is scheduled for the date selected.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Add scheduling listings in the frontend.

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video










<!-- wpjm:plugin-zip -->
----

| Plugin build for 9efb75d4096a334cde119cd56dcae2a8ed8b4be2 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2699-9efb75d4.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2699-9efb75d4)             |

<!-- /wpjm:plugin-zip -->
















