### PR TITLE
Fix stat display date

### DIFF
--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -179,10 +179,12 @@ class Stats_Dashboard {
 		ksort( $by_day );
 
 		$date_format = apply_filters( 'job_manager_get_dashboard_date_format', 'M d, Y' );
+		$timezone    = new \DateTimeZone( wp_timezone_string() );
 
 		$by_day_formatted = [];
 		foreach ( $by_day as $date => $data ) {
-			$date_fmt                              = wp_date( $date_format, strtotime( $date ) );
+			$date_obj                              = new \DateTime( $date, $timezone );
+			$date_fmt                              = wp_date( $date_format, $date_obj->getTimestamp(), $timezone );
 			$by_day_formatted[ $date_fmt ]         = $by_day[ $date ];
 			$by_day_formatted[ $date_fmt ]['date'] = $date_fmt;
 		}
@@ -192,7 +194,6 @@ class Stats_Dashboard {
 			'max'      => $max,
 			'y-labels' => [ $max / 2, $max ],
 		];
-
 		/**
 		 * Filter the job daily stat data, displayed as a chart in the job overlay.
 		 *


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Show dates according to site's timezone and not UTC

### Testing Instructions

* Set site's timezone to something far from UTC, like Pacific time was what I had
* Set a site impression or view and make sure that it would be UTC for the next day
* You can even just edit the stat manually in the database if that's easier
* Now make sure that the stat shows for the right day in the overlay



<!-- wpjm:plugin-zip -->
----

| Plugin build for 4e4a0fab3e51e96743ac8d9d18229aec443e4763 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/03/wp-job-manager-zip-2792-4e4a0fab.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/03/2792-4e4a0fab)             |

<!-- /wpjm:plugin-zip -->
