### PR TITLE
Fix with '_featured' and '_filled' meta on duplicated posts

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -673,10 +673,6 @@ class WP_Job_Manager_Writepanels {
 	public function save_job_listing_data( $post_id, $post ) {
 		global $wpdb;
 
-		// These need to exist.
-		add_post_meta( $post_id, '_filled', 0, true );
-		add_post_meta( $post_id, '_featured', 0, true );
-
 		// Save fields.
 		foreach ( $this->job_listing_fields() as $key => $field ) {
 			if ( isset( $field['type'] ) && 'info' === $field['type'] ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -205,7 +205,7 @@ class WP_Job_Manager_Post_Types {
 		add_filter( 'wp_insert_post_data', [ $this, 'fix_post_name' ], 10, 2 );
 		add_action( 'add_post_meta', [ $this, 'maybe_add_geolocation_data' ], 10, 3 );
 		add_action( 'update_post_meta', [ $this, 'update_post_meta' ], 10, 4 );
-		add_action( 'wp_insert_post', [ $this, 'maybe_add_default_meta_data' ], 10, 2 );
+		add_action( 'wp_after_insert_post', [ $this, 'maybe_add_default_meta_data' ], 10, 2 );
 		add_filter( 'post_types_to_delete_with_user', [ $this, 'delete_user_add_job_listings_post_type' ] );
 
 		add_action( 'transition_post_status', [ $this, 'track_job_submission' ], 10, 3 );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -970,10 +970,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @param  array $values
 	 */
 	protected function update_job_data( $values ) {
-		// Set defaults.
-		add_post_meta( $this->job_id, '_filled', 0, true );
-		add_post_meta( $this->job_id, '_featured', 0, true );
-
 		$maybe_attach = [];
 
 		// Loop fields and save meta and term data.

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '2.3.0' );
+define( 'JOB_MANAGER_VERSION', '2.3.0-dev' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Fixes #2827 

### Changes Proposed in this Pull Request

* Centralize `add_post_meta` to add `_filled` and `_featured` in a single place after the post is called.

### Testing Instructions

1. Apply this patch
2. Install ACF
3. Install a plugin to duplicate posts, like Yoast Duplicate Post
4. Create a custom field/form for job listings
5. Add a new job listing, fill it normally
6. Go to the job listing page on admin, click to Clone it
7. Edit the new post, edit the custom field, save, check if it doesn't break everything
8. 
<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix with '_featured' and '_filled' meta on duplicated posts

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

### Screenshot / Video


<!-- wpjm:plugin-zip -->
----

| Plugin build for fc3b10cf9b6d1ccff01b2ea9d816711ff013bd37 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/07/wp-job-manager-zip-2839-fc3b10cf.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/07/2839-fc3b10cf)             |

<!-- /wpjm:plugin-zip -->
