### PR TITLE
Bump to next version for addon compatibility checks

### DIFF
--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 2.1.1
+ * Version: 2.2.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.1
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '2.1.1' );
+define( 'JOB_MANAGER_VERSION', '2.2.0' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
See 435-gh-Automattic/wpjm-addons — this is to keeps the development version of Alerts working.

### Changes Proposed in this Pull Request

* Bump the version to the planned one that we already set in the Alerts add-on as the minimum

### Testing Instructions

* N/A

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes



<!-- wpjm:plugin-zip -->
----

| Plugin build for ac1bd8b505dbf70c46a011f92d0383f8d7de2561 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2707-ac1bd8b5.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2707-ac1bd8b5)             |

<!-- /wpjm:plugin-zip -->
