### PR TITLE
Add class autoloader

### DIFF
--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -77,15 +77,13 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-data-exporter.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-com-api.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-access-token.php';
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-guest-user.php';
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-guest-session.php';
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-ui.php';
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-ui-settings.php';
 
 		if ( is_admin() ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-admin.php';
 		}
+
+		\WP_Job_Manager\UI\UI::instance();
+		\WP_Job_Manager\UI\UI_Settings::instance();
 
 		// Load 3rd party customizations.
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/3rd-party.php';

--- a/includes/ui/class-ui-settings.php
+++ b/includes/ui/class-ui-settings.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @internal
  */
-class UISettings {
+class UI_Settings {
 
 	use Singleton;
 
@@ -333,5 +333,3 @@ class UISettings {
 
 	}
 }
-
-UISettings::instance();

--- a/includes/ui/class-ui.php
+++ b/includes/ui/class-ui.php
@@ -14,11 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-ui-elements.php';
-require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-notice.php';
-require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-modal-dialog.php';
-require_once JOB_MANAGER_PLUGIN_DIR . '/includes/ui/class-redirect-message.php';
-
 /**
  * Frontend UI elements of Job Manager.
  *
@@ -103,5 +98,3 @@ class UI {
 		return $css;
 	}
 }
-
-UI::instance();

--- a/wp-job-manager-autoload.php
+++ b/wp-job-manager-autoload.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Autoload plugin classes.
+ *
+ * @package wp-job-manager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Autoload plugin classes.
+ *
+ * @since $$next-version$$
+ */
+class WP_Job_Manager_Autoload {
+
+	/**
+	 * Namespace -> directory mappings.
+	 *
+	 * @var array
+	 */
+	private static $autoload_map = [];
+
+	/**
+	 * Add the autoloader.
+	 */
+	public static function init() {
+		spl_autoload_register( [ self::class, 'autoload' ] );
+	}
+
+	/**
+	 * Register a new plugin with a class prefix and directory to autoload.
+	 *
+	 * @param string $namespace Root namespace. Should start with WP_Job_Manager_.
+	 * @param string $dir Directory to autoload.
+	 */
+	public static function register( $namespace, $dir ) {
+		self::$autoload_map[ $namespace ] = $dir;
+	}
+
+	/**
+	 * Autoload plugin classes.
+	 *
+	 * @access private
+	 *
+	 * @param string $class_name Class name.
+	 */
+	public static function autoload( $class_name ) {
+
+		if ( ! str_starts_with( $class_name, 'WP_Job_Manager' ) || ! str_contains( $class_name, '\\' ) ) {
+			return;
+		}
+
+		list( $namespace, $file_name ) = explode( '\\', $class_name, 2 );
+
+		$root_dir = self::$autoload_map[ $namespace ];
+
+		$file_name = strtolower( $file_name );
+		$dirs      = explode( '\\', $file_name );
+		$file_name = array_pop( $dirs );
+		$file_name = str_replace( '_', '-', $file_name );
+
+		$file_dir = implode( '/', [ $root_dir, ...$dirs ] );
+
+		$file_paths = [
+			'class-' . $file_name . '.php',
+			'trait-' . $file_name . '.php',
+		];
+
+		foreach ( $file_paths as $file_path ) {
+			$file_path = $file_dir . '/' . $file_path;
+			if ( file_exists( $file_path ) ) {
+				require $file_path;
+				break;
+			}
+		}
+
+	}
+
+}

--- a/wp-job-manager-autoload.php
+++ b/wp-job-manager-autoload.php
@@ -53,7 +53,11 @@ class WP_Job_Manager_Autoload {
 			return;
 		}
 
-		list( $namespace, $file_name ) = explode( '\\', $class_name, 2 );
+		[ $namespace, $file_name ] = explode( '\\', $class_name, 2 );
+
+		if ( empty( $namespace ) || empty( $file_name ) || empty( self::$autoload_map[ $namespace ] ) ) {
+			return;
+		}
 
 		$root_dir = self::$autoload_map[ $namespace ];
 
@@ -73,7 +77,7 @@ class WP_Job_Manager_Autoload {
 			$file_path = $file_dir . '/' . $file_path;
 			if ( file_exists( $file_path ) ) {
 				require $file_path;
-				break;
+				return;
 			}
 		}
 

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -26,6 +26,10 @@ define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ )
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
+require_once dirname( __FILE__ ) . '/wp-job-manager-autoload.php';
+WP_Job_Manager_Autoload::init();
+WP_Job_Manager_Autoload::register( 'WP_Job_Manager', JOB_MANAGER_PLUGIN_DIR . '/includes' );
+
 require_once dirname( __FILE__ ) . '/includes/class-wp-job-manager-dependency-checker.php';
 if ( ! WP_Job_Manager_Dependency_Checker::check_dependencies() ) {
 	return;


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Add a new class autoloader that can be used for WP Job Manager and the addon plugins
* Resolves new namespaced classes to `includes/class-{name}.php`

### Testing Instructions

Usage example in plugins:
`\WP_Job_Manager_Autoload::register( __NAMESPACE__, JOB_MANAGER_ALERTS_PLUGIN_DIR . '/includes' );`

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes



<!-- wpjm:plugin-zip -->
----

| Plugin build for 0b52eaa6fabb3e1c39b2159bc6746285800d2d2e <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2756-0b52eaa6.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2756-0b52eaa6)             |

<!-- /wpjm:plugin-zip -->


