### PR TITLE
Adds a filter that disables promoted jobs

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -198,4 +198,6 @@ jQuery(document).ready(function($) {
 	});
 });
 
-initializePromoteModals();
+if ( job_manager_admin_params.promoted_jobs_enabled ) {
+	initializePromoteModals();
+}

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -178,10 +178,8 @@ class WP_Job_Manager_Admin {
 			}
 		}
 
-		if ( $this->are_promoted_jobs_enabled ) {
-			WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', null, true );
-			wp_enqueue_script( 'job_manager_notice_dismiss' );
-		}
+		WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', null, true );
+		wp_enqueue_script( 'job_manager_notice_dismiss' );
 
 		WP_Job_Manager::register_style( 'job_manager_admin_menu_css', 'css/menu.css', [] );
 		wp_enqueue_style( 'job_manager_admin_menu_css' );

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -34,6 +34,13 @@ class WP_Job_Manager_Admin {
 	private $settings_page;
 
 	/**
+	 * Whether promoted jobs are enabled.
+	 *
+	 * @var bool
+	 */
+	private $are_promoted_jobs_enabled;
+
+	/**
 	 * Allows for accessing single instance of class. Class should only be constructed once per call.
 	 *
 	 * @since  1.26.0
@@ -58,7 +65,14 @@ class WP_Job_Manager_Admin {
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-cpt.php';
 		WP_Job_Manager_CPT::instance();
 
-		include_once dirname( __FILE__ ) . '/class-wp-job-manager-promoted-jobs-admin.php';
+		/**
+		 * Documented in class-wp-job-manager.php
+		 */
+		$this->are_promoted_jobs_enabled = apply_filters( 'job_manager_enable_promoted_jobs', true );
+		if ( $this->are_promoted_jobs_enabled ) {
+			include_once dirname( __FILE__ ) . '/class-wp-job-manager-promoted-jobs-admin.php';
+		}
+
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-writepanels.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-setup.php';
 		include_once dirname( __FILE__ ) . '/class-wp-job-manager-addons-landing-page.php';
@@ -144,11 +158,12 @@ class WP_Job_Manager_Admin {
 					],
 					'ajax_url'                    => admin_url( 'admin-ajax.php' ),
 					'search_users_nonce'          => wp_create_nonce( 'search-users' ),
+					'promoted_jobs_enabled'       => $this->are_promoted_jobs_enabled,
 				]
 			);
 		}
 
-		if ( \WP_Job_Manager_Post_Types::PT_LISTING === $screen->id && $screen->is_block_editor() ) { // Check if it's block editor in job post.
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING === $screen->id && $screen->is_block_editor() && $this->are_promoted_jobs_enabled ) { // Check if it's block editor in job post.
 			$post = get_post();
 
 			if ( ! empty( $post ) ) {
@@ -163,8 +178,10 @@ class WP_Job_Manager_Admin {
 			}
 		}
 
-		WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', null, true );
-		wp_enqueue_script( 'job_manager_notice_dismiss' );
+		if ( $this->are_promoted_jobs_enabled ) {
+			WP_Job_manager::register_script( 'job_manager_notice_dismiss', 'js/admin/wpjm-notice-dismiss.js', null, true );
+			wp_enqueue_script( 'job_manager_notice_dismiss' );
+		}
 
 		WP_Job_Manager::register_style( 'job_manager_admin_menu_css', 'css/menu.css', [] );
 		wp_enqueue_style( 'job_manager_admin_menu_css' );

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -86,7 +86,17 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-data-exporter.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-settings.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-com-api.php';
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
+
+		/**
+		 * Controls whether promoted jobs are enabled.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $enable_promoted_jobs Whether promoted jobs are enabled.
+		 */
+		if ( apply_filters( 'job_manager_enable_promoted_jobs', true ) ) {
+			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
+		}
 
 		if ( is_admin() ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-admin.php';
@@ -267,7 +277,7 @@ class WP_Job_Manager {
 		if ( ! wp_next_scheduled( 'job_manager_email_daily_notices' ) ) {
 			wp_schedule_event( time(), 'daily', 'job_manager_email_daily_notices' );
 		}
-		if ( ! wp_next_scheduled( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK ) ) {
+		if ( class_exists( 'WP_Job_Manager_Promoted_Jobs_Status_Handler' ) && ! wp_next_scheduled( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK ) ) {
 			wp_schedule_event( time(), 'hourly', WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK );
 		}
 	}


### PR DESCRIPTION
Part of https://github.com/Automattic/greenhouse/issues/2085

### Changes Proposed in this Pull Request

* Adds a filter that disables promoted jobs functionality. 
* We can merge this now and set the default value to false whenever we want to disable it.

### Testing Instructions

* Add the snippet `add_filter('job_manager_enable_promoted_jobs', '__return_false' );`
* Go through admin and observe that there is no promoted jobs functionality and no console errors:
		* Delete `wp_job_manager_dismissed_notices` both from the options table and the users table to reset notices
		* Publish a new job and observe that no popup is shown
		* Go to job listings and observe that no Promote button exists
* Delete the snippet, repeat the steps, and observe that promote functionality works.



<!-- wpjm:plugin-zip -->
----

| Plugin build for 537bde6121b4a93d7d01d5e827e613c64752794c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/04/wp-job-manager-zip-2808-537bde61.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/04/2808-537bde61)             |

<!-- /wpjm:plugin-zip -->




