### PR TITLE
Term select field improvements

### DIFF
--- a/templates/form-fields/term-select-field.php
+++ b/templates/form-fields/term-select-field.php
@@ -37,7 +37,7 @@ if ( is_array( $selected ) ) {
 $args = [
 	'taxonomy'          => $field['taxonomy'],
 	'hierarchical'      => 1,
-	'show_option_all'   => true,
+	'show_option_all'   => false,
 	'option_none_value' => '',
 	'show_option_none'  => $placeholder,
 	'name'              => isset( $field['name'] ) ? $field['name'] : $key,

--- a/templates/form-fields/term-select-field.php
+++ b/templates/form-fields/term-select-field.php
@@ -8,19 +8,21 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.31.1
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+$term = get_term_by( 'slug', $field['default'], $field['taxonomy'] );
+
 // Get selected value.
 if ( isset( $field['value'] ) ) {
 	$selected = $field['value'];
 } elseif ( is_int( $field['default'] ) ) {
 	$selected = $field['default'];
-} elseif ( ! empty( $field['default'] ) && ( $term = get_term_by( 'slug', $field['default'], $field['taxonomy'] ) ) ) {
+} elseif ( ! empty( $field['default'] ) && $term ) {
 	$selected = $term->term_id;
 } else {
 	$selected = '';
@@ -31,14 +33,22 @@ if ( is_array( $selected ) ) {
 	$selected = current( $selected );
 }
 
-wp_dropdown_categories( apply_filters( 'job_manager_term_select_field_wp_dropdown_categories_args', [
+$args = [
 	'taxonomy'         => $field['taxonomy'],
 	'hierarchical'     => 1,
-	'show_option_all'  => false,
+	'show_option_all'  => true,
 	'show_option_none' => $field['required'] ? '' : '-',
 	'name'             => isset( $field['name'] ) ? $field['name'] : $key,
 	'orderby'          => 'name',
 	'selected'         => $selected,
-	'hide_empty'       => false
-], $key, $field ) );
+	'hide_empty'       => false,
+	'multiple'         => false,
+];
+
+if ( isset( $field['placeholder'] ) && ! empty( $field['placeholder'] ) ) {
+	$args['placeholder'] = $field['placeholder'];
+}
+
+job_manager_dropdown_categories( apply_filters( 'job_manager_term_select_field_wp_dropdown_categories_args', $args ) );
+
 if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>

--- a/templates/form-fields/term-select-field.php
+++ b/templates/form-fields/term-select-field.php
@@ -9,22 +9,29 @@
  * @package     wp-job-manager
  * @category    Template
  * @version     $$next-version$$
+ *
+ * @var array $key Form field name.
+ * @var array $field Form field data.
+ *
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$term        = get_term_by( 'slug', $field['default'], $field['taxonomy'] );
 $placeholder = array_key_exists( 'placeholder', $field ) && ! empty( $field['placeholder'] ) ? $field['placeholder'] : esc_html__( 'Select an Option...', 'wp-job-manager' );
+$selected = null;
 
 // Get selected value.
 if ( isset( $field['value'] ) ) {
 	$selected = $field['value'];
 } elseif ( is_int( $field['default'] ) ) {
 	$selected = $field['default'];
-} elseif ( ! empty( $field['default'] ) && $term ) {
-	$selected = $term->term_id;
+} elseif ( ! empty( $field['default'] ) ) {
+	$default = get_term_by( 'slug', $field['default'], $field['taxonomy'] );
+	if ( ! empty( $default ) ) {
+		$selected = $default->term_id;
+	}
 } else {
 	$selected = '';
 }

--- a/templates/form-fields/term-select-field.php
+++ b/templates/form-fields/term-select-field.php
@@ -15,7 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$term = get_term_by( 'slug', $field['default'], $field['taxonomy'] );
+$term        = get_term_by( 'slug', $field['default'], $field['taxonomy'] );
+$placeholder = array_key_exists( 'placeholder', $field ) && ! empty( $field['placeholder'] ) ? $field['placeholder'] : esc_html__( 'Select an Option...', 'wp-job-manager' );
 
 // Get selected value.
 if ( isset( $field['value'] ) ) {
@@ -34,21 +35,17 @@ if ( is_array( $selected ) ) {
 }
 
 $args = [
-	'taxonomy'         => $field['taxonomy'],
-	'hierarchical'     => 1,
-	'show_option_all'  => true,
-	'show_option_none' => $field['required'] ? '' : '-',
-	'name'             => isset( $field['name'] ) ? $field['name'] : $key,
-	'orderby'          => 'name',
-	'selected'         => $selected,
-	'hide_empty'       => false,
-	'multiple'         => false,
+	'taxonomy'          => $field['taxonomy'],
+	'hierarchical'      => 1,
+	'show_option_all'   => true,
+	'option_none_value' => '',
+	'show_option_none'  => $placeholder,
+	'name'              => isset( $field['name'] ) ? $field['name'] : $key,
+	'orderby'           => 'name',
+	'selected'          => $selected,
+	'hide_empty'        => false,
 ];
 
-if ( isset( $field['placeholder'] ) && ! empty( $field['placeholder'] ) ) {
-	$args['placeholder'] = $field['placeholder'];
-}
-
-job_manager_dropdown_categories( apply_filters( 'job_manager_term_select_field_wp_dropdown_categories_args', $args ) );
+wp_dropdown_categories( apply_filters( 'job_manager_term_select_field_wp_dropdown_categories_args', $args, $key, $field ) );
 
 if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>


### PR DESCRIPTION
### Changes Proposed in this Pull Request
This enhancement will enhance and broaden the current functionality of the `term-select-field.php`. Presently, the term-select field operates in a manner where it does not allow for the display of a default placeholder; instead, it defaults to displaying '-'. Unfortunately, there is currently no method to alter this default behavior.

With the changes added to the template, the select field will show the field's placeholder as a default option.

### Testing Instructions

* Add a new taxonomy
* Add the field to the submission form
```
frontend_wpjm_fields( $fields ) {
	$fields['job']['job_listing_qualification'] = [
		'label'       => esc_html__( 'Job Qualification', 'cariera' ),
		'type'        => 'term-multiselect',
		'taxonomy'    => 'job_listing_qualification',
		'required'    => false,
		'placeholder' => esc_html__( 'Choose a job qualification', 'cariera' ),
		'priority'    => 7,
	];

        return $fields;
}
add_filter( 'submit_job_form_fields', 'frontend_wpjm_extra_fields' );
```
* Check the field in the job submission form

### New or Updated Hooks and Templates

* Updated template: `templates/form-fields/term-select-field.php`

### Screenshot / Video
**Before:**
<img width="1140" alt="Screenshot 2024-04-05 at 6 31 50 PM" src="https://github.com/Automattic/WP-Job-Manager/assets/10162224/2ee29859-16d3-4aa7-98e6-d52f4d4b4441">

**After:**
<img width="1109" alt="Screenshot 2024-04-05 at 6 32 37 PM" src="https://github.com/Automattic/WP-Job-Manager/assets/10162224/54e7391d-450a-4323-b8c0-e234a0fb85e9">
