### PR TITLE
Ensure we archive the new autoload class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
       "!/readme.txt",
       "!/uninstall.php",
       "!/wp-job-manager.php",
+      "!/wp-job-manager-autoload.php",
       "!/wp-job-manager-deprecated.php",
       "!/wp-job-manager-functions.php",
       "!/wp-job-manager-template.php",


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Make sure to archive the new autoload class.

### Testing Instructions

* run `npm run build` and check the zip file to see that `wp-job-manager-autoload.php` is there in the root.


<!-- wpjm:plugin-zip -->
----

| Plugin build for f4a23a4adff4e8f23cdd7a37b554a35527110d02 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/03/wp-job-manager-zip-2788-f4a23a4a.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/03/2788-f4a23a4a)             |

<!-- /wpjm:plugin-zip -->
