### PR TITLE
Update job dashboard template

### DIFF
--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -1,0 +1,98 @@
+
+@import "mixins";
+
+#job-manager-job-dashboard {
+
+}
+
+.jm-dashboard-job, .jm-dashboard-header {
+	display: flex;
+	align-items: center;
+	padding: var(--jm-ui-space-sm);
+	gap: var(--jm-ui-space-sm);
+	margin: var(--jm-ui-space-sm) 0;
+	font-size: var(--jm-ui-font-size-m);
+}
+
+.jm-dashboard-header {
+	color: fadeCurrentColor(85%);
+	margin-bottom: unset;
+	padding-bottom: unset;
+}
+
+.jm-dashboard__intro {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	flex-wrap: wrap;
+	gap: var(--jm-ui-space-sm);
+}
+
+.jm-dashboard-job {
+	border: var(--jm-ui-border-size) solid var(--jm-ui-border-light);
+}
+
+.jm-dashboard-job-column {
+	flex: 1 1 calc(50% - var(--jm-ui-space-sm));
+	min-width: 0;
+}
+
+.jm-dashboard small {
+	font-size: var(--jm-ui-font-size-s);
+}
+
+.jm-dashboard-job-column.job_title {
+	flex: 1 1 200%;
+
+	.job-status {
+		text-transform: uppercase;
+		font-weight: 500;
+		font-size: var(--jm-ui-font-size-s);
+		line-height: var(--jm-ui-icon-size-s);
+		color: fadeCurrentColor( 80% );
+
+		.jm-ui-icon {
+			width: var(--jm-ui-icon-size-s);
+			height: var(--jm-ui-icon-size-s);
+		}
+	}
+}
+
+
+.jm-dashboard-job-column.actions {
+	flex: 0.5 1 100%;
+	text-align: right;
+}
+
+.jm-dashboard-job-column a.job-title {
+	font-weight: 600;
+	font-size: var(--jm-ui-font-size);
+	text-decoration: unset;
+}
+
+.jm-dashboard-job-column a.job-title:hover {
+	text-decoration: underline;
+}
+
+.jm-dashboard-action {
+	display: block;
+	text-decoration: none;
+
+}
+.jm-dashboard-action:where(:not(:hover):not(:focus)) {
+	color: inherit;
+}
+
+.job-dashboard-action-delete {
+	color: var(--jm-ui-danger-color);
+}
+
+@media (max-width: 600px) {
+	.jm-dashboard-job {
+		flex-wrap: wrap;
+	}
+
+	.jm-dashboard-header {
+		display: none;
+	}
+}

--- a/assets/css/ui.dialog.scss
+++ b/assets/css/ui.dialog.scss
@@ -80,10 +80,7 @@
 	opacity: 0.7;
 
 	.jm-ui-button__icon {
-		background-color: currentColor;
-		mask: var(--jm-ui-svg-close) no-repeat center center;
-		width: var(--jm-ui-icon-size);
-		height: var(--jm-ui-icon-size);
+		mask-image: var(--jm-ui-svg-close);
 	}
 
 }

--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -90,6 +90,13 @@
 	}
 }
 
+.jm-ui-button__icon {
+	background-color: currentColor;
+	mask: var(--jm-ui-svg-close) no-repeat center center;
+	width: var(--jm-ui-icon-size);
+	height: var(--jm-ui-icon-size);
+}
+
 .jm-ui-link {
 	border-radius: 2px;
 
@@ -102,7 +109,7 @@
 	}
 }
 
