### PR TITLE
Expand job listing search

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -792,7 +792,7 @@ class WP_Job_Manager_Post_Types {
 
 		if ( ! empty( $job_manager_keyword ) ) {
 			$query_args['s'] = $job_manager_keyword;
-			add_filter( 'posts_search', 'get_job_listings_keyword_search' );
+			add_filter( 'posts_search', 'get_job_listings_keyword_search', 10, 2 );
 		}
 
 		if ( empty( $query_args['meta_query'] ) ) {
@@ -808,7 +808,7 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'rss2_ns', [ $this, 'job_feed_namespace' ] );
 		add_action( 'rss2_item', [ $this, 'job_feed_item' ] );
 		do_feed_rss2( false );
-		remove_filter( 'posts_search', 'get_job_listings_keyword_search' );
+		remove_filter( 'posts_search', 'get_job_listings_keyword_search', 10 );
 	}
 
 	/**

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -351,6 +351,7 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 
 				$not_string = $is_excluding ? 'NOT ' : '';
 				$conditions = [];
+				$meta_value = $wildcard_search . $wpdb->esc_like( $search_term ) . $wildcard_search;
 
 				/**
 				 * Can be used to disable searching post meta for job searches.
@@ -359,7 +360,6 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 				 */
 				if ( apply_filters( 'job_listing_search_post_meta', true ) ) {
 
-					$meta_value = $wildcard_search . $wpdb->esc_like( $search_term ) . $wildcard_search;
 					// Only selected meta keys.
 					if ( $searchable_meta_keys ) {
 						$meta_keys = implode( "','", array_map( 'esc_sql', $searchable_meta_keys ) );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -196,7 +196,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		if ( ! empty( $job_manager_keyword ) && strlen( $job_manager_keyword ) >= apply_filters( 'job_manager_get_listings_keyword_length_threshold', 2 ) ) {
 			$query_args['s'] = $job_manager_keyword;
-			add_filter( 'posts_search', 'get_job_listings_keyword_search' );
+			add_filter( 'posts_search', 'get_job_listings_keyword_search', 10, 2 );
 		}
 
 		$query_args = apply_filters( 'job_manager_get_listings', $query_args, $args );
@@ -266,7 +266,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		do_action( 'after_get_job_listings', $query_args, $args );
 
-		remove_filter( 'posts_search', 'get_job_listings_keyword_search' );
+		remove_filter( 'posts_search', 'get_job_listings_keyword_search', 10 );
 
 		return $result;
 	}
@@ -303,66 +303,173 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 	 * @since 1.21.0
 	 * @since 1.26.0 Moved from the `posts_clauses` filter to the `posts_search` to use WP Query's keyword
 	 *               search for `post_title` and `post_content`.
-	 * @param string $search
+	 * @since $$next-version$$ Reimplemented to provide the same functionality with WP core search:
+	 *                 - Support for double quotes and negating terms (-).
+	 *                 - Breaks down terms into individual words.
+	 *                 - Meta and taxonomy name search happens together with search in title, excerpt and post content.
+	 *
+	 * @param string   $search   The search string.
+	 * @param WP_Query $wp_query The query.
+	 *
 	 * @return string
 	 */
-	function get_job_listings_keyword_search( $search ) {
-		global $wpdb, $job_manager_keyword;
+	function get_job_listings_keyword_search( $search, $wp_query ) {
+		global $wpdb;
 
-		// Searchable Meta Keys: set to empty to search all meta keys.
-		$searchable_meta_keys = [
-			'_job_location',
-			'_company_name',
-			'_application',
-			'_company_name',
-			'_company_tagline',
-			'_company_website',
-			'_company_twitter',
-		];
+		if ( ! function_exists( 'job_manager_construct_secondary_conditions' ) && ! function_exists( 'job_manager_construct_post_conditions' ) ) {
+				/**
+				 * Constructs SQL clauses that return posts which have metas and terms that include or exclude the search term.
+				 *
+				 * @param string $search_term    The search term.
+				 * @param bool   $is_excluding   Whether posts should be excluded if they match the search terms.
+				 * @param string $wildcard_search The wildcard character or empty string for exact matches.
+				 *
+				 * @return array The SQL clauses.
+				 */
+			function job_manager_construct_secondary_conditions( $search_term, $is_excluding, $wildcard_search ) {
+				global $wpdb;
 
-		$searchable_meta_keys = apply_filters( 'job_listing_searchable_meta_keys', $searchable_meta_keys );
+				if ( empty( $search_term ) ) {
+					return [];
+				}
 
-		// Set Search DB Conditions.
-		$conditions = [];
+				$searchable_meta_keys = [
+					'_application',
+					'_company_name',
+					'_company_tagline',
+					'_company_website',
+					'_company_twitter',
+					'_job_location',
+				];
 
-		// Search Post Meta.
-		if ( apply_filters( 'job_listing_search_post_meta', true ) ) {
+				/**
+				 * Filters the meta keys that are used in job search.
+				 *
+				 * @param array $searchable_meta_keys The meta keys.
+				 */
+				$searchable_meta_keys = apply_filters( 'job_listing_searchable_meta_keys', $searchable_meta_keys );
 
-			// Only selected meta keys.
-			if ( $searchable_meta_keys ) {
-				$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key IN ( '" . implode( "','", array_map( 'esc_sql', $searchable_meta_keys ) ) . "' ) AND meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
-			} else {
-				// No meta keys defined, search all post meta value.
-				$conditions[] = "{$wpdb->posts}.ID IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_value LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
+				$not_string = $is_excluding ? 'NOT ' : '';
+				$conditions = [];
+
+				/**
+				 * Can be used to disable searching post meta for job searches.
+				 *
+				 * @param bool $enable_meta_search Return false to disable meta search.
+				 */
+				if ( apply_filters( 'job_listing_search_post_meta', true ) ) {
+
+					$meta_value = $wildcard_search . $wpdb->esc_like( $search_term ) . $wildcard_search;
+					// Only selected meta keys.
+					if ( $searchable_meta_keys ) {
+						$meta_keys = implode( "','", array_map( 'esc_sql', $searchable_meta_keys ) );
+						//phpcs:disabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are safe or escaped.
+						$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID {$not_string}IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key IN ( '${meta_keys}' ) AND meta_value LIKE %s )", $meta_value );
+					} else {
+						// No meta keys defined, search all post meta value.
+						$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID {$not_string}IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_value LIKE %s )", $meta_value );
+						//phpcs:enabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					}
+				}
+
+				// Search taxonomy.
+				$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID ${not_string}IN ( SELECT object_id FROM {$wpdb->term_relationships} AS tr LEFT JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id LEFT JOIN {$wpdb->terms} AS t ON tt.term_id = t.term_id WHERE t.name LIKE %s )", $meta_value );
+
+				return $conditions;
+			}
+
+			/**
+			 * Constructs SQL clauses that return posts which include or exclude the search term in the provided columns.
+			 *
+			 * @see WP_Query::parse_search()
+			 *
+			 * @param string $search_term     The search term to match.
+			 * @param bool   $is_excluding    Whether posts that match the search term should be excluded.
+			 * @param string $wildcard_search The wildcard character or empty string for exact matches.
+			 * @param array  $search_columns   The columns to check.
+			 *
+			 * @return array The SQL clauses.
+			 */
+			function job_manager_construct_post_conditions( $search_term, $is_excluding, $wildcard_search, $search_columns ) {
+				global $wpdb;
+
+				if ( $is_excluding ) {
+					$like_op = 'NOT LIKE';
+				} else {
+					$like_op = 'LIKE';
+				}
+
+				$like = $wildcard_search . $wpdb->esc_like( $search_term ) . $wildcard_search;
+
+				$conditions = [];
+				foreach ( $search_columns as $search_column ) {
+					//phpcs:disabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are safe or escaped.
+					$conditions[] = $wpdb->prepare( "( {$wpdb->posts}.$search_column $like_op %s )", $like );
+				}
+
+				$allow_query_attachment_by_filename = apply_filters( 'wp_allow_query_attachment_by_filename', false );
+				if ( ! empty( $allow_query_attachment_by_filename ) ) {
+					$conditions[] = $wpdb->prepare( "(sq1.meta_value $like_op %s)", $like );
+					//phpcs:enabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				}
+
+				return $conditions;
 			}
 		}
 
-		// Search taxonomy.
-		$conditions[] = "{$wpdb->posts}.ID IN ( SELECT object_id FROM {$wpdb->term_relationships} AS tr LEFT JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id LEFT JOIN {$wpdb->terms} AS t ON tt.term_id = t.term_id WHERE t.name LIKE '%" . esc_sql( $job_manager_keyword ) . "%' )";
-
 		/**
-		 * Filters the conditions to use when querying job listings. Resulting array is joined with OR statements.
-		 *
-		 * @since 1.26.0
-		 *
-		 * @param array  $conditions          Conditions to join by OR when querying job listings.
-		 * @param string $job_manager_keyword Search query.
+		 * This function aims to provide similar search functionality with WP core while also including meta and taxonomy terms
+		 * in the searched columns. The functionality of WP_Query::parse_search is replicated but with additional SQL
+		 * clauses which are generated in the job_manager_construct_secondary_conditions function.
 		 */
-		$conditions = apply_filters( 'job_listing_search_conditions', $conditions, $job_manager_keyword );
-		if ( empty( $conditions ) ) {
+		$default_search_columns = [ 'post_title', 'post_excerpt', 'post_content' ];
+		$search_columns         = ! empty( $wp_query->query_vars['search_columns'] ) ? $wp_query->query_vars['search_columns'] : $default_search_columns;
+		if ( ! is_array( $search_columns ) ) {
+			$search_columns = [ $search_columns ];
+		}
+
+		$search_columns = (array) apply_filters( 'post_search_columns', $search_columns, $wp_query->query_vars['s'], $wp_query );
+
+		// Use only supported search columns.
+		$search_columns = array_intersect( $search_columns, $default_search_columns );
+		if ( empty( $search_columns ) ) {
+			$search_columns = $default_search_columns;
+		}
+
+		// Search terms starting with the exclusion prefix should be removed from the job search results.
+		$exclusion_prefix = apply_filters( 'wp_query_search_exclusion_prefix', '-' );
+		$wildcard_search  = ! empty( $wp_query->query_vars['exact'] ) ? '' : '%';
+		$new_search       = '';
+		$searchand        = '';
+
+		foreach ( $wp_query->query_vars['search_terms'] as $search_term ) {
+			$is_excluding = $exclusion_prefix && str_starts_with( $search_term, $exclusion_prefix );
+
+			if ( $is_excluding ) {
+				$search_term = substr( $search_term, 1 );
+				$andor_op    = 'AND';
+			} else {
+				$andor_op = 'OR';
+			}
+
+			$conditions = job_manager_construct_post_conditions( $search_term, $is_excluding, $wildcard_search, $search_columns );
+			$conditions = array_merge( $conditions, job_manager_construct_secondary_conditions( $search_term, $is_excluding, $wildcard_search ) );
+
+			$new_search .= "$searchand(" . implode( " $andor_op ", $conditions ) . ')';
+
+			$searchand = ' AND ';
+		}
+
+		if ( ! empty( $new_search ) ) {
+			$new_search = " AND ({$new_search}) ";
+			if ( ! is_user_logged_in() ) {
+				$new_search .= " AND ({$wpdb->posts}.post_password = '') ";
+			}
+		} else {
 			return $search;
 		}
 
-		$conditions_str = implode( ' OR ', $conditions );
-
-		if ( ! empty( $search ) ) {
-			$search = preg_replace( '/^ AND /', '', $search );
-			$search = " AND ( {$search} OR ( {$conditions_str} ) )";
-		} else {
-			$search = " AND ( {$conditions_str} )";
-		}
-
-		return $search;
+		return $new_search;
 	}
 endif;
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -404,6 +404,7 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 
 				$conditions = [];
 				foreach ( $search_columns as $search_column ) {
+					$search_column = esc_sql( $search_column );
 					//phpcs:disabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are safe or escaped.
 					$conditions[] = $wpdb->prepare( "( {$wpdb->posts}.$search_column $like_op %s )", $like );
 				}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -380,6 +380,7 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 
 			/**
 			 * Constructs SQL clauses that return posts which include or exclude the search term in the provided columns.
+			 * The function replicates the functionality of WP_Query::parse_search.
 			 *
 			 * @see WP_Query::parse_search()
 			 *
@@ -407,8 +408,10 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 					$conditions[] = $wpdb->prepare( "( {$wpdb->posts}.$search_column $like_op %s )", $like );
 				}
 
+				// Filter documented in WP_Query::get_posts.
 				$allow_query_attachment_by_filename = apply_filters( 'wp_allow_query_attachment_by_filename', false );
 				if ( ! empty( $allow_query_attachment_by_filename ) ) {
+					// sq1 is the wp_postmeta join for attachments in WP_Query::get_posts.
 					$conditions[] = $wpdb->prepare( "(sq1.meta_value $like_op %s)", $like );
 					//phpcs:enabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
@@ -428,6 +431,7 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 			$search_columns = [ $search_columns ];
 		}
 
+		// Filter documented in WP_Query::parse_search.
 		$search_columns = (array) apply_filters( 'post_search_columns', $search_columns, $wp_query->query_vars['s'], $wp_query );
 
 		// Use only supported search columns.


### PR DESCRIPTION
Fixes #2749

### Overview
There are many requests for improving the job search functionality in #1707. The most frequent one being to allow an 'OR' operator when searching. So if for example, a user enters 'software engineer' in search then the listings that contain either 'software' or 'engineer' should be returned. I don't think that we should make this the default behavior as:
- WP core search uses terms with an AND operator which means that it returns posts that contain both terms.
- From a user perspective the AND seems more useful as it allows to filter through many results. I would expect when adding more terms to make the search more specific than the other way around.
If we want to ever allow this, we should specifically support 'OR' and 'AND' operators.

Another, confusing part is that WP core search does partial searches which means that if someone searches for "Java" it will return listings that contain "JavaSript".

Finally, there are also the issues mentioned in #2749. We currently also search the meta fields but not in a consistent way with core. We also don't support negations (-) and phrase searches ("") for meta fields and categories.

This PR solves the issues in #2749 by providing the same functionality for meta and term searches with WP Core (which searches title content and excerpt). This means that for meta and categories:
- We now split search terms and look for each one individually.
- Each term has to exist to at least one of the metas, categories, post title, content and excerpt.
- Users can perform reverse searches with the minus sign e.g. -intern
- Users can perform phrase searches e.g. "software developer"

### Changes Proposed in this Pull Request

* get_job_listings_keyword_search had been reimplemented to construct the search clause from the beginning. Initially, I tried solutions that appended to the existing search clause, but it wasn't possible to achieve accurate results as the core search clauses belonged to a different combination of ANDs and ORs
* Now the SQL produced for each search term looks like this:
```
( ( wp_posts.post_title LIKE '%engineer%' )
                OR ( wp_posts.post_excerpt LIKE '%engineer%' )
                OR ( wp_posts.post_content LIKE '%engineer%' )
                OR wp_posts.id IN (SELECT post_id
                                   FROM   wp_postmeta
                                   WHERE  meta_key IN
                                          ( '_application',
                                            '_company_name'
                                            ,
                                            '_company_tagline',
                                                    '_company_website',
                                            '_company_twitter'
                                          )
                                          AND meta_value LIKE '%engineer%')
                OR wp_posts.id IN (SELECT object_id
                                   FROM   wp_term_relationships AS tr
                                          LEFT JOIN wp_term_taxonomy AS tt
                                                 ON tr.term_taxonomy_id =
                                                    tt.term_taxonomy_id
                                          LEFT JOIN wp_terms AS t
                                                 ON tt.term_id = t.term_id
                                   WHERE  t.name LIKE '%engineer%') )
AND ( ( wp_posts.post_title LIKE '%engin%' ) .....
```
* WP core limits the search terms count to 9 so I don't think that there is a risk for the query to become too large.
* I removed the `job_listing_search_conditions` hook as it wasn't possible to maintain anymore. Users can always override the whole `get_job_listings_keyword_search` function with the previous version to revert to the previous functionality.

### Testing Instructions

* Add listings that contain possible search terms in the title, post content, excerpt, job category, and job metas (e.g. company name or tagline)
* Go to the frontend and perform various searches. 
* Try using minus sign and double quotes, especially for meta fields and job categories.
* Try using category search and term search from the term plugin together with search terms.
* Observe that:
	* Each search term is included to at least one of the searched columns.
	* When using exclusion terms, observe that these are applied last.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Expand job meta and category searching with core WordPress search functionality.

### New or Updated Hooks and Templates
job_listing_search_conditions: Removed as it isn't possible to have it anymore. Users can rollback to previous functionality by overriding `get_job_listings_keyword_search` in `wp-job-manager-functions.php`

### Next Steps
Regarding further improvements in job listing search in general I think that we should avoid them as I think that the implementation is already complex. Any future steps should instead focus on integrating with well known plugins that expand core WP search.







<!-- wpjm:plugin-zip -->
----

| Plugin build for 07706c23923a9764b04c9cad2c9ba2f244912f10 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/05/wp-job-manager-zip-2821-07706c23.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/05/2821-07706c23)             |

<!-- /wpjm:plugin-zip -->












