### PR TITLE
Add job listing stats queries and views column

### DIFF
--- a/includes/class-job-listing-stats.php
+++ b/includes/class-job-listing-stats.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager_Stats
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class is responsible for initializing all aspects of stats for wpjm.
+ */
+class Job_Listing_Stats {
+
+	const JOB_LISTING_VIEW        = 'job_listing_view';
+	const JOB_LISTING_VIEW_UNIQUE = 'job_listing_view_unique';
+
+	/**
+	 * Job listing post ID.
+	 *
+	 * @var mixed
+	 */
+	private $job_id;
+
+	/**
+	 * Publish date of the job listing.
+	 *
+	 * @var string
+	 */
+	private $start_date;
+
+	/**
+	 * Stats for a single job listing.
+	 *
+	 * @param int $job_id
+	 */
+	public function __construct( $job_id ) {
+
+		$this->job_id     = $job_id;
+		$this->start_date = get_post_datetime( $job_id )->format( 'Y-m-d' );
+
+	}
+
+	/**
+	 * Get total stats for a job listing.
+	 *
+	 * @return array
+	 */
+	public function get_total_stats() {
+		return [
+			'view'        => $this->get_event_total( self::JOB_LISTING_VIEW ),
+			'view_unique' => $this->get_event_total( self::JOB_LISTING_VIEW_UNIQUE ),
+		];
+	}
+
+	/**
+	 * Get daily stats for a job listing.
+	 *
+	 * @return array
+	 */
+	public function get_daily_stats() {
+		return [
+			'view'        => $this->get_event_daily( self::JOB_LISTING_VIEW ),
+			'view_unique' => $this->get_event_daily( self::JOB_LISTING_VIEW_UNIQUE ),
+		];
+	}
+
+	/**
+	 * Get totals for an event.
+	 *
+	 * @param string $event
+	 *
+	 * @return int
+	 */
+	public function get_event_total( $event ) {
+
+		global $wpdb;
+
+		$cache_key = 'wpjm_stats_sum_' . $event . '_' . $this->job_id;
+		$sum       = wp_cache_get( $cache_key, Stats::CACHE_GROUP );
+
+		if ( false !== $sum ) {
+			return $sum;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$sum = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT SUM(count) FROM {$wpdb->wpjm_stats}
+              WHERE post_id = %d AND name = %s AND date >= %s",
+				$this->job_id,
+				$event,
+				$this->start_date
+			)
+		);
+
+		$sum = is_numeric( $sum ) ? (int) $sum : 0;
+
+		wp_cache_set( $cache_key, $sum, Stats::CACHE_GROUP, HOUR_IN_SECONDS );
+
+		return $sum;
+	}
+
+	/**
+	 * Get daily breakdown of stats for an event.
+	 *
+	 * @param string $event
+	 *
+	 * @return array
+	 */
+	public function get_event_daily( $event ) {
+		global $wpdb;
+
+		$cache_key = 'wpjm_stats_daily_' . $event . '_' . $this->job_id;
+		$views     = wp_cache_get( $cache_key, Stats::CACHE_GROUP );
+
+		if ( false !== $views ) {
+			return $views;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$views = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT date, count FROM {$wpdb->wpjm_stats}
+		  WHERE post_id = %d AND name = %s AND date BETWEEN %s AND %s
+		  ORDER BY date DESC",
+				$this->job_id,
+				$event,
+				$this->start_date,
+				( new \DateTime( 'yesterday' ) )->format( 'Y-m-d' )
+			),
+			OBJECT_K
+		);
+
+		wp_cache_set( $cache_key, $views, Stats::CACHE_GROUP, strtotime( 'tomorrow' ) - time() );
+
+		return $views;
+
+	}
+
+
+}

--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -16,6 +16,8 @@ class Stats_Dashboard {
 
 	use Singleton;
 
+	private const COLUMN_NAME = 'stats';
+
 	/**
 	 * Constructor.
 	 */
@@ -26,7 +28,7 @@ class Stats_Dashboard {
 		}
 
 		add_filter( 'job_manager_job_dashboard_columns', [ $this, 'add_stats_column' ] );
-		add_action( 'job_manager_job_dashboard_column_stats', [ $this, 'render_stats_column' ] );
+		add_action( 'job_manager_job_dashboard_column_' . self::COLUMN_NAME, [ $this, 'render_stats_column' ] );
 
 		add_filter( 'manage_edit-job_listing_columns', [ $this, 'add_stats_column' ], 20 );
 		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'maybe_render_job_listing_posts_custom_column' ], 2 );
