### PR TITLE
Add stats unique listing view and ajax - based endpoint

### DIFF
--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -60,7 +60,6 @@
 				}
 			}
 		} );
-		// console.log( statsToRecord ); return;
 
 		var postData = new URLSearchParams();
 		postData.append( '_ajax_nonce', ajaxNonce );

--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -1,4 +1,4 @@
-/* global wpjm_stats */
+/* global job_manager_stats */
 ( function () {
 	function ready(fn) {
 		if (document.readyState !== 'loading') {

--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -1,14 +1,8 @@
 /* global job_manager_stats */
-( function () {
-	// From https://youmightnotneedjquery.com/#ready
-	function ready( fn ) {
-		if ( document.readyState !== 'loading' ) {
-			fn();
-		} else {
-			document.addEventListener( 'DOMContentLoaded', fn );
-		}
-	}
 
+import domReady from '@wordpress/dom-ready';
+
+( function () {
 	function updateDailyUnique( key ) {
 		var date = new Date();
 		var expiresAtTimestamp = date.getTime() + 24 * 60 * 60 * 1000;
@@ -25,7 +19,7 @@
 		return false;
 	}
 
-	ready( function () {
+	domReady( function () {
 		var statsToRecord = [];
 		var jobStatsSettings = window.job_manager_stats;
 		var ajaxUrl = jobStatsSettings.ajax_url;

--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -1,5 +1,6 @@
 /* global job_manager_stats */
 ( function () {
+	// From https://youmightnotneedjquery.com/#ready
 	function ready(fn) {
 		if (document.readyState !== 'loading') {
 			fn();
@@ -8,11 +9,13 @@
 		}
 	}
 
-	function createCookie(name,value,days,path) {
+	// Cookie funcs are copied verbatim from http://www.quirksmode.org/js/cookies.html, tweaked to include path.
+	function createCookie( name, value, days, path ) {
+		var expires = "";
 		if (days) {
 			var date = new Date();
-			date.setTime(date.getTime()+(days*24*60*60*1000));
-			var expires = "; expires="+date.toGMTString();
+			date.setTime( date.getTime() + ( days * 24 * 60 * 60 * 1000 ) );
+			var expires = "; expires=" + date.toGMTString();
 		}
 		else var expires = "";
 		document.cookie = name+"="+value+expires+"; path=" + path;

--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -64,7 +64,6 @@
 			body: postData,
 		} ).finally( function () {
 			setUniques();
-			console.log( 'sent' );
 		} );
 	} );
 } )();

--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -4,37 +4,36 @@ import domReady from '@wordpress/dom-ready';
 
 ( function () {
 	function updateDailyUnique( key ) {
-		var date = new Date();
-		var expiresAtTimestamp = date.getTime() + 24 * 60 * 60 * 1000;
+		const date = new Date();
+		const expiresAtTimestamp = date.getTime() + 24 * 60 * 60 * 1000;
 		window.localStorage[key] = expiresAtTimestamp;
 	}
 
 	function getDailyUnique( name ) {
 		if ( window.localStorage[name] ) {
-			var date = new Date();
-			var now = date.getTime();
-			var expiration = parseInt( window.localStorage[name], 10 );
+			const date = new Date();
+			const now  = date.getTime();
+			const expiration = parseInt( window.localStorage[ name ], 10 );
 			return expiration >= now;
 		}
 		return false;
 	}
 
 	domReady( function () {
-		var statsToRecord = [];
-		var jobStatsSettings = window.job_manager_stats;
-		var ajaxUrl = jobStatsSettings.ajax_url;
-		var ajaxNonce = jobStatsSettings.ajax_nonce;
-		var uniquesToSet = [];
-		var setUniques = function () {
-			uniquesToSet.forEach( function ( uniqueKey ) {
+		const statsToRecord = [];
+		const jobStatsSettings = window.job_manager_stats;
+		const ajaxUrl          = jobStatsSettings.ajax_url;
+		const ajaxNonce      = jobStatsSettings.ajax_nonce;
+		const uniquesToSet = [];
+		const setUniques   = function() {
+			uniquesToSet.forEach( function( uniqueKey ) {
 				updateDailyUnique( uniqueKey );
 			} );
 		};
 
-		jobStatsSettings.stats_to_log.forEach( function ( statToRecord ) {
-			// do something.
-			var statToRecordKey = statToRecord.name;
-			var uniqueKey = statToRecord.unique_key || '';
+		jobStatsSettings.stats_to_log?.forEach( function ( statToRecord ) {
+			const statToRecordKey = statToRecord.name;
+			const uniqueKey       = statToRecord.unique_key || '';
 			if ( uniqueKey.length === 0 ) {
 				statsToRecord.push( statToRecordKey );
 			} else {
@@ -45,11 +44,11 @@ import domReady from '@wordpress/dom-ready';
 			}
 		} );
 
-		var postData = new URLSearchParams( {
+		const postData = new URLSearchParams( {
 			_ajax_nonce: ajaxNonce,
 			post_id: jobStatsSettings.post_id || 0,
 			action: 'job_manager_log_stat',
-			stats: statsToRecord.join( ',' )
+			stats: statsToRecord.join( ',' ),
 		} );
 
 		fetch( ajaxUrl, {

--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -1,42 +1,41 @@
 /* global job_manager_stats */
 ( function () {
 	// From https://youmightnotneedjquery.com/#ready
-	function ready(fn) {
-		if (document.readyState !== 'loading') {
+	function ready( fn ) {
+		if ( document.readyState !== 'loading' ) {
 			fn();
 		} else {
-			document.addEventListener('DOMContentLoaded', fn);
+			document.addEventListener( 'DOMContentLoaded', fn );
 		}
 	}
 
 	// Cookie funcs are copied verbatim from http://www.quirksmode.org/js/cookies.html, tweaked to include path.
 	function createCookie( name, value, days, path ) {
-		var expires = "";
-		if (days) {
+		var expires = '';
+		if ( days ) {
 			var date = new Date();
-			date.setTime( date.getTime() + ( days * 24 * 60 * 60 * 1000 ) );
-			var expires = "; expires=" + date.toGMTString();
-		}
-		else var expires = "";
-		document.cookie = name+"="+value+expires+"; path=" + path;
+			date.setTime( date.getTime() + days * 24 * 60 * 60 * 1000 );
+			var expires = '; expires=' + date.toGMTString();
+		} else var expires = '';
+		document.cookie = name + '=' + value + expires + '; path=' + path;
 	}
 
-	function readCookie(name) {
-		var nameEQ = name + "=";
-		var ca = document.cookie.split(';');
-		for(var i=0;i < ca.length;i++) {
-			var c = ca[i];
-			while (c.charAt(0)==' ') c = c.substring(1,c.length);
-			if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+	function readCookie( name ) {
+		var nameEQ = name + '=';
+		var ca = document.cookie.split( ';' );
+		for ( var i = 0; i < ca.length; i++ ) {
+			var c = ca[ i ];
+			while ( c.charAt( 0 ) == ' ' ) c = c.substring( 1, c.length );
+			if ( c.indexOf( nameEQ ) == 0 ) return c.substring( nameEQ.length, c.length );
 		}
 		return null;
 	}
 
-	function eraseCookie(name) {
-		createCookie(name,"",-1);
+	function eraseCookie( name ) {
+		createCookie( name, '', -1 );
 	}
 
-	ready( function ()  {
+	ready( function () {
 		var statsToRecord = [];
 		var jobStatsSettings = window.job_manager_stats;
 		var ajaxUrl = jobStatsSettings.ajax_url;
@@ -48,7 +47,6 @@
 			} );
 		};
 
-
 		jobStatsSettings.stats_to_log.forEach( function ( statToRecord ) {
 			// do something.
 			var statToRecordKey = statToRecord.name;
@@ -56,7 +54,7 @@
 			if ( uniqueKey.length === 0 ) {
 				statsToRecord.push( statToRecordKey );
 			} else {
-				if ( null === readCookie( uniqueKey) ) {
+				if ( null === readCookie( uniqueKey ) ) {
 					cookiesToSet.push( uniqueKey );
 					statsToRecord.push( statToRecordKey );
 				}
@@ -68,14 +66,14 @@
 		postData.append( '_ajax_nonce', ajaxNonce );
 		postData.append( 'post_id', jobStatsSettings.post_id || 0 );
 		postData.append( 'action', 'job_manager_log_stat' );
-		postData.append( 'stats', statsToRecord.join(',') );
+		postData.append( 'stats', statsToRecord.join( ',' ) );
 		fetch( ajaxUrl, {
 			method: 'POST',
-			credentials: "same-origin",
+			credentials: 'same-origin',
 			body: postData,
 		} ).finally( function () {
 			setCookies();
-			console.log( 'sent');
+			console.log( 'sent' );
 		} );
 	} );
-}() );
+} )();

--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -1,0 +1,78 @@
+/* global wpjm_stats */
+( function () {
+	function ready(fn) {
+		if (document.readyState !== 'loading') {
+			fn();
+		} else {
+			document.addEventListener('DOMContentLoaded', fn);
+		}
+	}
+
+	function createCookie(name,value,days,path) {
+		if (days) {
+			var date = new Date();
+			date.setTime(date.getTime()+(days*24*60*60*1000));
+			var expires = "; expires="+date.toGMTString();
+		}
+		else var expires = "";
+		document.cookie = name+"="+value+expires+"; path=" + path;
+	}
+
+	function readCookie(name) {
+		var nameEQ = name + "=";
+		var ca = document.cookie.split(';');
+		for(var i=0;i < ca.length;i++) {
+			var c = ca[i];
+			while (c.charAt(0)==' ') c = c.substring(1,c.length);
+			if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+		}
+		return null;
+	}
+
+	function eraseCookie(name) {
+		createCookie(name,"",-1);
+	}
+
+	ready( function ()  {
+		var statsToRecord = [];
+		var jobStatsSettings = window.job_manager_stats;
+		var ajaxUrl = jobStatsSettings.ajax_url;
+		var ajaxNonce = jobStatsSettings.ajax_nonce;
+		var cookiesToSet = [];
+		var setCookies = function () {
+			cookiesToSet.forEach( function ( uniqueKey ) {
+				createCookie( uniqueKey, 1, 1, '' );
+			} );
+		};
+
+
+		jobStatsSettings.stats_to_log.forEach( function ( statToRecord ) {
+			// do something.
+			var statToRecordKey = statToRecord.name;
+			var uniqueKey = statToRecord.unique_key || '';
+			if ( uniqueKey.length === 0 ) {
+				statsToRecord.push( statToRecordKey );
+			} else {
+				if ( null === readCookie( uniqueKey) ) {
+					cookiesToSet.push( uniqueKey );
+					statsToRecord.push( statToRecordKey );
+				}
+			}
+		} );
+		// console.log( statsToRecord ); return;
+
+		var postData = new URLSearchParams();
+		postData.append( '_ajax_nonce', ajaxNonce );
+		postData.append( 'post_id', jobStatsSettings.post_id || 0 );
+		postData.append( 'action', 'job_manager_log_stat' );
+		postData.append( 'stats', statsToRecord.join(',') );
+		fetch( ajaxUrl, {
+			method: 'POST',
+			credentials: "same-origin",
+			body: postData,
+		} ).finally( function () {
+			setCookies();
+			console.log( 'sent');
+		} );
+	} );
+}() );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -256,7 +256,7 @@ class Stats {
 		\WP_Job_Manager::register_script(
 			'wp-job-manager-stats',
 			'js/wpjm-stats.js',
-			[],
+			[ 'wp-dom-ready' ],
 			true
 		);
 

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -194,7 +194,7 @@ class Stats {
 	 * @return void
 	 */
 	public function maybe_log_stat_ajax() {
-		if ( ! ( defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
+		if ( ! wp_doing_ajax() ) {
 			return;
 		}
 

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -289,7 +289,7 @@ class Stats {
 				],
 				'job_listing_view_unique' => [
 					'unique'          => true,
-					'unique_callback' => [ self::class, 'unique_by_post_id' ],
+					'unique_callback' => [ $this, 'unique_by_post_id' ],
 				],
 			]
 		);

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -252,7 +252,7 @@ class Stats {
 		\WP_Job_Manager::register_script(
 			'wp-job-manager-stats',
 			'js/wpjm-stats.js',
-			[ 'jquery' ],
+			[],
 			true
 		);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const files = {
 	'js/job-submission': 'js/job-submission.js',
 	'js/multiselect': 'js/multiselect.js',
 	'js/term-multiselect': 'js/term-multiselect.js',
+	'js/wpjm-stats': 'js/wpjm-stats.js',
 	'js/admin/job-editor': 'js/admin/job-editor.js',
 	'js/admin/wpjm-notice-dismiss': 'js/admin/wpjm-notice-dismiss.js',
 	'js/admin/job-tags-upsell': 'js/admin/job-tags-upsell.js',


### PR DESCRIPTION
Fixes #2731

### Changes Proposed in this Pull Request

* Introduces an ajax endpoint for recording multiple stats at once.
* Adds ~cookie-based~ localSorage-based unique stat recording.
* Removes logging of stats in the backend. Reason is that pages can be cached.

Notes:

* Caveat: this will not work if JS is disabled. Maybe something we should think about.
* This is not a comprehensive solution for all the different stat use cases we want to cover, but contains the kernels of a solution.
* The general idea of stats being a declarative key-value thing seems appealing and close to how wpjm does things in other places like e.g. forms, or how wp rest api declares endpoints. Also it is easy to extend and refactor, without a class explosion.
* Deriving a stat's unique key should probably be a callback in the future. This is also somethihg that can be handled in this declarative stat style by having certain definition elements accept/be callbacks.
* We might want to optimize inserts, but we can do that later.
* Any better idea for the js cookie funcs? (Edit: we used localStorage instead)


### Testing Instructions

* Visit a job listing page.
* Check that one view and one unique view are added to the db.
* Refresh.
* Check that unique view is not incremented.
* Delete cookie. Refresh.
* Check that one view and one unique view are added to the db.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* 

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video














<!-- wpjm:plugin-zip -->
----

| Plugin build for 83ba197ee2e960b1c48f5af9d788d27de8504fee <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2738-83ba197e.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2738-83ba197e)             |

<!-- /wpjm:plugin-zip -->
























