### PR TITLE
Fix methods removed instead of deprecated in 2.3.0

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -633,7 +633,7 @@ class WP_Job_Manager_Shortcodes {
 	 * @output string
 	 */
 	public function job_dashboard_title_column_status( $job ) {
-		__deprecated_function( __METHOD__, '$$next-version$$', 'Job_Dashboard_Shortcode::the_job_status' );
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Job_Dashboard_Shortcode::the_job_status' );
 		Job_Dashboard_Shortcode::instance()->the_status( $job );
 	}
 

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -146,6 +146,28 @@ class WP_Job_Manager_Shortcodes {
 	}
 
 	/**
+	 * Handles actions which need to be run before the shortcode e.g. post actions.
+	 *
+	 * @deprecated $$next-version$$ - Moved to Job_Dashboard_Shortcode.
+	 */
+	public function shortcode_action_handler() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Job_Dashboard_Shortcode::handle_actions' );
+		Job_Dashboard_Shortcode::instance()->handle_actions();
+	}
+
+	/**
+	 * Handles actions on job dashboard.
+	 *
+	 * @throws Exception On action handling error.
+	 *
+	 * @deprecated $$next-version$$ - Moved to Job_Dashboard_Shortcode.
+	 */
+	public function job_dashboard_handler() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Job_Dashboard_Shortcode::handle_actions' );
+		Job_Dashboard_Shortcode::instance()->handle_actions();
+	}
+
+	/**
 	 * Displays edit job form.
 	 *
 	 * @deprecated 2.3.0 - Moved to Job_Dashboard_Shortcode.
@@ -586,6 +608,36 @@ class WP_Job_Manager_Shortcodes {
 
 		return ob_get_clean();
 	}
+
+	/**
+	 * Add expiration details to the job dashboard date column.
+	 *
+	 * @param \WP_Post $job
+	 *
+	 * @deprecated $$next-version$$ - Moved to Job_Dashboard_Shortcode.
+	 *
+	 * @output string
+	 */
+	public function job_dashboard_date_column_expires( $job ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Job_Dashboard_Shortcode::the_expiration_date' );
+		Job_Dashboard_Shortcode::instance()->the_expiration_date( $job );
+	}
+
+	/**
+	 * Add job status to the job dashboard title column.
+	 *
+	 * @param \WP_Post $job
+	 *
+	 * @deprecated $$next-version$$ - Moved to Job_Dashboard_Shortcode.
+	 *
+	 * @output string
+	 */
+	public function job_dashboard_title_column_status( $job ) {
+		__deprecated_function( __METHOD__, '$$next-version$$', 'Job_Dashboard_Shortcode::the_job_status' );
+		Job_Dashboard_Shortcode::instance()->the_status( $job );
+	}
+
+
 
 }
 


### PR DESCRIPTION
Fixes #2824

### Changes Proposed in this Pull Request

* Add back removed methods and deprecated them instead

### Testing Instructions

* Smoke test the `[job_dashboard]` shortcode

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Dev: Fix deprecated `WP_Job_Manager_Shortcodes` methods

### Screenshot / Video



<!-- wpjm:plugin-zip -->
----

| Plugin build for 4213330667e2495b50bf7c8eb1d9e09519f6e914 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2024/08/wp-job-manager-zip-2847-42133306.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2024/08/2847-42133306)             |

<!-- /wpjm:plugin-zip -->