-.jm-ui-actions {
+.jm-ui-actions-row {
 	display: flex;
 	flex-direction: row;
 	gap: var(--jm-ui-space-s);
@@ -114,4 +121,76 @@
 	.jm-ui-button--link ~ .jm-ui-button--link {
 		margin-left: calc(-1 * var(--jm-ui-space-s));
 	}
+}
+
+.jm-ui-icon {
+	display: inline-block;
+	flex: 0 0 auto;
+	width: var(--jm-ui-icon-size);
+	height: var(--jm-ui-icon-size);
+	mask-size: 100% 100%;
+
+	&[data-icon=check] {
+		background-color: currentColor;
+		mask-image:  url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cg stroke-width=\'1.5\'%3e%3cpath stroke=\'%231E1E1E\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath stroke=\'black\' d=\'m15.96 8.18-5.34 7.18-3.1-2.3\'/%3e%3c/g%3e%3c/svg%3e');
+	}
+
+	&[data-icon=check-circle] {
+		background-color: currentColor;
+		mask-image:  url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cg stroke-width=\'1.5\'%3e%3cpath stroke=\'%231E1E1E\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath stroke=\'black\' d=\'m15.96 8.18-5.34 7.18-3.1-2.3\'/%3e%3c/g%3e%3c/svg%3e');
+	}
+
+	&[data-icon=check] {
+		background-color: currentColor;
+		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' fill-rule='evenodd' d='m17.93 7.98-7.2 9.68-4.52-3.36.9-1.2 3.31 2.46 6.3-8.48 1.2.9Z' clip-rule='evenodd'/%3e%3c/svg%3e");
+	}
+
+	&[data-icon=star] {
+		background-color: currentColor;
+		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' d='M11.78 4.45a.25.25 0 0 1 .44 0l2.07 4.2c.04.07.11.12.2.13l4.62.68c.2.02.28.28.14.42l-3.35 3.26a.25.25 0 0 0-.07.23l.79 4.6c.03.2-.18.36-.37.27l-4.13-2.18a.25.25 0 0 0-.24 0l-4.13 2.18a.25.25 0 0 1-.37-.27l.8-4.6a.25.25 0 0 0-.08-.23L4.75 9.88a.25.25 0 0 1 .14-.42l4.63-.68a.25.25 0 0 0 .19-.13l2.07-4.2Z'/%3e%3c/svg%3e");
+	}
+
+	&[data-icon=info] {
+		background-color: currentColor;
+		mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3ccircle cx=\'12\' cy=\'12\' r=\'8\' stroke=\'black\' stroke-width=\'1.5\'/%3e%3cpath fill=\'black\' d=\'M11 11h2v6h-2zm0-4h2v2h-2z\'/%3e%3c/svg%3e');
+	}
+
+	&[data-icon=alert] {
+		background-color: currentColor;
+		mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cpath stroke=\'%231E1E1E\' stroke-width=\'1.5\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath fill=\'%231E1E1E\' d=\'M13 7h-2v6h2V7Zm0 8h-2v2h2v-2Z\'/%3e%3c/svg%3e');
+	}
+}
+
+/*
+ * Action menu.
+ */
+.jm-ui-actions-menu {
+	position: relative;
+	display: inline-block;
+}
+
+.jm-ui-action-menu__open-button {
+	cursor: pointer;
+
+	.jm-ui-button__icon {
+		mask-image: var(--jm-ui-svg-ellipsis-v);
+	}
+}
+
+.jm-ui-action-menu__content {
+	position: absolute;
+	right: 0;
+	top: calc(100% + 2px);
+	border: var(--jm-ui-border-size) solid var(--jm-ui-border-strong);
+	border-radius: var(--jm-ui-radius);
+	background-color: var(--jm-ui-background-color, #fff);
+	box-shadow: var(--jm-ui-shadow-popover);
+	padding: var(--jm-ui-space-s);
+	z-index: 10;
+	font-size: var(--jm-ui-font-size-s);
+	text-align: left;
+	white-space: nowrap;
+
+	display: flex;
+	flex-direction: column;
 }

--- a/assets/css/ui.neutral.scss
+++ b/assets/css/ui.neutral.scss
@@ -13,15 +13,19 @@
 	--jm-ui-radius-4x: calc(4 * var(--jm-ui-radius));
 
 	--jm-ui-accent-color: inherit;
+	--jm-ui-danger-color: #cc1818;
+	--jm-ui-error-color: #cc1818;
+	--jm-ui-info-color: #4e71ec;
+	--jm-ui-success-color: #4ab866;
 	--jm-ui-accent-color-contrast: #ffffff;
 
 	--jm-ui-button-color: var(--jm-ui-accent-color);
 	--jm-ui-button-contrast: var(--jm-ui-accent-color-contrast, #ffffff);
 	--jm-ui-link-color: var(--jm-ui-accent-color, inherit);
 
-	--jm-ui-notice-error: #cc1818;
-	--jm-ui-notice-info: #4e71ec;
-	--jm-ui-notice-success: #4ab866;
+	--jm-ui-notice-error: var(--jm-ui-danger-color);
+	--jm-ui-notice-info: var(--jm-ui-info-color);
+	--jm-ui-notice-success: var(--jm-ui-success-color);
 	--jm-ui-notice-strong: var(--jm-ui-border-strong);
 
 	--jm-ui-notice-shadow: none;
@@ -43,17 +47,24 @@
 	--jm-ui-space-xxl: calc(24 * var(--jm-ui-space-base)); // 96px
 
 	--jm-ui-font-size: 16px;
+	--jm-ui-font-size-m: 14px;
+	--jm-ui-font-size-s: 12px;
 	--jm-ui-heading-font-size: 20px;
 	--jm-ui-large-font-size: 24px;
 	--jm-ui-button-font-size: 14px;
 	--jm-ui-icon-size: 24px;
+	--jm-ui-icon-size-m: 20px;
+	--jm-ui-icon-size-s: 18px;
 
 	--jm-ui-shadow-modal: 0 0.7px 1px 0 rgba(0, 0, 0, 0.15),
 	0 2.7px 3.8px -0.2px rgba(0, 0, 0, 0.15),
 	0px 5.5px 7.8px -0.3px rgba(0, 0, 0, 0.15),
 	0.1px 11.5px 16.4px -0.5px rgba(0, 0, 0, 0.15);
 
+	--jm-ui-shadow-popover: 0px 2px 6px 0px rgba(0, 0, 0, 0.05);
+
 	--jm-ui-svg-close: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' d='m12 13.06 3.71 3.71 1.06-1.06-3.7-3.71 3.7-3.71-1.06-1.06-3.71 3.7-3.71-3.7-1.06 1.06 3.7 3.71-3.7 3.71 1.06 1.06 3.71-3.7Z'/%3e%3c/svg%3e");
-	--jm-ui-svg-arrow-down: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='32' height='6' viewBox='0 0 16 10'%3e%3cpath fill='currentColor' fill-rule='evenodd' d='M0 1.6 1.53 0 8 6.95 14.5 0 16 1.6 8 10 0 1.6Z' clip-rule='evenodd'/%3e%3c/svg%3e");
-	--jm-ui-svg-check: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='%231E1E1E' stroke-width='1.5' d='m18.93 6-8.9 11.97-5.16-3.84'/%3e%3c/svg%3e");
+	--jm-ui-svg-arrow-down: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='32' height='6' viewBox='0 0 16 10'%3e%3cpath fill='black' fill-rule='evenodd' d='M0 1.6 1.53 0 8 6.95 14.5 0 16 1.6 8 10 0 1.6Z' clip-rule='evenodd'/%3e%3c/svg%3e");
+	--jm-ui-svg-check: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='black' stroke-width='1.5' d='m18.93 6-8.9 11.97-5.16-3.84'/%3e%3c/svg%3e");
+	--jm-ui-svg-ellipsis-v: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' fill-rule='evenodd' d='M11 19v-2h2v2h-2Zm0-6v-2h2v2h-2Zm0-6V5h2v2h-2Z' clip-rule='evenodd'/%3e%3c/svg%3e");
 }

--- a/assets/css/ui.notice.scss
+++ b/assets/css/ui.notice.scss
@@ -33,7 +33,7 @@
 		&.color-#{$color} {
 			border-color: var(--jm-ui-notice-#{$color});
 			background-color: color-mix(in srgb, transparent, var(--jm-ui-notice-#{$color}) var(--jm-ui-background-opacity));
-			.jm-notice__icon {
+			.jm-ui-icon {
 				color: var(--jm-ui-notice-#{$color});
 			}
 		}
@@ -88,28 +88,6 @@
 		{
 			padding: var(--jm-ui-space-s2) var(--jm-ui-space-sm);
 		}
-	}
-}
-
-.jm-notice__icon {
-	flex: 0 0 auto;
-	width: var(--jm-ui-icon-size);
-	height: var(--jm-ui-icon-size);
-	mask-size: 100% 100%;
-
-	&[data-icon=check] {
-		background-color: currentColor;
-		mask-image:  url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cg stroke-width=\'1.5\'%3e%3cpath stroke=\'%231E1E1E\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath stroke=\'black\' d=\'m15.96 8.18-5.34 7.18-3.1-2.3\'/%3e%3c/g%3e%3c/svg%3e');
-	}
-
-	&[data-icon=info] {
-		background-color: currentColor;
-		mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3ccircle cx=\'12\' cy=\'12\' r=\'8\' stroke=\'black\' stroke-width=\'1.5\'/%3e%3cpath fill=\'black\' d=\'M11 11h2v6h-2zm0-4h2v2h-2z\'/%3e%3c/svg%3e');
-	}
-
-	&[data-icon=alert] {
-		background-color: currentColor;
-		mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cpath stroke=\'%231E1E1E\' stroke-width=\'1.5\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath fill=\'%231E1E1E\' d=\'M13 7h-2v6h2V7Zm0 8h-2v2h2v-2Z\'/%3e%3c/svg%3e');
 	}
 }
 

