### PR TITLE
Optimize job listing view count

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -164,25 +164,19 @@ class Stats {
 	 * @return void
 	 */
 	private function hook() {
-		add_action( 'wp', [ $this, 'maybe_log_listing_view' ] );
+		add_filter( 'job_manager_single_job_content', [ $this, 'maybe_log_listing_view' ], 10, 2 );
 	}
 
 	/**
 	 * Log a (non-unique) listing page view.
 	 *
-	 * @return void
+	 * @param string   $content The post content for the job listing.
+	 * @param \WP_Post $post The job listing post object.
+	 * @return string
 	 */
-	public function maybe_log_listing_view() {
-		if ( is_admin() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
-			return;
-		}
+	public function maybe_log_listing_view( $content, $post ) {
+		$this->log_stat( 'job_listing_view', [ 'post_id' => get_post( $post )->ID ] );
 
-		$post_id   = absint( get_queried_object_id() );
-		$post_type = get_post_type( $post_id );
-		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post_type ) {
-			return;
-		}
-
-		$this->log_stat( 'job_listing_view', [ 'post_id' => $post_id ] );
+		return $content;
 	}
 }


### PR DESCRIPTION
Follow-up to #2728

### Changes Proposed in this Pull Request

* Use filter `job_manager_single_job_content` to detect visits to job listings and count job listing views as appropriate

### Testing Instructions

On a WP installation running this version of the plugin:

1. Create a job listing
2. Visit the job listing 
3. Verify if the count in the table `wp_wpjm_stats` is increased
4. Visit the job listing again
5. Verify if the count in the table `wp_wpjm_stats` is increased


### Release Notes


<!-- wpjm:plugin-zip -->
----

| Plugin build for ea947e153f4547c6bdf5dc914852e55c87e1b0a2 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2732-ea947e15.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2732-ea947e15)             |

<!-- /wpjm:plugin-zip -->
