### PR TITLE
Add new notice about latest release

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -204,9 +204,6 @@
     <InvalidReturnStatement>
       <code><![CDATA[new WP_Error( 'error', $e->getMessage() )]]></code>
     </InvalidReturnStatement>
-    <ParadoxicalCondition>
-      <code><![CDATA[! defined( 'ABSPATH' )]]></code>
-    </ParadoxicalCondition>
   </file>
   <file src="includes/class-wp-job-manager-install.php">
     <UndefinedPropertyFetch>

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -159,7 +159,7 @@ $notice-success: #43af99;
 	}
 	&--landing &__image img {
 		max-width: 100%;
-		max-height: 500px;
+		max-height: 400px;
 	}
 
 }

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -51,8 +51,19 @@ $notice-success: #43af99;
 		aspect-ratio: 1;
 	}
 
+	&__label {
+		font-weight: 600;
+		background: var(--wpjm-brand-color-shade-4);
+		color: var(--wpjm-brand-color-primary);
+		border-radius: 40px;
+		padding: 6px 12px;
+		display: inline-block;
+		text-transform: uppercase;
+		align-self: flex-start;
+		font-size: 12px;
+	}
+
 	&__heading {
-		margin: 0 0 8px 0;
 		font-weight: 700;
 		font-size: 16px;
 		letter-spacing: -0.36px;
@@ -62,11 +73,25 @@ $notice-success: #43af99;
 	&__message {
 		flex: 1 1 min-content;
 		align-self: center;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
 		min-width: min(100%, 400px);
+		line-height: 1.5;
 
 		&, p {
 			font-size: 14px;
 		}
+
+		ul {
+			margin: 0;
+			padding-left: 10px;
+			list-style-type: '•';
+		}
+		li {
+			padding-left: 10px;
+		}
+
 
 	}
 
@@ -106,6 +131,35 @@ $notice-success: #43af99;
 		&:hover {
 			color: var(--wpjm-brand-color-primary);
 		}
+	}
+
+	&--landing {
+		padding: 40px 40px;
+		align-items: flex-start;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	&--landing &__top {
+		flex-direction: column;
+		gap: 20px;
+		align-items: flex-start;
+	}
+
+	&--landing &__message {
+		gap: 20px;
+	}
+
+	&--landing &__heading {
+		font-size: 40px;
+		letter-spacing: -0.8px;
+	}
+
+	&--landing &__image {
+		max-width: 50%;
+	}
+	&--landing &__image img {
+		max-width: 100%;
+		max-height: 500px;
 	}
 
 }

