### PR TITLE
Set minDate in jquery datepicker

### DIFF
--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -1,7 +1,9 @@
 /* global job_manager_datepicker */
 jQuery(document).ready( function() {
+	var $date_today = new Date();
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
+		minDate    : $date_today,
 	};
 
 	if ( typeof job_manager_datepicker !== 'undefined' ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2705

### Changes Proposed in this Pull Request

* Add `minDate` for datepicker so you can't select date in the past for date options.

### Testing Instructions

* Make sure you have `Enable scheduled listings` enabled in the Settings
* Go to the frontend and create a job
* Make sure you can't select a previous date for the `Scheduled Date` option
* Also try with Application Deadline and in the backend, should be the same result

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix: prevent past dates from being used in the datepicker


<!-- wpjm:plugin-zip -->
----

| Plugin build for 6bb7e0215887d94113d4499669450728fd1a66e6 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2737-6bb7e021.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2737-6bb7e021)             |

<!-- /wpjm:plugin-zip -->
