### PR TITLE
Update styles for checkbox, radio input

### DIFF
--- a/assets/css/ui.form.scss
+++ b/assets/css/ui.form.scss
@@ -29,6 +29,10 @@
 		}
 	}
 
+	[hidden] {
+		display: none;
+	}
+
 	input,
 	input[type],
 	textarea,

--- a/assets/css/ui.form.scss
+++ b/assets/css/ui.form.scss
@@ -117,17 +117,50 @@
 
 	input[type='checkbox'],
 	input[type='radio'] {
-		border: unset;
 		padding: var(--jm-ui-space-xs);
-		flex-grow: 0;
 		width: var(--jm-ui-icon-size);
-		height: var(--jm-ui-icon-size);
-		margin-left: 0;
-		margin-right: var(--jm-ui-space-s);
-		vertical-align: middle;
+		aspect-ratio: 1;
+		flex: 0 0 var(--jm-ui-icon-size);
+		align-self: baseline;
+		accent-color: currentColor;
+		appearance: unset;
+		position: relative;
 
 		+ label {
 			page-break-before: avoid;
+		}
+
+		&:focus, &:focus-visible, &:focus-within {
+			outline: unset;
+			outline: 2px solid currentColor;
+		}
+
+		&:checked::before {
+			content: '';
+			background: currentColor;
+			position: absolute;
+			left: 0;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			margin: auto;
+			width: 100%;
+			aspect-ratio: 1;
+		}
+	}
+
+	input[type='checkbox']:checked::before {
+		mask: var(--jm-ui-svg-check) center center;
+		mask-size: contain;
+	}
+
+	input[type='radio'] {
+		border-radius: 50%;
+		transform: scale(0.9);
+		&:checked::before {
+			background: currentColor;
+			border-radius: 50%;
+			width: 50%;
 		}
 	}
 
@@ -144,6 +177,8 @@
 
 		input {
 			background: unset;
+			border: unset;
+			outline: unset;
 		}
 
 		.select2-selection {
@@ -219,12 +254,26 @@
 	.jm-form-field {
 		margin: var(--jm-ui-space-s) 0;
 
+		&:empty {
+			display: none;
+		}
+	}
+
+	.jm-form-field:has(label:first-child) {
 		display: flex;
 		align-items: baseline;
 		gap: var(--jm-ui-space-m);
 		> * {
 			flex: 1;
 		}
+	}
+
+	.jm-form-field:has(input[type=checkbox]),
+	.jm-form-field:has(input[type=radio]),
+	{
+		display: flex;
+		align-items: center;
+		gap: var(--jm-ui-space-s2);
 	}
 
 	.jm-form-large-field {
@@ -234,7 +283,7 @@
 	}
 
 	.jm-form-fine-print {
-		font-size: 80%;
+		font-size: 90%;
 	}
 
 	.jm-form-input--inline {
@@ -273,7 +322,7 @@ body:has(.jm-form) .select2-dropdown {
 		background-color: fadeCurrentColor(15%);
 	}
 
-	.select2-results__option[aria-selected="true"] {
+	.select2-results__option[aria-selected='true'] {
 		color: inherit;
 		background-color: fadeCurrentColor(5%);
 	}

--- a/assets/css/ui.neutral.scss
+++ b/assets/css/ui.neutral.scss
@@ -54,5 +54,6 @@
 	0.1px 11.5px 16.4px -0.5px rgba(0, 0, 0, 0.15);
 
 	--jm-ui-svg-close: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' d='m12 13.06 3.71 3.71 1.06-1.06-3.7-3.71 3.7-3.71-1.06-1.06-3.71 3.7-3.71-3.7-1.06 1.06 3.7 3.71-3.7 3.71 1.06 1.06 3.71-3.7Z'/%3e%3c/svg%3e");
-	--jm-ui-svg-arrow-down: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'32\' height=\'6\' viewBox=\'0 0 16 10\'%3e%3cpath fill=\'currentColor\' fill-rule=\'evenodd\' d=\'M0 1.6 1.53 0 8 6.95 14.5 0 16 1.6 8 10 0 1.6Z\' clip-rule=\'evenodd\'/%3e%3c/svg%3e');
+	--jm-ui-svg-arrow-down: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='32' height='6' viewBox='0 0 16 10'%3e%3cpath fill='currentColor' fill-rule='evenodd' d='M0 1.6 1.53 0 8 6.95 14.5 0 16 1.6 8 10 0 1.6Z' clip-rule='evenodd'/%3e%3c/svg%3e");
+	--jm-ui-svg-check: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='%231E1E1E' stroke-width='1.5' d='m18.93 6-8.9 11.97-5.16-3.84'/%3e%3c/svg%3e");
 }


### PR DESCRIPTION
A small improvement for the new Alerts feature.

### Changes Proposed in this Pull Request

* Add styling so radio and checkbox inputs are consistent with the other form elements
* Make sure inputs with the hidden attribute are hidden

### Testing Instructions

* Used in the Job Alerts extension's Add alert modal
* See 446-gh-Automattic/wpjm-addons for testing

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Improve checkbox and radio inputs for styled forms

### Screenshot / Video

<img width="618" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/7a782a22-8a32-478d-8d13-0e85c9090aa1">



<!-- wpjm:plugin-zip -->
----

| Plugin build for 0c85c5ec9106c62c88e4f7af7426977f0bf54caa <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2718-0c85c5ec.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2718-0c85c5ec)             |

<!-- /wpjm:plugin-zip -->

