### PR TITLE
Add job overlay to admin

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -74,9 +74,6 @@
       <code>WP_Job_manager</code>
       <code>WP_Job_manager</code>
     </InvalidClass>
-    <ParadoxicalCondition>
-      <code><![CDATA[! defined( 'ABSPATH' )]]></code>
-    </ParadoxicalCondition>
   </file>
   <file src="includes/admin/class-wp-job-manager-cpt.php">
     <InvalidArgument>

--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -216,7 +216,6 @@
   <file src="includes/class-wp-job-manager-post-types.php">
     <InvalidArgument>
       <code>$job_data</code>
-      <code>$pending_jobs</code>
       <code><![CDATA[[
 				apply_filters(
 					'register_post_type_job_guest_user',

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -99,6 +99,12 @@ a.wpjm-activate-license-link:active {
 	}
 }
 
+.column-stats {
+	a {
+		display: block;
+	}
+}
+
 /** Promote Job Modal **/
 .promote-buttons-group {
 	.button {

--- a/assets/css/job-overlay.scss
+++ b/assets/css/job-overlay.scss
@@ -79,6 +79,10 @@
 		flex-wrap: wrap;
 	}
 
+	&:empty {
+		display: none;
+	}
+
 }
 
 .jm-job-overlay-details-box {

--- a/assets/js/job-dashboard.js
+++ b/assets/js/job-dashboard.js
@@ -30,7 +30,10 @@ async function showOverlay( eventOrId ) {
 	eventOrId.preventDefault?.();
 	overlayDialog.showModal();
 
-	const id = eventOrId.target?.dataset.jobId ?? eventOrId;
+	const dashboardRowId = eventOrId.target?.dataset.jobId;
+	const adminRowId = eventOrId.target?.closest( 'tr' )?.id?.replace( 'post-', '' );
+
+	const id = dashboardRowId ?? adminRowId ?? eventOrId;
 
 	if ( ! id ) {
 		return;
@@ -42,7 +45,7 @@ async function showOverlay( eventOrId ) {
 	contentElement.innerHTML = '<a class="jm-ui-spinner"></a>';
 
 	try {
-		const response = await fetch( `${ overlayEndpoint }?job_id=${ id }` );
+		const response = await fetch( `${ overlayEndpoint }&job_id=${ id }` );
 
 		if ( ! response.ok ) {
 			throw new Error( response.statusText );
@@ -56,7 +59,7 @@ async function showOverlay( eventOrId ) {
 	}
 
 	const clearHash = () => {
-		history.replaceState( null, '', window.location.pathname );
+		history.replaceState( null, '', window.location.pathname + window.location.search );
 		overlayDialog.removeEventListener( 'close', clearHash );
 	};
 
@@ -67,7 +70,7 @@ async function showOverlay( eventOrId ) {
 
 function setupStatsOverlay() {
 	document
-		.querySelectorAll( '.jm-dashboard-job .job-title' )
+		.querySelectorAll( '.jm-dashboard-job .job-title, tr.job_listing td.column-stats' )
 		.forEach( el => el.addEventListener( 'click', showOverlay ) );
 
 	const urlHash = window.location.hash?.substring( 1 );

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -5,6 +5,8 @@
  * @package wp-job-manager
  */
 
+use WP_Job_Manager\Job_Overlay;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -64,6 +66,7 @@ class WP_Job_Manager_Admin {
 
 		$this->settings_page = WP_Job_Manager_Settings::instance();
 		WP_Job_Manager_Addons_Landing_Page::instance();
+		Job_Overlay::instance();
 
 		add_action( 'admin_init', [ $this, 'admin_init' ] );
 		add_action( 'current_screen', [ $this, 'conditional_includes' ] );

--- a/includes/class-job-overlay.php
+++ b/includes/class-job-overlay.php
@@ -9,6 +9,8 @@ namespace WP_Job_Manager;
 
 use WP_Job_Manager\UI\Modal_Dialog;
 use WP_Job_Manager\UI\Notice;
+use WP_Job_Manager\UI\UI;
+use WP_Job_Manager\UI\UI_Elements;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -28,6 +30,10 @@ class Job_Overlay {
 	 */
 	public function __construct() {
 		add_action( 'job_manager_ajax_job_dashboard_overlay', [ $this, 'ajax_job_overlay' ] );
+		add_action( 'wp_ajax_job_dashboard_overlay', [ $this, 'ajax_job_overlay' ] );
+		add_action( 'admin_footer', [ $this, 'init_admin_dashboard_overlay' ], 10 );
+		add_action( 'job_manager_job_dashboard', [ $this, 'init_dashboard_overlay' ], 10 );
+		add_action( 'job_manager_job_overlay_footer', [ $this, 'output_footer_actions' ], 10 );
 
 	}
 
@@ -35,14 +41,28 @@ class Job_Overlay {
 	 * Render the job dashboard overlay content for an AJAX request.
 	 */
 	public function ajax_job_overlay() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce check.
+		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['_wpnonce'] ), 'job_dashboard_overlay' ) ) {
+			wp_send_json_error(
+				Notice::error(
+					[
+						'message' => __( 'Invalid request.', 'wp-job-manager' ),
+						'classes' => [ 'type-dialog' ],
+					]
+				)
+			);
+
+			return;
+		}
+
 		$job_id = isset( $_REQUEST['job_id'] ) ? absint( $_REQUEST['job_id'] ) : null;
 
 		$job = $job_id ? get_post( $job_id ) : null;
 
 		$shortcode = Job_Dashboard_Shortcode::instance();
 
-		if ( empty( $job ) || ! $shortcode->is_job_available_on_dashboard( $job ) ) {
+		if ( ! $shortcode->can_manage_job( $job ) ) {
 			wp_send_json_error(
 				Notice::error(
 					[
@@ -55,7 +75,7 @@ class Job_Overlay {
 			return;
 		}
 
-		$content = $this->get_job_overlay( $job );
+		$content = $this->render_job_overlay( $job );
 
 		wp_send_json_success( $content );
 
@@ -65,6 +85,11 @@ class Job_Overlay {
 	 * Output the modal element.
 	 */
 	public function output_modal_element() {
+
+		UI::instance()->enqueue_styles();
+		wp_enqueue_style( 'wp-job-manager-job-dashboard' );
+		wp_enqueue_script( 'wp-job-manager-job-dashboard' );
+
 		$overlay = new Modal_Dialog(
 			[
 				'id'    => 'jmDashboardOverlay',
@@ -83,23 +108,111 @@ class Job_Overlay {
 	 *
 	 * @return string
 	 */
-	private function get_job_overlay( $job ) {
-
-		$job_actions = Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+	private function render_job_overlay( $job ) {
 
 		ob_start();
 
 		get_job_manager_template(
 			'job-dashboard-overlay.php',
 			[
-				'job'         => $job,
-				'job_actions' => $job_actions,
+				'job' => $job,
 			]
 		);
 
 		$content = ob_get_clean();
 
 		return $content;
+	}
+
+	/**
+	 * Load and output overlay dependencies on the job listings screen.
+	 *
+	 * @output Modal HTML.
+	 *
+	 * @return void
+	 */
+	public function init_admin_dashboard_overlay() {
+		$screen = get_current_screen();
+
+		if ( ! $screen || 'edit-job_listing' !== $screen->id ) {
+			return;
+		}
+
+		$this->init_dashboard_overlay();
+	}
+
+	/**
+	 * Load scripts and output HTML skeleton for the job dashboard overlay.
+	 *
+	 * @output Modal HTML.
+	 *
+	 * @return void
+	 */
+	public function init_dashboard_overlay() {
+
+		\WP_Job_Manager::register_script( 'wp-job-manager-job-dashboard', 'js/job-dashboard.js', null, true );
+		\WP_Job_Manager::register_style( 'wp-job-manager-job-dashboard', 'css/job-dashboard.css', [ 'wp-job-manager-ui' ] );
+
+		$endpoint = is_admin()
+			? add_query_arg( [ 'action' => 'job_dashboard_overlay' ], admin_url( 'admin-ajax.php' ) )
+			: \WP_Job_Manager_Ajax::get_endpoint( 'job_dashboard_overlay' );
+		$endpoint = wp_nonce_url( $endpoint, 'job_dashboard_overlay' );
+
+		wp_localize_script(
+			'wp-job-manager-job-dashboard',
+			'job_manager_job_dashboard',
+			[
+				'i18nConfirmDelete' => esc_html__( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
+				'overlayEndpoint'   => $endpoint,
+				'statsEnabled'      => \WP_Job_Manager\Stats::is_enabled(),
+			]
+		);
+
+		$this->output_modal_element();
+	}
+
+	/**
+	 * Output the job actions in the overlay footer.
+	 *
+	 * @param \WP_Post $job
+	 */
+	public function output_footer_actions( $job ) {
+
+		if ( is_admin() ) {
+			return;
+		}
+
+		$job_actions = Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$buttons = [];
+		$actions = [];
+		if ( ! empty( $job_actions ) ) {
+			$primary = Job_Dashboard_Shortcode::get_primary_action( $job, $job_actions );
+
+			if ( $primary ) {
+				$buttons[] = [
+					'label'   => $primary['label'],
+					'url'     => $primary['url'],
+					'class'   => 'job-dashboard-action-' . esc_attr( $primary['name'] ),
+					'primary' => false,
+				];
+			}
+
+			foreach ( $job_actions as $action ) {
+				if ( ! empty( $primary ) && $primary['name'] === $action['name'] ) {
+					continue;
+				}
+				$actions[] = [
+					'label' => $action['label'],
+					'url'   => $action['url'],
+					'class' => 'job-dashboard-action-' . esc_attr( $action['name'] ),
+				];
+			}
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in UI classes.
+		echo UI_Elements::actions( $buttons, $actions );
+
 	}
 
 

--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -35,7 +35,7 @@ class Stats_Dashboard {
 		add_filter( 'job_manager_job_dashboard_columns', [ $this, 'add_stats_column' ] );
 		add_action( 'job_manager_job_dashboard_column_' . self::COLUMN_NAME, [ $this, 'render_stats_column' ] );
 
-		add_filter( 'manage_edit-job_listing_columns', [ $this, 'add_stats_column' ], 20 );
+		add_filter( 'manage_edit-job_listing_columns', [ $this, 'add_stats_column' ] );
 		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'maybe_render_job_listing_posts_custom_column' ], 2 );
 
 		add_action( 'job_manager_job_overlay_content', [ $this, 'output_job_stats' ], 12 );
@@ -81,7 +81,9 @@ class Stats_Dashboard {
 		global $post;
 
 		if ( self::COLUMN_NAME === $column ) {
+			echo '<a href="#' . esc_attr( $post->ID ) . ' ">';
 			$this->render_stats_column( $post );
+			echo '</a>';
 		}
 	}
 

--- a/includes/class-stats-dashboard.php
+++ b/includes/class-stats-dashboard.php
@@ -36,7 +36,7 @@ class Stats_Dashboard {
 		add_action( 'job_manager_job_dashboard_column_' . self::COLUMN_NAME, [ $this, 'render_stats_column' ] );
 
 		add_filter( 'manage_edit-job_listing_columns', [ $this, 'add_stats_column' ] );
-		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'maybe_render_job_listing_posts_custom_column' ], 2 );
+		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'maybe_render_admin_stats_column' ], 2 );
 
 		add_action( 'job_manager_job_overlay_content', [ $this, 'output_job_stats' ], 12 );
 	}
@@ -77,10 +77,10 @@ class Stats_Dashboard {
 	 *
 	 * @param string $column
 	 */
-	public function maybe_render_job_listing_posts_custom_column( $column ) {
+	public function maybe_render_admin_stats_column( $column ) {
 		global $post;
 
-		if ( self::COLUMN_NAME === $column ) {
+		if ( self::COLUMN_NAME === $column && ! empty( $post->ID ) ) {
 			echo '<a href="#' . esc_attr( $post->ID ) . ' ">';
 			$this->render_stats_column( $post );
 			echo '</a>';

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -6,6 +6,8 @@
  * @since   1.33.0
  */
 
+use WP_Job_Manager\Job_Overlay;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -540,7 +542,6 @@ class WP_Job_Manager {
 
 		wp_register_script( 'jquery-deserialize', JOB_MANAGER_PLUGIN_URL . '/assets/lib/jquery-deserialize/jquery.deserialize.js', [ 'jquery' ], '1.2.1', true );
 		self::register_script( 'wp-job-manager-ajax-filters', 'js/ajax-filters.js', $ajax_filter_deps, true );
-		self::register_script( 'wp-job-manager-job-dashboard', 'js/job-dashboard.js', null, true );
 		self::register_script( 'wp-job-manager-job-application', 'js/job-application.js', [ 'jquery' ], true );
 		self::register_script( 'wp-job-manager-job-submission', 'js/job-submission.js', [ 'jquery' ], true );
 		wp_localize_script( 'wp-job-manager-ajax-filters', 'job_manager_ajax_filters', $ajax_data );
@@ -571,15 +572,7 @@ class WP_Job_Manager {
 			]
 		);
 
-		wp_localize_script(
-			'wp-job-manager-job-dashboard',
-			'job_manager_job_dashboard',
-			[
-				'i18nConfirmDelete' => esc_html__( 'Are you sure you want to delete this listing?', 'wp-job-manager' ),
-				'overlayEndpoint'   => WP_Job_Manager_Ajax::get_endpoint( 'job_dashboard_overlay' ),
-				'statsEnabled'      => \WP_Job_Manager\Stats::is_enabled(),
-			]
-		);
+		Job_Overlay::instance()->init_dashboard_overlay();
 
 		wp_localize_script(
 			'wp-job-manager-job-submission',

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,11 +29,11 @@
 				<referencedClass name="WP_CLI" />
 			</errorLevel>
 		</UndefinedClass>
-		<InvalidScalarArgument>
+		<InvalidArgument>
 			<errorLevel type="suppress">
 				<referencedFunction name="esc_attr" />
 			</errorLevel>
-		</InvalidScalarArgument>
+		</InvalidArgument>
 	</issueHandlers>
 	<stubs>
 		<file name="wp-job-manager.php" />

--- a/templates/job-dashboard-overlay.php
+++ b/templates/job-dashboard-overlay.php
@@ -9,7 +9,6 @@
  * @version     $$next-version$$
  *
  * @var WP_Post $job Array of job post results.
- * @var array   $job_actions
  */
 
 use WP_Job_Manager\Job_Dashboard_Shortcode;
@@ -58,35 +57,5 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 		<?php do_action( 'job_manager_job_overlay_content', $job ); ?>
 
 	</div>
-	<div class="jm-job-overlay-footer">
-		<?php
-		$buttons = [];
-		$actions = [];
-		if ( ! empty( $job_actions ) ) {
-			$primary = Job_Dashboard_Shortcode::get_primary_action( $job, $job_actions );
-
-			if ( $primary ) {
-				$buttons[] = [
-					'label' => $primary['label'],
-					'url'   => $primary['url'],
-					'class' => 'job-dashboard-action-' . esc_attr( $primary['name'] ),
-					'primary' => false,
-				];
-			}
-
-			foreach ( $job_actions as $action ) {
-				if ( ! empty( $primary ) && $primary['name'] === $action['name'] ) {
-					continue;
-				}
-				$actions[] = [
-					'label' => $action['label'],
-					'url'   => $action['url'],
-					'class' => 'job-dashboard-action-' . esc_attr( $action['name'] ),
-				];
-			}
-		}
-
-		echo UI_Elements::actions( $buttons, $actions );
-		?>
-	</div>
+	<div class="jm-job-overlay-footer"><?php do_action( 'job_manager_job_overlay_footer', $job ); ?></div>
 </div>

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -100,6 +100,4 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 		<?php endif; ?>
 	</div>
 	<?php get_job_manager_template( 'pagination.php', [ 'max_num_pages' => $max_num_pages ] ); ?>
-
-	<?php Job_Overlay::instance()->output_modal_element(); ?>
 </div>


### PR DESCRIPTION
Fixes #2748 

### Changes Proposed in this Pull Request

* Open stats overlay when clicking the "Views" cell in the job listings admin screen
* Move a few things around to support this

### Testing Instructions

* Compile JS, make sure stats are enabled
* Open the job listings admin screen, click on the "X views, Y impressions" cells
* Check that the stats overlay opens correctly
* Open the employer dashboard on the frontend too, and double-check that the overlay and the job actions (Mark as filled, Duplicate etc) keep working

### Screenshot / Video

<img width="1685" alt="image" src="https://github.com/Automattic/WP-Job-Manager/assets/176949/44d51bfe-111c-4210-8c38-6322c3fb687c">





<!-- wpjm:plugin-zip -->
----

| Plugin build for 0e4fdf2c285707219653a8820ecc370c5b065e9f <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/04/wp-job-manager-zip-2804-0e4fdf2c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/04/2804-0e4fdf2c)             |

<!-- /wpjm:plugin-zip -->








