### PR TITLE
Add featured_first to output jobs and improve bool check

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -730,6 +730,7 @@ class WP_Job_Manager_Shortcodes {
 						'featured'          => $atts['featured'],
 						'filled'            => $atts['filled'],
 						'remote_position'   => $atts['remote_position'],
+						'featured_first'    => $atts['featured_first'],
 					]
 				)
 			);

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -181,7 +181,11 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			];
 		}
 
-		if ( 'true' === $args['featured_first'] && 'featured' !== $args['orderby'] && 'rand_featured' !== $args['orderby'] ) {
+		if ( isset( $args['featured_first'] ) ) {
+			$args['featured_first'] = filter_var( $args['featured_first'], FILTER_VALIDATE_BOOLEAN );
+		}
+
+		if ( true === $args['featured_first'] && 'featured' !== $args['orderby'] && 'rand_featured' !== $args['orderby'] ) {
 			$query_args['orderby'] = [
 				'menu_order'           => 'ASC',
 				$query_args['orderby'] => $query_args['order'],


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2721

### Changes Proposed in this Pull Request

* Add the `featured_first` parameter to the `output_jobs` function so it will still use it if it's not being passed through AJAX
* Improve type checking in the shortcode

### Testing Instructions

* Create a page with the shortcode [jobs orderby="ID" featured_first="true" order="DESC" show_filters="true"]
* Visit the page and you can see that it works as expected.
* Edit the jobs page and disable the filters: [jobs orderby="ID" featured_first="true" order="DESC" show_filters="false"]
* Visit the page, and you can see the featured job listings are shown on top as expected.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix: 'featured_first' argument now works when 'show_filters' is set to false.



<!-- wpjm:plugin-zip -->
----

| Plugin build for 03d3c56ac8851dec6c77f53196fc711aff061be0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2725-03d3c56a.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2725-03d3c56a)             |

<!-- /wpjm:plugin-zip -->
