### PR TITLE
Add company column to dashboard when user has multiple companies

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -55,11 +55,6 @@
       <code>COOKIE_DOMAIN</code>
     </UndefinedConstant>
   </file>
-  <file src="includes/admin/class-notices-conditions-checker.php">
-    <MissingFile>
-      <code><![CDATA[require_once ABSPATH . 'wp-admin/includes/plugin.php']]></code>
-    </MissingFile>
-  </file>
   <file src="includes/admin/class-wp-job-manager-admin-notices.php">
     <InternalClass>
       <code>new Notices_Conditions_Checker()</code>
@@ -268,12 +263,6 @@
     <InvalidArgument>
       <code><![CDATA[array_values( get_job_listing_types( 'id=>slug' ) )]]></code>
     </InvalidArgument>
-    <ParadoxicalCondition>
-      <code><![CDATA[! defined( 'ABSPATH' )]]></code>
-    </ParadoxicalCondition>
-    <RedundantPropertyInitializationCheck>
-      <code><![CDATA[isset( $this->job_dashboard_job_ids )]]></code>
-    </RedundantPropertyInitializationCheck>
     <UndefinedPropertyFetch>
       <code><![CDATA[$term->term_id]]></code>
     </UndefinedPropertyFetch>
@@ -345,10 +334,6 @@
     <InvalidScalarArgument>
       <code><![CDATA[$this->job_id]]></code>
     </InvalidScalarArgument>
-    <MissingFile>
-      <code><![CDATA[include_once ABSPATH . 'wp-admin/includes/image.php']]></code>
-      <code><![CDATA[include_once ABSPATH . 'wp-admin/includes/media.php']]></code>
-    </MissingFile>
     <TypeDoesNotContainType>
       <code>! is_string( $attachment_url )</code>
       <code>empty( $attachment_url ) || ! is_string( $attachment_url )</code>
@@ -396,9 +381,6 @@
     <InvalidArgument>
       <code><![CDATA[$this->get_plugin_versions()]]></code>
     </InvalidArgument>
-    <MissingFile>
-      <code><![CDATA[require_once ABSPATH . 'wp-admin/includes/plugin.php']]></code>
-    </MissingFile>
     <UndefinedVariable>
       <code>$item</code>
       <code>$plugin_data</code>
@@ -455,9 +437,6 @@
     <InvalidReturnType>
       <code>null|WP_Error</code>
     </InvalidReturnType>
-    <MissingFile>
-      <code><![CDATA[include_once ABSPATH . 'wp-admin/includes/plugin.php']]></code>
-    </MissingFile>
   </file>
   <file src="lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php">
     <TypeDoesNotContainType>
@@ -501,10 +480,6 @@
       <code>array</code>
       <code>bool</code>
     </InvalidReturnType>
-    <MissingFile>
-      <code><![CDATA[include_once ABSPATH . 'wp-admin/includes/file.php']]></code>
-      <code><![CDATA[include_once ABSPATH . 'wp-admin/includes/media.php']]></code>
-    </MissingFile>
     <NullableReturnStatement>
       <code><![CDATA[$return_datetime ? null : '']]></code>
     </NullableReturnStatement>

--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -2,8 +2,10 @@
 @import 'mixins';
 @import 'job-overlay';
 
-#job-manager-job-dashboard {
+.jm-dashboard {
+	container-type: inline-size;
 
+	--jm-dashboard-company-logo-size: calc(var(--jm-ui-icon-size) + 2 * var(--jm-ui-space-xs));
 }
 
 .jm-dashboard-job, .jm-dashboard-header {
@@ -50,6 +52,14 @@
 	flex: 1 1 200%;
 }
 
+.jm-dashboard-job-column.company {
+
+	flex: 0 0 var(--jm-dashboard-company-logo-size);
+	.jm-dashboard-header & {
+		visibility: hidden;
+	}
+}
+
 .jm-dashboard .job-status {
 	text-transform: uppercase;
 	font-weight: 500;
@@ -77,8 +87,8 @@
 }
 
 .jm-dashboard img.company_logo {
-	width: var(--jm-ui-icon-size);
-	height: var(--jm-ui-icon-size);
+	width: var(--jm-dashboard-company-logo-size);
+	height: var(--jm-dashboard-company-logo-size);
 	object-fit: contain;
 }
 
@@ -112,12 +122,19 @@
 	color: var(--jm-ui-danger-color);
 }
 
