### PR TITLE
Add stats admin settings screen

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -528,6 +528,45 @@ class WP_Job_Manager_Settings {
 						],
 					],
 				],
+				'stats'          => [
+					__( 'Stats', 'wp-job-manager' ),
+					[
+						[
+							'name'       => 'job_manager_stats_enable',
+							'std'        => '0',
+							'label'      => __( 'Enable stats', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable stats', 'wp-job-manager' ),
+							'desc'       => __( 'Enable recording various stats (e.g. listing views) and showing them to employers', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+						],
+						[
+							'name'       => 'job_manager_stats_require_paid_listing',
+							'std'        => '0',
+							'label'      => __( 'Require paid listing', 'wp-job-manager' ),
+							'cb_label'   => __( 'Require paid listing', 'wp-job-manager' ),
+							'desc'       => __( 'Only display stats to employers that purchased a paid-listing package', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+						],
+						[
+							'name'       => 'job_manager_stats_default_date_range',
+							'std'        => '30',
+							'label'      => __( 'Stats default date range', 'wp-job-manager' ),
+							'desc'       => __( 'The default date range (in days) of stats to display in the frontend dashboard', 'wp-job-manager' ),
+							'type'       => 'number',
+							'attributes' => [],
+						],
+						[
+							'name'       => 'job_manager_stats_retention',
+							'std'        => '90',
+							'label'      => __( 'Stats retention', 'wp-job-manager' ),
+							'desc'       => __( 'Max time stats data will be retained.', 'wp-job-manager' ),
+							'type'       => 'number',
+							'attributes' => [],
+						],
+					],
+				],
 				'job_visibility' => [
 					__( 'Job Visibility', 'wp-job-manager' ),
 					[

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -541,15 +541,6 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 						],
 						[
-							'name'       => 'job_manager_stats_require_paid_listing',
-							'std'        => '0',
-							'label'      => __( 'Require paid listing', 'wp-job-manager' ),
-							'cb_label'   => __( 'Require paid listing', 'wp-job-manager' ),
-							'desc'       => __( 'Only display stats to employers that purchased a paid-listing package', 'wp-job-manager' ),
-							'type'       => 'checkbox',
-							'attributes' => [],
-						],
-						[
 							'name'       => 'job_manager_stats_default_date_range',
 							'std'        => '30',
 							'label'      => __( 'Stats default date range', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -561,7 +561,7 @@ class WP_Job_Manager_Settings {
 							'name'       => 'job_manager_stats_retention',
 							'std'        => '90',
 							'label'      => __( 'Retention Period (days)', 'wp-job-manager' ),
-							'desc'       => __( 'Max time stats data will be retained.', 'wp-job-manager' ),
+							'desc'       => __( 'Enter the maximum number of days for which statistics data will be retained.', 'wp-job-manager' ),
 							'type'       => 'number',
 							'attributes' => [],
 						],

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -560,7 +560,7 @@ class WP_Job_Manager_Settings {
 						[
 							'name'       => 'job_manager_stats_retention',
 							'std'        => '90',
-							'label'      => __( 'Stats retention', 'wp-job-manager' ),
+							'label'      => __( 'Retention Period (days)', 'wp-job-manager' ),
 							'desc'       => __( 'Max time stats data will be retained.', 'wp-job-manager' ),
 							'type'       => 'number',
 							'attributes' => [],


### PR DESCRIPTION
Fixes #2729

### Changes Proposed in this Pull Request

* Introduces the stats admin settings screeen. Defaults to stats not being enabled.

### Testing Instructions

* Visit the admin settings of job manager. You can see the stats section.
* Test they save correctly.
* Any thoughts on the labels etc...

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* N/A 

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* N/A

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* N/A

### Screenshot / Video

<img width="1273" alt="Screenshot 2024-01-31 at 3 55 38 PM" src="https://github.com/Automattic/WP-Job-Manager/assets/500744/b92f628f-01a3-4ff0-bbee-c6fb57aa7d29">





<!-- wpjm:plugin-zip -->
----

| Plugin build for 6b9f6cbc008a73d447919b6a787758794cb666be <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2730-6b9f6cbc.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2730-6b9f6cbc)             |

<!-- /wpjm:plugin-zip -->






