### PR TITLE
Add Job Overlay

### DIFF
--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -1,5 +1,6 @@
 
-@import "mixins";
+@import 'mixins';
+@import 'job-overlay';
 
 #job-manager-job-dashboard {
 
@@ -41,20 +42,20 @@
 	font-size: var(--jm-ui-font-size-s);
 }
 
-.jm-dashboard-job-column.job_title {
+.jm-dashboard .job_title {
 	flex: 1 1 200%;
+}
 
-	.job-status {
-		text-transform: uppercase;
-		font-weight: 500;
-		font-size: var(--jm-ui-font-size-s);
-		line-height: var(--jm-ui-icon-size-s);
-		color: fadeCurrentColor( 80% );
+.jm-dashboard .job-status {
+	text-transform: uppercase;
+	font-weight: 500;
+	font-size: var(--jm-ui-font-size-s);
+	line-height: var(--jm-ui-icon-size-s);
+	color: fadeCurrentColor( 80% );
 
-		.jm-ui-icon {
-			width: var(--jm-ui-icon-size-s);
-			height: var(--jm-ui-icon-size-s);
-		}
+	.jm-ui-icon {
+		width: var(--jm-ui-icon-size-s);
+		height: var(--jm-ui-icon-size-s);
 	}
 }
 

--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -29,6 +29,10 @@
 	gap: var(--jm-ui-space-sm);
 }
 
+.jm-dashboard__filters {
+	font-size: var(--jm-ui-button-font-size);
+}
+
 .jm-dashboard-job {
 	border: var(--jm-ui-border-size) solid var(--jm-ui-border-light);
 }
@@ -51,12 +55,31 @@
 	font-weight: 500;
 	font-size: var(--jm-ui-font-size-s);
 	line-height: var(--jm-ui-icon-size-s);
-	color: fadeCurrentColor( 80% );
+	color: fadeCurrentColor( 70% );
+	margin: var(--jm-ui-space-xxs) 0;
+
+	.jm-ui-row {
+		gap: var(--jm-ui-space-xxxs);
+	}
+
+	.jm-separator {
+		color: fadeCurrentColor( 20% );
+	}
 
 	.jm-ui-icon {
 		width: var(--jm-ui-icon-size-s);
 		height: var(--jm-ui-icon-size-s);
 	}
+
+	.job-status-rejected {
+		color: var(--jm-ui-error-color);
+	}
+}
+
+.jm-dashboard img.company_logo {
+	width: var(--jm-ui-icon-size);
+	height: var(--jm-ui-icon-size);
+	object-fit: contain;
 }
 
 
@@ -68,6 +91,7 @@
 .jm-dashboard-job-column a.job-title {
 	font-weight: 600;
 	font-size: var(--jm-ui-font-size);
+	line-height: 1.2;
 	text-decoration: unset;
 }
 

--- a/assets/css/job-overlay.scss
+++ b/assets/css/job-overlay.scss
@@ -1,0 +1,79 @@
+
+.jm-dashboard__overlay {
+	width: var(--wp--style--global--wide-size, 1200px);
+	height: 80vh;
+	--jm-dialog-padding: var(--jm-ui-space-ml);
+
+	.jm-ui-spinner {
+		--size: 64px;
+	}
+
+	.jm-dialog-close {
+		top: var(--jm-dialog-padding);
+		right: var(--jm-dialog-padding);
+		color: inherit;
+	}
+}
+
+.jm-job-overlay {
+	align-self: stretch;
+	flex: 1;
+	padding: var(--jm-ui-space-ml);
+	display: flex;
+	flex-direction: column;
+	gap: var(--jm-ui-space-sm);
+	animation: jm-fade-in 200ms ease-in;
+
+	font-size: var(--jm-ui-font-size-m);
+}
+
+.jm-job-overlay-header {
+	border-bottom: var(--jm-ui-border-size) solid var(--jm-ui-border-faint);
+	display: flex;
+	justify-content: space-between;
+	gap: var(--jm-ui-space-m);
+	padding-right: calc( var(--jm-ui-icon-size) + var(--jm-ui-space-s) );
+	padding-bottom: var(--jm-ui-space-sm);
+	flex: 0 0 min-content;
+
+	.job_title {
+		font-size: var(--jm-ui-heading-font-size);
+		line-height: 1.2;
+		font-weight: 600;
+	}
+}
+.jm-job-overlay-content {
+	flex: 1 1 auto;
+	overflow: auto;
+}
+
+.jm-job-overlay-footer {
+	border-top: var(--jm-ui-border-size) solid var(--jm-ui-border-faint);
+	padding-top: var(--jm-dialog-padding);
+
+	.jm-ui-actions-row {
+		gap: var(--jm-ui-space-sm);
+	}
+
+}
+
+.jm-job-overlay-details-box {
+	background: var(--jm-ui-faint-color);
+	padding: var(--jm-ui-space-m);
+}
+
+@media (max-width: 600px) {
+	.jm-dashboard__overlay
+	{
+		height: 100%;
+	}
+}
+
+@keyframes jm-job-overlay-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}

