### PR TITLE
Add check to for $input_job_expires

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1075,7 +1075,7 @@ class WP_Job_Manager_Post_Types {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
 		$input_job_expires          = isset( $_POST['_job_expires'] ) ? sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) : null;
-		$input_job_expires_datetime = DateTimeImmutable::createFromFormat( 'Y-m-d', $input_job_expires, wp_timezone() );
+		$input_job_expires_datetime = ! empty( $input_job_expires ) ? DateTimeImmutable::createFromFormat( 'Y-m-d', $input_job_expires, wp_timezone() ) : null;
 
 		// See if the user has set the expiry manually.
 		if ( ! empty( $input_job_expires_datetime ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2692

### Changes Proposed in this Pull Request

* Add a check to make sure `$input_job_expires` is not empty

### Testing Instructions

* Create a new job from the frontend
* Go approve the job from the backend
* Make sure no PHP Deprecated notices show

### Release Notes

* Fix PHP Deprecated issue happeneing on job approvals.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 26c2ecf806275aa6701afecebf0e66ebba866716 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2701-26c2ecf8.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2701-26c2ecf8)             |

<!-- /wpjm:plugin-zip -->
