### PR TITLE
Remove sending e-mails as multipart

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -485,9 +485,6 @@
     <InvalidCast>
       <code>$email_class</code>
     </InvalidCast>
-    <InvalidGlobal>
-      <code>global $phpmailer;</code>
-    </InvalidGlobal>
     <InvalidScalarArgument>
       <code>$email_class</code>
       <code>$template_segment</code>

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -844,18 +844,10 @@ final class WP_Job_Manager_Email_Notifications {
 				continue;
 			}
 
-			$set_alt_body = function( $mailer ) use ( $content_plain ) {
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$mailer->AltBody = $content_plain;
-
-				return $mailer;
-			};
-
-			$set_content_type = fn() => 'multipart/alternative';
+			$set_content_type = fn() => 'text/html';
 
 			if ( ! $is_plain_text_only ) {
 				add_filter( 'wp_mail_content_type', $set_content_type );
-				add_filter( 'phpmailer_init', $set_alt_body );
 			}
 
 			if ( wp_mail( $to_email, $args['subject'], $body, $headers, $args['attachments'] ) ) {
@@ -863,15 +855,6 @@ final class WP_Job_Manager_Email_Notifications {
 			}
 
 			remove_filter( 'wp_mail_content_type', $set_content_type );
-			remove_filter( 'phpmailer_init', $set_alt_body );
-
-			// Make sure AltBody is not sticking around for a different email.
-			global $phpmailer;
-
-			if ( $phpmailer instanceof \PHPMailer\PHPMailer\PHPMailer ) {
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$phpmailer->AltBody = '';
-			}
 		}
 
 		$job_manager_doing_email = false;

--- a/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-email-notifications.php
@@ -118,7 +118,7 @@ class WP_Test_WP_Job_Manager_Email_Notifications extends WPJM_BaseTest {
 		$this->assertEquals( 'Test Subject', $sent_email->subject );
 		$this->assertStringContainsString( '<strong>test</strong>', $sent_email->body );
 		$this->assertStringContainsString( 'From: From Name <from@example.com>', $sent_email->header );
-		$this->assertStringContainsString( 'Content-Type: text/html;', $sent_email->body );
+		$this->assertStringContainsString( 'Content-Type: text/html;', $sent_email->header );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2753 more

### Changes Proposed in this Pull Request

* Send only HTML or only plaintext version of the e-mails (depending on settings)

### Testing Instructions

* Send out HTML emails (eg new job submitted notification, job alert) and check that they are rendered correctly

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix issues with rich e-mails on some e-mail providers




<!-- wpjm:plugin-zip -->
----

| Plugin build for 79b3e3f7c14f0203dc3f3b1ae659338a5409153b <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2775-79b3e3f7.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2775-79b3e3f7)             |

<!-- /wpjm:plugin-zip -->




