### PR TITLE
Do not return mixed type

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1093,7 +1093,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 *
 	 * @return false|mixed
 	 */
-	private function maybe_format_future_datetime( string $maybe_date_string ): mixed {
+	private function maybe_format_future_datetime( string $maybe_date_string ) {
 		if ( empty( $maybe_date_string ) ) {
 			return false;
 		}


### PR DESCRIPTION
Fixes #2722

### Changes Proposed in this Pull Request

* Removes mixed return type as it is not supported in 7.x		

### Testing Instructions

* Submit a job and observe that the there are no errors

<!-- wpjm:plugin-zip -->
----

| Plugin build for 7cac449889ee2b2e05e9b1f577209092d02f9763 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/01/wp-job-manager-zip-2726-7cac4498.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/01/2726-7cac4498)             |

<!-- /wpjm:plugin-zip -->
