### PR TITLE
Add workaround for Safari action menu focusout

### DIFF
--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -155,8 +155,11 @@ class UI_Elements {
 	 */
 	public static function actions_menu( $content ) {
 		$label = __( 'Actions', 'wp-job-manager' );
+
+		$close = esc_attr( 'event.currentTarget.contains(event.relatedTarget) || setTimeout(() => this.open = false, 100 )' );
+
 		return <<<HTML
-<details class="jm-ui-actions-menu" onfocusout="event.currentTarget.contains(event.relatedTarget) || ( this.open = false )">
+<details class="jm-ui-actions-menu" onfocusout="{$close}">
 	<summary tabindex="0" class="jm-ui-action-menu__open-button jm-ui-button--icon"
 		aria-label="{$label}">
 		<span class="jm-ui-button__icon"></span>


### PR DESCRIPTION
Fixes #2832 

### Changes Proposed in this Pull Request

* Add workaround (a small timeout) in the action menu focusout handler for Safari. For some reason the browser is not setting the `relatedTarget` when a link inside the menu is clicked, causing the menu to close.

### Testing Instructions

* Open the employer dashboard (`[job_dashboard]`) page in Safari
* Click on the ` ⠇ ` action menu and verify the actions are working

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix job dashboard actions menu in Safari

### Screenshots

<img width="1316" alt="image" src="https://github.com/user-attachments/assets/a491e538-b51e-4f86-a19c-c0c5777751d2">


<!-- wpjm:plugin-zip -->
----

| Plugin build for 8181fa955b5e4ee1dd5c6806d11732d55ac939df <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/07/wp-job-manager-zip-2838-8181fa95.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/07/2838-8181fa95)             |

<!-- /wpjm:plugin-zip -->
