### PR TITLE
Fix PHP 8.3 deprecations

### DIFF
--- a/includes/class-wp-job-manager-usage-tracking.php
+++ b/includes/class-wp-job-manager-usage-tracking.php
@@ -160,7 +160,7 @@ class WP_Job_Manager_Usage_Tracking extends WP_Job_Manager_Usage_Tracking_Base {
 	 * @return self
 	 */
 	public static function get_instance() {
-		return self::get_instance_for_subclass( get_class() );
+		return self::get_instance_for_subclass( static::class );
 	}
 
 	/**

--- a/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -11,7 +11,7 @@ class Usage_Tracking_Test_Subclass extends WP_Job_Manager_Usage_Tracking_Base {
 	const TRACKING_ENABLED_OPTION_NAME = 'testing-usage-tracking-enabled';
 
 	public static function get_instance() {
-		return self::get_instance_for_subclass( get_class() );
+		return self::get_instance_for_subclass( static::class );
 	}
 
 	public function get_prefix() {

--- a/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -15,6 +15,7 @@ Usage_Tracking_Test_Subclass::get_instance();
 class WP_Job_Manager_Usage_Tracking_Test extends WP_UnitTestCase {
 	private $event_counts       = array();
 	private $track_http_request = array();
+	private $usage_tracking;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
@@ -3,6 +3,8 @@
 require 'includes/admin/class-wp-job-manager-cpt.php';
 
 class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
+	protected WP_Job_Manager_CPT $job_manager_cpt;
+
 	public function setUp(): void {
 		parent::setUp();
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -363,17 +363,18 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 					// Only selected meta keys.
 					if ( $searchable_meta_keys ) {
 						$meta_keys = implode( "','", array_map( 'esc_sql', $searchable_meta_keys ) );
-						//phpcs:disabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are safe or escaped.
-						$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID {$not_string}IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key IN ( '${meta_keys}' ) AND meta_value LIKE %s )", $meta_value );
+						// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are safe or escaped.
+						$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID {$not_string}IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key IN ( '{$meta_keys}' ) AND meta_value LIKE %s )", $meta_value );
 					} else {
 						// No meta keys defined, search all post meta value.
 						$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID {$not_string}IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_value LIKE %s )", $meta_value );
-						//phpcs:enabled WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+						// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					}
 				}
 
 				// Search taxonomy.
-				$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID ${not_string}IN ( SELECT object_id FROM {$wpdb->term_relationships} AS tr LEFT JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id LEFT JOIN {$wpdb->terms} AS t ON tt.term_id = t.term_id WHERE t.name LIKE %s )", $meta_value );
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are safe or escaped.
+				$conditions[] = $wpdb->prepare( "{$wpdb->posts}.ID {$not_string}IN ( SELECT object_id FROM {$wpdb->term_relationships} AS tr LEFT JOIN {$wpdb->term_taxonomy} AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id LEFT JOIN {$wpdb->terms} AS t ON tt.term_id = t.term_id WHERE t.name LIKE %s )", $meta_value );
 
 				return $conditions;
 			}


### PR DESCRIPTION
Fixes #2807

### Changes Proposed in this Pull Request

* Fix some code deprecations

### Testing Instructions

* No logic changes

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix PHP 8.3 support




<!-- wpjm:plugin-zip -->
----

| Plugin build for 72f6d73673de9ade667590ac2c4081b21211b0ec <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/07/wp-job-manager-zip-2836-72f6d736.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/07/2836-72f6d736)             |

<!-- /wpjm:plugin-zip -->
