### PR TITLE
Add Stats Schema

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,9 +51,11 @@ jobs:
         php: [ '7.4', '8.0', '8.1' ]
         include:
           - php: '7.4'
-            wp: '6.0'
+            wp: '6.2'
           - php: '7.4'
-            wp: '6.1'
+            wp: '6.3'
+          - php: '7.4'
+            wp: '6.4'
     env:
       WP_VERSION: ${{ matrix.wp }}
       PHP_VERSION: ${{ matrix.php }}

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -28,7 +28,18 @@ class Stats {
 	 * Do initialization of all the things needed for stats.
 	 */
 	public function init() {
-		// Do init stuff.
+		$this->initialize_wpdb();
+	}
+
+	/**
+	 * Initialize the alias for the stats table on the wpdb object.
+	 *
+	 * @return void
+	 */
+	private function initialize_wpdb() {
+		global $wpdb;
+		$wpdb->job_manager_stats = $wpdb->prefix . 'job_manager_stats';
+		$wpdb->tables[]          = 'job_manager_stats';
 	}
 
 	/**

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -38,6 +38,9 @@ class Stats {
 	 */
 	private function initialize_wpdb() {
 		global $wpdb;
+		if ( isset( $wpdb->job_manager_stats ) ) {
+			return;
+		}
 		$wpdb->job_manager_stats = $wpdb->prefix . 'job_manager_stats';
 		$wpdb->tables[]          = 'job_manager_stats';
 	}

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -64,7 +64,7 @@ class Stats {
 				`group` varchar(255) DEFAULT '',
 				`count` bigint(20) unsigned not null default 1,
 				PRIMARY KEY (`id`),
-				KEY `name_date_group`  (`name`, `date`, `group`)
+				INDEX `idx_wpjm_stats_name_date_group`  (`name`, `date`, `group`)
 			) {$collate}",
 			]
 		);

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -55,13 +55,13 @@ class Stats {
 			[
 				"CREATE TABLE {$wpdb->job_manager_stats} (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-				`date` DATE NOT NULL CURRENT_DATE
+				`date` DATE NOT NULL,
 				`post_id` bigint(20) DEFAULT NULL,
 				`name` varchar(255) NOT NULL,
 				`group` varchar(255) DEFAULT '',
 				`count` bigint(20) unsigned not null default 1,
-				PRIMARY KEY (id),
-				KEY name_date_group (`name`, `date`, `group`)
+				PRIMARY KEY (`id`),
+				KEY `name_date_group`  (`name`, `date`, `group`)
 			) {$collate}",
 			]
 		);

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -55,7 +55,7 @@ class Stats {
 			[
 				"CREATE TABLE {$wpdb->job_manager_stats} (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-				`date` DATE NOT NULL,
+				`date` date NOT NULL,
 				`post_id` bigint(20) DEFAULT NULL,
 				`name` varchar(255) NOT NULL,
 				`group` varchar(255) DEFAULT '',

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -43,6 +43,31 @@ class Stats {
 	}
 
 	/**
+	 * Migrate the stats table to the latest version.
+	 *
+	 * @return void
+	 */
+	public function migrate() {
+		global $wpdb;
+		$collate = $wpdb->get_charset_collate();
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		\dbDelta(
+			[
+				"CREATE TABLE {$wpdb->job_manager_stats} (
+				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				`date` DATE NOT NULL CURRENT_DATE
+				`post_id` bigint(20) DEFAULT NULL,
+				`name` varchar(255) NOT NULL,
+				`group` varchar(255) DEFAULT '',
+				`count` bigint(20) unsigned not null default 1,
+				PRIMARY KEY (id),
+				KEY name_date_group (`name`, `date`, `group`)
+			) {$collate}",
+			]
+		);
+	}
+
+	/**
 	 * Perform plugin activation-related stats actions.
 	 *
 	 * @return void

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -38,11 +38,11 @@ class Stats {
 	 */
 	private function initialize_wpdb() {
 		global $wpdb;
-		if ( isset( $wpdb->job_manager_stats ) ) {
+		if ( isset( $wpdb->wpjm_stats ) ) {
 			return;
 		}
-		$wpdb->job_manager_stats = $wpdb->prefix . 'job_manager_stats';
-		$wpdb->tables[]          = 'job_manager_stats';
+		$wpdb->wpjm_stats = $wpdb->prefix . 'wpjm_stats';
+		$wpdb->tables[]   = 'wpjm_stats';
 	}
 
 	/**
@@ -56,7 +56,7 @@ class Stats {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		\dbDelta(
 			[
-				"CREATE TABLE {$wpdb->job_manager_stats} (
+				"CREATE TABLE {$wpdb->wpjm_stats} (
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				`date` date NOT NULL,
 				`post_id` bigint(20) DEFAULT NULL,

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -257,6 +257,11 @@ class WP_Job_Manager_Data_Cleaner {
 		foreach ( self::$custom_tables as $custom_table ) {
 			$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $wpdb->prefix . $custom_table ) );
 		}
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.UnsupportedPlaceholder
+		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 	}
 
 	/**

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -34,7 +34,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 * @var $custom_tables
 	 */
 	private static $custom_tables = [
-		'job_manager_stats',
+		'wpjm_stats',
 	];
 
 	/**

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -29,6 +29,15 @@ class WP_Job_Manager_Data_Cleaner {
 	];
 
 	/**
+	 * Custom tables to be deleted.
+	 *
+	 * @var $custom_tables
+	 */
+	private static $custom_tables = [
+		'job_manager_stats',
+	];
+
+	/**
 	 * Taxonomies to be deleted.
 	 *
 	 * @var $taxonomies
@@ -195,6 +204,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 */
 	public static function cleanup_all() {
 		self::cleanup_custom_post_types();
+		self::cleanup_custom_tables();
 		self::cleanup_taxonomies();
 		self::cleanup_pages();
 		self::cleanup_cron_jobs();
@@ -228,6 +238,24 @@ class WP_Job_Manager_Data_Cleaner {
 					wp_delete_post( $item, true );
 				}
 			}
+		}
+	}
+
+	/**
+	 * Cleanup data for custom tables.
+	 *
+	 * @return void
+	 */
+	private static function cleanup_custom_tables() {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- We need to delete the custom tables.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- We don't cache DROP TABLE.
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnsupportedPlaceholder -- %i is supported since WP 6.2.
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- %i is supported since WP 6.2.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange -- We really need to delete the custom tables.
+		foreach ( self::$custom_tables as $custom_table ) {
+			$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $wpdb->prefix . $custom_table ) );
 		}
 	}
 

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -31,9 +31,9 @@ class WP_Job_Manager_Data_Cleaner {
 	/**
 	 * Custom tables to be deleted.
 	 *
-	 * @var $custom_tables
+	 * @var array
 	 */
-	private static $custom_tables = [
+	private const CUSTOM_TABLES = [
 		'wpjm_stats',
 	];
 
@@ -254,7 +254,7 @@ class WP_Job_Manager_Data_Cleaner {
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnsupportedPlaceholder -- %i is supported since WP 6.2.
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- %i is supported since WP 6.2.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange -- We really need to delete the custom tables.
-		foreach ( self::$custom_tables as $custom_table ) {
+		foreach ( self::CUSTOM_TABLES as $custom_table ) {
 			$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $wpdb->prefix . $custom_table ) );
 		}
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -76,6 +76,8 @@ class WP_Job_Manager_Install {
 			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
 		}
 
+		\WP_Job_Manager\Stats::instance()->migrate();
+
 		delete_transient( 'wp_job_manager_addons_html' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );
 	}


### PR DESCRIPTION
Fixes #2715

### Changes Proposed in this Pull Request

* Add logic to initialize alias for stats table on wpdb 
* Add method to migrate the table for the latest version (and run it on plugin activation!)

### Testing Instructions

Check if the plugin can be activated on a new WP install just fine, without any errors on the error log. Also check if the `wp_job_manager_stats` is created as appropriate

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* 

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video









<!-- wpjm:plugin-zip -->
----

| Plugin build for dd028a7782d2800439fa3a2fb2c41248697c3bc8 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2719-dd028a77.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2719-dd028a77)             |

<!-- /wpjm:plugin-zip -->














