### PR TITLE
Return public jobs only in the endpoints

### DIFF
--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -163,7 +163,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 
 		$args = [
 			'post_type'           => \WP_Job_Manager_Post_Types::PT_LISTING,
-			'post_status'         => array_merge( array_keys( get_job_listing_post_statuses() ), [ 'trash' ] ),
+			'post_status'         => 'publish',
 			'no_found_rows'       => true,
 			'ignore_sticky_posts' => true,
 			'posts_per_page'      => -1,
@@ -270,13 +270,16 @@ class WP_Job_Manager_Promoted_Jobs_API {
 	public function get_job_data( $request ) {
 		$job_id = $request->get_param( 'job_id' );
 		$post   = get_post( $job_id );
+
 		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== get_post_type( $post ) ) {
 			return new WP_Error( 'not_found', __( 'The promoted job was not found', 'wp-job-manager' ), [ 'status' => 404 ] );
 		}
+
 		$controller = get_post_type_object( \WP_Job_Manager_Post_Types::PT_LISTING )->get_rest_controller();
-		if ( ! ( $controller instanceof WP_REST_Posts_Controller ) || ! $controller->check_read_permission( $post ) ) {
+		if ( ! ( $controller instanceof WP_REST_Posts_Controller ) || ! $controller->check_read_permission( $post ) || 'publish' !== $post->post_status ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to view this job.', 'wp-job-manager' ), [ 'status' => rest_authorization_required_code() ] );
 		}
+
 		$job_data = $this->prepare_item_for_response( get_post( $job_id ) );
 		if ( is_wp_error( $job_data ) ) {
 			return $job_data;


### PR DESCRIPTION
29-gh-Automattic/WP-Job-Manager-Private

<!-- wpjm:plugin-zip -->
----

| Plugin build for a33f28002ea3225f0ad076168486fad481dbc443 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/04/wp-job-manager-zip-2814-a33f2800.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/04/2814-a33f2800)             |

<!-- /wpjm:plugin-zip -->