--- a/assets/css/ui.dialog.scss
+++ b/assets/css/ui.dialog.scss
@@ -38,7 +38,8 @@
 }
 
 .jm-dialog::backdrop {
-	background-color: unset;
+	background-color: transparent;
+	backdrop-filter: blur(4px);
 }
 
 .jm-dialog-modal {
@@ -74,7 +75,7 @@
 	bottom: 0;
 	z-index: -1;
 	background-color: rgb(0 0 0 / 0.1);
-	backdrop-filter: blur(4px);
+
 }
 
 .jm-dialog-close {
@@ -95,7 +96,7 @@
 	animation: jm-dialog-open 0.2s cubic-bezier(.08, .6, .5, .98);
 }
 
-.jm-dialog[open]::backdrop {
+.jm-dialog[open] .jm-dialog-backdrop {
 	animation: jm-dialog-backdrop-fade-in 0.2s cubic-bezier(.08, .6, .5, .98);
 }
 

--- a/assets/css/ui.dialog.scss
+++ b/assets/css/ui.dialog.scss
@@ -22,7 +22,7 @@
 
 .jm-dialog {
 	font-size: var(--jm-ui-font-size);
-	--jm-local-notice-padding: var(--jm-ui-space-l);
+	--jm-dialog-padding: var(--jm-ui-space-l);
 }
 
 .jm-dialog .jm-notice {
@@ -30,7 +30,7 @@
 	border: unset;
 	width: 100%;
 	min-width: unset;
-	padding: var(--jm-local-notice-padding);
+	padding: var(--jm-dialog-padding);
 
 	.jm-notice__details {
 		align-self: stretch;
@@ -43,10 +43,6 @@
 
 .jm-dialog-modal {
 	position: relative;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
 	width: var(--wp--style--global--content-size, 640px);
 	max-width: calc(100% - var(--jm-ui-space-s) * 2);
 	max-height: 100%;
@@ -57,6 +53,17 @@
 	color: var(--jm-ui-text-color, #1a1a1a);
 	box-shadow: var(--jm-ui-shadow-modal);
 
+	overscroll-behavior: contain;
+
+}
+
+.jm-dialog-modal-content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	width: 100%;
 }
 
 .jm-dialog-backdrop {
@@ -73,9 +80,8 @@
 .jm-dialog-close {
 	position: absolute;
 	z-index: 1;
-	padding: var(--jm-ui-space-xxxs);
-	top: calc(var(--jm-local-notice-padding) - var(--jm-ui-space-xxxs));
-	right: calc(var(--jm-local-notice-padding) - var(--jm-ui-space-xxxs) - 8px);
+	top: calc(var(--jm-dialog-padding) - var(--jm-ui-space-xs));
+	right: calc(var(--jm-dialog-padding) - var(--jm-ui-space-xs) - 8px);
 	cursor: pointer;
 	opacity: 0.7;
 
@@ -159,7 +165,7 @@
 	}
 
 	.jm-dialog {
-		--jm-local-notice-padding: var(--jm-ui-space-sm);
+		--jm-dialog-padding: var(--jm-ui-space-sm);
 	}
 
 	.jm-dialog .jm-form, .jm-dialog .jm-notice {

--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -198,3 +198,23 @@
 	display: flex;
 	flex-direction: column;
 }
+
+.jm-ui-spinner {
+	display: inline-block;
+	--size: 24px;
+	width: var(--size);
+	height: var(--size);
+	border: 2px solid currentColor;
+	border-bottom-color: transparent;
+	border-radius: 50%;
+	animation: jm-ui-spinner-spin 1s linear infinite;
+}
+
+@keyframes jm-ui-spinner-spin {
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
+}

--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -1,4 +1,16 @@
 
+.jm-ui-row {
+	display: flex;
+	gap: var(--jm-ui-space-xs);
+	align-items: center;
+}
+
+.jm-ui-col {
+	display: flex;
+	flex-direction: column;
+	gap: var(--jm-ui-space-xs);
+}
+
 .jm-ui-button,
 .jm-ui-button--outline,
 .jm-ui-button--link,
@@ -133,35 +145,34 @@
 	width: var(--jm-ui-icon-size);
 	height: var(--jm-ui-icon-size);
 	mask-size: 100% 100%;
+	background-color: currentColor;
 
 	&[data-icon=check] {
-		background-color: currentColor;
-		mask-image:  url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cg stroke-width=\'1.5\'%3e%3cpath stroke=\'%231E1E1E\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath stroke=\'black\' d=\'m15.96 8.18-5.34 7.18-3.1-2.3\'/%3e%3c/g%3e%3c/svg%3e');
+		mask-image: var(--jm-ui-svg-check);
 	}
 
 	&[data-icon=check-circle] {
-		background-color: currentColor;
-		mask-image:  url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cg stroke-width=\'1.5\'%3e%3cpath stroke=\'%231E1E1E\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath stroke=\'black\' d=\'m15.96 8.18-5.34 7.18-3.1-2.3\'/%3e%3c/g%3e%3c/svg%3e');
-	}
-
-	&[data-icon=check] {
-		background-color: currentColor;
-		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' fill-rule='evenodd' d='m17.93 7.98-7.2 9.68-4.52-3.36.9-1.2 3.31 2.46 6.3-8.48 1.2.9Z' clip-rule='evenodd'/%3e%3c/svg%3e");
+		mask-image:  url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cg stroke-width='1.5'%3e%3cpath stroke='black' d='M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z'/%3e%3cpath stroke='black' d='m15.96 8.18-5.34 7.18-3.1-2.3'/%3e%3c/g%3e%3c/svg%3e");
 	}
 
 	&[data-icon=star] {
-		background-color: currentColor;
 		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' d='M11.78 4.45a.25.25 0 0 1 .44 0l2.07 4.2c.04.07.11.12.2.13l4.62.68c.2.02.28.28.14.42l-3.35 3.26a.25.25 0 0 0-.07.23l.79 4.6c.03.2-.18.36-.37.27l-4.13-2.18a.25.25 0 0 0-.24 0l-4.13 2.18a.25.25 0 0 1-.37-.27l.8-4.6a.25.25 0 0 0-.08-.23L4.75 9.88a.25.25 0 0 1 .14-.42l4.63-.68a.25.25 0 0 0 .19-.13l2.07-4.2Z'/%3e%3c/svg%3e");
 	}
 
 	&[data-icon=info] {
-		background-color: currentColor;
-		mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3ccircle cx=\'12\' cy=\'12\' r=\'8\' stroke=\'black\' stroke-width=\'1.5\'/%3e%3cpath fill=\'black\' d=\'M11 11h2v6h-2zm0-4h2v2h-2z\'/%3e%3c/svg%3e');
+		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3ccircle cx='12' cy='12' r='8' stroke='black' stroke-width='1.5'/%3e%3cpath fill='black' d='M11 11h2v6h-2zm0-4h2v2h-2z'/%3e%3c/svg%3e");
 	}
 
 	&[data-icon=alert] {
-		background-color: currentColor;
-		mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cpath stroke=\'%231E1E1E\' stroke-width=\'1.5\' d=\'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z\'/%3e%3cpath fill=\'%231E1E1E\' d=\'M13 7h-2v6h2V7Zm0 8h-2v2h2v-2Z\'/%3e%3c/svg%3e');
+		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='black' stroke-width='1.5' d='M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z'/%3e%3cpath fill='black' d='M13 7h-2v6h2V7Zm0 8h-2v2h2v-2Z'/%3e%3c/svg%3e");
+	}
+
+	&[data-icon=location] {
+		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' d='M12 9c-.8 0-1.5.7-1.5 1.5S11.2 12 12 12s1.5-.7 1.5-1.5S12.8 9 12 9Zm0-5c-3.6 0-6.5 2.8-6.5 6.2 0 .8.3 1.8.9 3.1.5 1.1 1.2 2.3 2 3.6.7 1 3 3.8 3.2 3.9l.4.5.4-.5c.2-.2 2.6-2.9 3.2-3.9.8-1.2 1.5-2.5 2-3.6.6-1.3.9-2.3.9-3.1C18.5 6.8 15.6 4 12 4Zm4.3 8.7c-.5 1-1.1 2.2-1.9 3.4-.5.7-1.7 2.2-2.4 3-.7-.8-1.9-2.3-2.4-3-.8-1.2-1.4-2.3-1.9-3.3-.6-1.4-.7-2.2-.7-2.5 0-2.6 2.2-4.7 5-4.7s5 2.1 5 4.7c0 .2-.1 1-.7 2.4Z'/%3e%3c/svg%3e");
+	}
+
+	&[data-icon=edit] {
+		mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath fill='black' d='m19 7-3-3-8.5 8.5-1 4 4-1L19 7Zm-7 11.5H5V20h7v-1.5Z'/%3e%3c/svg%3e");
 	}
 }
 
