### PR TITLE
Only load editor script if block editor

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -135,7 +135,7 @@ class WP_Job_Manager_Admin {
 			wp_enqueue_script( 'job_manager_admin_js' );
 
 			WP_Job_Manager::register_script( 'job_tags_upsell_js', 'js/admin/job-tags-upsell.js', [], true );
-			if ( ! class_exists( 'WP_Job_Manager_Job_Tags' ) ) {
+			if ( ! class_exists( 'WP_Job_Manager_Job_Tags' ) && $screen->is_block_editor() ) {
 				wp_enqueue_script( 'job_tags_upsell_js' );
 			}
 


### PR DESCRIPTION
Fixes #2830

### Changes Proposed in this Pull Request

* Don't load the job tags upsell script if the current screen is not a block editor

### Testing Instructions

* Activate the Classic editor plugin
* Edit a job listing
* Check that there is no JS error in the console

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix classic editor support for job listings


<!-- wpjm:plugin-zip -->
----

| Plugin build for a4f4e4ceaaf53e90fcf4b5c54163cc358184cd25 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/07/wp-job-manager-zip-2837-a4f4e4ce.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/07/2837-a4f4e4ce)             |

<!-- /wpjm:plugin-zip -->
