### PR TITLE
Allow duplication on all post statuses

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -477,11 +477,6 @@ class WP_Job_Manager_Shortcodes {
 						'nonce' => $base_nonce_action_name,
 					];
 				}
-
-				$actions['duplicate'] = [
-					'label' => __( 'Duplicate', 'wp-job-manager' ),
-					'nonce' => $base_nonce_action_name,
-				];
 				break;
 			case 'expired':
 				if ( job_manager_get_permalink( 'submit_job_form' ) ) {
@@ -509,6 +504,21 @@ class WP_Job_Manager_Shortcodes {
 				break;
 		}
 
+		/**
+		 * Filter the post statuses that are allowed to be duplicated.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array Post statuses to filter - default is just 'publish'.
+		 */
+		$post_status = apply_filters( 'custom_post_status_filter', [ 'publish' ] );
+
+		if ( in_array( $job->post_status, $post_status, true ) ) {
+			$actions['duplicate'] = [
+				'label' => __( 'Duplicate', 'wp-job-manager' ),
+				'nonce' => $base_nonce_action_name,
+			];
+		}
 		$actions['delete'] = [
 			'label' => __( 'Delete', 'wp-job-manager' ),
 			'nonce' => $base_nonce_action_name,

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -504,22 +504,11 @@ class WP_Job_Manager_Shortcodes {
 				break;
 		}
 
-		/**
-		 * Filter the post statuses that are allowed to be duplicated.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param array Post statuses to filter - default is just 'publish'.
-		 */
-		$post_status = apply_filters( 'job_manager_allowed_post_status_duplicate_jobs', [ 'publish' ] );
-
-		if ( in_array( $job->post_status, $post_status, true ) ) {
-			$actions['duplicate'] = [
-				'label' => __( 'Duplicate', 'wp-job-manager' ),
-				'nonce' => $base_nonce_action_name,
-			];
-		}
-		$actions['delete'] = [
+		$actions['duplicate'] = [
+			'label' => __( 'Duplicate', 'wp-job-manager' ),
+			'nonce' => $base_nonce_action_name,
+		];
+		$actions['delete']    = [
 			'label' => __( 'Delete', 'wp-job-manager' ),
 			'nonce' => $base_nonce_action_name,
 		];

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -511,7 +511,7 @@ class WP_Job_Manager_Shortcodes {
 		 *
 		 * @param array Post statuses to filter - default is just 'publish'.
 		 */
-		$post_status = apply_filters( 'custom_post_status_filter', [ 'publish' ] );
+		$post_status = apply_filters( 'job_manager_allowed_post_status_duplicate_jobs', [ 'publish' ] );
 
 		if ( in_array( $job->post_status, $post_status, true ) ) {
 			$actions['duplicate'] = [


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2470

### Changes Proposed in this Pull Request

* Adds a filter `job_manager_allowed_post_status_duplicate_jobs` that will allow people to filter which post status will be allowed to duplicate jobs in the Job Dashboard
* Default is to allow just ‘publish’ status, which won’t change any behaviours.

### Testing Instructions

* Apply this PR
* Add a filter like this to your site:

```
add_filter( 'job_manager_allowed_post_status_duplicate_jobs', function( $post_status ) {
    $post_status[] = 'preview';
    return $post_status;
});
```
* Make sure you have a "draft" job in your job dashboard
* Ensure that you can now duplicate it!

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* New filter, `job_manager_allowed_post_status_duplicate_jobs` will let you set specific post statuses that will have the duplicate optionin the Job Dashboard.



<!-- wpjm:plugin-zip -->
----

| Plugin build for 82286ded26febb5ba3b64e21f0b29c11b10cccbc <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/02/wp-job-manager-zip-2780-82286ded.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/02/2780-82286ded)             |

<!-- /wpjm:plugin-zip -->


