### PR TITLE
Add supporting changes for the alert modal

### DIFF
--- a/assets/css/ui.dialog.scss
+++ b/assets/css/ui.dialog.scss
@@ -4,7 +4,6 @@
 }
 
 .jm-dialog-open {
-
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -21,6 +20,7 @@
 }
 
 .jm-dialog {
+	font-size: var(--jm-ui-font-size);
 	--jm-local-notice-padding: var(--jm-ui-space-l);
 }
 
@@ -74,7 +74,7 @@
 	z-index: 1;
 	padding: var(--jm-ui-space-xxxs);
 	top: calc(var(--jm-local-notice-padding) - var(--jm-ui-space-xxxs));
-	right: calc(var(--jm-local-notice-padding) - var(--jm-ui-space-xxxs));
+	right: calc(var(--jm-local-notice-padding) - var(--jm-ui-space-xxxs) - 8px);
 	cursor: pointer;
 	opacity: 0.7;
 
@@ -151,5 +151,15 @@
 
 	100% {
 		opacity: 1;
+	}
+}
+
+.jm-dialog .jm-form {
+
+	display: flex;
+	flex-direction: column;
+	gap: var(--jm-ui-space-sm);
+	> * {
+		margin: unset;
 	}
 }

--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -22,7 +22,7 @@
 .jm-ui-button--icon,
 .jm-ui-link,
 {
-	font-size: 14px;
+	font-size: var(--jm-ui-button-font-size);
 	font-weight: 400;
 	letter-spacing: -0.1px;
 

--- a/assets/css/ui.form.scss
+++ b/assets/css/ui.form.scss
@@ -1,0 +1,267 @@
+
+@import 'mixins';
+
+.jm-form {
+
+	.jm-form-section {
+		margin: unset;
+	}
+
+	.jm-form-section-header {
+		margin: var(--jm-ui-space-m) auto;
+	}
+
+	.jm-form-section-header__title {
+		font-weight: bold;
+	}
+
+	.jm-form-section-header__description {
+		font-size: 0.85em;
+		margin: var(--jm-ui-space-s) auto;
+	}
+
+	fieldset {
+		border: unset;
+
+		label,
+		legend {
+			display: block;
+		}
+	}
+
+	input,
+	input[type],
+	textarea,
+	select,
+	input::placeholder,
+	input.placeholder,
+	.jm-ui-placeholder,
+	{
+		box-sizing: border-box;
+		font-family: inherit;
+		font-size: inherit;
+		font-stretch: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		height: auto;
+		line-height: 2;
+		padding: unset;
+		margin: unset;
+	}
+
+	input,
+	input[type],
+	textarea,
+	select,
+	{
+		width: 100%;
+		background: var(--jm-ui-input-background, color-mix(in srgb, transparent, #fff 5%));
+		color: var(--jm-ui-input-color, currentColor);
+		border: 1px solid fadeCurrentColor(20%);
+		padding: var(--jm-ui-space-xxs) var(--jm-ui-space-s);
+		border-radius: var(--jm-ui-radius-2x);
+
+		&:focus, &:focus-visible, &:focus-within {
+			border: 1px solid currentColor;
+			outline: 1px solid currentColor;
+		}
+	}
+
+	input::placeholder,
+	input.placeholder,
+	.jm-ui-placeholder,
+	{
+		opacity: .5;
+	}
+
+	textarea {
+		min-height: calc( 5 * var(--jm-ui-icon-size) );
+	}
+
+	label {
+		display: inline-block;
+		font-weight: normal;
+
+		+ * {
+			page-break-before: always;
+		}
+
+		> input {
+			margin-bottom: 0;
+		}
+	}
+
+	input[type='submit'],
+	input[type='reset'],
+	input[type='button'],
+	button {
+		padding: var(--jm-ui-space-s) var(--jm-ui-space-sm);
+		text-decoration: none;
+		outline: unset;
+		cursor: pointer;
+
+		transition: color 0.2s ease-out, background 0.2s ease-out;
+
+		&:focus, &:focus-visible {
+			outline: 1.5px solid fadeCurrentColor(85%);
+			outline-offset: 1.5px;
+		}
+
+		&[disabled] {
+			opacity: 0.5;
+			filter: grayscale(0.8);
+			cursor: not-allowed;
+		}
+
+	}
+
+	input[type='checkbox'],
+	input[type='radio'] {
+		border: unset;
+		padding: var(--jm-ui-space-xs);
+		flex-grow: 0;
+		width: var(--jm-ui-icon-size);
+		height: var(--jm-ui-icon-size);
+		margin-left: 0;
+		margin-right: var(--jm-ui-space-s);
+		vertical-align: middle;
+
+		+ label {
+			page-break-before: avoid;
+		}
+	}
+
+	select {
+		background-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'32\' height=\'6\' viewBox=\'0 0 16 10\'%3e%3cpath fill=\'currentColor\' fill-rule=\'evenodd\' d=\'M0 1.6 1.53 0 8 6.95 14.5 0 16 1.6 8 10 0 1.6Z\' clip-rule=\'evenodd\'/%3e%3c/svg%3e');
+		background-position: center right;
+		background-repeat: no-repeat;
+		-webkit-appearance: none;
+		appearance: none;
+		padding-right: var(--jm-ui-space-ml);
+	}
+
+	.select2-container.select2-container.select2-container {
+
+		input {
+			background: unset;
+		}
+
+		.select2-selection {
+			@extend select;
+			padding-left: var(--jm-ui-space-xs);
+		}
+
+		.select2-selection .select2-selection__placeholder {
+			@extend .jm-ui-placeholder;
+		}
+
+
+		.select2-selection .select2-selection__arrow {
+			display: none;
+		}
+
+		.select2-selection--multiple .select2-selection__rendered li {
+			margin: unset !important;
+		}
+
+		.select2-selection--multiple .select2-selection__rendered {
+			display: flex;
+			flex-wrap: wrap;
+			gap: var(--jm-ui-space-xs);
+		}
+
+		.select2-selection__choice {
+			display: flex;
+			gap: var(--jm-ui-space-s);
+			padding: 0 var(--jm-ui-space-s2);
+			background-color: fadeCurrentColor(5%);
+			border: unset;
+			border-radius: var(--jm-ui-radius-2x);
+
+
+		}
+
+		.select2-selection__choice__remove {
+			color: inherit;
+			background: currentColor;
+			order: 1;
+			mask: var(--jm-ui-svg-close) no-repeat center center;
+			margin: unset;
+			width: 18px;
+		}
+
+	}
+
+	&.job-manager-form {
+
+		fieldset {
+			margin: 0 0 1em 0;
+			padding: 0 0 1em 0;
+			display: flex;
+			flex-wrap: wrap;
+			align-items: baseline;
+			border-radius: unset;
+			border-color: fadeCurrentColor(15%);
+		}
+	}
+
+	.jm-form-actions {
+		display: flex;
+		gap: var(--jm-ui-space-s);
+		justify-content: center;
+		align-items: center;
+
+		> * {
+			flex: 1 1 auto;
+		}
+	}
+
+	.jm-form-field {
+		margin: var(--jm-ui-space-s) 0;
+
+		display: flex;
+		align-items: baseline;
+		gap: var(--jm-ui-space-m);
+		> * {
+			flex: 1;
+		}
+	}
+
+	.jm-form-large-field {
+		font-weight: bold;
+		font-size: var(--jm-ui-large-font-size);
+		margin: var(--jm-ui-space-xs) 0;
+	}
+
+	.jm-form-fine-print {
+		font-size: 80%;
+	}
+
+}
+
+body:has(.jm-form) .select2-dropdown {
+
+	& {
+		background-color: var(--jm-ui-background-color, #fff);
+		color: var(--jm-ui-text-color, #1a1a1a);
+		border: unset;
+		box-shadow: var(--jm-ui-shadow-modal);
+		overflow: clip;
+		border-radius: var(--jm-ui-radius);
+	}
+
+	.select2-results__option {
+		padding: var(--jm-ui-space-xs) var(--jm-ui-space-s);
+	}
+
+	.select2-results__option--highlighted {
+		color: inherit;
+		background-color: fadeCurrentColor(15%);
+	}
+
+	.select2-results__option[aria-selected="true"] {
+		color: inherit;
+		background-color: fadeCurrentColor(5%);
+	}
+
+}

--- a/assets/css/ui.neutral.scss
+++ b/assets/css/ui.neutral.scss
@@ -44,6 +44,8 @@
 
 	--jm-ui-font-size: 16px;
 	--jm-ui-heading-font-size: 20px;
+	--jm-ui-large-font-size: 24px;
+	--jm-ui-button-font-size: 14px;
 	--jm-ui-icon-size: 24px;
 
 	--jm-ui-shadow-modal: 0 0.7px 1px 0 rgba(0, 0, 0, 0.15),

--- a/assets/css/ui.notice.scss
+++ b/assets/css/ui.notice.scss
@@ -71,10 +71,6 @@
 		.jm-notice__message {
 			font-weight: 400;
 		}
-		.jm-ui-button,
-		.jm-ui-action, {
-			font-size: 16px;
-		}
 	}
 
 	&.type-dialog {
@@ -137,7 +133,6 @@
 	position: relative;
 	line-height: var(--jm-ui-icon-size);
 }
-
 
 .jm-notice__message-wrap {
 	display: flex;

--- a/assets/css/ui.scss
+++ b/assets/css/ui.scss
@@ -3,5 +3,7 @@
 
 @import 'ui.neutral';
 @import 'ui.elements';
+@import 'ui.form';
 @import 'ui.notice';
 @import 'ui.dialog';
+

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -217,8 +217,8 @@ jQuery( document ).ready( function( $ ) {
 			append = false;
 		}
 
-		if ( typeof result.showing === 'string' && result.showing ) {
-			var $showing_el = jQuery( '<span>' ).html( result.showing );
+		if ( typeof result.showing === 'string' && result.showing || result.showing_links ) {
+			var $showing_el = jQuery( '<span>' ).html( result.showing || '&nbsp;' );
 			$showing
 				.show()
 				.html( '' )

--- a/includes/ui/class-modal-dialog.php
+++ b/includes/ui/class-modal-dialog.php
@@ -30,6 +30,13 @@ class Modal_Dialog {
 	private string $id;
 
 	/**
+	 * Options for the dialog.
+	 *
+	 * @var array
+	 */
+	private array $options;
+
+	/**
 	 * Create a new dialog instance.
 	 *
 	 * @param array $options {
@@ -42,11 +49,14 @@ class Modal_Dialog {
 		$options = wp_parse_args(
 			$options,
 			[
-				'id' => null,
+				'id'    => null,
+				'class' => null,
+				'style' => null,
 			]
 		);
 
-		$this->id = $options['id'] ?? 'jm' . uniqid();
+		$this->options = $options;
+		$this->id      = $options['id'] ?? 'jm' . uniqid();
 	}
 
 	/**
@@ -69,13 +79,15 @@ class Modal_Dialog {
 		$id          = $this->id;
 		$close_label = __( 'Close', 'wp-job-manager' );
 
+		$class   = esc_attr( $this->options['class'] ?? '' );
+		$style   = esc_attr( $this->options['style'] ?? '' );
 		$content = str_replace( '{close}', $id . '.close(); event.preventDefault();', $content );
 
 		return <<<HTML
 <dialog class="jm-dialog" id="{$id}">
 	<div class="jm-dialog-open">
 		<div class="jm-dialog-backdrop" onclick="{$id}.close()"></div>
-		<div class="jm-dialog-modal">
+		<div class="jm-dialog-modal {$class}" style="{$style}">
 			{$content}
 			<a href="#" role="button" class="jm-ui-button--icon jm-dialog-close" onclick="{$id}.close()" aria-label="{$close_label}"><span class="jm-ui-button__icon"></span></a>
 		</div>

--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -83,19 +83,17 @@ class UI_Elements {
 			$args['url'] = '#';
 		}
 
-		$button = new \WP_HTML_Tag_Processor( '<a><span>' . esc_html( $args['label'] ) . '</span></a>' );
-		$button->next_tag();
-
-		$button->add_class( $class );
-		$button->set_attribute( 'href', $args['url'] );
+		$attrs = [
+			'class' => $class,
+			'href'  => esc_url( $args['url'] ),
+		];
 
 		if ( ! empty( $args['onclick'] ) ) {
-			$button->set_attribute( 'onclick', $args['onclick'] );
-			$button->set_attribute( 'role', 'button' );
+			$attrs['onclick'] = $args['onclick'];
+			$attrs['role']    = 'button';
 		}
 
-		return $button->get_updated_html();
-
+		return '<a ' . self::html_attrs( $attrs ) . '><span>' . esc_html( $args['label'] ) . '</span></a>';
 	}
 
 	/**
@@ -172,5 +170,24 @@ class UI_Elements {
 		$allowed_tags = array_merge( $kses_defaults, $svg_args );
 
 		return wp_kses( $code, $allowed_tags );
+	}
+
+	/**
+	 * Generate HTML attributes string. Escapes attributes.
+	 *
+	 * @param array $attributes Attributes array with key => value pairs.
+	 *
+	 * @return string HTML attributes string.
+	 */
+	private static function html_attrs( $attributes ) {
+		$attributes_html = array_map(
+			function( $key, $value ) {
+				return esc_attr( $key ) . '="' . esc_attr( $value ) . '"';
+			},
+			array_keys( $attributes ),
+			array_values( $attributes )
+		);
+
+		return implode( ' ', $attributes_html );
 	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -534,7 +534,16 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 		$return = '';
 
 		foreach ( $links as $key => $link ) {
-			$return .= '<a href="' . esc_url( $link['url'] ) . '" class="' . esc_attr( $key ) . '">' . wp_kses_post( $link['name'] ) . '</a>';
+			$a = new WP_HTML_Tag_Processor( '<a>' . wp_kses_post( $link['name'] ) . '</a>' );
+			$a->next_tag();
+			$a->set_attribute( 'href', esc_url( $link['url'] ) );
+			$a->add_class( esc_attr( $key ) );
+
+			if ( ! empty( $link['onclick'] ) ) {
+				$a->set_attribute( 'onclick', esc_attr( $link['onclick'] ) );
+			}
+
+			$return .= $a->get_updated_html();
 		}
 
 		return $return;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -534,16 +534,8 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 		$return = '';
 
 		foreach ( $links as $key => $link ) {
-			$a = new WP_HTML_Tag_Processor( '<a>' . wp_kses_post( $link['name'] ) . '</a>' );
-			$a->next_tag();
-			$a->set_attribute( 'href', esc_url( $link['url'] ) );
-			$a->add_class( esc_attr( $key ) );
-
-			if ( ! empty( $link['onclick'] ) ) {
-				$a->set_attribute( 'onclick', esc_attr( $link['onclick'] ) );
-			}
-
-			$return .= $a->get_updated_html();
+			$attrs   = ! empty( $link['onclick'] ) ? ' onclick="' . esc_attr( $link['onclick'] ) . '"' : '';
+			$return .= '<a href="' . esc_url( $link['url'] ) . '" class="' . esc_attr( $key ) . '"' . $attrs . '>' . wp_kses_post( $link['name'] ) . '</a>';
 		}
 
 		return $return;


### PR DESCRIPTION
Part of 186-gh-Automattic/wpjm-addons


### Changes Proposed in this Pull Request

* Always show "RSS", "Add alert" links in search so feeds or alerts can be used without searching for a keyword first. (Fixes #1749 — looks like the previous fix wasn't really working)
* Allow adding `onclick` handlers to these links
* Allow adding custom styles to the modal dialog
* Add form styles. This is not used anywhere yet, and for now it'll only be for the form inside the new alert modal. Later this will be the drop-in form styles for the various WPJM and add-on forms when the theme is not styling forms. 

### Testing Instructions

* See 440-gh-Automattic/wpjm-addons
* To test the whole form stylesheet, add the `jm-form` class manually to a `<form>`, like the submit job or add alert forms. 

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix RSS, Reset, Add Alert links not showing on search page without a keyword

### Screenshot / Video

For context these are the links in question:

![image](https://github.com/Automattic/WP-Job-Manager/assets/176949/790a9e44-1176-4103-9c73-018e92690ac4)



<!-- wpjm:plugin-zip -->
----

| Plugin build for 0722e1d5d8c010930de5003ba1b148be1fee6873 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2708-0722e1d5.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2708-0722e1d5)             |

<!-- /wpjm:plugin-zip -->