-@media (max-width: 600px) {
+@container (width < 540px)
+{
 	.jm-dashboard-job {
 		flex-wrap: wrap;
 	}
 
 	.jm-dashboard-header {
 		display: none;
+	}
+
+
+	.jm-dashboard-job-column.company ~ .jm-dashboard-job-column.job_title {
+		flex-basis: calc( 100% - var(--jm-dashboard-company-logo-size) - var(--jm-ui-space-sm) );
+		order: -1;
 	}
 }

--- a/assets/css/job-overlay.scss
+++ b/assets/css/job-overlay.scss
@@ -60,6 +60,7 @@
 .jm-job-overlay-details-box {
 	background: var(--jm-ui-faint-color);
 	padding: var(--jm-ui-space-m);
+	--jm-dashboard-company-logo-size: var(--jm-ui-icon-size);
 }
 
 @media (max-width: 600px) {

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -517,7 +517,7 @@ class Job_Dashboard_Shortcode {
 	 * @output string
 	 */
 	public static function the_job_title( $job ) {
-		echo '<a class="job-title" data-job-id="' . esc_attr( $job->ID ) . '" href="' . esc_url( get_permalink( $job->ID ) ) . '">' . esc_html( get_the_title( $job ) ?? $job->ID ) . '</a>';
+		echo '<a class="job-title" data-job-id="' . esc_attr( (string) $job->ID ) . '" href="' . esc_url( get_permalink( $job->ID ) ) . '">' . esc_html( get_the_title( $job ) ?? $job->ID ) . '</a>';
 	}
 
 	/**
@@ -581,7 +581,7 @@ class Job_Dashboard_Shortcode {
 	public static function get_job_dashboard_page_url() {
 		$page_id = get_option( 'job_manager_job_dashboard_page_id' );
 		if ( $page_id ) {
-			return get_permalink( $page_id );
+			return (string) get_permalink( $page_id );
 		} else {
 			return home_url( '/' );
 		}
@@ -596,7 +596,7 @@ class Job_Dashboard_Shortcode {
 	 */
 	public function is_job_available_on_dashboard( \WP_Post $job ) {
 		// Check cache of currently displayed job dashboard IDs first to avoid lots of queries.
-		if ( isset( $this->job_dashboard_job_ids ) && in_array( (int) $job->ID, $this->job_dashboard_job_ids, true ) ) {
+		if ( ! empty( $this->job_dashboard_job_ids ) && in_array( (int) $job->ID, $this->job_dashboard_job_ids, true ) ) {
 			return true;
 		}
 

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -53,13 +53,27 @@ class Job_Dashboard_Shortcode {
 
 		add_filter( 'paginate_links', [ $this, 'filter_paginate_links' ], 10, 1 );
 
+		add_action( 'job_manager_job_dashboard_column_company', [ self::class, 'the_company' ] );
 		add_action( 'job_manager_job_dashboard_column_date', [ self::class, 'the_date' ] );
 		add_action( 'job_manager_job_dashboard_column_date', [ self::class, 'the_expiration_date' ] );
 
+		add_action( 'job_manager_job_dashboard_columns', [ $this, 'maybe_display_company_column' ], 8 );
 		add_action( 'job_manager_job_dashboard_column_job_title', [ self::class, 'the_job_title' ], 10 );
 		add_action( 'job_manager_job_dashboard_column_job_title', [ self::class, 'the_status' ], 12 );
 
 		Job_Overlay::instance();
+	}
+	/**
+	 * Add 'company' column if user has multiple companies.
+	 *
+	 * @param array $columns
+	 */
+	public function maybe_display_company_column( $columns ) {
+		if ( $this->user_has_multiple_companies() ) {
+			$columns = array_merge( [ 'company' => __( 'Company', 'wp-job-manager' ) ], $columns );
+		}
+
+		return $columns;
 	}
 
 	/**
@@ -460,6 +474,17 @@ class Job_Dashboard_Shortcode {
 			// translators: Placeholder is the expiration date of the job listing.
 			echo '<div class="job-expires"><small>' . UI_Elements::rel_time( $expiration, __( 'Expires in %s', 'wp-job-manager' ) ) . '</small></div>';
 		}
+	}
+
+	/**
+	 * Show company details.
+	 *
+	 * @param \WP_Post $job
+	 *
+	 * @output string
+	 */
+	public static function the_company( $job ) {
+		the_company_logo( 'thumbnail', '', $job );
 	}
 
 	/**

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -115,14 +115,14 @@ class Stats {
 
 		$args         = array_merge( self::DEFAULT_LOG_STAT_ARGS, $args );
 		$group        = $args['group'];
-		$post_id      = $args['post_id'];
+		$post_id      = absint( $args['post_id'] );
 		$increment_by = $args['increment_by'];
 
 		if (
 			strlen( $name ) > 255 ||
 			strlen( $group ) > 255 ||
-			! is_numeric( $post_id ) ||
-			! is_numeric( $increment_by ) ) {
+			! $post_id ||
+			! is_integer( $increment_by ) ) {
 			return false;
 		}
 

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -43,7 +43,7 @@ class WP_Job_Manager {
 	/**
 	 * Stats.
 	 *
-	 * @var WP_Job_Manager_Stats
+	 * @var WP_Job_Manager\Stats
 	 */
 	public $stats;
 


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Add helper to check if user has jobs posted by multiple companies
* If so, show a company column in the dashboard with the company logo
* Tweak responsive styles to use container query

### Testing Instructions

* Have jobs with multiple companies
* Check that their logo shows on the job dashboard

### Screenshot / Video

<img width="1232" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/22d975fb-2fc0-43d8-8d11-d1feaa795a79">





<!-- wpjm:plugin-zip -->
----

| Plugin build for 9d3fe865b32d00db4950d675d388b8eed456b1d4 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2769-9d3fe865.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2769-9d3fe865)             |

<!-- /wpjm:plugin-zip -->