--- a/includes/ui/class-notice.php
+++ b/includes/ui/class-notice.php
@@ -32,7 +32,7 @@ class Notice {
 
 		return self::render(
 			array_merge(
-				[ 'icon' => 'check' ],
+				[ 'icon' => 'check-circle' ],
 				$args
 			)
 		);

--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -26,10 +26,11 @@ class UI_Elements {
 	 * Generate HTML for a notice icon.
 	 *
 	 * @param string|null $icon Icon name or a safe SVG code.
+	 * @param string      $label Accessible icon label.
 	 *
 	 * @return string Icon HTML.
 	 */
-	public static function icon( $icon ) {
+	public static function icon( $icon, $label = '' ) {
 
 		if ( empty( $icon ) ) {
 			return '';
@@ -39,10 +40,14 @@ class UI_Elements {
 
 		$is_classname = preg_match( '/^[\w-]+$/i', $icon );
 
-		$html = '<div class="jm-notice__icon"';
+		$html = '<span class="jm-ui-icon"';
 
 		if ( $is_classname ) {
 			$html .= ' data-icon="' . esc_attr( $icon ) . '"';
+		}
+
+		if ( $label ) {
+			$html .= ' aria-label="' . esc_attr( $label ) . '"';
 		}
 
 		$html .= '>';
@@ -51,7 +56,7 @@ class UI_Elements {
 			$html .= self::esc_svg( $icon );
 		}
 
-		$html .= '</div>';
+		$html .= '</span>';
 
 		return $html;
 	}
@@ -130,7 +135,63 @@ class UI_Elements {
 			return '';
 		}
 
-		return '<div class="jm-ui-actions">' . implode( '', $actions_html ) . '</div>';
+		return '<div class="jm-ui-actions-row">' . implode( '', $actions_html ) . '</div>';
+
+	}
+
+	/**
+	 * Generate an actions button with a dropdown menu.
+	 *
+	 * @param string $content Escaped HTML content.
+	 *
+	 * @return string Actions menu HTML.
+	 */
+	public static function actions_menu( $content ) {
+		$label = __( 'Actions', 'wp-job-manager' );
+		return <<<HTML
+<details class="jm-ui-actions-menu" onfocusout="event.currentTarget.contains(event.relatedTarget) || ( this.open = false )">
+	<summary tabindex="0" class="jm-ui-action-menu__open-button jm-ui-button--icon"
+		aria-label="{$label}">
+		<span class="jm-ui-button__icon"></span>
+	</summary>
+	<div class="jm-ui-action-menu__content">
+	{$content}
+	</div>
+</details>
+HTML;
+
+	}
+
+	/**
+	 * Generate HTML for a relative time string.
+	 *
+	 * @param string|\DateTimeInterface|int $time Time string, DateTime object, or timestamp.
+	 * @param string                        $format_string Sprintf-compatible format string. Should contain a %s placeholder for the time.
+	 *
+	 * @return string
+	 */
+	public static function rel_time( $time, $format_string = '%s' ) {
+
+		if ( is_string( $time ) ) {
+			$timestamp = strtotime( $time );
+		}
+
+		if ( $time instanceof \DateTimeInterface ) {
+			$timestamp = $time->getTimestamp();
+		}
+
+		if ( is_numeric( $time ) ) {
+			$timestamp = $time;
+		}
+
+		if ( empty( $timestamp ) ) {
+			return '';
+		}
+
+		$abs_time = date_i18n( get_option( 'date_format' ), $timestamp );
+		$rel_time = human_time_diff( $timestamp );
+
+		return '<time datetime="' . esc_attr( $abs_time ) . '" title="' . esc_attr( $abs_time ) . '">' . esc_html( sprintf( $format_string, $rel_time ) ) . '</time>';
 
 	}
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,6 +67,7 @@
 		<properties>
 			<property name="customEscapingFunctions" type="array">
 				<element value="wpjm_esc_json"/>
+				<element value="UI_Elements"/>
 			</property>
 		</properties>
 	</rule>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -8,8 +8,9 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.41.0
+ * @version     $$next-version$$
  *
+ * @since $$next-version$$ Switched to a responsive layout. job_manager_job_dashboard_column_{$key} action is called for all columns.
  * @since 1.34.4 Available job actions are passed in an array (`$job_actions`, keyed by job ID) and not generated in the template.
  * @since 1.35.0 Switched to new date functions.
  *

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -14,91 +14,88 @@
  * @since 1.35.0 Switched to new date functions.
  *
  * @var array     $job_dashboard_columns Array of the columns to show on the job dashboard page.
- * @var int       $max_num_pages         Maximum number of pages
- * @var WP_Post[] $jobs                  Array of job post results.
- * @var array     $job_actions           Array of actions available for each job.
+ * @var int       $max_num_pages Maximum number of pages
+ * @var WP_Post[] $jobs Array of job post results.
+ * @var array     $job_actions Array of actions available for each job.
  */
+
+use WP_Job_Manager\UI\UI_Elements;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$submission_limit			= ! empty( get_option( 'job_manager_submission_limit' ) ) ? absint( get_option( 'job_manager_submission_limit' ) ) : false;
-$submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
+$submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 ?>
-<div id="job-manager-job-dashboard">
-	<p><?php esc_html_e( 'Your listings are shown in the table below.', 'wp-job-manager' ); ?></p>
-	<table class="job-manager-jobs">
-		<thead>
-			<tr>
-				<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
-					<th class="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $column ); ?></th>
-				<?php endforeach; ?>
-			</tr>
-		</thead>
-		<tbody>
+
+<div id="job-manager-job-dashboard" class="alignwide">
+	<div class="jm-dashboard__intro">
+		<p><?php esc_html_e( 'Your listings are shown in the table below.', 'wp-job-manager' ); ?></p>
+		<?php if ( job_manager_user_can_submit_job_listing() ) : ?>
+			<div>
+				<a class="wp-element-button button"
+					href="<?php echo esc_url( get_permalink( $submit_job_form_page_id ) ); ?>"><?php esc_html_e( 'Add Job', 'wp-job-manager' ); ?></a>
+			</div>
+		<?php endif; ?>
+	</div>
+	<div class="job-manager-jobs jm-dashboard">
+		<div class="jm-dashboard-header">
+			<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
+				<div
+					class="jm-dashboard-job-column <?php echo esc_attr( $key ); ?>"><?php echo esc_html( $column ); ?></div>
+			<?php endforeach; ?>
+			<div class="jm-dashboard-job-column actions"><?php esc_html_e( 'Actions', 'wp-job-manager' ); ?></div>
+		</div>
+		<div class="jm-dashboard-rows">
 			<?php if ( ! $jobs ) : ?>
-				<tr>
-					<td colspan="<?php echo intval( count( $job_dashboard_columns ) ); ?>"><?php esc_html_e( 'You do not have any active listings.', 'wp-job-manager' ); ?></td>
-				</tr>
+				<div
+					class="jm-dashboard-empty"><?php esc_html_e( 'You do not have any active listings.', 'wp-job-manager' ); ?></div>
 			<?php else : ?>
 				<?php foreach ( $jobs as $job ) : ?>
-					<tr>
+					<div class="jm-dashboard-job">
 						<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
-							<td class="<?php echo esc_attr( $key ); ?>">
-								<?php if ('job_title' === $key ) : ?>
-									<?php if ( $job->post_status == 'publish' ) : ?>
-										<a href="<?php echo esc_url( get_permalink( $job->ID ) ); ?>"><?php wpjm_the_job_title( $job ); ?></a>
-										<?php if ( WP_Job_Manager_Helper_Renewals::job_can_be_renewed( $job ) ) : ?>
-											<small>(<?php esc_html_e('Expires soon', 'wp-job-manager'); ?>)</small>
-										<?php endif; ?>
-									<?php else : ?>
-										<?php wpjm_the_job_title( $job ); ?> <small>(<?php the_job_status( $job ); ?>)</small>
-									<?php endif; ?>
-									<?php echo is_position_featured( $job ) ? '<span class="featured-job-icon" title="' . esc_attr__( 'Featured Job', 'wp-job-manager' ) . '"></span>' : ''; ?>
-									<ul class="job-dashboard-actions">
-										<?php
-											if ( ! empty( $job_actions[ $job->ID ] ) ) {
-												foreach ( $job_actions[ $job->ID ] as $action => $value ) {
-													$action_url = add_query_arg( [
-														'action' => $action,
-														'job_id' => $job->ID
-													] );
-													if ( $value['nonce'] ) {
-														$action_url = wp_nonce_url( $action_url, $value['nonce'] );
-													}
-													echo '<li><a href="' . esc_url( $action_url ) . '" class="job-dashboard-action-' . esc_attr( $action ) . '">' . esc_html( $value['label'] ) . '</a></li>';
-												}
-											}
-										?>
-									</ul>
-								<?php elseif ('date' === $key ) : ?>
-									<?php echo esc_html( wp_date( get_option( 'date_format' ), get_post_datetime( $job )->getTimestamp() ) ); ?>
-								<?php elseif ('expires' === $key ) : ?>
-									<?php
-									$job_expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
-									echo esc_html( $job_expires ? wp_date( get_option( 'date_format' ), $job_expires->getTimestamp() ) : '&ndash;' );
-									?>
-								<?php elseif ('filled' === $key ) : ?>
-									<?php echo is_position_filled( $job ) ? '&#10004;' : '&ndash;'; ?>
-								<?php else : ?>
-									<?php do_action( 'job_manager_job_dashboard_column_' . $key, $job ); ?>
-								<?php endif; ?>
-							</td>
+							<div class="jm-dashboard-job-column <?php echo esc_attr( $key ); ?>"
+								aria-label="<?php echo esc_attr( $column ); ?>">
+								<?php
+
+								switch ( $key ) {
+									case 'job_title':
+										echo '<a class="job-title" href="' . esc_url( get_permalink( $job->ID ) ) . '">' . ( wpjm_get_the_job_title( $job ) ?? $job->ID ) . '</a>';
+										break;
+									case 'date':
+										echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', 'M d, Y' ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
+
+										break;
+								}
+
+								do_action( 'job_manager_job_dashboard_column_' . $key, $job );
+
+								?>
+							</div>
 						<?php endforeach; ?>
-					</tr>
+						<div class="jm-dashboard-job-column actions job-dashboard-job-actions">
+							<?php
+							$actions_html = '';
+							if ( ! empty( $job_actions[ $job->ID ] ) ) {
+								foreach ( $job_actions[ $job->ID ] as $action => $value ) {
+									$action_url = add_query_arg( [
+										'action' => $action,
+										'job_id' => $job->ID
+									] );
+									if ( $value['nonce'] ) {
+										$action_url = wp_nonce_url( $action_url, $value['nonce'] );
+									}
+									$actions_html .= '<a href="' . esc_url( $action_url ) . '" class=" jm-dashboard-action jm-ui-button--link job-dashboard-action-' . esc_attr( $action ) . '">' . esc_html( $value['label'] ) . '</a>' . "\n";
+								}
+							}
+
+							echo UI_Elements::actions_menu( $actions_html );
+							?>
+						</div>
+					</div>
 				<?php endforeach; ?>
 			<?php endif; ?>
-		</tbody>
-		<?php if ( job_manager_user_can_submit_job_listing() ) : ?>
-			<tfoot>
-				<tr>
-					<td colspan="<?php echo count( $job_dashboard_columns ); ?>">
-						<a href="<?php echo esc_url( get_permalink( $submit_job_form_page_id ) ); ?>"><?php esc_html_e( 'Add Job', 'wp-job-manager' ); ?></a>
-					</td>
-				</tr>
-			</tfoot>
-		<?php endif; ?>
-	</table>
+		</div>
+	</div>
 	<?php get_job_manager_template( 'pagination.php', [ 'max_num_pages' => $max_num_pages ] ); ?>
 </div>

--- a/templates/notice.php
+++ b/templates/notice.php
@@ -42,7 +42,7 @@ if ( in_array( 'message-icon', $classes, true ) ) {
 
 ?>
 
-<div class="jm-notice <?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+<div class="jm-notice <?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="status">
 	<?php if ( $title ) : ?>
 		<div class="jm-notice__header">
 			<?php echo $icon_html; ?>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ const files = {
 	'css/ui': 'css/ui.scss',
 	'css/job-listings': 'css/job-listings.scss',
 	'css/job-submission': 'css/job-submission.scss',
+	'css/job-dashboard': 'css/job-dashboard.scss',
 	'css/setup': 'css/setup.scss',
 	'css/menu': 'css/menu.scss',
 };


### PR DESCRIPTION
Fixes #2741

### Changes Proposed in this Pull Request

* Update the template and CSS for the [job_dashboard] shortcode. Replace tables with a responsive flex layout
* Fold some columns into status and date, move actions to a menu

### Testing Instructions

* Have some jobs and visit the page with the `[job_dashboard]` shortcode. Check it out in various screen sizes

Note some things will still be tweaked to look or work better, and addons add various columns that are not yet optimized for the changes 


### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* `job_manager_job_dashboard_column_{$key}` action is now called for all columns
* `Filled` and `Expires` columns are removed and moved to the status and date sections


### Screenshot / Video

<img width="1127" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/48f86e84-4286-4396-a9ff-f51d22e395a9">

<img width="369" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/0855f4de-47ac-4a56-aada-d14d3d13b281">


<!-- wpjm:plugin-zip -->
----

| Plugin build for 2c11d69b0c40856922c2799ccf349a74d1ae18d7 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2754-2c11d69b.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2754-2c11d69b)             |

<!-- /wpjm:plugin-zip -->
