### PR TITLE
Repair edit job listing screen.

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -136,7 +136,7 @@ abstract class WP_Job_Manager_Form {
 	 * @param array $atts Attributes to use in the view handler.
 	 */
 	public function output( $atts = [] ) {
-		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_scripts();
+		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_recaptcha();
 		$step_key = $this->get_step_key( $this->step );
 		$this->show_errors();
 		$this->show_messages();
@@ -323,7 +323,7 @@ abstract class WP_Job_Manager_Form {
 	 */
 	public function enqueue_scripts() {
 		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::enqueue_scripts' );
-		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_scripts();
+		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_recaptcha();
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -322,7 +322,44 @@ abstract class WP_Job_Manager_Form {
 	 */
 	public function enqueue_scripts() {
 		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::enqueue_scripts' );
-		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_scripts();
+		WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->enqueue_scripts();
+	}
+
+
+	/**
+	 * Output the reCAPTCHA field.
+	 *
+	 * @deprecated
+	 */
+	public function display_recaptcha_field() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::display_recaptcha_field' );
+		WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->display_recaptcha_field();
+	}
+
+	/**
+	 * Validate a reCAPTCHA field.
+	 *
+	 * @param bool $success
+	 *
+	 * @deprecated
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function validate_recaptcha_field( $success ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::validate_recaptcha_field' );
+		return WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->validate_recaptcha_field( $success );
+	}
+
+	/**
+	 * Checks whether reCAPTCHA has been set up and is available.
+	 *
+	 * @deprecated
+	 *
+	 * @return bool
+	 */
+	public function is_recaptcha_available() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::is_recaptcha_available' );
+		return WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->is_recaptcha_available();
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -136,7 +136,6 @@ abstract class WP_Job_Manager_Form {
 	 * @param array $atts Attributes to use in the view handler.
 	 */
 	public function output( $atts = [] ) {
-		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_recaptcha();
 		$step_key = $this->get_step_key( $this->step );
 		$this->show_errors();
 		$this->show_messages();
@@ -323,7 +322,7 @@ abstract class WP_Job_Manager_Form {
 	 */
 	public function enqueue_scripts() {
 		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::enqueue_scripts' );
-		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_recaptcha();
+		WP_Job_Manager\WP_Job_Manager_Recaptcha::enqueue_scripts();
 	}
 
 	/**

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -343,7 +343,7 @@ abstract class WP_Job_Manager_Form {
 	 *
 	 * @deprecated
 	 *
-	 * @return bool|WP_Error
+	 * @return bool|\WP_Error
 	 */
 	public function validate_recaptcha_field( $success ) {
 		_deprecated_function( __METHOD__, '$$next-version$$', 'WP_Job_Manager\WP_Job_Manager_Form::validate_recaptcha_field' );

--- a/includes/class-wp-job-manager-recaptcha.php
+++ b/includes/class-wp-job-manager-recaptcha.php
@@ -121,9 +121,11 @@ class WP_Job_Manager_Recaptcha {
 	/**
 	 * Checks whether reCAPTCHA has been set up and is available.
 	 *
+	 * @access private
+	 *
 	 * @return bool
 	 */
-	private function is_recaptcha_available() {
+	public function is_recaptcha_available() {
 		$is_recaptcha_available = ! empty( $this->site_key ) && ! empty( $this->secret_key );
 
 		/**

--- a/includes/class-wp-job-manager-recaptcha.php
+++ b/includes/class-wp-job-manager-recaptcha.php
@@ -139,7 +139,7 @@ class WP_Job_Manager_Recaptcha {
 	}
 
 	/**
-	 * Dispaly the reCAPTCHA field in the form.
+	 * Display the reCAPTCHA field in the form.
 	 *
 	 * @access private
 	 *

--- a/includes/class-wp-job-manager-recaptcha.php
+++ b/includes/class-wp-job-manager-recaptcha.php
@@ -55,12 +55,6 @@ class WP_Job_Manager_Recaptcha {
 		$this->site_key          = get_option( self::RECAPTCHA_SITE_KEY );
 		$this->secret_key        = get_option( self::RECAPTCHA_SECRET_KEY );
 		$this->recaptcha_version = get_option( self::RECAPTCHA_VERSION, 'v2' );
-
-		if ( $this->use_recaptcha_field() ) {
-			add_action( 'submit_job_form_end', [ $this, 'display_recaptcha_field' ] );
-			add_filter( 'submit_job_form_validate_fields', [ $this, 'validate_recaptcha_field' ] );
-			add_filter( 'submit_draft_job_form_validate_fields', [ $this, 'validate_recaptcha_field' ] );
-		}
 	}
 
 	/**
@@ -76,10 +70,16 @@ class WP_Job_Manager_Recaptcha {
 	}
 
 	/**
-	 * Enqueue the scripts for the form.
+	 * Enqueue the scripts and add appropriate hooks for the recaptcha to load.
 	 */
-	public static function enqueue_scripts() {
+	public static function enqueue_recaptcha() {
 		$instance = self::instance();
+
+		if ( $instance->use_recaptcha_field() ) {
+			add_action( 'submit_job_form_end', [ $instance, 'display_recaptcha_field' ] );
+			add_filter( 'submit_job_form_validate_fields', [ $instance, 'validate_recaptcha_field' ] );
+			add_filter( 'submit_draft_job_form_validate_fields', [ $instance, 'validate_recaptcha_field' ] );
+		}
 
 		if (
 			$instance->use_recaptcha_field() &&

--- a/includes/class-wp-job-manager-recaptcha.php
+++ b/includes/class-wp-job-manager-recaptcha.php
@@ -55,36 +55,57 @@ class WP_Job_Manager_Recaptcha {
 		$this->site_key          = get_option( self::RECAPTCHA_SITE_KEY );
 		$this->secret_key        = get_option( self::RECAPTCHA_SECRET_KEY );
 		$this->recaptcha_version = get_option( self::RECAPTCHA_VERSION, 'v2' );
+
+	}
+
+	/**
+	 * Enables the reCAPTCHA field on the form. To do that, it checks if the provided option is enabled and if it is
+	 * it adds the necessary hooks to display and validate the reCAPTCHA field.
+	 *
+	 * @param string $recaptcha_enabled_option The options name to check if the reCAPTCHA field is enabled.
+	 * @param array  $display_hooks The hooks to display the reCAPTCHA field.
+	 * @param array  $validate_hooks The hooks to validate the reCAPTCHA field.
+	 *
+	 * @return void
+	 */
+	public function maybe_enable_recaptcha( string $recaptcha_enabled_option, array $display_hooks, array $validate_hooks ) {
+		if ( $this->use_recaptcha_field( $recaptcha_enabled_option ) ) {
+			foreach ( $display_hooks as $display_hook ) {
+				add_action( $display_hook, [ $this, 'display_recaptcha_field' ] );
+			}
+
+			foreach ( $validate_hooks as $validate_hook ) {
+				add_filter( $validate_hook, [ $this, 'validate_recaptcha_field' ] );
+			}
+
+			add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+		}
 	}
 
 	/**
 	 * Use reCAPTCHA field on the form?
 	 *
+	 * @param string $option_name The options name to check if the reCAPTCHA field is enabled.
+	 *
 	 * @return bool
 	 */
-	public function use_recaptcha_field() {
+	private function use_recaptcha_field( $option_name ) {
 		if ( ! $this->is_recaptcha_available() ) {
 			return false;
 		}
-		return 1 === absint( get_option( 'job_manager_enable_recaptcha_job_submission' ) );
+
+		return 1 === absint( get_option( $option_name ) );
 	}
 
 	/**
 	 * Enqueue the scripts and add appropriate hooks for the recaptcha to load.
+	 *
+	 * @access private
 	 */
-	public static function enqueue_recaptcha() {
+	public function enqueue_scripts() {
 		$instance = self::instance();
 
-		if ( $instance->use_recaptcha_field() ) {
-			add_action( 'submit_job_form_end', [ $instance, 'display_recaptcha_field' ] );
-			add_filter( 'submit_job_form_validate_fields', [ $instance, 'validate_recaptcha_field' ] );
-			add_filter( 'submit_draft_job_form_validate_fields', [ $instance, 'validate_recaptcha_field' ] );
-		}
-
-		if (
-			$instance->use_recaptcha_field() &&
-			in_array( $instance->recaptcha_version, [ 'v2', 'v3' ], true )
-		) {
+		if ( in_array( $instance->recaptcha_version, [ 'v2', 'v3' ], true ) ) {
 			$recaptcha_version = $instance->recaptcha_version;
 			$recaptcha_url     = '';
 
@@ -102,7 +123,7 @@ class WP_Job_Manager_Recaptcha {
 	 *
 	 * @return bool
 	 */
-	public function is_recaptcha_available() {
+	private function is_recaptcha_available() {
 		$is_recaptcha_available = ! empty( $this->site_key ) && ! empty( $this->secret_key );
 
 		/**
@@ -117,6 +138,8 @@ class WP_Job_Manager_Recaptcha {
 
 	/**
 	 * Dispaly the reCAPTCHA field in the form.
+	 *
+	 * @access private
 	 *
 	 * @return void
 	 */
@@ -141,6 +164,8 @@ class WP_Job_Manager_Recaptcha {
 	 * Validate a reCAPTCHA field.
 	 *
 	 * @param bool $success
+	 *
+	 * @access private
 	 *
 	 * @return bool|WP_Error
 	 */

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -80,7 +80,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		WP_Job_Manager_Helper_Renewals::instance( $this );
 
 		// Recaptcha support.
-		WP_Job_Manager\WP_Job_Manager_Recaptcha::instance();
+		WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->maybe_enable_recaptcha(
+			'job_manager_enable_recaptcha_job_submission',
+			[ 'submit_job_form_end' ],
+			[ 'submit_job_form_validate_fields', 'submit_draft_job_form_validate_fields' ]
+		);
 
 		if ( $this->use_agreement_checkbox() ) {
 			add_action( 'submit_job_form_end', [ $this, 'display_agreement_checkbox_field' ] );


### PR DESCRIPTION
### Oveview
This fixes an issue to the edit job listing screen. To reproduce:

1. Create a job and publish it
2. Set up a recaptcha and enable it in the settings (any version will do, go to https://www.google.com/recaptcha to create keys if you don't have some already)
3. Go to the job dashboard
4. Edit the job
5. After doing some change try to save the listing
6. At this point the update fails and nothing happens

The problem was that we added the actions to the `WP_Job_Manager_Recaptcha` constructor. This way the hooks were added even when we wanted to call utility methods and the captcha was also enqueued to the dashboard page.

### Changes Proposed in this Pull Request

* I moved the hook registration from the constructor to `equeue_scripts`. This way we only enqueue the captcha when we need to.

### Testing Instructions

* Test together with: https://github.com/Automattic/wpjm-addons/pull/481
* Follow the steps from the overview and observe that nothing is broken now.
* Also try testing recaptcha functionality in general to ensure that nothing else is broken.
* Additionally, we should test how the changes in reCAPTCHA work in relation to different plugin versions:
	* The newest version of the paid plugins should work with the previous version of WPJM (i.e. 2.2.2) but with v2 reCAPTCHA only
	* The previous versions of the paid plugins should work with latest version of WPJM but with warnings printed as we deprecated the old methods.






<!-- wpjm:plugin-zip -->
----

| Plugin build for 42aae9cb2f587f2da93c4d5984a20c00db365607 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/04/wp-job-manager-zip-2802-42aae9cb.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/04/2802-42aae9cb)             |

<!-- /wpjm:plugin-zip -->










