### PR TITLE
Add search to job dashboard

### DIFF
--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -28,6 +28,10 @@
 
 	transition: color 0.2s ease-out, background 0.2s ease-out;
 
+	&:focus:not(:focus-visible) {
+		outline: unset;
+	}
+
 	&:focus-visible {
 		outline: 1.5px solid fadeCurrentColor(85%);
 		outline-offset: 1.5px;

--- a/assets/css/ui.form.scss
+++ b/assets/css/ui.form.scss
@@ -177,6 +177,13 @@
 		padding-right: var(--jm-ui-space-ml);
 	}
 
+	input[type].jm-ui-input--search-icon {
+		background-image: var(--jm-ui-svg-search);
+		background-position: var(--jm-ui-space-xs) center;
+		background-repeat: no-repeat;
+		padding-left: calc(var(--jm-ui-space-ml) + var(--jm-ui-space-xs));
+	}
+
 	.select2-container.select2-container.select2-container {
 
 		input {

--- a/assets/css/ui.neutral.scss
+++ b/assets/css/ui.neutral.scss
@@ -67,4 +67,5 @@
 	--jm-ui-svg-arrow-down: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='32' height='6' viewBox='0 0 16 10'%3e%3cpath fill='black' fill-rule='evenodd' d='M0 1.6 1.53 0 8 6.95 14.5 0 16 1.6 8 10 0 1.6Z' clip-rule='evenodd'/%3e%3c/svg%3e");
 	--jm-ui-svg-check: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='black' stroke-width='1.5' d='m18.93 6-8.9 11.97-5.16-3.84'/%3e%3c/svg%3e");
 	--jm-ui-svg-ellipsis-v: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' fill-rule='evenodd' d='M11 19v-2h2v2h-2Zm0-6v-2h2v2h-2Zm0-6V5h2v2h-2Z' clip-rule='evenodd'/%3e%3c/svg%3e");
+	--jm-ui-svg-search: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' fill-rule='evenodd' d='M19 11a6 6 0 0 1-9.68 4.74l-3.79 3.79-1.06-1.06 3.79-3.8A6 6 0 1 1 19 11Zm-1.5 0a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z' clip-rule='evenodd'/%3e%3c/svg%3e");
 }

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -18,8 +18,10 @@
  * @var int       $max_num_pages Maximum number of pages
  * @var WP_Post[] $jobs Array of job post results.
  * @var array     $job_actions Array of actions available for each job.
+ * @var string    $search_input Search input.
  */
 
+use WP_Job_Manager\UI\Notice;
 use WP_Job_Manager\UI\UI_Elements;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,27 +33,45 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 
 <div id="job-manager-job-dashboard" class="alignwide">
 	<div class="jm-dashboard__intro">
-		<p><?php esc_html_e( 'Your listings are shown in the table below.', 'wp-job-manager' ); ?></p>
-		<?php if ( job_manager_user_can_submit_job_listing() ) : ?>
-			<div>
-				<a class="wp-element-button button"
-					href="<?php echo esc_url( get_permalink( $submit_job_form_page_id ) ); ?>"><?php esc_html_e( 'Add Job', 'wp-job-manager' ); ?></a>
-			</div>
-		<?php endif; ?>
+		<div class="jm-dashboard__filters">
+			<form method="GET" action="" class="jm-form">
+				<div style="display: flex; gap: 12px;">
+					<input type="search" name="search" class="jm-ui-input--search-icon"
+						placeholder="<?php esc_attr_e( 'Search', 'wp-job-manager' ); ?>"
+						value="<?php echo esc_attr( $search_input ); ?>"
+						aria-label="<?php esc_attr_e( 'Search', 'wp-job-manager' ); ?>" />
+				</div>
+			</form>
+		</div>
+		<div class="jm-dashboard__actions">
+			<?php if ( job_manager_user_can_submit_job_listing() ) : ?>
+				<a class="jm-ui-button"
+					href="<?php echo esc_url( get_permalink( $submit_job_form_page_id ) ); ?>"><span><?php esc_html_e( 'Add Job', 'wp-job-manager' ); ?></span></a>
+			<?php endif; ?>
+		</div>
 	</div>
 	<div class="job-manager-jobs jm-dashboard">
-		<div class="jm-dashboard-header">
-			<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
-				<div
-					class="jm-dashboard-job-column <?php echo esc_attr( $key ); ?>"><?php echo esc_html( $column ); ?></div>
-			<?php endforeach; ?>
-			<div class="jm-dashboard-job-column actions"><?php esc_html_e( 'Actions', 'wp-job-manager' ); ?></div>
-		</div>
-		<div class="jm-dashboard-rows">
-			<?php if ( ! $jobs ) : ?>
-				<div
-					class="jm-dashboard-empty"><?php esc_html_e( 'You do not have any active listings.', 'wp-job-manager' ); ?></div>
-			<?php else : ?>
+		<?php if ( ! $jobs ) : ?>
+			<div
+				class="jm-dashboard-empty">
+				<?php echo Notice::dialog(
+					[
+						'message' => $search_input
+							// translators: Placeholder is the search term.
+							? sprintf( __( 'No results found for "%s".', 'wp-job-manager' ), $search_input )
+							: __( 'You do not have any active listings.', 'wp-job-manager' )
+					]
+				); ?>
+			</div>
+		<?php else : ?>
+			<div class="jm-dashboard-header">
+				<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
+					<div
+						class="jm-dashboard-job-column <?php echo esc_attr( $key ); ?>"><?php echo esc_html( $column ); ?></div>
+				<?php endforeach; ?>
+				<div class="jm-dashboard-job-column actions"><?php esc_html_e( 'Actions', 'wp-job-manager' ); ?></div>
+			</div>
+			<div class="jm-dashboard-rows">
 				<?php foreach ( $jobs as $job ) : ?>
 					<div class="jm-dashboard-job">
 						<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
@@ -95,8 +115,8 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 						</div>
 					</div>
 				<?php endforeach; ?>
-			<?php endif; ?>
-		</div>
+			</div>
+		<?php endif; ?>
 	</div>
 	<?php get_job_manager_template( 'pagination.php', [ 'max_num_pages' => $max_num_pages ] ); ?>
 </div>


### PR DESCRIPTION
Fixes #2736, part of #667

Stacked on #2759 #2754 

### Changes Proposed in this Pull Request

* Add a free text search field to the job dashboard

### Testing Instructions

* Have jobs, view the [job_dashboard] page
* Try searching for keywords


<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Add search to the job dashboard

### Screenshot / Video

<img width="1334" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/551ff231-eadc-4b9d-a4d7-faa61911d259">



<!-- wpjm:plugin-zip -->
----

| Plugin build for 0860a2f056797a34bad95709154d85c3eb2259ef <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2760-0860a2f0.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2760-0860a2f0)             |

<!-- /wpjm:plugin-zip -->


