### PR TITLE
Fix rest-api php warning.

### DIFF
--- a/includes/class-wp-job-manager-rest-api.php
+++ b/includes/class-wp-job-manager-rest-api.php
@@ -36,6 +36,10 @@ class WP_Job_Manager_REST_API {
 		$fields       = WP_Job_Manager_Post_Types::get_job_listing_fields();
 		$data         = $response->get_data();
 
+		if ( ! isset( $data['meta'] ) ) {
+			$data['meta'] = [];
+		}
+
 		foreach ( $data['meta'] as $meta_key => $meta_value ) {
 			if ( isset( $fields[ $meta_key ] ) && is_callable( $fields[ $meta_key ]['auth_view_callback'] ) ) {
 				$is_viewable = call_user_func( $fields[ $meta_key ]['auth_view_callback'], false, $meta_key, $post->ID, $current_user->ID );


### PR DESCRIPTION
Fixes #2702

### Changes Proposed in this Pull Request

* fixes warnings related to missing array key

### Testing Instructions

* Check that no errors occur when using the rest api. (This popped up when testing in the frontend on the jobs page)

<!-- wpjm:plugin-zip -->
----

| Plugin build for 52d6f59c91d2b026430c2aaf9fa4fd13ec349cee <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2703-52d6f59c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2703-52d6f59c)             |

<!-- /wpjm:plugin-zip -->
