### PR TITLE
Add stats batch logging, unit tests, small tweaks

### DIFF
--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -145,9 +145,11 @@
 	width: var(--jm-ui-icon-size);
 	height: var(--jm-ui-icon-size);
 	mask-size: 100% 100%;
-	background-color: currentColor;
 
-	mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='black' stroke-dasharray='4 4' stroke-width='1.5' d='M20 12a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z'/%3e%3c/svg%3e");
+	&:where(:not(.jm-ui-icon--svg)) {
+		background-color: currentColor;
+		mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cpath stroke=\'black\' stroke-dasharray=\'4 4\' stroke-width=\'1.5\' d=\'M20 12a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z\'/%3e%3c/svg%3e');
+	}
 
 	&[data-icon=check] {
 		mask-image: var(--jm-ui-svg-check);

--- a/includes/class-dev-tools.php
+++ b/includes/class-dev-tools.php
@@ -65,6 +65,8 @@ class Dev_Tools {
 
 		$stats->delete_stats( $job_id );
 
+		$records = [];
+
 		for ( $i = 0; $i <= $days + 1; $i++ ) {
 			$views        = (int) max( 0, $views + $trend * wp_rand( 0, 1000 ) );
 			$trend        = wp_rand( 0, 10 ) / 10 - 0.5;
@@ -74,34 +76,30 @@ class Dev_Tools {
 
 			$log .= $views . ' ';
 
-			$stats->log_stat(
-				Job_Listing_Stats::VIEW,
-				[
-					'post_id' => $job_id,
-					'count'   => $views,
-					'date'    => $date,
-				]
-			);
+			$records[] = [
+				'name'    => Job_Listing_Stats::VIEW,
+				'post_id' => $job_id,
+				'count'   => $views,
+				'date'    => $date,
+			];
 
-			$stats->log_stat(
-				Job_Listing_Stats::VIEW_UNIQUE,
-				[
-					'post_id' => $job_id,
-					'count'   => $unique_views,
-					'date'    => $date,
-				]
-			);
+			$records[] = [
+				'name'    => Job_Listing_Stats::VIEW_UNIQUE,
+				'post_id' => $job_id,
+				'count'   => $unique_views,
+				'date'    => $date,
+			];
 
-			$stats->log_stat(
-				Job_Listing_Stats::SEARCH_IMPRESSION,
-				[
-					'post_id' => $job_id,
-					'count'   => $impressions,
-					'date'    => $date,
-				]
-			);
+			$records[] = [
+				'name'    => Job_Listing_Stats::SEARCH_IMPRESSION,
+				'post_id' => $job_id,
+				'count'   => $impressions,
+				'date'    => $date,
+			];
 
 		}
+
+		$stats->batch_log_stats( $records );
 
 		\WP_CLI::log( \WP_CLI::colorize( 'Stats generated from %C' . $start_date->format( 'Y-m-d' ) . '%n for %C' . $days . ' days%n: ' ) . $log );
 

--- a/includes/class-job-listing-stats.php
+++ b/includes/class-job-listing-stats.php
@@ -58,19 +58,6 @@ class Job_Listing_Stats {
 	}
 
 	/**
-	 * Get total stats for a job listing.
-	 *
-	 * @return array
-	 */
-	public function get_total_stats() {
-		return [
-			'view'        => $this->get_event_total( self::VIEW ),
-			'view_unique' => $this->get_event_total( self::VIEW_UNIQUE ),
-			'search'      => $this->get_event_total( self::SEARCH_IMPRESSION ),
-		];
-	}
-
-	/**
 	 * Get total counts for an event.
 	 *
 	 * @param string $event

--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -212,6 +212,10 @@ class Stats_Dashboard {
 	private function get_stat_summaries( \WP_Post $job ) {
 		$job_stats = new Job_Listing_Stats( $job->ID );
 
+		$views        = $job_stats->get_event_total( Job_Listing_Stats::VIEW );
+		$views_unique = $job_stats->get_event_total( Job_Listing_Stats::VIEW_UNIQUE );
+		$views_repeat = $views - $views_unique;
+
 		/**
 		 * Filter the job stat summaries, displayed in the job overlay.
 		 *
@@ -227,12 +231,12 @@ class Stats_Dashboard {
 						[
 							'icon'  => 'color-page-view',
 							'label' => __( 'Page Views', 'wp-job-manager' ),
-							'value' => $job_stats->get_event_total( Job_Listing_Stats::VIEW ),
+							'value' => $views,
 						],
 						[
 							'icon'  => 'color-unique-view',
 							'label' => __( 'Unique Visitors', 'wp-job-manager' ),
-							'value' => $job_stats->get_event_total( Job_Listing_Stats::VIEW_UNIQUE ),
+							'value' => $views_unique,
 						],
 					],
 					'column' => 1,
@@ -253,19 +257,14 @@ class Stats_Dashboard {
 					'title'  => __( 'Interest', 'wp-job-manager' ),
 					'stats'  => [
 						[
-							'icon'  => 'search',
-							'label' => __( 'Search clicks', 'wp-job-manager' ),
-							'value' => 'TODO',
-						],
-						[
 							'icon'  => 'cursor',
-							'label' => __( 'Apply clicks', 'wp-job-manager' ),
+							'label' => __( 'Apply Clicks', 'wp-job-manager' ),
 							'value' => $job_stats->get_event_total( Job_Listing_Stats::APPLY_CLICK ),
 						],
 						[
-							'icon'  => 'history',
-							'label' => __( 'Repeat viewers', 'wp-job-manager' ),
-							'value' => 'TODO',
+							'icon'  => 'url("data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cg fill=\'black\'%3e%3cpath d=\'M16.6 7.4a6.5 6.5 0 0 0-9.17-.02L8.7 8.66l-3.9.36.36-3.9 1.2 1.2a8 8 0 1 1-2.3 6.72l1.49-.2A6.5 6.5 0 1 0 16.6 7.4Z\'/%3e%3cpath d=\'m12 7-1 5c0 .37.2.7.51.87l4.13 2.76-2.74-4.11L12 7Z\'/%3e%3c/g%3e%3c/svg%3e")',
+							'label' => __( 'Repeat Views', 'wp-job-manager' ),
+							'value' => $views_repeat,
 						],
 					],
 					'column' => 2,

--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -216,7 +216,7 @@ class Stats_Dashboard {
 		$views_unique       = $job_stats->get_event_total( Job_Listing_Stats::VIEW_UNIQUE );
 		$views_repeat       = $views - $views_unique;
 		$search_impressions = $job_stats->get_event_total( Job_Listing_Stats::SEARCH_IMPRESSION );
-		$search_clicks      = $views_unique / $search_impressions * 100;
+		$search_clicks      = $search_impressions ? $views_unique / $search_impressions * 100 : 0;
 
 		/**
 		 * Filter the job stat summaries, displayed in the job overlay.

--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -212,9 +212,11 @@ class Stats_Dashboard {
 	private function get_stat_summaries( \WP_Post $job ) {
 		$job_stats = new Job_Listing_Stats( $job->ID );
 
-		$views        = $job_stats->get_event_total( Job_Listing_Stats::VIEW );
-		$views_unique = $job_stats->get_event_total( Job_Listing_Stats::VIEW_UNIQUE );
-		$views_repeat = $views - $views_unique;
+		$views              = $job_stats->get_event_total( Job_Listing_Stats::VIEW );
+		$views_unique       = $job_stats->get_event_total( Job_Listing_Stats::VIEW_UNIQUE );
+		$views_repeat       = $views - $views_unique;
+		$search_impressions = $job_stats->get_event_total( Job_Listing_Stats::SEARCH_IMPRESSION );
+		$search_clicks      = $views_unique / $search_impressions * 100;
 
 		/**
 		 * Filter the job stat summaries, displayed in the job overlay.
@@ -230,12 +232,12 @@ class Stats_Dashboard {
 					'stats'  => [
 						[
 							'icon'  => 'color-page-view',
-							'label' => __( 'Page Views', 'wp-job-manager' ),
+							'label' => __( 'Page views', 'wp-job-manager' ),
 							'value' => $views,
 						],
 						[
 							'icon'  => 'color-unique-view',
-							'label' => __( 'Unique Visitors', 'wp-job-manager' ),
+							'label' => __( 'Unique visitors', 'wp-job-manager' ),
 							'value' => $views_unique,
 						],
 					],
@@ -247,8 +249,8 @@ class Stats_Dashboard {
 					'stats'  => [
 						[
 							'icon'  => 'search',
-							'label' => __( 'Search Impressions', 'wp-job-manager' ),
-							'value' => $job_stats->get_event_total( Job_Listing_Stats::SEARCH_IMPRESSION ),
+							'label' => __( 'Search impressions', 'wp-job-manager' ),
+							'value' => $search_impressions,
 						],
 					],
 					'column' => 1,
@@ -257,8 +259,13 @@ class Stats_Dashboard {
 					'title'  => __( 'Interest', 'wp-job-manager' ),
 					'stats'  => [
 						[
+							'icon'    => 'search',
+							'label'   => __( 'Search click-through rate', 'wp-job-manager' ),
+							'percent' => $search_clicks,
+						],
+						[
 							'icon'  => 'cursor',
-							'label' => __( 'Apply Clicks', 'wp-job-manager' ),
+							'label' => __( 'Apply clicks', 'wp-job-manager' ),
 							'value' => $job_stats->get_event_total( Job_Listing_Stats::APPLY_CLICK ),
 						],
 						[

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager\Stats_Script
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Add and handle frontend script to collect stats.
+ *
+ * @since $$next-version$$
+ */
+class Stats_Script {
+	use Singleton;
+
+	/**
+	 * Run any hooks related to stats.
+	 *
+	 * @return void
+	 */
+	private function __construct() {
+		add_action( 'wp_ajax_job_manager_log_stat', [ $this, 'ajax_log_stat' ] );
+		add_action( 'wp_ajax_nopriv_job_manager_log_stat', [ $this, 'ajax_log_stat' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'maybe_enqueue_stats_scripts' ] );
+	}
+
+	/**
+	 * Log multiple stats in one go. Triggered in an ajax call.
+	 *
+	 * @return bool
+	 */
+	public function ajax_log_stat() {
+		if ( ! wp_doing_ajax() ) {
+			return false;
+		}
+
+		$post_data = stripslashes_deep( $_POST );
+
+		if ( ! isset( $post_data['_ajax_nonce'] ) || ! wp_verify_nonce( $post_data['_ajax_nonce'], 'ajax-nonce' ) ) {
+			return false;
+		}
+
+		$stats_json = $post_data['stats'] ?? '[]';
+		$stats      = json_decode( $stats_json, true );
+
+		if ( empty( $stats ) ) {
+			return false;
+		}
+
+		$errors           = [];
+		$registered_stats = $this->get_registered_stat_names();
+
+		$stats = array_filter(
+			$stats,
+			function( $stat ) use ( $registered_stats ) {
+				return in_array( $stat['name'], $registered_stats, true );
+			}
+		);
+
+		return Stats::instance()->batch_log_stats( $stats );
+	}
+
+	/**
+	 * Get stat names.
+	 *
+	 * @return int[]|string[]
+	 */
+	private function get_registered_stat_names() {
+		return array_keys( $this->get_registered_stats() );
+	}
+
+	/**
+	 * Register any frontend scripts for job listings.
+	 *
+	 * @access private
+	 */
+	public function maybe_enqueue_stats_scripts() {
+
+		\WP_Job_Manager::register_script(
+			'wp-job-manager-stats',
+			'js/wpjm-stats.js',
+			[
+				'wp-dom-ready',
+				'wp-hooks',
+			],
+			true
+		);
+
+		global $post;
+
+		if ( is_wpjm_job_listing() ) {
+			$this->enqueue_stats_script( 'listing', $post->ID );
+		}
+
+		if ( $this->page_has_jobs_shortcode( $post ) ) {
+			$this->enqueue_stats_script( 'jobs', $post->ID );
+		}
+
+	}
+
+	/**
+	 * Register scripts for given screen.
+	 *
+	 * @param string $page Which page.
+	 * @param int    $post_id Which id.
+	 *
+	 * @return void
+	 */
+	private function enqueue_stats_script( $page = 'listing', $post_id = 0 ) {
+
+		$script_data = [
+			'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
+			'ajaxNonce' => wp_create_nonce( 'ajax-nonce' ),
+			'postId'    => $post_id,
+			'stats'     => $this->get_stats_for_ajax( $post_id, $page ),
+		];
+
+		wp_enqueue_script( 'wp-job-manager-stats' );
+		wp_localize_script(
+			'wp-job-manager-stats',
+			'job_manager_stats',
+			$script_data
+		);
+
+	}
+
+	/**
+	 * Get all the registered stats.
+	 *
+	 * @return array
+	 */
+	private function get_registered_stats() {
+		return (array) apply_filters(
+			'wpjm_get_registered_stats',
+			[
+				Job_Listing_Stats::VIEW              => [
+					'type'   => 'action',
+					'action' => 'page-load',
+					'page'   => 'listing',
+				],
+				Job_Listing_Stats::VIEW_UNIQUE       => [
+					'type'   => 'action',
+					'action' => 'page-load',
+					'unique' => true,
+					'page'   => 'listing',
+				],
+				Job_Listing_Stats::APPLY_CLICK       => [
+					'type'   => 'domEvent',
+					'args'   => [
+						'element' => 'input.application_button',
+						'event'   => 'click',
+					],
+					'unique' => true,
+					'page'   => 'listing',
+				],
+				'search_view'                        => [
+					'type'   => 'action',
+					'action' => 'page-load',
+					'page'   => 'jobs',
+				],
+				'search_view_unique'                 => [
+					'type'   => 'action',
+					'action' => 'page-load',
+					'page'   => 'jobs',
+					'unique' => true,
+				],
+				Job_Listing_Stats::SEARCH_IMPRESSION => [
+					'type' => 'impression',
+					'args' => [
+						'container' => 'ul.job_listings',
+						'item'      => 'li.job_listing',
+					],
+					'page' => 'jobs',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Determine what stats should be added to the kind of page the user is viewing.
+	 *
+	 * @param int    $post_id Optional post id.
+	 * @param string $page The page in question.
+	 *
+	 * @return array
+	 */
+	private function get_stats_for_ajax( $post_id = 0, $page = 'listing' ) {
+		$ajax_stats = [];
+		foreach ( $this->get_registered_stats() as $stat_name => $stat_data ) {
+			if ( $page !== $stat_data['page'] ) {
+				continue;
+			}
+
+			$stat_ajax = [
+				'name'    => $stat_name,
+				'post_id' => $post_id,
+				'type'    => $stat_data['type'] ?? '',
+				'action'  => $stat_data['action'] ?? '',
+				'args'    => $stat_data['args'] ?? '',
+			];
+
+			if ( ! empty( $stat_data['unique'] ) ) {
+				$unique_callback         = $stat_data['unique_callback'] ?? [ $this, 'get_post_id_unique_key' ];
+				$stat_ajax['unique_key'] = call_user_func( $unique_callback, $stat_name, $post_id );
+			}
+
+			$ajax_stats[] = $stat_ajax;
+		}
+
+		return $ajax_stats;
+	}
+
+	/**
+	 * Derive unique key by post id.
+	 *
+	 * @access private
+	 *
+	 * @param string $stat_name Name.
+	 * @param int    $post_id Post id.
+	 *
+	 * @return string
+	 */
+	public function get_post_id_unique_key( $stat_name, $post_id ) {
+		return $stat_name . '_' . $post_id;
+	}
+
+	/**
+	 * Any page containing a job shortcode is eligible.
+	 *
+	 * @param \WP_Post $post The post.
+	 *
+	 * @return bool
+	 */
+	private function page_has_jobs_shortcode( $post ) {
+		return $post && has_shortcode( $post->post_content, 'jobs' );
+	}
+
+}

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -82,8 +82,8 @@ class Stats {
 				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				`date` date NOT NULL,
 				`post_id` bigint(20) DEFAULT NULL,
-				`name` varchar(255) NOT NULL,
-				`group` varchar(255) DEFAULT '',
+				`name` varchar(50) NOT NULL,
+				`group` varchar(50) DEFAULT '',
 				`count` bigint(20) unsigned not null default 1,
 				PRIMARY KEY (`id`),
 				UNIQUE INDEX `idx_wpjm_stats_name_date_group_post_id`  (`name`, `date`, `group`, `post_id`)
@@ -214,8 +214,8 @@ class Stats {
 
 		if (
 			empty( $args['name'] ) ||
-			strlen( $args['name'] ) > 255 ||
-			strlen( $args['group'] ) > 255 ||
+			strlen( $args['name'] ) > 50 ||
+			strlen( $args['group'] ) > 50 ||
 			empty( $args['post_id'] ) ||
 			! is_integer( $args['count'] ) ) {
 			return false;

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -50,8 +50,7 @@ class Stats {
 		}
 
 		Stats_Dashboard::instance();
-
-		$this->init_hooks();
+		Stats_Script::instance();
 	}
 
 	/**
@@ -125,8 +124,10 @@ class Stats {
 
 		return $this->batch_log_stats(
 			[
-				'name' => $name,
-				... $args,
+				array_merge(
+					[ 'name' => $name ],
+					$args
+				),
 			]
 		);
 	}
@@ -137,11 +138,11 @@ class Stats {
 	 * @param array[] $stats {
 	 * Array of stats to log, with the following fields.
 	 *
-	 * @type string  $name The stat name.
-	 * @type int     $post_id Post ids to log the stat for.
-	 * @type string  $group Additional data (eg keyword) for the stat.
-	 * @type int     $count The amount to increment the stat by.
-	 * @type string  $date Date in YYYY-MM-DD format.
+	 * @type string   $name The stat name.
+	 * @type int      $post_id Post ids to log the stat for.
+	 * @type string   $group Additional data (eg keyword) for the stat.
+	 * @type int      $count The amount to increment the stat by.
+	 * @type string   $date Date in YYYY-MM-DD format.
 	 * }
 	 *
 	 * @return bool
@@ -151,7 +152,6 @@ class Stats {
 		if ( ! self::is_enabled() ) {
 			return false;
 		}
-
 		$stats = array_map( [ $this, 'parse_stats' ], $stats );
 		$stats = array_filter( $stats );
 
@@ -189,11 +189,11 @@ class Stats {
 	 * @param array $args {
 	 * Stat data.
 	 *
-	 * @type string  $name The stat name.
-	 * @type string  $group Additional data (eg keyword) for the stat.
-	 * @type int     $post_id The post_id this stat belongs to.
-	 * @type int     $count The amount to increment the stat by.
-	 * @type string  $date Date in YYYY-MM-DD format.
+	 * @type string $name The stat name.
+	 * @type string $group Additional data (eg keyword) for the stat.
+	 * @type int    $post_id The post_id this stat belongs to.
+	 * @type int    $count The amount to increment the stat by.
+	 * @type string $date Date in YYYY-MM-DD format.
 	 * }
 	 *
 	 * @return array|false
@@ -213,9 +213,10 @@ class Stats {
 		$args['post_id'] = absint( $args['post_id'] );
 
 		if (
+			empty( $args['name'] ) ||
 			strlen( $args['name'] ) > 255 ||
 			strlen( $args['group'] ) > 255 ||
-			! $args['post_id'] ||
+			empty( $args['post_id'] ) ||
 			! is_integer( $args['count'] ) ) {
 			return false;
 		}
@@ -235,232 +236,41 @@ class Stats {
 	}
 
 	/**
-	 * Perform plugin activation-related stats actions.
+	 * Delete all stats for a given job.
 	 *
-	 * @return void
-	 */
-	public function activate() {
-	}
-
-	/**
-	 * Run any hooks related to stats.
-	 *
-	 * @return void
-	 */
-	private function init_hooks() {
-		add_action( 'wp_ajax_job_manager_log_stat', [ $this, 'ajax_log_stat' ] );
-		add_action( 'wp_ajax_nopriv_job_manager_log_stat', [ $this, 'ajax_log_stat' ] );
-		add_action( 'wp_enqueue_scripts', [ $this, 'maybe_enqueue_stats_scripts' ] );
-	}
-
-	/**
-	 * Log multiple stats in one go. Triggered in an ajax call.
-	 *
-	 * @return bool
-	 */
-	public function ajax_log_stat() {
-		if ( ! wp_doing_ajax() ) {
-			return false;
-		}
-
-		$post_data = stripslashes_deep( $_POST );
-
-		if ( ! isset( $post_data['_ajax_nonce'] ) || ! wp_verify_nonce( $post_data['_ajax_nonce'], 'ajax-nonce' ) ) {
-			return false;
-		}
-
-		$stats_json = $post_data['stats'] ?? '[]';
-		$stats      = json_decode( $stats_json, true );
-
-		if ( empty( $stats ) ) {
-			return false;
-		}
-
-		$errors           = [];
-		$registered_stats = $this->get_registered_stat_names();
-
-		$stats = array_filter(
-			$stats,
-			function( $stat ) use ( $registered_stats ) {
-				return in_array( $stat['name'], $registered_stats, true );
-			}
-		);
-
-		return $this->batch_log_stats( $stats );
-	}
-
-	/**
-	 * Get stat names.
-	 *
-	 * @return int[]|string[]
-	 */
-	private function get_registered_stat_names() {
-		return array_keys( $this->get_registered_stats() );
-	}
-
-	/**
-	 * Register any frontend scripts for job listings.
-	 *
-	 * @access private
-	 */
-	public function maybe_enqueue_stats_scripts() {
-
-		\WP_Job_Manager::register_script(
-			'wp-job-manager-stats',
-			'js/wpjm-stats.js',
-			[
-				'wp-dom-ready',
-				'wp-hooks',
-			],
-			true
-		);
-
-		global $post;
-
-		if ( is_wpjm_job_listing() ) {
-			$this->enqueue_stats_script( 'listing', $post->ID );
-		}
-
-		if ( $this->page_has_jobs_shortcode( $post ) ) {
-			$this->enqueue_stats_script( 'jobs', $post->ID );
-		}
-
-	}
-
-	/**
-	 * Register scripts for given screen.
-	 *
-	 * @param string $page Which page.
-	 * @param int    $post_id Which id.
-	 *
-	 * @return void
-	 */
-	private function enqueue_stats_script( $page = 'listing', $post_id = 0 ) {
-
-		$script_data = [
-			'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
-			'ajaxNonce' => wp_create_nonce( 'ajax-nonce' ),
-			'postId'    => $post_id,
-			'stats'     => $this->get_stats_for_ajax( $post_id, $page ),
-		];
-
-		wp_enqueue_script( 'wp-job-manager-stats' );
-		wp_localize_script(
-			'wp-job-manager-stats',
-			'job_manager_stats',
-			$script_data
-		);
-
-	}
-
-	/**
-	 * Get all the registered stats.
+	 * @param string $stat_name
+	 * @param int    $post_id
+	 * @param null   $date
 	 *
 	 * @return array
 	 */
-	private function get_registered_stats() {
-		return (array) apply_filters(
-			'wpjm_get_registered_stats',
-			[
-				Job_Listing_Stats::VIEW              => [
-					'type'   => 'action',
-					'action' => 'page-load',
-					'page'   => 'listing',
-				],
-				Job_Listing_Stats::VIEW_UNIQUE       => [
-					'type'   => 'action',
-					'action' => 'page-load',
-					'unique' => true,
-					'page'   => 'listing',
-				],
-				Job_Listing_Stats::APPLY_CLICK       => [
-					'type'   => 'domEvent',
-					'args'   => [
-						'element' => 'input.application_button',
-						'event'   => 'click',
-					],
-					'unique' => true,
-					'page'   => 'listing',
-				],
-				'search_view'                        => [
-					'type'   => 'action',
-					'action' => 'page-load',
-					'page'   => 'jobs',
-				],
-				'search_view_unique'                 => [
-					'type'   => 'action',
-					'action' => 'page-load',
-					'page'   => 'jobs',
-					'unique' => true,
-				],
-				Job_Listing_Stats::SEARCH_IMPRESSION => [
-					'type' => 'impression',
-					'args' => [
-						'container' => 'ul.job_listings',
-						'item'      => 'li.job_listing',
-					],
-					'page' => 'jobs',
-				],
-			]
-		);
-	}
+	public function get_stats( $stat_name = '', $post_id = null, $date = null ) {
+		global $wpdb;
 
-	/**
-	 * Determine what stats should be added to the kind of page the user is viewing.
-	 *
-	 * @param int    $post_id Optional post id.
-	 * @param string $page The page in question.
-	 *
-	 * @return array
-	 */
-	private function get_stats_for_ajax( $post_id = 0, $page = 'listing' ) {
-		$ajax_stats = [];
-		foreach ( $this->get_registered_stats() as $stat_name => $stat_data ) {
-			if ( $page !== $stat_data['page'] ) {
-				continue;
-			}
+		$query  = "SELECT * FROM {$wpdb->wpjm_stats} WHERE 1=1 ";
+		$params = [];
 
-			$stat_ajax = [
-				'name'    => $stat_name,
-				'post_id' => $post_id,
-				'type'    => $stat_data['type'] ?? '',
-				'action'  => $stat_data['action'] ?? '',
-				'args'    => $stat_data['args'] ?? '',
-			];
-
-			if ( ! empty( $stat_data['unique'] ) ) {
-				$unique_callback         = $stat_data['unique_callback'] ?? [ $this, 'unique_by_post_id' ];
-				$stat_ajax['unique_key'] = call_user_func( $unique_callback, $stat_name, $post_id );
-			}
-
-			$ajax_stats[] = $stat_ajax;
+		if ( ! empty( $stat_name ) ) {
+			$query   .= ' AND name = %s';
+			$params[] = $stat_name;
 		}
 
-		return $ajax_stats;
-	}
+		if ( ! empty( $post_id ) ) {
+			$query   .= ' AND post_id = %d';
+			$params[] = $post_id;
+		}
 
-	/**
-	 * Derive unique key by post id.
-	 *
-	 * @access private
-	 *
-	 * @param string $stat_name Name.
-	 * @param int    $post_id Post id.
-	 *
-	 * @return string
-	 */
-	public function unique_by_post_id( $stat_name, $post_id ) {
-		return $stat_name . '_' . $post_id;
-	}
+		if ( ! empty( $date ) ) {
+			$query   .= ' AND date = %s';
+			$params[] = $date;
+		}
 
-	/**
-	 * Any page containing a job shortcode is eligible.
-	 *
-	 * @param \WP_Post $post The post.
-	 *
-	 * @return bool
-	 */
-	public function page_has_jobs_shortcode( $post ) {
-		return $post && has_shortcode( $post->post_content, 'jobs' );
+		if ( ! empty( $params ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Dynamic query.
+			$query = $wpdb->prepare( $query, $params );
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared above.
+		return $wpdb->get_results( $query );
 	}
 }

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -149,7 +149,6 @@ class WP_Job_Manager {
 	 * Performs plugin activation steps.
 	 */
 	public function activate() {
-		\WP_Job_Manager\Stats::instance()->activate();
 		WP_Job_Manager_Ajax::add_endpoint();
 		unregister_post_type( \WP_Job_Manager_Post_Types::PT_LISTING );
 		add_filter( 'pre_option_job_manager_enable_types', '__return_true' );

--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -39,8 +39,10 @@ class UI_Elements {
 		$html = '';
 
 		$is_classname = preg_match( '/^[\w-]+$/i', $icon );
+		$is_url       = preg_match( '/^url\(/i', $icon );
+		$is_svg       = preg_match( '/^<svg/i', $icon );
 
-		$html = '<span class="jm-ui-icon"';
+		$html = '<span class="jm-ui-icon' . ( $is_svg ? ' jm-ui-icon--svg' : '' ) . '"';
 
 		if ( $is_classname ) {
 			$html .= ' data-icon="' . esc_attr( $icon ) . '"';
@@ -50,9 +52,13 @@ class UI_Elements {
 			$html .= ' aria-label="' . esc_attr( $label ) . '"';
 		}
 
+		if ( $is_url ) {
+			$html .= ' style="mask-image: ' . esc_attr( $icon ) . '"';
+		}
+
 		$html .= '>';
 
-		if ( ! $is_classname ) {
+		if ( $is_svg ) {
 			$html .= self::esc_svg( $icon );
 		}
 

--- a/templates/job-stats.php
+++ b/templates/job-stats.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php
 				foreach ( $chart['y-labels'] as $label ) {
 					$position = ( $label / $chart['max'] ) * 100;
-					echo '<div class="jm-chart-y-axis__label" style="bottom: ' . esc_attr( $position ) . '%;"><span>' . esc_html( $label ) . '</span></div>';
+					echo '<div class="jm-chart-y-axis__label" style="bottom: ' . esc_attr( $position ) . '%;"><span>' . esc_html( number_format_i18n( $label ) ) . '</span></div>';
 				}
 				?>
 			</div>
@@ -56,16 +56,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<strong><?php echo esc_html( $day['date'] ); ?></strong>
 							</div>
 							<div class="jm-ui-row">
-								<?php esc_html_e( 'Search Impressions', 'wp-job-manager' ); ?>
-								<strong><?php echo esc_html( $day['impressions'] ); ?></strong>
+								<?php esc_html_e( 'Search impressions', 'wp-job-manager' ); ?>
+								<strong><?php echo esc_html( number_format_i18n( $day['impressions'] ) ); ?></strong>
 							</div>
 							<div class="jm-ui-row">
-								<?php esc_html_e( 'Page Views', 'wp-job-manager' ); ?>
-								<strong><?php echo esc_html( $day['views'] ); ?></strong>
+								<?php esc_html_e( 'Page views', 'wp-job-manager' ); ?>
+								<strong><?php echo esc_html( number_format_i18n( $day['views'] ) ); ?></strong>
 							</div>
 							<div class="jm-ui-row">
-								<?php esc_html_e( 'Unique Visitors', 'wp-job-manager' ); ?>
-								<strong><?php echo esc_html( $day['uniques'] ); ?></strong>
+								<?php esc_html_e( 'Unique visitors', 'wp-job-manager' ); ?>
+								<strong><?php echo esc_html( number_format_i18n( $day['uniques'] ) ); ?></strong>
 							</div>
 
 
@@ -115,10 +115,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 									<?php echo esc_html( $stat['label'] ); ?>
 								</div>
 								<div class="jm-stat-value">
-									<?php echo esc_html( $stat['value'] ); ?>
-									<?php if ( ! empty( $stat['percent'] ) ) : ?>
+									<?php if ( isset( $stat['value'] ) ) : ?>
+										<?php echo esc_html( number_format_i18n( $stat['value'] ) ); ?>
+									<?php endif; ?>
+									<?php if ( isset( $stat['percent'] ) ) : ?>
 										<span
-											class="jm-stat-value-percent"><?php echo esc_html( $stat['percent'] ); ?>%</span>
+											class="jm-stat-value-percent"><?php echo esc_html( number_format_i18n( $stat['percent'], 2 ) ); ?>%</span>
 									<?php endif; ?>
 								</div>
 								<?php if ( isset( $stat['background'] ) ) : ?>

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace WP_Job_Manager;
+
+class WP_Test_Stats extends \WPJM_BaseTest {
+
+	//setup
+	public function setUp(): void {
+		parent::setUp();
+		update_option( Stats::OPTION_ENABLE_STATS, true );
+		Stats::instance()->migrate_db();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+	}
+
+	public function test_log_stat_creates_record() {
+		$job_id = $this->factory->job_listing->create();
+
+		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => $job_id, 'count' => 1 ] );
+
+		$stats = Stats::instance()->get_stats( null, $job_id );
+
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 'test_stat', $stats[0]->name );
+
+	}
+
+	public function test_log_stat_exits_when_disabled() {
+		update_option( Stats::OPTION_ENABLE_STATS, false );
+		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => 1, 'count' => 1 ] );
+
+		$stats = Stats::instance()->get_stats( null, 1 );
+
+		$this->assertEmpty( $stats );
+
+	}
+
+	public function test_log_stat_increases_count() {
+
+		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => 1, 'count' => 1 ] );
+		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => 1, 'count' => 1 ] );
+
+		$stats = Stats::instance()->get_stats( 'test_stat', 1 );
+
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 2, $stats[0]->count );
+
+	}
+
+	public function test_batch_log_stats_creates_records() {
+
+		$stats = [
+			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => 2, 'count' => 2 ],
+			[ 'name' => 'test_stat_2', 'post_id' => 1, 'count' => 1 ],
+		];
+
+		Stats::instance()->batch_log_stats( $stats );
+
+		$stats = Stats::instance()->get_stats();
+
+		$this->assertCount( 3, $stats );
+
+	}
+
+	public function test_batch_log_stats_increases_counts() {
+
+		$stats = [
+			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => 2, 'count' => 2 ],
+		];
+
+		Stats::instance()->batch_log_stats( $stats );
+		Stats::instance()->batch_log_stats( $stats );
+
+		$stats = Stats::instance()->get_stats();
+
+		$this->assertCount( 2, $stats );
+		$this->assertEquals( 4, $stats[0]->count );
+		$this->assertEquals( 4, $stats[1]->count );
+
+	}
+
+	public function test_delete_stats_deletes_post_stats() {
+
+		$stats = [
+			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => 2, 'count' => 2 ],
+			[ 'name' => 'test_stat_2', 'post_id' => 1, 'count' => 1 ],
+		];
+
+		Stats::instance()->batch_log_stats( $stats );
+
+		Stats::instance()->delete_stats( 1 );
+
+		$stats = Stats::instance()->get_stats( null, 1 );
+
+		$this->assertEmpty( $stats );
+
+	}
+
+	public function test_job_listing_stats_counts_totals() {
+
+		$job_id = $this->factory->job_listing->create();
+
+		Stats::instance()->batch_log_stats( [
+			[ 'name' => 'test_stat', 'post_id' => $job_id, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => $job_id, 'count' => 1 ],
+		] );
+
+		$job_stats = new Job_Listing_Stats( $job_id );
+
+		$total = $job_stats->get_event_total( 'test_stat' );
+
+		$this->assertEquals( 2, $total );
+	}
+
+	public function test_job_listing_stats_counts_daily_stats() {
+
+		$job_id = $this->factory->job_listing->create();
+
+		Stats::instance()->batch_log_stats( [
+			[ 'name' => 'test_stat', 'post_id' => $job_id, 'count' => 1, 'date' => '2020-01-01' ],
+			[ 'name' => 'test_stat', 'post_id' => $job_id, 'count' => 1, 'date' => '2020-01-01' ],
+			[ 'name' => 'test_stat', 'post_id' => $job_id, 'count' => 1, 'date' => '2020-01-02' ],
+		] );
+
+		$job_stats = new Job_Listing_Stats( $job_id, [
+			new \DateTime( '2020-01-01' ),
+			new \DateTime( '2020-01-02' ),
+		] );
+
+		$daily = $job_stats->get_event_daily( 'test_stat' );
+
+		$this->assertEquals( [ '2020-01-01' => 2, '2020-01-02' => 1 ], $daily );
+
+	}
+
+	public function test_ajax_stats_logged() {
+
+		Stats_Script::instance();
+
+		$job_id = $this->factory->job_listing->create();
+
+		$_POST = [
+			'stats'       => json_encode( [
+				[
+					'post_id' => $job_id,
+					'name'    => 'job_view',
+				],
+				[
+					'post_id' => $job_id,
+					'name'    => 'job_view_unique',
+				],
+			] ),
+			'_ajax_nonce' => wp_create_nonce( 'ajax-nonce' ),
+		];
+
+		do_action( 'wp_ajax_job_manager_log_stat' );
+
+		$stats = Stats::instance()->get_stats( null, $job_id );
+
+		$this->assertEquals( [ 'job_view', 'job_view_unique' ], wp_list_pluck( $stats, 'name' ) );
+
+	}
+
+}


### PR DESCRIPTION
Collecting a few more things here that support addons adding their own stats.  

### Changes Proposed in this Pull Request

Under the hood:
* Add batch logging, insert multiple stat records in one query. This is most useful for the Alerts add-on but I also switched the ajax logger over for quicker search impressions
* Move ajax stats to dedicated class, remove some unused methods
* Add unit tests
* Lower column size to `varchar(50)` for `name` and `group` column in the stats table
* Improve UI icon helper for addons adding using custom icons

Stats overlay:
* Add repeat job views count (just the difference between total and unique for now)
* Add click through rate
* Format numbers, tweak labels

### Testing Instructions

* Enable stats, click around job search and open job pages
* Check in the job dashboard that the impressions and views are showing up

### Screenshot / Video

<img width="844" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/69f3a46b-917f-4c44-8c7a-de2fa9d21ae9">



<!-- wpjm:plugin-zip -->
----

| Plugin build for 15e705bec87f9ac206b8822f53353b3907e71070 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/03/wp-job-manager-zip-2787-15e705be.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/03/2787-15e705be)             |

<!-- /wpjm:plugin-zip -->




