### PR TITLE
Remove array class arguments

### DIFF
--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -96,7 +96,7 @@ class UI_Elements {
 		}
 
 		$attrs = [
-			'class' => join( ' ', [ $class, $args['class'] ] ),
+			'class' => implode( ' ', [ $class, $args['class'] ] ),
 			'href'  => esc_url( $args['url'] ),
 		];
 

--- a/includes/ui/class-ui-settings.php
+++ b/includes/ui/class-ui-settings.php
@@ -91,7 +91,6 @@ class UI_Settings {
 					[
 						'url'   => '/',
 						'label' => 'Sign in',
-						'class' => [],
 					],
 				],
 			]
@@ -139,12 +138,10 @@ class UI_Settings {
 					[
 						'url'   => '/',
 						'label' => 'Sign in',
-						'class' => [],
 					],
 					[
 						'url'   => '/',
 						'label' => 'Create Account',
-						'class' => [],
 					],
 				],
 			]


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Raised here: https://wordpress.org/support/topic/php-warning-array-to-string-conversion-with-fix/
* Although this code exists only in a test shortcode, I think we should still fix it as we might copy these examples and cause a warning in the future

### Testing Instructions

* Add the `job_manager_ui_test` shortcode in a page
* Visit the page and observe that no warnings are raised.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 84468f63976a96c982dad1bc8ce40cce59217836 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/06/wp-job-manager-zip-2828-84468f63.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/06/2828-84468f63)             |

<!-- /wpjm:plugin-zip -->
