### PR TITLE
Tweak dialog CSS

### DIFF
--- a/assets/css/ui.dialog.scss
+++ b/assets/css/ui.dialog.scss
@@ -152,9 +152,6 @@
 
 @media (max-width: 600px) {
 
-	.jm-dialog-modal {
-
-	}
 	.jm-dialog-open {
 		justify-content: flex-end;
 	}

--- a/assets/css/ui.dialog.scss
+++ b/assets/css/ui.dialog.scss
@@ -1,22 +1,23 @@
 .jm-dialog[open] {
 	border: unset;
 	background: unset;
+	padding: unset;
+	margin: unset;
+	position: static;
 }
 
 .jm-dialog-open {
 	position: fixed;
-	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	width: 100vw;
-	height: 100vh;
+	width: 100%;
+	height: 100%;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
 	z-index: 1000;
 	display: flex;
-
 }
 
 .jm-dialog {
@@ -29,7 +30,6 @@
 	border: unset;
 	width: 100%;
 	min-width: unset;
-
 	padding: var(--jm-local-notice-padding);
 
 	.jm-notice__details {
@@ -38,8 +38,7 @@
 }
 
 .jm-dialog::backdrop {
-	background-color: rgb(0 0 0 / 0.1);
-	backdrop-filter: blur(4px);
+	background-color: unset;
 }
 
 .jm-dialog-modal {
@@ -49,11 +48,11 @@
 	align-items: center;
 	justify-content: center;
 	width: var(--wp--style--global--content-size, 640px);
-	max-width: calc(100% - var(--jm-ui-space-s));
-	margin: auto;
-	max-height: 80vh;
+	max-width: calc(100% - var(--jm-ui-space-s) * 2);
+	max-height: 100%;
+	margin: var(--jm-ui-space-s);
 	overflow: hidden;
-	border-radius: var(--jm-ui-radius);
+	border-radius: var(--jm-ui-radius-2x);
 	background-color: var(--jm-ui-background-color, #fff);
 	color: var(--jm-ui-text-color, #1a1a1a);
 	box-shadow: var(--jm-ui-shadow-modal);
@@ -61,12 +60,14 @@
 }
 
 .jm-dialog-backdrop {
-	position: absolute;
-	top: 0;
+	position: fixed;
 	left: 0;
 	right: 0;
+	height: 110vh;
 	bottom: 0;
 	z-index: -1;
+	background-color: rgb(0 0 0 / 0.1);
+	backdrop-filter: blur(4px);
 }
 
 .jm-dialog-close {
@@ -85,21 +86,6 @@
 		height: var(--jm-ui-icon-size);
 	}
 
-}
-
-@media (max-width: 600px) {
-	.jm-dialog-open {
-		align-items: flex-end;
-	}
-
-	.jm-dialog-modal {
-		margin-bottom: var(--jm-ui-space-xs);
-
-	}
-
-	.jm-dialog {
-		--jm-local-notice-padding: var(--jm-ui-space-m);
-	}
 }
 
 .jm-dialog[open] .jm-dialog-open {
@@ -161,5 +147,28 @@
 	gap: var(--jm-ui-space-sm);
 	> * {
 		margin: unset;
+	}
+}
+
+@media (max-width: 600px) {
+
+	.jm-dialog-modal {
+
+	}
+	.jm-dialog-open {
+		justify-content: flex-end;
+	}
+
+	.jm-dialog-modal {
+		margin-bottom: var(--jm-ui-space-xs);
+
+	}
+
+	.jm-dialog {
+		--jm-local-notice-padding: var(--jm-ui-space-sm);
+	}
+
+	.jm-dialog .jm-form, .jm-dialog .jm-notice {
+		gap: var(--jm-ui-space-s);
 	}
 }

--- a/assets/css/ui.neutral.scss
+++ b/assets/css/ui.neutral.scss
@@ -54,4 +54,5 @@
 	0.1px 11.5px 16.4px -0.5px rgba(0, 0, 0, 0.15);
 
 	--jm-ui-svg-close: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' d='m12 13.06 3.71 3.71 1.06-1.06-3.7-3.71 3.7-3.71-1.06-1.06-3.71 3.7-3.71-3.7-1.06 1.06 3.7 3.71-3.7 3.71 1.06 1.06 3.71-3.7Z'/%3e%3c/svg%3e");
+	--jm-ui-svg-arrow-down: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'32\' height=\'6\' viewBox=\'0 0 16 10\'%3e%3cpath fill=\'currentColor\' fill-rule=\'evenodd\' d=\'M0 1.6 1.53 0 8 6.95 14.5 0 16 1.6 8 10 0 1.6Z\' clip-rule=\'evenodd\'/%3e%3c/svg%3e');
 }


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Improve CSS around the new modal dialog and forms:
* Compress things a bit to better fit on a phone screen with the keyboard open
* Positioning tweaks for mobile
* 

### Testing Instructions

* See 441-gh-Automattic/wpjm-addons

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes




<!-- wpjm:plugin-zip -->
----

| Plugin build for 9b09c43f3e0a176030a1b48835f7a592d3f0e3ea <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2709-9b09c43f.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2709-9b09c43f)             |

<!-- /wpjm:plugin-zip -->


