### PR TITLE
Add apply clicked stat

### DIFF
--- a/assets/js/wpjm-stats.js
+++ b/assets/js/wpjm-stats.js
@@ -1,8 +1,11 @@
 /* global job_manager_stats */
 
 import domReady from '@wordpress/dom-ready';
+import { createHooks } from '@wordpress/hooks';
 
 ( function () {
+	window.wpjmStatHooks = window.wpjmStatHooks || createHooks();
+
 	function updateDailyUnique( key ) {
 		const date = new Date();
 		const expiresAtTimestamp = date.getTime() + 24 * 60 * 60 * 1000;
@@ -19,30 +22,23 @@ import domReady from '@wordpress/dom-ready';
 		return false;
 	}
 
-	domReady( function () {
-		const statsToRecord = [];
+	function setUniques( uniquesToSet ) {
+		uniquesToSet.forEach( function( uniqueKey ) {
+			updateDailyUnique( uniqueKey );
+		} );
+	}
+
+	window.wpjmLogStats = window.wpjmLogStats || function ( statsToRecord, uniquesToSet ) {
 		const jobStatsSettings = window.job_manager_stats;
 		const ajaxUrl          = jobStatsSettings.ajax_url;
-		const ajaxNonce      = jobStatsSettings.ajax_nonce;
-		const uniquesToSet = [];
-		const setUniques   = function() {
-			uniquesToSet.forEach( function( uniqueKey ) {
-				updateDailyUnique( uniqueKey );
-			} );
-		};
+		const ajaxNonce        = jobStatsSettings.ajax_nonce;
 
-		jobStatsSettings.stats_to_log?.forEach( function ( statToRecord ) {
-			const statToRecordKey = statToRecord.name;
-			const uniqueKey       = statToRecord.unique_key || '';
-			if ( uniqueKey.length === 0 ) {
-				statsToRecord.push( statToRecordKey );
-			} else {
-				if ( false === getDailyUnique( uniqueKey ) ) {
-					uniquesToSet.push( uniqueKey );
-					statsToRecord.push( statToRecordKey );
-				}
-			}
-		} );
+		uniquesToSet = uniquesToSet || [];
+		statsToRecord = statsToRecord || [];
+
+		if ( statsToRecord.length < 1 ) {
+			return Promise.resolve(); // Could also be an error.
+		}
 
 		const postData = new URLSearchParams( {
 			_ajax_nonce: ajaxNonce,
@@ -51,12 +47,82 @@ import domReady from '@wordpress/dom-ready';
 			stats: statsToRecord.join( ',' ),
 		} );
 
-		fetch( ajaxUrl, {
+		return fetch( ajaxUrl, {
 			method: 'POST',
 			credentials: 'same-origin',
 			body: postData,
 		} ).finally( function () {
-			setUniques();
+			setUniques( uniquesToSet );
 		} );
+	};
+
+	function hookStatsForTrigger( statsByTrigger, triggerName ) {
+		const statsToRecord    = [];
+		const uniquesToSet     = [];
+		const stats            = statsByTrigger[triggerName] || [];
+		const events           = {};
+
+		stats.forEach( function ( statToRecord ) {
+			const statToRecordKey = statToRecord.name;
+			const uniqueKey       = statToRecord.unique_key || '';
+			const isUnique        = uniqueKey.length > 0;
+
+			if ( ! isUnique ) {
+				statsToRecord.push( statToRecordKey );
+			} else {
+				if ( false === getDailyUnique( uniqueKey ) ) {
+					uniquesToSet.push( uniqueKey );
+					statsToRecord.push( statToRecordKey );
+				}
+			}
+
+			if ( statToRecord.element && statToRecord.event ) {
+				const elemToAttach = document.querySelector( statToRecord.element );
+				if ( elemToAttach && ! events[statToRecord.element] ) {
+					elemToAttach.addEventListener( statToRecord.event, function ( e ) {
+						if ( isUnique && false !== getDailyUnique( uniqueKey ) ) {
+							return;
+						}
+
+						window.wpjmStatHooks.doAction( triggerName );
+					} );
+					events[statToRecord.element] = true;
+				}
+			}
+		} );
+
+		// Hook action to call logStats.
+		window.wpjmStatHooks.addAction( triggerName, 'wpjm-stats', function () {
+			window.wpjmLogStats( statsToRecord, uniquesToSet );
+		}, 10 );
+	}
+
+
+	domReady( function () {
+		const jobStatsSettings = window.job_manager_stats;
+
+		const statsByTrigger = jobStatsSettings.stats_to_log?.reduce( function ( accum, statToRecord ) {
+			const triggerName = statToRecord.trigger || '';
+
+			if ( triggerName.length < 1 ) {
+				return accum;
+			}
+
+			if ( ! accum[triggerName] ) {
+				accum[triggerName] = [];
+			}
+
+			accum[triggerName].push( statToRecord );
+
+			return accum;
+		}, {} );
+
+		Object.keys( statsByTrigger ).forEach( function ( triggerName) {
+			hookStatsForTrigger( statsByTrigger, triggerName );
+		} );
+
+		// Kick things off.
+		console.log('kick thing off');
+		window.wpjmStatHooks.doAction( 'page-load' );
 	} );
 } )();

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -275,7 +275,10 @@ class Stats {
 		\WP_Job_Manager::register_script(
 			'wp-job-manager-stats',
 			'js/wpjm-stats.js',
-			[ 'wp-dom-ready' ],
+			[
+				'wp-dom-ready',
+				'wp-hooks',
+			],
 			true
 		);
 
@@ -303,10 +306,19 @@ class Stats {
 		return (array) apply_filters(
 			'wpjm_get_registered_stats',
 			[
-				'job_listing_view'        => [
+				'job_listing_view'                 => [
 					'log_callback' => [ $this, 'log_stat' ], // Example of overriding how we log this.
+					'trigger'      => 'page-load',
 				],
-				'job_listing_view_unique' => [
+				'job_listing_view_unique'          => [
+					'unique'          => true,
+					'unique_callback' => [ $this, 'unique_by_post_id' ],
+					'trigger'         => 'page-load',
+				],
+				'job_listing_apply_button_clicked' => [
+					'trigger'         => 'apply-button-clicked',
+					'element'         => 'input.application_button',
+					'event'           => 'click',
 					'unique'          => true,
 					'unique_callback' => [ $this, 'unique_by_post_id' ],
 				],
@@ -325,7 +337,10 @@ class Stats {
 		$ajax_stats = [];
 		foreach ( $this->get_registered_stats() as $stat_name => $stat_data ) {
 			$stat_ajax = [
-				'name' => $stat_name,
+				'name'    => $stat_name,
+				'trigger' => $stat_data['trigger'] ?? '',
+				'element' => $stat_data['element'] ?? '',
+				'event'   => $stat_data['event'] ?? '',
 			];
 
 			if ( ! empty( $stat_data['unique'] ) ) {


### PR DESCRIPTION
Fixes #2752

### Changes Proposed in this Pull Request

* Adds a unique stat for when apply button is clicked on a listing.
* Refactors JS frontend code to accommodate hooking events to arbitrary elements.
* Refactors php code to account for ^^.

### Testing Instructions

* Visit a listing page and click on apply several times.
* Check db that only one time is recorded.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* 

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video


<!-- wpjm:plugin-zip -->
----

| Plugin build for 888cfc853845799ca9c52f653fd0a9bef630eff0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2763-888cfc85.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2763-888cfc85)             |

<!-- /wpjm:plugin-zip -->
