### PR TITLE
Add a method that checks if the current guest has a normal account

### DIFF
--- a/includes/class-guest-session.php
+++ b/includes/class-guest-session.php
@@ -52,14 +52,13 @@ class Guest_Session {
 	 * @return bool
 	 */
 	public static function current_guest_has_account() : bool {
-		$session = self::instance();
-		$session->init();
+		$user = self::get_current_guest();
 
-		if ( false === $session->user ) {
+		if ( false === $user ) {
 			return false;
 		}
 
-		return (bool) get_user_by( 'email', $session->user->user_email );
+		return (bool) get_user_by( 'email', $user->user_email );
 	}
 
 	/**

--- a/includes/class-guest-session.php
+++ b/includes/class-guest-session.php
@@ -47,6 +47,22 @@ class Guest_Session {
 	}
 
 	/**
+	 * Checks if the current guest user has an account.
+	 *
+	 * @return bool
+	 */
+	public static function current_guest_has_account() : bool {
+		$session = self::instance();
+		$session->init();
+
+		if ( false === $session->user ) {
+			return false;
+		}
+
+		return (bool) get_user_by( 'email', $session->user->user_email );
+	}
+
+	/**
 	 * Initialize the guest session based on URL token or session cookie.
 	 * If only a URL token is present, it will be set as a session cookie.
 	 *


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Adds a method that checks if the email in the guest account exists in a normal account

### Testing Instructions

* To be tested with: https://github.com/Automattic/wpjm-addons/pull/436


<!-- wpjm:plugin-zip -->
----

| Plugin build for 38d5ed59b2391d26135d5eb56d0095f97148545f <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2700-38d5ed59.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2700-38d5ed59)             |

<!-- /wpjm:plugin-zip -->