@@ -175,6 +186,9 @@
 
 .jm-ui-action-menu__open-button {
 	cursor: pointer;
+	&::-webkit-details-marker {
+		display: none;
+	}
 
 	.jm-ui-button__icon {
 		mask-image: var(--jm-ui-svg-ellipsis-v);

--- a/assets/css/ui.neutral.scss
+++ b/assets/css/ui.neutral.scss
@@ -56,7 +56,7 @@
 	--jm-ui-button-font-size: 14px;
 	--jm-ui-icon-size: 24px;
 	--jm-ui-icon-size-m: 20px;
-	--jm-ui-icon-size-s: 18px;
+	--jm-ui-icon-size-s: 14px;
 
 	--jm-ui-shadow-modal: 0 0.7px 1px 0 rgba(0, 0, 0, 0.15),
 	0 2.7px 3.8px -0.2px rgba(0, 0, 0, 0.15),

--- a/assets/css/ui.neutral.scss
+++ b/assets/css/ui.neutral.scss
@@ -1,6 +1,7 @@
 
 :root {
 	--jm-ui-border-light: #{fadeCurrentColor(15%)};
+	--jm-ui-border-faint: #{fadeCurrentColor(5%)};
 	--jm-ui-border-strong: currentColor;
 	--jm-ui-border-size: 1px;
 
@@ -12,6 +13,7 @@
 	--jm-ui-radius-2x: calc(2 * var(--jm-ui-radius));
 	--jm-ui-radius-4x: calc(4 * var(--jm-ui-radius));
 
+	--jm-ui-faint-color: #{fadeCurrentColor(2.5%)};
 	--jm-ui-accent-color: inherit;
 	--jm-ui-danger-color: #cc1818;
 	--jm-ui-error-color: #cc1818;

--- a/assets/js/job-dashboard.js
+++ b/assets/js/job-dashboard.js
@@ -31,11 +31,20 @@ async function showOverlay( event ) {
 	const contentElement = overlayDialog.querySelector( '.jm-dialog-modal-content' );
 	contentElement.innerHTML = '<a class="jm-ui-spinner"></a>';
 
-	const { success, data } = await (
-		await fetch( `${ overlayEndpoint }?job_id=${ this.dataset.jobId }` )
-	 ).json();
+	try {
+		const response = await fetch( `${ overlayEndpoint }?job_id=${ this.dataset.jobId }` );
 
-	contentElement.innerHTML = data;
+		if ( ! response.ok ) {
+			throw new Error( response.statusText );
+		}
+
+		const { data } = await response.json();
+
+		contentElement.innerHTML = data;
+	}
+	catch ( error ) {
+		contentElement.innerHTML = `<div class="jm-notice color-error has-text-align-center" role="status">${ error.message }</div>`;
+	}
 
 	setupEvents( contentElement );
 }

--- a/assets/js/job-dashboard.js
+++ b/assets/js/job-dashboard.js
@@ -1,8 +1,49 @@
 /* global job_manager_job_dashboard */
-jQuery(document).ready(function($) {
 
-	$('.job-dashboard-action-delete').click(function() {
-		return window.confirm( job_manager_job_dashboard.i18n_confirm_delete );
-	});
+import domReady from '@wordpress/dom-ready';
 
-});
+// eslint-disable-next-line camelcase
+const { i18nConfirmDelete, overlayEndpoint } = job_manager_job_dashboard;
+
+function setupEvents( root ) {
+	root
+		.querySelectorAll( '.job-dashboard-action-delete' )
+		.forEach( el => el.addEventListener( 'click', confirmDelete ) );
+}
+
+function confirmDelete( event ) {
+	// eslint-disable-next-line no-alert
+	if ( ! window.confirm( i18nConfirmDelete ) ) {
+		event.preventDefault();
+	}
+}
+
+async function showOverlay( event ) {
+	const overlayDialog = document.getElementById( 'jmDashboardOverlay' );
+
+	if ( ! overlayDialog ) {
+		return true;
+	}
+
+	event.preventDefault();
+	overlayDialog.showModal();
+
+	const contentElement = overlayDialog.querySelector( '.jm-dialog-modal-content' );
+	contentElement.innerHTML = '<a class="jm-ui-spinner"></a>';
+
+	const { success, data } = await (
+		await fetch( `${ overlayEndpoint }?job_id=${ this.dataset.jobId }` )
+	 ).json();
+
+	contentElement.innerHTML = data;
+
+	setupEvents( contentElement );
+}
+
+domReady( () => {
+	setupEvents( document );
+
+	document
+		.querySelectorAll( '.jm-dashboard-job .job-title' )
+		.forEach( el => el.addEventListener( 'click', showOverlay ) );
+} );

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/class-job-overlay.php';
+
 /**
  * Job Dashboard Shortcode.
  *
@@ -51,10 +53,13 @@ class Job_Dashboard_Shortcode {
 
 		add_filter( 'paginate_links', [ $this, 'filter_paginate_links' ], 10, 1 );
 
-		add_action( 'job_manager_job_dashboard_column_date', [ $this, 'job_dashboard_date_column_expires' ] );
-		add_action( 'job_manager_job_dashboard_column_job_title', [ $this, 'job_dashboard_title_column_status' ] );
+		add_action( 'job_manager_job_dashboard_column_date', [ self::class, 'the_date' ] );
+		add_action( 'job_manager_job_dashboard_column_date', [ self::class, 'the_expiration_date' ] );
 
-		add_action( 'job_manager_ajax_job_dashboard_overlay', [ $this, 'ajax_job_overlay' ] );
+		add_action( 'job_manager_job_dashboard_column_job_title', [ self::class, 'the_job_title' ], 10 );
+		add_action( 'job_manager_job_dashboard_column_job_title', [ self::class, 'the_status' ], 12 );
+
+		Job_Overlay::instance();
 	}
 
 	/**
@@ -441,46 +446,13 @@ class Job_Dashboard_Shortcode {
 	}
 
 	/**
-	 * Render the job dashboard overlay content for an AJAX request.
-	 */
-	public function ajax_job_overlay() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$job_id = isset( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : null;
-
-		$job = $job_id ? get_post( $job_id ) : null;
-
-		if ( empty( $job ) || ! $this->is_job_available_on_dashboard( $job ) ) {
-			wp_send_json_error( __( 'Invalid Job ID.', 'wp-job-manager' ) );
-
-			return;
-		}
-
-		$job_actions = $this->get_job_actions( $job );
-
-		ob_start();
-
-		get_job_manager_template(
-			'job-dashboard-overlay.php',
-			[
-				'job'         => $job,
-				'job_actions' => $job_actions,
-			]
-		);
-
-		$content = ob_get_clean();
-
-		wp_send_json_success( $content );
-
-	}
-
-	/**
 	 * Add expiration details to the job dashboard date column.
 	 *
 	 * @param \WP_Post $job
 	 *
 	 * @output string
 	 */
-	public function job_dashboard_date_column_expires( $job ) {
+	public static function the_expiration_date( $job ) {
 		$expiration = \WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
 
 		if ( 'publish' === $job->post_status && ! empty( $expiration ) ) {
@@ -491,30 +463,87 @@ class Job_Dashboard_Shortcode {
 	}
 
 	/**
+	 * Show location.
+	 *
+	 * @param \WP_Post $job
+	 *
+	 * @output string
+	 */
+	public static function the_location( $job ) {
+		$location = get_the_job_location( $job );
+
+		if ( ! $location ) {
+			return;
+		}
+
+		?>
+		<div class="jm-ui-row">
+			<?php echo UI_Elements::icon( 'location' ); ?>
+			<?php echo esc_html( $location ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show job title.
+	 *
+	 * @param \WP_Post $job
+	 *
+	 * @output string
+	 */
+	public static function the_job_title( $job ) {
+		echo '<a class="job-title" data-job-id="' . esc_attr( $job->ID ) . '" href="' . esc_url( get_permalink( $job->ID ) ) . '">' . esc_html( get_the_title( $job ) ?? $job->ID ) . '</a>';
+	}
+
+	/**
+	 * Show job title.
+	 *
+	 * @param \WP_Post $job
+	 *
+	 * @output string
+	 */
+	public static function the_date( $job ) {
+		echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', 'M d, Y' ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
+	}
+
+	/**
 	 * Add job status to the job dashboard title column.
 	 *
 	 * @param \WP_Post $job
 	 *
 	 * @output string
 	 */
-	public function job_dashboard_title_column_status( $job ) {
+	public static function the_status( $job ) {
 
-		echo '<div class="job-status">';
+		echo '<div class="job-status jm-ui-row">';
 
 		$status = [];
 
 		if ( is_position_filled( $job ) ) {
-			$status[] = '<span class="job-status-filled">' . esc_html__( 'Filled', 'wp-job-manager' ) . '</span>';
+			$status[] = '<span class="job-status-filled jm-ui-row">'
+						. UI_Elements::icon( 'check' )
+						. esc_html__( 'Filled', 'wp-job-manager' ) . '</span>';
 		}
 
 		if ( is_position_featured( $job ) && 'publish' === $job->post_status ) {
-			$status[] = '<span class="job-status-featured">' . esc_html__( 'Featured', 'wp-job-manager' ) . '</span>';
+			$status[] = '<span class="job-status-featured jm-ui-row">'
+						. UI_Elements::icon( 'star' )
+						. esc_html__( 'Featured', 'wp-job-manager' ) . '</span>';
 		}
 
-		$status[] = '<span class="job-status-' . esc_attr( $job->post_status ) . '">' . esc_html( get_the_job_status( $job ) ) . '</span>';
+		$status_icon = [
+			'pending'         => 'alert',
+			'pending_payment' => 'alert',
+			'draft'           => 'edit',
+			'expired'         => 'alert',
+		][ $job->post_status ] ?? null;
+
+		$status[] = '<span class="job-status-' . esc_attr( $job->post_status ) . ' jm-ui-row">'
+					. ( $status_icon ? UI_Elements::icon( $status_icon ) : '' )
+					. esc_html( get_the_job_status( $job ) ) . '</span>';
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
-		echo implode( ', ', $status );
+		echo implode( '<span class="jm-separator">|</span>', $status );
 
 		echo '</div>';
 	}
@@ -540,7 +569,7 @@ class Job_Dashboard_Shortcode {
 	 *
 	 * @return bool
 	 */
-	private function is_job_available_on_dashboard( \WP_Post $job ) {
+	public function is_job_available_on_dashboard( \WP_Post $job ) {
 		// Check cache of currently displayed job dashboard IDs first to avoid lots of queries.
 		if ( isset( $this->job_dashboard_job_ids ) && in_array( (int) $job->ID, $this->job_dashboard_job_ids, true ) ) {
 			return true;
@@ -591,6 +620,29 @@ class Job_Dashboard_Shortcode {
 		 * @param array $args Arguments to pass to \WP_Query.
 		 */
 		return apply_filters( 'job_manager_get_dashboard_jobs_args', $args );
+	}
+
+	/**
+	 * Check if the current user has multiple companies.
+	 *
+	 * @return bool
+	 */
+	private function user_has_multiple_companies() {
+		global $wpdb;
+
+		$user_id = get_current_user_id();
+
+		$cache_key       = 'wpjm_user_' . $user_id . '_companies_count';
+		$companies_count = get_transient( $cache_key );
+
+		if ( false === $companies_count ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Query is cached.
+			$companies_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT meta_value) FROM {$wpdb->postmeta} WHERE meta_key = '_company_name' AND `meta_value` != '' AND post_id IN (SELECT ID FROM {$wpdb->posts} WHERE post_author = %d AND post_type = 'job_listing')", $user_id ) );
+
+			set_transient( $cache_key, $companies_count, 24 * HOUR_IN_SECONDS );
+		}
+
+		return $companies_count > 1;
 	}
 
 }

--- a/includes/class-job-overlay.php
+++ b/includes/class-job-overlay.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * File containing the class Job_Overlay.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+use WP_Job_Manager\UI\Modal_Dialog;
+use WP_Job_Manager\UI\Notice;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Job details overlay.
+ *
+ * @since $$next-version$$
+ */
+class Job_Overlay {
+
+	use Singleton;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'job_manager_ajax_job_dashboard_overlay', [ $this, 'ajax_job_overlay' ] );
+	}
+
+	/**
+	 * Render the job dashboard overlay content for an AJAX request.
+	 */
+	public function ajax_job_overlay() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$job_id = isset( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : null;
+
+		$job = $job_id ? get_post( $job_id ) : null;
+
+		$shortcode = Job_Dashboard_Shortcode::instance();
+
+		if ( empty( $job ) || ! $shortcode->is_job_available_on_dashboard( $job ) ) {
+			wp_send_json_error(
+				Notice::error(
+					[
+						'message' => __( 'Invalid Job ID.', 'wp-job-manager' ),
+						'classes' => [ 'type-dialog' ],
+					]
+				)
+			);
+
+			return;
+		}
+
+		$job_actions = $shortcode->get_job_actions( $job );
+
+		ob_start();
+
+		get_job_manager_template(
+			'job-dashboard-overlay.php',
+			[
+				'job'         => $job,
+				'job_actions' => $job_actions,
+			]
+		);
+
+		$content = ob_get_clean();
+
+		wp_send_json_success( $content );
+
+	}
+
+	/**
+	 * Output the modal element.
+	 */
+	public function output_modal_element() {
+		$overlay = new Modal_Dialog(
+			[
+				'id'    => 'jmDashboardOverlay',
+				'class' => 'jm-dashboard__overlay',
+			]
+		);
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in Modal_Dialog class.
+		echo $overlay->render( '' );
+	}
+}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -543,7 +543,7 @@ class WP_Job_Manager {
 
 		wp_register_script( 'jquery-deserialize', JOB_MANAGER_PLUGIN_URL . '/assets/lib/jquery-deserialize/jquery.deserialize.js', [ 'jquery' ], '1.2.1', true );
 		self::register_script( 'wp-job-manager-ajax-filters', 'js/ajax-filters.js', $ajax_filter_deps, true );
-		self::register_script( 'wp-job-manager-job-dashboard', 'js/job-dashboard.js', [ 'jquery' ], true );
+		self::register_script( 'wp-job-manager-job-dashboard', 'js/job-dashboard.js', null, true );
 		self::register_script( 'wp-job-manager-job-application', 'js/job-application.js', [ 'jquery' ], true );
 		self::register_script( 'wp-job-manager-job-submission', 'js/job-submission.js', [ 'jquery' ], true );
 		wp_localize_script( 'wp-job-manager-ajax-filters', 'job_manager_ajax_filters', $ajax_data );

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -578,7 +578,8 @@ class WP_Job_Manager {
 			'wp-job-manager-job-dashboard',
 			'job_manager_job_dashboard',
 			[
-				'i18n_confirm_delete' => esc_html__( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
+				'i18nConfirmDelete' => esc_html__( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
+				'overlayEndpoint'   => WP_Job_Manager_Ajax::get_endpoint( 'job_dashboard_overlay' ),
 			]
 		);
 

--- a/includes/ui/class-modal-dialog.php
+++ b/includes/ui/class-modal-dialog.php
@@ -88,8 +88,8 @@ class Modal_Dialog {
 	<div class="jm-dialog-open">
 		<div class="jm-dialog-backdrop" onclick="{$id}.close()"></div>
 		<div class="jm-dialog-modal {$class}" style="{$style}">
-			{$content}
-			<a href="#" role="button" class="jm-ui-button--icon jm-dialog-close" onclick="{$id}.close()" aria-label="{$close_label}"><span class="jm-ui-button__icon"></span></a>
+			<div class="jm-dialog-modal-content">{$content}</div>
+			<a href="#" role="button" class="jm-ui-button--icon jm-dialog-close" onclick="{$id}.close();  event.preventDefault();" aria-label="{$close_label}"><span class="jm-ui-button__icon"></span></a>
 		</div>
 	</div>
 </dialog>

--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -81,6 +81,7 @@ class UI_Elements {
 				'label'   => '',
 				'url'     => '',
 				'onclick' => '',
+				'class'   => '',
 			]
 		);
 
@@ -89,7 +90,7 @@ class UI_Elements {
 		}
 
 		$attrs = [
-			'class' => $class,
+			'class' => join( ' ', [ $class, $args['class'] ] ),
 			'href'  => esc_url( $args['url'] ),
 		];
 

--- a/templates/job-dashboard-overlay.php
+++ b/templates/job-dashboard-overlay.php
@@ -9,9 +9,10 @@
  * @version     $$next-version$$
  *
  * @var WP_Post $job Array of job post results.
- * @var array $job_actions
+ * @var array   $job_actions
  */
 
+use WP_Job_Manager\Job_Dashboard_Shortcode;
 use WP_Job_Manager\UI\UI_Elements;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -26,19 +27,34 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 		<div class="">
 
 			<div class="job_title" role="heading"><?php echo esc_html( get_the_title( $job ) ?? $job->ID ); ?></div>
-			<?php do_action( 'job_manager_job_dashboard_column_job_title', $job ); ?>
+			<?php Job_Dashboard_Shortcode::the_status( $job ); ?>
 		</div>
 		<div class="actions">
 			<?php
 			echo UI_Elements::button( [
-				'url'  => get_permalink( $job->ID ),
+				'url'   => get_permalink( $job->ID ),
 				'label' => __( 'View', 'wp-job-manager' ),
 			], 'jm-ui-button--link' );
 			?>
 		</div>
 	</div>
 	<div class="jm-job-overlay-content">
+		<div class="jm-job-overlay-details-box">
 
+			<div class="jm-ui-row" style="justify-content: space-between; align-items: flex-start">
+				<div class="jm-ui-col">
+					<?php Job_Dashboard_Shortcode::the_location( $job ); ?>
+					<div class="jm-ui-row">
+						<?php the_company_logo( 'thumbnail', '', $job ); ?>
+						<?php echo esc_html( get_the_company_name( $job ) ); ?>
+					</div>
+				</div>
+				<div class="jm-ui-col">
+					<?php do_action( 'job_manager_job_dashboard_column_date', $job ); ?>
+				</div>
+			</div>
+
+		</div>
 	</div>
 	<div class="jm-job-overlay-footer">
 		<?php
@@ -53,9 +69,9 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 					$action_url = wp_nonce_url( $action_url, $value['nonce'] );
 				}
 				$actions[] = [
-					'label'  => $value['label'],
-					'url'    => $action_url,
-					'class'  => 'job-dashboard-action-' . esc_attr( $action ),
+					'label' => $value['label'],
+					'url'   => $action_url,
+					'class' => 'job-dashboard-action-' . esc_attr( $action ),
 				];
 			}
 		}

--- a/templates/job-dashboard-overlay.php
+++ b/templates/job-dashboard-overlay.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Job dashboard overlay.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     wp-job-manager
+ * @category    Template
+ * @version     $$next-version$$
+ *
+ * @var WP_Post $job Array of job post results.
+ * @var array $job_actions
+ */
+
+use WP_Job_Manager\UI\UI_Elements;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+$submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
+?>
+
+<div class="jm-job-overlay jm-dashboard">
+	<div class="jm-job-overlay-header">
+		<div class="">
+
+			<div class="job_title" role="heading"><?php echo esc_html( get_the_title( $job ) ?? $job->ID ); ?></div>
+			<?php do_action( 'job_manager_job_dashboard_column_job_title', $job ); ?>
+		</div>
+		<div class="actions">
+			<?php
+			echo UI_Elements::button( [
+				'url'  => get_permalink( $job->ID ),
+				'label' => __( 'View', 'wp-job-manager' ),
+			], 'jm-ui-button--link' );
+			?>
+		</div>
+	</div>
+	<div class="jm-job-overlay-content">
+
+	</div>
+	<div class="jm-job-overlay-footer">
+		<?php
+		$actions_html = '';
+		if ( ! empty( $job_actions ) ) {
+			foreach ( $job_actions as $action => $value ) {
+				$action_url = add_query_arg( [
+					'action' => $action,
+					'job_id' => $job->ID,
+				], '' );
+				if ( $value['nonce'] ) {
+					$action_url = wp_nonce_url( $action_url, $value['nonce'] );
+				}
+				$actions[] = [
+					'label'  => $value['label'],
+					'url'    => $action_url,
+					'class'  => 'job-dashboard-action-' . esc_attr( $action ),
+				];
+			}
+		}
+
+		echo UI_Elements::actions( [], $actions );
+		?>
+	</div>
+</div>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -21,7 +21,7 @@
  * @var string    $search_input Search input.
  */
 
-use WP_Job_Manager\UI\Modal_Dialog;
+use WP_Job_Manager\Job_Overlay;
 use WP_Job_Manager\UI\Notice;
 use WP_Job_Manager\UI\UI_Elements;
 
@@ -78,21 +78,7 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 						<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
 							<div class="jm-dashboard-job-column <?php echo esc_attr( $key ); ?>"
 								aria-label="<?php echo esc_attr( $column ); ?>">
-								<?php
-
-								switch ( $key ) {
-									case 'job_title':
-										echo '<a class="job-title" data-job-id="' . esc_attr( $job->ID ) . '" href="' . esc_url( get_permalink( $job->ID ) ) . '">' . esc_html( get_the_title( $job ) ?? $job->ID ) . '</a>';
-										break;
-									case 'date':
-										echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', 'M d, Y' ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
-
-										break;
-								}
-
-								do_action( 'job_manager_job_dashboard_column_' . $key, $job );
-
-								?>
+								<?php do_action( 'job_manager_job_dashboard_column_' . $key, $job ); ?>
 							</div>
 						<?php endforeach; ?>
 						<div class="jm-dashboard-job-column actions job-dashboard-job-actions">
@@ -121,11 +107,5 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 	</div>
 	<?php get_job_manager_template( 'pagination.php', [ 'max_num_pages' => $max_num_pages ] ); ?>
 
-	<?php
-	$overlay = new Modal_Dialog( [
-		'id'    => 'jmDashboardOverlay',
-		'class' => 'jm-dashboard__overlay',
-	] );
-
-	echo $overlay->render( '' ); ?>
+	<?php Job_Overlay::instance()->output_modal_element(); ?>
 </div>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -21,6 +21,7 @@
  * @var string    $search_input Search input.
  */
 
+use WP_Job_Manager\UI\Modal_Dialog;
 use WP_Job_Manager\UI\Notice;
 use WP_Job_Manager\UI\UI_Elements;
 
@@ -81,7 +82,7 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 
 								switch ( $key ) {
 									case 'job_title':
-										echo '<a class="job-title" href="' . esc_url( get_permalink( $job->ID ) ) . '">' . ( wpjm_get_the_job_title( $job ) ?? $job->ID ) . '</a>';
+										echo '<a class="job-title" data-job-id="' . esc_attr( $job->ID ) . '" href="' . esc_url( get_permalink( $job->ID ) ) . '">' . esc_html( get_the_title( $job ) ?? $job->ID ) . '</a>';
 										break;
 									case 'date':
 										echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', 'M d, Y' ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
@@ -101,7 +102,7 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 								foreach ( $job_actions[ $job->ID ] as $action => $value ) {
 									$action_url = add_query_arg( [
 										'action' => $action,
-										'job_id' => $job->ID
+										'job_id' => $job->ID,
 									] );
 									if ( $value['nonce'] ) {
 										$action_url = wp_nonce_url( $action_url, $value['nonce'] );
@@ -119,4 +120,12 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 		<?php endif; ?>
 	</div>
 	<?php get_job_manager_template( 'pagination.php', [ 'max_num_pages' => $max_num_pages ] ); ?>
+
+	<?php
+	$overlay = new Modal_Dialog( [
+		'id'    => 'jmDashboardOverlay',
+		'class' => 'jm-dashboard__overlay',
+	] );
+
+	echo $overlay->render( '' ); ?>
 </div>


### PR DESCRIPTION
Fixes #2743 

### Changes Proposed in this Pull Request

* Add a basic job overlay template
* Add AJAX endpoint to return it
* Open a modal with the job overlay content when clicking on the job title

### Testing Instructions

* Open the job dashboard page
* Click on the job titles
* Check that a modal opens and content loads for the clicked job. (Just basic details, still mostly empty)

### Screenshot / Video

<img width="1291" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/35dd205e-6b0a-4f2e-a2dc-28d362e34077">



<!-- wpjm:plugin-zip -->
----

| Plugin build for a672d90724db870894a291875882bb51050bd0fd <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2762-a672d907.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2762-a672d907)             |

<!-- /wpjm:plugin-zip -->