--- a/includes/admin/class-release-notice.php
+++ b/includes/admin/class-release-notice.php
@@ -13,16 +13,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Admin notice about changes and new features introduced in the latest release.
+ * Update this class for each release to highlight new features or changes.
  */
 class Release_Notice {
+	public const NOTICE_ID = 'release_notice_2_3_0';
 
 	/**
 	 * Set up notice.
 	 */
 	public static function init() {
 		add_filter( 'wpjm_admin_notices', [ __CLASS__, 'add_release_notice' ] );
+		add_action( 'job_manager_action_enable_stats', [ self::class, 'enable_feature' ] );
+	}
 
-		add_action( 'job_manager_action_enable_stats', fn() => \WP_Job_Manager_Settings::instance()->set_setting( \WP_Job_Manager\Stats::OPTION_ENABLE_STATS, '1' ) );
+	/**
+	 * Enable the highlighted feature.
+	 *
+	 * @return void
+	 */
+	public static function enable_feature() {
+		\WP_Job_Manager_Settings::instance()->set_setting( \WP_Job_Manager\Stats::OPTION_ENABLE_STATS, '1' );
 	}
 
 	/**
@@ -35,23 +45,20 @@ class Release_Notice {
 	public static function add_release_notice( $notices ) {
 
 		// Make sure to update the version number in the notice ID when changing this notice for a new release.
-
-		$notice_id = 'release_notice_2_3_0';
-
-		$action_url            = \WP_Job_Manager_Admin_Notices::get_action_url( 'enable_stats', $notice_id );
-		$notices[ $notice_id ] = [
+		$action_url                 = \WP_Job_Manager_Admin_Notices::get_action_url( 'enable_stats', self::NOTICE_ID );
+		$notices[ self::NOTICE_ID ] = [
 			'type'          => 'site-wide',
 			'label'         => 'New',
 			'heading'       => 'Job Statistics',
 
 			'message'       => '<div>' . __(
 				'
-<p>Collect analytics data about site visitors for each job listing. Display the detailed statistics in the refreshed jobs dashboard.</p>
+<p>Collect analytics about site visitors for each job listing. Display the detailed statistics in the refreshed jobs dashboard.</p>
 <ul>
-	<li>Page views and unique visitors with daily breakdown</li>
-	<li>Search impressions and apply button clicks</li>
-	<li>Add-on integration: Job alert impressions, bookmarks, application stats</li>
-	<li>GDPR-compliant, with no personal user information collected</li>
+	<li>Tracks page views and unique visitors, search impressions and apply button clicks.</li>
+	<li>Adds a new overlay to the employer dashboard with aggregated statistics and a daily breakdown chart.</li>
+	<li>Integrates with Job Alerts, Applications, and Bookmarks add-ons.</li>
+	<li>GDPR-compliant, with no personal user information collected.</li>
 </ul>
 ',
 				'wp-job-manager'
@@ -64,7 +71,7 @@ class Release_Notice {
 				],
 				[
 					'label'   => __( 'Dismiss', 'wp-job-manager' ),
-					'url'     => \WP_Job_Manager_Admin_Notices::get_dismiss_url( $notice_id ),
+					'url'     => \WP_Job_Manager_Admin_Notices::get_dismiss_url( self::NOTICE_ID ),
 					'primary' => false,
 				],
 				[

--- a/includes/admin/class-release-notice.php
+++ b/includes/admin/class-release-notice.php
@@ -50,7 +50,6 @@ class Release_Notice {
 			'type'          => 'site-wide',
 			'label'         => 'New',
 			'heading'       => 'Job Statistics',
-
 			'message'       => '<div>' . __(
 				'
 <p>Collect analytics about site visitors for each job listing. Display the detailed statistics in the refreshed jobs dashboard.</p>

--- a/includes/admin/class-release-notice.php
+++ b/includes/admin/class-release-notice.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * File containing the class \WP_Job_Manager\Admin\Release_Notice.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Admin notice about changes and new features introduced in the latest release.
+ */
+class Release_Notice {
+
+	/**
+	 * Set up notice.
+	 */
+	public static function init() {
+		add_filter( 'wpjm_admin_notices', [ __CLASS__, 'add_release_notice' ] );
+
+		add_action( 'job_manager_action_enable_stats', fn() => \WP_Job_Manager_Settings::instance()->set_setting( \WP_Job_Manager\Stats::OPTION_ENABLE_STATS, '1' ) );
+	}
+
+	/**
+	 * Add a release notice for the 2.3.0 release.
+	 *
+	 * @param array $notices
+	 *
+	 * @return array
+	 */
+	public static function add_release_notice( $notices ) {
+
+		// Make sure to update the version number in the notice ID when changing this notice for a new release.
+
+		$notice_id = 'release_notice_2_3_0';
+
+		$action_url            = \WP_Job_Manager_Admin_Notices::get_action_url( 'enable_stats', $notice_id );
+		$notices[ $notice_id ] = [
+			'type'          => 'site-wide',
+			'label'         => 'New',
+			'heading'       => 'Job Statistics',
+
+			'message'       => '<div>' . __(
+				'
+<p>Collect analytics data about site visitors for each job listing. Display the detailed statistics in the refreshed jobs dashboard.</p>
+<ul>
+	<li>Page views and unique visitors with daily breakdown</li>
+	<li>Search impressions and apply button clicks</li>
+	<li>Add-on integration: Job alert impressions, bookmarks, application stats</li>
+	<li>GDPR-compliant, with no personal user information collected</li>
+</ul>
+',
+				'wp-job-manager'
+			) . '</div>',
+			'actions'       => [
+				[
+					'label'   => __( 'Enable', 'wp-job-manager' ),
+					'url'     => $action_url,
+					'primary' => true,
+				],
+				[
+					'label'   => __( 'Dismiss', 'wp-job-manager' ),
+					'url'     => \WP_Job_Manager_Admin_Notices::get_dismiss_url( $notice_id ),
+					'primary' => false,
+				],
+				[
+					'label' => __( 'See what\'s new in 2.3', 'wp-job-manager' ),
+					'url'   => 'https://wpjobmanager.com/2024/03/27/new-in-2-3-job-statistics/',
+					'class' => 'is-link',
+				],
+			],
+			'icon'          => false,
+			'level'         => 'landing',
+			'image'         => 'https://wpjobmanager.com/wp-content/uploads/2024/03/jm-230-release.png',
+			'dismissible'   => false,
+			'extra_details' => '',
+			'conditions'    => [
+				[
+					'type'    => 'screens',
+					'screens' => [ 'edit-job_listing' ],
+				],
+			],
+		];
+
+		return $notices;
+	}
+
+}

--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -413,7 +413,7 @@ class WP_Job_Manager_Admin_Notices {
 	/**
 	 * Save notice state as dismissed.
 	 *
-	 * @param int $notice_id Notice ID.
+	 * @param string $notice_id Notice ID.
 	 *
 	 * @return void
 	 */

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -83,6 +83,16 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
+	 * Set a single setting.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value Value.
+	 */
+	public function set_setting( $option, $value ) {
+		update_option( $option, $value );
+	}
+
+	/**
 	 * Initializes the configuration for the plugin's setting fields.
 	 *
 	 * @access protected

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -5,6 +5,8 @@
  * @package wp-job-manager
  */
 
+use WP_Job_Manager\Admin\Release_Notice;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -74,6 +76,9 @@ class WP_Job_Manager_Install {
 			$permalink_options                 = (array) json_decode( get_option( 'job_manager_permalinks', '[]' ), true );
 			$permalink_options['jobs_archive'] = '';
 			update_option( 'job_manager_permalinks', wp_json_encode( $permalink_options ) );
+
+			update_option( \WP_Job_Manager\Stats::OPTION_ENABLE_STATS, true );
+			\WP_Job_Manager_Admin_Notices::dismiss_notice( Release_Notice::NOTICE_ID );
 		}
 
 		\WP_Job_Manager\Stats::instance()->migrate_db();


### PR DESCRIPTION
Fixes #2796

### Changes Proposed in this Pull Request

* Add a new release notice class
* Add new styles and options to support this notice layout

### Testing Instructions

* Notice should show up on the Job Manager (Job Listings) admin screen
* Disable Job Statistics in the settings
* In the notice, click 'Enable'. Check that the setting is enabled and the notice disappears
* Check that dismissing the various notices makes them disappear, even after refreshing the page
* Use `wp option delete wp_job_manager_dismissed_notices` to un-dismiss all notices
* Also check if the notice text needs any improvements

### Screenshot / Video

<img width="1575" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/5db027fb-9d26-4972-b23f-4c5c96812f8f">






<!-- wpjm:plugin-zip -->
----

| Plugin build for 317970f2af056ecf60393476759d59cbabe6abfc <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/04/wp-job-manager-zip-2798-317970f2.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/04/2798-317970f2)             |

<!-- /wpjm:plugin-zip -->