@@ -39,7 +41,7 @@ class Stats_Dashboard {
 	 * @return array
 	 */
 	public function add_stats_column( $columns ) {
-		$columns['stats'] = __( 'Views', 'wp-job-manager' );
+		$columns[ self::COLUMN_NAME ] = __( 'Views', 'wp-job-manager' );
 		return $columns;
 
 	}
@@ -52,7 +54,6 @@ class Stats_Dashboard {
 	public function render_stats_column( $job ) {
 		$stats = new Job_Listing_Stats( $job->ID );
 		$total = $stats->get_total_stats();
-		$daily = $stats->get_daily_stats();
 
 		$views = $total['view'];
 
@@ -70,7 +71,7 @@ class Stats_Dashboard {
 	public function maybe_render_job_listing_posts_custom_column( $column ) {
 		global $post;
 
-		if ( 'stats' === $column ) {
+		if ( self::COLUMN_NAME === $column ) {
 			$this->render_stats_column( $post );
 		}
 	}

--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * File containing the class Stats_Dashboard.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+/**
+ * Job listing stats for the jobs dashboard.
+ *
+ * @since $$next-version$$
+ */
+class Stats_Dashboard {
+
+	use Singleton;
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+
+		if ( ! Stats::is_enabled() ) {
+			return;
+		}
+
+		add_filter( 'job_manager_job_dashboard_columns', [ $this, 'add_stats_column' ] );
+		add_action( 'job_manager_job_dashboard_column_stats', [ $this, 'render_stats_column' ] );
+
+		add_filter( 'manage_edit-job_listing_columns', [ $this, 'add_stats_column' ], 20 );
+		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'maybe_render_job_listing_posts_custom_column' ], 2 );
+	}
+
+	/**
+	 * Add a new column to the job dashboards.
+	 *
+	 * @param array $columns
+	 * @return array
+	 */
+	public function add_stats_column( $columns ) {
+		$columns['stats'] = __( 'Views', 'wp-job-manager' );
+		return $columns;
+
+	}
+
+	/**
+	 * Output the stats column content.
+	 *
+	 * @param \WP_Post $job
+	 */
+	public function render_stats_column( $job ) {
+		$stats = new Job_Listing_Stats( $job->ID );
+		$total = $stats->get_total_stats();
+		$daily = $stats->get_daily_stats();
+
+		$views = $total['view'];
+
+		// translators: %1d is the number of views.
+		$views_str = '<span>' . sprintf( _n( '%1d view', '%1d views', $views, 'wp-job-manager' ), $views ) . '</span>';
+
+		echo wp_kses_post( $views_str );
+	}
+
+	/**
+	 * Output stats column for the job listing post type admin screen.
+	 *
+	 * @param  string $column
+	 */
+	public function maybe_render_job_listing_posts_custom_column( $column ) {
+		global $post;
+
+		if ( 'stats' === $column ) {
+			$this->render_stats_column( $post );
+		}
+	}
+}

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -17,14 +17,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Stats {
 	use Singleton;
 
-	const TABLE       = 'wpjm_stats';
-	const CACHE_GROUP = 'wpjm_stats';
+	const         CACHE_GROUP = 'wpjm_stats';
 
 	const DEFAULT_LOG_STAT_ARGS = [
 		'group'        => '',
 		'post_id'      => 0,
 		'increment_by' => 1,
 	];
+
+	private const TABLE = 'wpjm_stats';
 
 	/**
 	 * Constructor.

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -17,6 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Stats {
 	use Singleton;
 
+	const TABLE       = 'wpjm_stats';
+	const CACHE_GROUP = 'wpjm_stats';
+
 	const DEFAULT_LOG_STAT_ARGS = [
 		'group'        => '',
 		'post_id'      => 0,
@@ -34,6 +37,12 @@ class Stats {
 	 * Do initialization of all the things needed for stats.
 	 */
 	public function init() {
+
+		include_once __DIR__ . '/class-job-listing-stats.php';
+		include_once __DIR__ . '/class-stats-dashboard.php';
+
+		Stats_Dashboard::instance();
+
 		$this->initialize_wpdb();
 		$this->hook();
 	}
@@ -48,8 +57,8 @@ class Stats {
 		if ( isset( $wpdb->wpjm_stats ) ) {
 			return;
 		}
-		$wpdb->wpjm_stats = $wpdb->prefix . 'wpjm_stats';
-		$wpdb->tables[]   = 'wpjm_stats';
+		$wpdb->wpjm_stats = $wpdb->prefix . self::TABLE;
+		$wpdb->tables[]   = self::TABLE;
 	}
 
 	/**
@@ -75,6 +84,15 @@ class Stats {
 			) {$collate}",
 			]
 		);
+	}
+
+	/**
+	 * Check if collecting and showing statistics are enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return get_option( 'job_manager_stats_enable', false );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2717, fixes #2740

### Changes Proposed in this Pull Request

* Add a `Job_Listing_Stats` class that handles queries for stats of a single job listing
* Add methods to sum up total stats, and to get daily breakdown
* Add a stats column with the total views in the [job_dashboard] shortcode and in the job listing admin screen

### Testing Instructions

* Enable stats in the setting
* Visit a few listings
* View the frontend job dashboard and see that the views are counted
* Also check the same thing in the WP-Admin Job Listings screen




<!-- wpjm:plugin-zip -->
----

| Plugin build for 2c2a7e38f188a9a4ada52155759bae33826fce96 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2750-2c2a7e38.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2750-2c2a7e38)             |

<!-- /wpjm:plugin-zip -->


