### PR TITLE
Add primary action to job dashboard and overlay

### DIFF
--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -118,12 +118,8 @@
 	text-decoration: none;
 }
 .jm-dashboard-action--primary {
-	&:not(:hover):not(:active) {
-		color: inherit;
-	}
 	flex-basis: fit-content;
 	white-space: nowrap;
-	font-weight: 600;
 }
 
 .jm-dashboard-action:where(:not(:hover):not(:focus)) {
@@ -138,6 +134,7 @@
 {
 	.jm-dashboard-job {
 		flex-wrap: wrap;
+		align-items: flex-start;
 	}
 
 	.jm-dashboard-header {

--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -96,6 +96,10 @@
 .jm-dashboard-job-column.actions {
 	flex: 0.5 1 100%;
 	text-align: right;
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	gap: var(--jm-ui-space-m);
 }
 
 .jm-dashboard-job-column a.job-title {
@@ -112,8 +116,16 @@
 .jm-dashboard-action {
 	display: block;
 	text-decoration: none;
-
 }
+.jm-dashboard-action--primary {
+	&:not(:hover):not(:active) {
+		color: inherit;
+	}
+	flex-basis: fit-content;
+	white-space: nowrap;
+	font-weight: 600;
+}
+
 .jm-dashboard-action:where(:not(:hover):not(:focus)) {
 	color: inherit;
 }
@@ -132,6 +144,9 @@
 		display: none;
 	}
 
+	.jm-dashboard-job-column.actions {
+		justify-content: space-between;
+	}
 
 	.jm-dashboard-job-column.company ~ .jm-dashboard-job-column.job_title {
 		flex-basis: calc( 100% - var(--jm-dashboard-company-logo-size) - var(--jm-ui-space-sm) );

--- a/assets/css/job-overlay.scss
+++ b/assets/css/job-overlay.scss
@@ -76,6 +76,7 @@
 
 	.jm-ui-actions-row {
 		gap: var(--jm-ui-space-sm);
+		flex-wrap: wrap;
 	}
 
 }
@@ -89,7 +90,28 @@
 @media (max-width: 600px) {
 	.jm-dashboard__overlay {
 		height: 100%;
+		max-width: 100%;
+		margin-bottom: 0;
 	}
+
+	.jm-job-overlay-footer {
+		.jm-ui-actions-row {
+			gap: var(--jm-ui-space-s);
+
+			* {
+				font-size: var(--jm-ui-font-size-s);
+			}
+		}
+
+		.jm-ui-button--outline {
+			padding: var(--jm-ui-space-xxs) var(--jm-ui-space-s2);
+		}
+
+		.jm-ui-button--link {
+			padding: var(--jm-ui-space-xxs) var(--jm-ui-space-xs);
+		}
+	}
+
 }
 
 @keyframes jm-job-overlay-fade-in {

--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -69,7 +69,6 @@
 
 .jm-ui-button--small,
 {
-	border-radius: 2px;
 	padding: var(--jm-ui-space-xxs) var(--jm-ui-space-s);
 	gap: var(--jm-ui-space-xs);
 	font-size: var(--jm-ui-font-size-s);

--- a/assets/css/ui.elements.scss
+++ b/assets/css/ui.elements.scss
@@ -37,6 +37,7 @@
 	font-size: var(--jm-ui-button-font-size);
 	font-weight: 400;
 	letter-spacing: -0.1px;
+	white-space: nowrap;
 
 	transition: color 0.2s ease-out, background 0.2s ease-out;
 
@@ -64,6 +65,16 @@
 			background-color: color-mix(in srgb, #fff, currentColor 85%);
 		}
 	}
+}
+
+.jm-ui-button--small,
+{
+	border-radius: 2px;
+	padding: var(--jm-ui-space-xxs) var(--jm-ui-space-s);
+	gap: var(--jm-ui-space-xs);
+	font-size: var(--jm-ui-font-size-s);
+	font-weight: 400;
+	letter-spacing: -0.1px;
 }
 
 .jm-ui-button__a {

--- a/templates/job-dashboard-overlay.php
+++ b/templates/job-dashboard-overlay.php
@@ -60,25 +60,33 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 	</div>
 	<div class="jm-job-overlay-footer">
 		<?php
-		$actions_html = '';
+		$buttons = [];
+		$actions = [];
 		if ( ! empty( $job_actions ) ) {
-			foreach ( $job_actions as $action => $value ) {
-				$action_url = add_query_arg( [
-					'action' => $action,
-					'job_id' => $job->ID,
-				], '' );
-				if ( $value['nonce'] ) {
-					$action_url = wp_nonce_url( $action_url, $value['nonce'] );
+			$primary = Job_Dashboard_Shortcode::get_primary_action( $job, $job_actions );
+
+			if ( $primary ) {
+				$buttons[] = [
+					'label' => $primary['label'],
+					'url'   => $primary['url'],
+					'class' => 'job-dashboard-action-' . esc_attr( $primary['name'] ),
+					'primary' => false,
+				];
+			}
+
+			foreach ( $job_actions as $action ) {
+				if ( ! empty( $primary ) && $primary['name'] === $action['name'] ) {
+					continue;
 				}
 				$actions[] = [
-					'label' => $value['label'],
-					'url'   => $action_url,
-					'class' => 'job-dashboard-action-' . esc_attr( $action ),
+					'label' => $action['label'],
+					'url'   => $action['url'],
+					'class' => 'job-dashboard-action-' . esc_attr( $action['name'] ),
 				];
 			}
 		}
 
-		echo UI_Elements::actions( [], $actions );
+		echo UI_Elements::actions( $buttons, $actions );
 		?>
 	</div>
 </div>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -82,18 +82,12 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 							</div>
 						<?php endforeach; ?>
 						<div class="jm-dashboard-job-column actions job-dashboard-job-actions">
+							<?php do_action( 'job_manager_job_dashboard_column_actions', $job, $job_actions[ $job->ID ] ?? [] ); ?>
 							<?php
 							$actions_html = '';
 							if ( ! empty( $job_actions[ $job->ID ] ) ) {
-								foreach ( $job_actions[ $job->ID ] as $action => $value ) {
-									$action_url = add_query_arg( [
-										'action' => $action,
-										'job_id' => $job->ID,
-									] );
-									if ( $value['nonce'] ) {
-										$action_url = wp_nonce_url( $action_url, $value['nonce'] );
-									}
-									$actions_html .= '<a href="' . esc_url( $action_url ) . '" class=" jm-dashboard-action jm-ui-button--link job-dashboard-action-' . esc_attr( $action ) . '">' . esc_html( $value['label'] ) . '</a>' . "\n";
+								foreach ( $job_actions[ $job->ID ] as $action ) {
+									$actions_html .= '<a href="' . esc_url( $action['url'] ) . '" class=" jm-dashboard-action jm-ui-button--link job-dashboard-action-' . esc_attr( $action['name'] ) . '">' . esc_html( $action['label'] ) . '</a>' . "\n";
 								}
 							}
 

--- a/templates/job-stats.php
+++ b/templates/job-stats.php
@@ -108,7 +108,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</div>
 						<?php foreach ( $section['stats'] as $stat ) : ?>
 							<div class="jm-stat-row jm-ui-row">
-								<?php if ( $stat['icon'] ) {
+								<?php if ( isset( $stat['icon'] ) ) {
 									echo UI_Elements::icon( $stat['icon'], $stat['label'] );
 								} ?>
 								<div class="jm-stat-label">


### PR DESCRIPTION
Fixes #2747 

### Changes Proposed in this Pull Request

* In the job dashboard, add a button for the most relevant action to each row
* Same in the job overlay footer
* Fix action links in the overlay
* Improve mobile overlay styling

### Testing Instructions

* Build frontend with `npm run start`
* Open up the job dashboard and check that jobs have a button with the primary action
* Check that the actions are working as expected


### Screenshot / Video

<img width="1335" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/2ad77a0b-372d-413a-b521-369fe1bb84b7">




<!-- wpjm:plugin-zip -->
----

| Plugin build for 14f70e2b956b93d9521797694fa3c455579e8fc2 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/04/wp-job-manager-zip-2800-14f70e2b.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/04/2800-14f70e2b)             |

<!-- /wpjm:plugin-zip -->


