### PR TITLE
Set the default dateFormat if it’s empty

### DIFF
--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -1,5 +1,8 @@
 /* global job_manager_datepicker */
 jQuery(document).ready( function() {
+	if ( jQuery.datepicker._defaults.dateFormat == '' ) {
+		jQuery.datepicker._defaults.dateFormat = 'MM d, yy';
+	}
 	var $date_today = new Date();
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
@@ -21,7 +24,6 @@ jQuery(document).ready( function() {
 			}
 		} );
 		$target.datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
-		$target.datepicker("option", "dateFormat", $target.datepicker("option", "dateFormat") || "MM d, yy");
 		if ( $target.val() ) {
 			var dateParts = $target.val().split('-');
 			if ( 3 === dateParts.length ) {

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -593,6 +593,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function custom_columns( $column ) {
 		global $post;
+		$date_format = get_option( 'date_format' ) ?: 'F j, Y';
 
 		switch ( $column ) {
 			case \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE:
@@ -658,14 +659,14 @@ class WP_Job_Manager_CPT {
 				}
 				break;
 			case 'job_posted':
-				echo '<strong>' . esc_html( wp_date( get_option( 'date_format' ), get_post_timestamp() ) ) . '</strong><span>';
+				echo '<strong>' . esc_html( wp_date( $date_format, get_post_timestamp() ) ) . '</strong><span>';
 				// translators: %s placeholder is the username of the user.
 				echo ( empty( $post->post_author ) ? esc_html__( 'by a guest', 'wp-job-manager' ) : sprintf( esc_html__( 'by %s', 'wp-job-manager' ), '<a href="' . esc_url( add_query_arg( 'author', $post->post_author ) ) . '">' . esc_html( get_the_author() ) . '</a>' ) ) . '</span>';
 				break;
 			case 'job_expires':
 				$job_expiration = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $post );
 				if ( $job_expiration ) {
-					echo '<strong>' . esc_html( wp_date( get_option( 'date_format' ), $job_expiration->getTimestamp() ) ) . '</strong>';
+					echo '<strong>' . esc_html( wp_date( $date_format, $job_expiration->getTimestamp() ) ) . '</strong>';
 				} else {
 					echo '&ndash;';
 				}

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -446,7 +446,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function post_updated_messages( $messages ) {
 		global $post, $post_ID, $wp_post_types;
-		$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
+		$wp_date_format = get_option( 'date_format' ) ?: JOB_MANAGER_DATE_FORMAT_FALLBACK;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes based on input.
 		$revision_title = isset( $_GET['revision'] ) ? wp_post_revision_title( (int) $_GET['revision'], false ) : false;

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -446,6 +446,7 @@ class WP_Job_Manager_CPT {
 	 */
 	public function post_updated_messages( $messages ) {
 		global $post, $post_ID, $wp_post_types;
+		$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No changes based on input.
 		$revision_title = isset( $_GET['revision'] ) ? wp_post_revision_title( (int) $_GET['revision'], false ) : false;
@@ -470,7 +471,7 @@ class WP_Job_Manager_CPT {
 				// translators: %1$s is the singular name of the post type; %2$s is the date the post will be published; %3$s is the URL to preview the listing.
 				__( '%1$s scheduled for: <strong>%2$s</strong>. <a target="_blank" href="%3$s">Preview</a>', 'wp-job-manager' ),
 				$wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name,
-				wp_date( get_option( 'date_format' ) . ' @ ' . get_option( 'time_format' ), get_post_timestamp() ),
+				wp_date( $wp_date_format . ' @ ' . get_option( 'time_format' ), get_post_timestamp() ),
 				esc_url( get_permalink( $post_ID ) )
 			),
 			// translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -585,7 +585,7 @@ class WP_Job_Manager_Writepanels {
 		global $post, $thepostid, $wp_post_types;
 
 		$thepostid      = $post->ID;
-		$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
+		$wp_date_format = get_option( 'date_format' ) ?: JOB_MANAGER_DATE_FORMAT_FALLBACK;
 		echo '<div class="wp_job_manager_meta_data">';
 
 		wp_nonce_field( 'save_meta_data', 'job_manager_nonce' );

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -94,15 +94,15 @@ class WP_Job_Manager_Writepanels {
 		}
 
 		if ( isset( $fields['_job_expires'] ) && ! isset( $fields['_job_expires']['value'] ) ) {
-			$job_expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $post_id );
-
+			$job_expires                           = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $post_id );
+			$wp_date_format                        = get_option( 'date_format' ) ?: 'F j, Y';
 			$fields['_job_expires']['placeholder'] = null;
 			if ( ! empty( $job_expires ) ) {
 				$fields['_job_expires']['value'] = $job_expires->format( 'Y-m-d' );
 			} else {
 				$assumed_expiration_date = calculate_job_expiry( $post_id, true );
 				if ( $assumed_expiration_date ) {
-					$fields['_job_expires']['placeholder'] = wp_date( get_option( 'date_format' ), $assumed_expiration_date->getTimestamp() );
+					$fields['_job_expires']['placeholder'] = wp_date( $wp_date_format, $assumed_expiration_date->getTimestamp() );
 				}
 				$fields['_job_expires']['value'] = '';
 			}
@@ -584,8 +584,8 @@ class WP_Job_Manager_Writepanels {
 	public function job_listing_data( $post ) {
 		global $post, $thepostid, $wp_post_types;
 
-		$thepostid = $post->ID;
-
+		$thepostid      = $post->ID;
+		$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
 		echo '<div class="wp_job_manager_meta_data">';
 
 		wp_nonce_field( 'save_meta_data', 'job_manager_nonce' );
@@ -618,7 +618,7 @@ class WP_Job_Manager_Writepanels {
 				// translators: %1$s is placeholder for singular name of the job listing post type; %2$s is the intl formatted date the listing was last modified.
 				esc_html__( '%1$s was last modified by the user on %2$s.', 'wp-job-manager' ),
 				esc_html( $wp_post_types[ \WP_Job_Manager_Post_Types::PT_LISTING ]->labels->singular_name ),
-				esc_html( wp_date( get_option( 'date_format' ), (int) $user_edited_timestamp ) )
+				esc_html( wp_date( $wp_date_format, (int) $user_edited_timestamp ) )
 			);
 			echo '</em>';
 			echo '</p>';

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -311,9 +311,10 @@ final class WP_Job_Manager_Email_Notifications {
 			];
 		}
 
-		$job_expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
+		$job_expires    = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
+		$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
 		if ( ! empty( $job_expires ) ) {
-			$job_expires_str       = wp_date( get_option( 'date_format' ), $job_expires->getTimestamp() );
+			$job_expires_str       = wp_date( $wp_date_format, $job_expires->getTimestamp() );
 			$fields['job_expires'] = [
 				'label' => __( 'Listing expires', 'wp-job-manager' ),
 				'value' => $job_expires_str,

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -312,7 +312,7 @@ final class WP_Job_Manager_Email_Notifications {
 		}
 
 		$job_expires    = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
-		$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
+		$wp_date_format = get_option( 'date_format' ) ?: JOB_MANAGER_DATE_FORMAT_FALLBACK;
 		if ( ! empty( $job_expires ) ) {
 			$job_expires_str       = wp_date( $wp_date_format, $job_expires->getTimestamp() );
 			$fields['job_expires'] = [

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -25,6 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $submission_limit			= ! empty( get_option( 'job_manager_submission_limit' ) ) ? absint( get_option( 'job_manager_submission_limit' ) ) : false;
 $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
+$wp_date_format             = get_option( 'date_format' ) ?: 'F j, Y';
 ?>
 <div id="job-manager-job-dashboard">
 	<p><?php esc_html_e( 'Your listings are shown in the table below.', 'wp-job-manager' ); ?></p>
@@ -73,11 +74,11 @@ $submit_job_form_page_id	= get_option( 'job_manager_submit_job_form_page_id' );
 										?>
 									</ul>
 								<?php elseif ('date' === $key ) : ?>
-									<?php echo esc_html( wp_date( get_option( 'date_format' ), get_post_datetime( $job )->getTimestamp() ) ); ?>
+									<?php echo esc_html( wp_date( $wp_date_format, get_post_datetime( $job )->getTimestamp() ) ); ?>
 								<?php elseif ('expires' === $key ) : ?>
 									<?php
 									$job_expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job );
-									echo esc_html( $job_expires ? wp_date( get_option( 'date_format' ), $job_expires->getTimestamp() ) : '&ndash;' );
+									echo esc_html( $job_expires ? wp_date( $wp_date_format, $job_expires->getTimestamp() ) : '&ndash;' );
 									?>
 								<?php elseif ('filled' === $key ) : ?>
 									<?php echo is_position_filled( $job ) ? '&#10004;' : '&ndash;'; ?>

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -758,10 +758,11 @@ function wpjm_get_registration_fields() {
  * @param int|WP_Post $post (default: null).
  */
 function the_job_publish_date( $post = null ) {
-	$date_format = get_option( 'job_manager_date_format' );
+	$date_format    = get_option( 'job_manager_date_format' );
+	$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
 
 	if ( 'default' === $date_format ) {
-		$display_date = esc_html__( 'Posted on ', 'wp-job-manager' ) . wp_date( get_option( 'date_format' ), get_post_timestamp( $post ) );
+		$display_date = esc_html__( 'Posted on ', 'wp-job-manager' ) . wp_date( $wp_date_format, get_post_timestamp( $post ) );
 	} else {
 		$post_timestamp = get_post_timestamp( $post );
 		$current_time   = time();
@@ -786,10 +787,11 @@ function the_job_publish_date( $post = null ) {
  * @return string|int|false
  */
 function get_the_job_publish_date( $post = null ) {
-	$date_format = get_option( 'job_manager_date_format' );
+	$date_format    = get_option( 'job_manager_date_format' );
+	$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
 
 	if ( 'default' === $date_format ) {
-		return wp_date( get_option( 'date_format' ), get_post_datetime()->getTimestamp() );
+		return wp_date( $wp_date_format, get_post_datetime()->getTimestamp() );
 	} else {
 		// translators: Placeholder %s is the relative, human readable time since the job listing was posted.
 		return sprintf( __( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( get_post_timestamp(), time() ) );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -759,7 +759,7 @@ function wpjm_get_registration_fields() {
  */
 function the_job_publish_date( $post = null ) {
 	$date_format    = get_option( 'job_manager_date_format' );
-	$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
+	$wp_date_format = get_option( 'date_format' ) ?: JOB_MANAGER_DATE_FORMAT_FALLBACK;
 
 	if ( 'default' === $date_format ) {
 		$display_date = esc_html__( 'Posted on ', 'wp-job-manager' ) . wp_date( $wp_date_format, get_post_timestamp( $post ) );
@@ -788,7 +788,7 @@ function the_job_publish_date( $post = null ) {
  */
 function get_the_job_publish_date( $post = null ) {
 	$date_format    = get_option( 'job_manager_date_format' );
-	$wp_date_format = get_option( 'date_format' ) ?: 'F j, Y';
+	$wp_date_format = get_option( 'date_format' ) ?: JOB_MANAGER_DATE_FORMAT_FALLBACK;
 
 	if ( 'default' === $date_format ) {
 		return wp_date( $wp_date_format, get_post_datetime()->getTimestamp() );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -25,6 +25,7 @@ define( 'JOB_MANAGER_VERSION', '2.2.2' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+define( 'JOB_MANAGER_DATE_FORMAT_FALLBACK', 'F j, Y' );
 
 require_once dirname( __FILE__ ) . '/wp-job-manager-autoload.php';
 WP_Job_Manager_Autoload::init();


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2739

### Changes Proposed in this Pull Request

* Previously, we were setting a datepicker option if it was empty, but it was causing some issues with showing the dateformat in the editor.  Now, this will just set the default in case the default dateFormat is empty.
* Bonus: also added a fallback for the main Jobs view in case there is no DateFormat

### Testing Instructions

* Settings > General - set the Date Format to `Custom`, clear out the custom format and save.
* Go to a Job Listing, make sure you can save an expiry date
* Refresh to make sure it's still there!
* Go to the Jobs page and make sure you see the dates in the column view as well.
* Do the same thing now but select a Date Format of your choosing!

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix: Expiry date not showing up in backend editor.
* Fix: Add fallback to date format for Jobs view in case it's missing.




<!-- wpjm:plugin-zip -->
----

| Plugin build for 5b318b12806dbc22f58216ca0f4fe37f9b16b4b5 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/03/wp-job-manager-zip-2779-5b318b12.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/03/2779-5b318b12)             |

<!-- /wpjm:plugin-zip -->




