### PR TITLE
Add usage tracking for settings

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -110,6 +110,9 @@
     <NullArgument>
       <code>null</code>
     </NullArgument>
+    <ParadoxicalCondition>
+      <code><![CDATA[! defined( 'ABSPATH' )]]></code>
+    </ParadoxicalCondition>
     <UndefinedDocblockClass>
       <code>stirng|int</code>
     </UndefinedDocblockClass>

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -322,7 +322,6 @@ abstract class WP_Job_Manager_Form {
 	 * Enqueue the scripts for the form.
 	 */
 	public function enqueue_scripts() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::enqueue_scripts' );
 		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_scripts();
 	}
 

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -57,7 +57,6 @@ class WP_Job_Manager_Admin {
 		WP_Job_Manager_CPT::instance();
 
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-promoted-jobs-admin.php';
-		include_once dirname( __FILE__ ) . '/class-wp-job-manager-settings.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-writepanels.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-setup.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-addons-landing-page.php';

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -251,7 +251,7 @@ class WP_Job_Manager_Settings {
 								'any' => __( 'Jobs will be shown if within ANY selected category', 'wp-job-manager' ),
 								'all' => __( 'Jobs will be shown if within ALL selected categories', 'wp-job-manager' ),
 							],
-							'track'   => 'bool',
+							'track'   => 'value',
 						],
 						[
 							'name'       => 'job_manager_enable_types',
@@ -312,7 +312,7 @@ class WP_Job_Manager_Settings {
 							'type'        => 'text',
 							'placeholder' => __( 'e.g. USD', 'wp-job-manager' ),
 							'attributes'  => [],
-							'track'       => 'bool',
+							'track'       => 'value',
 						],
 						[
 							'name'       => 'job_manager_enable_salary_unit',
@@ -333,7 +333,7 @@ class WP_Job_Manager_Settings {
 							'type'       => 'select',
 							'options'    => job_manager_get_salary_unit_options(),
 							'attributes' => [],
-							'track'      => 'bool',
+							'track'      => 'value',
 						],
 						[
 							'name'     => 'job_manager_display_location_address',

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -83,13 +83,23 @@ class WP_Job_Manager_Settings {
 	}
 
 	/**
+	 * Set a single setting.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value Value.
+	 */
+	public function set_setting( $option, $value ) {
+		update_option( $option, $value );
+	}
+
+	/**
 	 * Initializes the configuration for the plugin's setting fields.
 	 *
 	 * @access protected
 	 */
 	protected function init_settings() {
 		// Prepare roles option.
-		$roles         = get_editable_roles();
+		$roles         = function_exists( 'get_editable_roles' ) ? get_editable_roles() : [];
 		$account_roles = [];
 
 		foreach ( $roles as $key => $role ) {
@@ -115,6 +125,7 @@ class WP_Job_Manager_Settings {
 								'relative' => __( 'Relative to the current date (e.g., 1 day, 1 week, 1 month ago)', 'wp-job-manager' ),
 								'default'  => __( 'Default date format as defined in Settings', 'wp-job-manager' ),
 							],
+							'track'   => 'value',
 						],
 						[
 							'name'       => \WP_Job_Manager\Stats::OPTION_ENABLE_STATS,
@@ -124,6 +135,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Collect anonymous visitor data about job listings (page views, search impressions), and show them in the job dashboard.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_google_maps_api_key',
@@ -141,6 +153,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => '',
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_bypass_trash_on_uninstall',
@@ -150,6 +163,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => '',
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 					],
 				],
@@ -163,6 +177,7 @@ class WP_Job_Manager_Settings {
 							'label'       => __( 'Listings Per Page', 'wp-job-manager' ),
 							'desc'        => __( 'Number of job listings to display per page.', 'wp-job-manager' ),
 							'attributes'  => [],
+							'track'       => 'value',
 						],
 						[
 							'name'    => 'job_manager_job_listing_pagination_type',
@@ -174,6 +189,7 @@ class WP_Job_Manager_Settings {
 								'load_more'  => __( 'Load More Listings button', 'wp-job-manager' ),
 								'pagination' => __( 'Page numbered links', 'wp-job-manager' ),
 							],
+							'track'   => 'value',
 						],
 						[
 							'name'       => 'job_manager_hide_filled_positions',
@@ -183,6 +199,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Filled job listings will not be included in search results, sitemap and feeds.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_hide_expired',
@@ -192,6 +209,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Expired job listings will not be shown to the users on the job board.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_hide_expired_content',
@@ -201,6 +219,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Your site will display the titles of expired listings, but not the content of the listings. Otherwise, expired listings display their full content minus the application area.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_categories',
@@ -210,6 +229,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'This lets users select from a list of categories when submitting a job. Note: an admin has to create categories before site users can select them.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_default_category_multiselect',
@@ -219,6 +239,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'The category selection box will default to allowing multiple selections on the [jobs] shortcode. Without this, visitors will only be able to select a single category when filtering jobs.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'    => 'job_manager_category_filter_type',
@@ -230,6 +251,7 @@ class WP_Job_Manager_Settings {
 								'any' => __( 'Jobs will be shown if within ANY selected category', 'wp-job-manager' ),
 								'all' => __( 'Jobs will be shown if within ALL selected categories', 'wp-job-manager' ),
 							],
+							'track'   => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_types',
@@ -239,6 +261,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'This lets users select from a list of types when submitting a job. Note: an admin has to create types before site users can select them.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_multi_job_type',
@@ -248,6 +271,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'This allows users to select more than one type when submitting a job. The metabox on the post editor and the selection box on the front-end job submission form will both reflect this.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_remote_position',
@@ -257,6 +281,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'This lets users select if the listing is a remote position when submitting a job.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_salary',
@@ -266,6 +291,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'This lets users add a salary when submitting a job.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_salary_currency',
@@ -275,6 +301,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'This lets users add a salary currency when submitting a job.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'        => 'job_manager_default_salary_currency',
@@ -285,6 +312,7 @@ class WP_Job_Manager_Settings {
 							'type'        => 'text',
 							'placeholder' => __( 'e.g. USD', 'wp-job-manager' ),
 							'attributes'  => [],
+							'track'       => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_salary_unit',
@@ -294,6 +322,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'This lets users add a salary unit when submitting a job.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_default_salary_unit',
@@ -304,6 +333,7 @@ class WP_Job_Manager_Settings {
 							'type'       => 'select',
 							'options'    => job_manager_get_salary_unit_options(),
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'     => 'job_manager_display_location_address',
@@ -312,6 +342,7 @@ class WP_Job_Manager_Settings {
 							'cb_label' => __( 'Display Location Address', 'wp-job-manager' ),
 							'desc'     => __( 'Display the full address of the job listing location if it is detected by Google Maps Geocoding API. If full address is not available then it will display whatever text the user submitted for the location.', 'wp-job-manager' ),
 							'type'     => 'checkbox',
+							'track'    => 'bool',
 						],
 						[
 							'name'     => 'job_manager_strip_job_description_shortcodes',
@@ -320,6 +351,7 @@ class WP_Job_Manager_Settings {
 							'cb_label' => __( 'Strip shortcodes from Job description', 'wp-job-manager' ),
 							'desc'     => __( 'If enabled, shortcodes will be stripped from the job description on the single job listing page.', 'wp-job-manager' ),
 							'type'     => 'checkbox',
+							'track'    => 'bool',
 						],
 					],
 				],
@@ -334,6 +366,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Limits job listing submissions to registered, logged-in users.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_enable_registration',
@@ -343,6 +376,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Includes account creation on the listing submission form, to allow non-registered users to create an account and submit a job listing simultaneously.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 
@@ -353,6 +387,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Allow employers to set a date in the future for the listing to publish.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_generate_username_from_email',
@@ -362,6 +397,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Automatically generates usernames for new accounts from the registrant\'s email address. If this is not enabled, a "username" field will display instead.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_use_standard_password_setup_email',
@@ -371,6 +407,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Sends an email to the user with their username and a link to set their password. If this is not enabled, a "password" field will display instead, and their email address won\'t be verified.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'    => 'job_manager_registration_role',
@@ -379,6 +416,7 @@ class WP_Job_Manager_Settings {
 							'desc'    => __( 'Any new accounts created during submission will have this role. If you haven\'t enabled account creation during submission in the options above, your own method of assigning roles will apply.', 'wp-job-manager' ),
 							'type'    => 'select',
 							'options' => $account_roles,
+							'track'   => 'value',
 						],
 						[
 							'name'       => 'job_manager_submission_requires_approval',
@@ -388,6 +426,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Sets all new submissions to "pending." They will not appear on your site until an admin approves them.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_user_can_edit_pending_submissions',
@@ -397,6 +436,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Users can continue to edit pending listings until they are approved by an admin.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 						[
 							'name'       => 'job_manager_user_edit_published_submissions',
@@ -411,6 +451,7 @@ class WP_Job_Manager_Settings {
 								'yes_moderated' => __( 'Users can edit, but edits require admin approval', 'wp-job-manager' ),
 							],
 							'attributes' => [],
+							'track'      => 'value',
 						],
 						[
 							'name'              => 'job_manager_submission_duration',
@@ -421,6 +462,7 @@ class WP_Job_Manager_Settings {
 							'attributes'        => [],
 							'sanitize_callback' => [ $this, 'sanitize_submission_duration' ],
 							'placeholder'       => __( 'No limit', 'wp-job-manager' ),
+							'track'             => 'value',
 						],
 						[
 							'name'              => 'job_manager_renewal_days',
@@ -430,6 +472,7 @@ class WP_Job_Manager_Settings {
 							'type'              => 'number',
 							'attributes'        => [],
 							'sanitize_callback' => [ $this, 'sanitize_renewal_days' ],
+							'track'             => 'value',
 						],
 						[
 							'name'              => 'job_manager_submission_limit',
@@ -440,6 +483,7 @@ class WP_Job_Manager_Settings {
 							'attributes'        => [],
 							'sanitize_callback' => [ $this, 'sanitize_submission_limit' ],
 							'placeholder'       => __( 'No limit', 'wp-job-manager' ),
+							'track'             => 'value',
 						],
 						[
 							'name'    => 'job_manager_allowed_application_method',
@@ -452,6 +496,7 @@ class WP_Job_Manager_Settings {
 								'email' => __( 'Email addresses only', 'wp-job-manager' ),
 								'url'   => __( 'Website URLs only', 'wp-job-manager' ),
 							],
+							'track'   => 'value',
 						],
 						[
 							'name'       => 'job_manager_show_agreement_job_submission',
@@ -461,6 +506,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => __( 'Require a Terms and Conditions checkbox to be marked before a job can be submitted. The linked page can be set from the <a href="#settings-job_pages" class="nav-internal">Pages</a> settings tab.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 					],
 				],
@@ -486,6 +532,7 @@ class WP_Job_Manager_Settings {
 								'v2' => __( 'reCaptcha v2', 'wp-job-manager' ),
 								'v3' => __( 'reCaptcha v3', 'wp-job-manager' ),
 							],
+							'track'       => 'value',
 						],
 						[
 							'name'        => 'job_manager_recaptcha_site_key',
@@ -513,6 +560,7 @@ class WP_Job_Manager_Settings {
 							'desc'       => sprintf( __( 'This will help prevent bots from submitting job listings. You must have entered a valid site key and secret key above.', 'wp-job-manager' ), 'https://www.google.com/recaptcha/admin#list' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
+							'track'      => 'bool',
 						],
 					],
 				],
@@ -525,6 +573,7 @@ class WP_Job_Manager_Settings {
 							'label' => __( 'Submit Job Form Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page where you\'ve used the [submit_job_form] shortcode. This lets the plugin know the location of the form.', 'wp-job-manager' ),
 							'type'  => 'page',
+							'track' => 'bool',
 						],
 						[
 							'name'  => 'job_manager_job_dashboard_page_id',
@@ -532,6 +581,7 @@ class WP_Job_Manager_Settings {
 							'label' => __( 'Job Dashboard Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page where you\'ve used the [job_dashboard] shortcode. This lets the plugin know the location of the dashboard.', 'wp-job-manager' ),
 							'type'  => 'page',
+							'track' => 'bool',
 						],
 						[
 							'name'  => 'job_manager_jobs_page_id',
@@ -539,6 +589,7 @@ class WP_Job_Manager_Settings {
 							'label' => __( 'Job Listings Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page where you\'ve used the [jobs] shortcode. This lets the plugin know the location of the job listings page.', 'wp-job-manager' ),
 							'type'  => 'page',
+							'track' => 'bool',
 						],
 						[
 							'name'  => 'job_manager_terms_and_conditions_page_id',
@@ -546,6 +597,7 @@ class WP_Job_Manager_Settings {
 							'label' => __( 'Terms and Conditions Page', 'wp-job-manager' ),
 							'desc'  => __( 'Select the page to link when "Terms and Conditions Checkbox" is enabled. See setting in "Job Submission" tab.', 'wp-job-manager' ),
 							'type'  => 'page',
+							'track' => 'bool',
 						],
 					],
 				],
@@ -560,6 +612,7 @@ class WP_Job_Manager_Settings {
 							'sanitize_callback' => [ $this, 'sanitize_capabilities' ],
 							// translators: Placeholder %s is the url to the WordPress core documentation for capabilities and roles.
 							'desc'              => sprintf( __( 'Enter which <a href="%s">roles or capabilities</a> allow visitors to browse job listings. If no value is selected, everyone (including logged out guests) will be able to browse job listings.', 'wp-job-manager' ), 'http://codex.wordpress.org/Roles_and_Capabilities' ),
+							'track'             => 'bool',
 						],
 						[
 							'name'              => 'job_manager_view_job_listing_capability',
@@ -569,6 +622,7 @@ class WP_Job_Manager_Settings {
 							'sanitize_callback' => [ $this, 'sanitize_capabilities' ],
 							// translators: Placeholder %s is the url to the WordPress core documentation for capabilities and roles.
 							'desc'              => sprintf( __( 'Enter which <a href="%s">roles or capabilities</a> allow visitors to view a single job listing. If no value is selected, everyone (including logged out guests) will be able to view job listings.', 'wp-job-manager' ), 'http://codex.wordpress.org/Roles_and_Capabilities' ),
+							'track'             => 'bool',
 						],
 					],
 				],

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -470,6 +470,7 @@ final class WP_Job_Manager_Email_Notifications {
 				'label'        => false,
 				'std'          => self::get_email_setting_defaults( $email_notification_key ),
 				'settings'     => self::get_email_setting_fields( $email_notification_key ),
+				'track'        => 'bool',
 			];
 		}
 

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -82,6 +82,7 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-email-template.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-email-notifications.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-data-exporter.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-settings.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-com-api.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -776,6 +776,29 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 		$this->assertEquals( 1, $base_fields['paid'] );
 	}
 
+
+	/**
+	 * Tests that get_usage_data() returns the plugin settings.
+	 *
+	 * @since 1.30.0
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_get_settings() {
+		$published = 3;
+		$expired   = 2;
+
+		update_option( 'job_manager_enable_types', '1' );
+		update_option( 'job_manager_hide_filled_positions', '1' );
+		update_option( 'job_manager_google_maps_api_key', '000000000' );
+
+		$this->create_job_listings_with_meta( '_company_name', 'Automattic', $published, $expired );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $data['settings_enable_types'], '1' );
+		$this->assertEquals( $data['settings_hide_filled_positions'], '1' );
+		$this->assertTrue( empty( $data['settings_google_maps_api_key'] ) );
+	}
+
 	/**
 	 * Adds fake license to one of the products.
 	 */


### PR DESCRIPTION
Fixes #2797

### Changes Proposed in this Pull Request

* Send setting field data along when sending usage tracking data
* Configure which settings fields are included with a `track` key in the settings config
* Move a few things around so the Settings class is available
* Fix an issue with licensed plugin info not matching formatting rules for Tracks

### Testing Instructions

* Run the cron event `job_manager_usage_tracking_send_usage_data`
* Wait 10 minutes
* Check for the `wpjm_stats_log` event in Tracks Live View. Username can be used to filter, it's the full site URL (Like `http://paper.local`)
* Check that `settings_` fields are included





<!-- wpjm:plugin-zip -->
----

| Plugin build for 20d4d78c18def330d414ae224b989b06998f79e7 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/04/wp-job-manager-zip-2799-20d4d78c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/04/2799-20d4d78c)             |

<!-- /wpjm:plugin-zip -->




