### PR TITLE
Add required attribute to file input field

### DIFF
--- a/templates/form-fields/file-field.php
+++ b/templates/form-fields/file-field.php
@@ -46,7 +46,8 @@ if ( ! empty( $field['ajax'] ) && job_manager_user_can_upload_file_via_ajax() ) 
 	type="file"
 	class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"
 	data-file_types="<?php echo esc_attr( implode( '|', $allowed_mime_types ) ); ?>"
-	<?php if ( ! empty( $field['multiple'] ) ) echo 'multiple'; ?>
+	<?php if ( ! empty( $field['required'] ) ) echo ' required'; ?>
+	<?php if ( ! empty( $field['multiple'] ) ) echo ' multiple'; ?>
 	<?php if ( $file_limit ) echo ' data-file_limit="' . absint( $file_limit ) . '"';?>
 	<?php if ( ! empty( $field['file_limit_message'] ) ) echo ' data-file_limit_message="' . esc_attr( $field['file_limit_message'] ) . '"';?>
 	name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?><?php if ( ! empty( $field['multiple'] ) ) echo '[]'; ?>"


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2177

### Changes Proposed in this Pull Request

* Make sure the `required` attribute is added to the file input when appropriate, similar to the rest of the field types

### Testing Instructions

*See #2177 to test it with the Applications add-on

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix file input field for forms not marked as required

### Screenshot / Video


<!-- wpjm:plugin-zip -->
----

| Plugin build for 4bd7a249af34859f679273386b0702622195c41d <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/08/wp-job-manager-zip-2846-4bd7a249.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/08/2846-4bd7a249)             |

<!-- /wpjm:plugin-zip -->
