### PR TITLE
Job Visibility Enhancement: Submit Job Listing

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -624,6 +624,16 @@ class WP_Job_Manager_Settings {
 							'desc'              => sprintf( __( 'Enter which <a href="%s">roles or capabilities</a> allow visitors to view a single job listing. If no value is selected, everyone (including logged out guests) will be able to view job listings.', 'wp-job-manager' ), 'http://codex.wordpress.org/Roles_and_Capabilities' ),
 							'track'             => 'bool',
 						],
+						[
+							'name'              => 'job_manager_submit_job_listing_capability',
+							'std'               => [],
+							'label'             => __( 'Submit Job Capability', 'wp-job-manager' ),
+							'type'              => 'capabilities',
+							'sanitize_callback' => [ $this, 'sanitize_capabilities' ],
+							// translators: Placeholder %s is the url to the WordPress core documentation for capabilities and roles.
+							'desc'              => sprintf( __( 'Enter which <a href="%s">roles or capabilities</a> allow visitors to submit a job listing. If no value is selected, everyone (including logged out guests) will be able to submit job listings.', 'wp-job-manager' ), 'http://codex.wordpress.org/Roles_and_Capabilities' ),
+							'track'             => 'bool',
+						],
 					],
 				],
 			]

--- a/templates/access-denied-submit-job_listing.php
+++ b/templates/access-denied-submit-job_listing.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Message to display when access is denied to a submit a job listing.
+ *
+ * This template can be overridden by copying it to yourtheme/job_manager/access-denied-submit-job_listing.php.
+ *
+ * @see         https://wpjobmanager.com/document/template-overrides/
+ * @author      Automattic
+ * @package     wp-job-manager
+ * @category    Template
+ * @since       $$next_version$$
+ * @version     $$next_version$$
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<p class="job-manager-error"><?php esc_html_e( 'Sorry, you do not have permission to submit a job listing.', 'wp-job-manager' ); ?></p>

--- a/templates/job-submit.php
+++ b/templates/job-submit.php
@@ -15,10 +15,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-global $post, $job_manager;
+global $job_manager;
 $captcha_version = WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->get_recaptcha_version();
 
-if ( job_manager_user_can_view_submit_job_listing( $post->ID ) ) : ?>
+if ( job_manager_user_can_view_submit_job_listing() ) : ?>
 	<form action="<?php echo esc_url( $action ); ?>" method="post" id="submit-job-form" class="job-manager-form" enctype="multipart/form-data">
 
 		<?php

--- a/templates/job-submit.php
+++ b/templates/job-submit.php
@@ -8,55 +8,39 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.34.3
+ * @version     $$next_version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-global $job_manager;
+global $post, $job_manager;
 $captcha_version = WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->get_recaptcha_version();
-?>
-<form action="<?php echo esc_url( $action ); ?>" method="post" id="submit-job-form" class="job-manager-form" enctype="multipart/form-data">
 
-	<?php
-	if ( isset( $resume_edit ) && $resume_edit ) {
-		printf( '<p><strong>' . esc_html__( "You are editing an existing job. %s", 'wp-job-manager' ) . '</strong></p>', '<a href="?job_manager_form=submit-job&new=1&key=' . esc_attr( $resume_edit ) . '">' . esc_html__( 'Create A New Job', 'wp-job-manager' ) . '</a>' );
-	}
-	?>
+if ( job_manager_user_can_view_submit_job_listing( $post->ID ) ) : ?>
+	<form action="<?php echo esc_url( $action ); ?>" method="post" id="submit-job-form" class="job-manager-form" enctype="multipart/form-data">
 
-	<?php do_action( 'submit_job_form_start' ); ?>
+		<?php
+		if ( isset( $resume_edit ) && $resume_edit ) {
+			printf( '<p><strong>' . esc_html__( "You are editing an existing job. %s", 'wp-job-manager' ) . '</strong></p>', '<a href="?job_manager_form=submit-job&new=1&key=' . esc_attr( $resume_edit ) . '">' . esc_html__( 'Create A New Job', 'wp-job-manager' ) . '</a>' );
+		}
+		?>
 
-	<?php if ( apply_filters( 'submit_job_form_show_signin', true ) ) : ?>
+		<?php do_action( 'submit_job_form_start' ); ?>
 
-		<?php get_job_manager_template( 'account-signin.php' ); ?>
+		<?php if ( apply_filters( 'submit_job_form_show_signin', true ) ) : ?>
 
-	<?php endif; ?>
+			<?php get_job_manager_template( 'account-signin.php' ); ?>
 
-	<?php if ( job_manager_user_can_post_job() || job_manager_user_can_edit_job( $job_id ) ) : ?>
+		<?php endif; ?>
 
-		<!-- Job Information Fields -->
-		<?php do_action( 'submit_job_form_job_fields_start' ); ?>
+		<?php if ( job_manager_user_can_post_job() || job_manager_user_can_edit_job( $job_id ) ) : ?>
 
-		<?php foreach ( $job_fields as $key => $field ) : ?>
-			<fieldset class="fieldset-<?php echo esc_attr( $key ); ?> fieldset-type-<?php echo esc_attr( $field['type'] ); ?>">
-				<label for="<?php echo esc_attr( $key ); ?>"><?php echo wp_kses_post( $field['label'] ) . wp_kses_post( apply_filters( 'submit_job_form_required_label', $field['required'] ? '' : ' <small>' . __( '(optional)', 'wp-job-manager' ) . '</small>', $field ) ); ?></label>
-				<div class="field <?php echo $field['required'] ? 'required-field' : ''; ?>">
-					<?php get_job_manager_template( 'form-fields/' . $field['type'] . '-field.php', [ 'key' => $key, 'field' => $field ] ); ?>
-				</div>
-			</fieldset>
-		<?php endforeach; ?>
+			<!-- Job Information Fields -->
+			<?php do_action( 'submit_job_form_job_fields_start' ); ?>
 
-		<?php do_action( 'submit_job_form_job_fields_end' ); ?>
-
-		<!-- Company Information Fields -->
-		<?php if ( $company_fields ) : ?>
-			<h2><?php esc_html_e( 'Company Details', 'wp-job-manager' ); ?></h2>
-
-			<?php do_action( 'submit_job_form_company_fields_start' ); ?>
-
-			<?php foreach ( $company_fields as $key => $field ) : ?>
+			<?php foreach ( $job_fields as $key => $field ) : ?>
 				<fieldset class="fieldset-<?php echo esc_attr( $key ); ?> fieldset-type-<?php echo esc_attr( $field['type'] ); ?>">
 					<label for="<?php echo esc_attr( $key ); ?>"><?php echo wp_kses_post( $field['label'] ) . wp_kses_post( apply_filters( 'submit_job_form_required_label', $field['required'] ? '' : ' <small>' . __( '(optional)', 'wp-job-manager' ) . '</small>', $field ) ); ?></label>
 					<div class="field <?php echo $field['required'] ? 'required-field' : ''; ?>">
@@ -65,28 +49,48 @@ $captcha_version = WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->get_reca
 				</fieldset>
 			<?php endforeach; ?>
 
-			<?php do_action( 'submit_job_form_company_fields_end' ); ?>
+			<?php do_action( 'submit_job_form_job_fields_end' ); ?>
+
+			<!-- Company Information Fields -->
+			<?php if ( $company_fields ) : ?>
+				<h2><?php esc_html_e( 'Company Details', 'wp-job-manager' ); ?></h2>
+
+				<?php do_action( 'submit_job_form_company_fields_start' ); ?>
+
+				<?php foreach ( $company_fields as $key => $field ) : ?>
+					<fieldset class="fieldset-<?php echo esc_attr( $key ); ?> fieldset-type-<?php echo esc_attr( $field['type'] ); ?>">
+						<label for="<?php echo esc_attr( $key ); ?>"><?php echo wp_kses_post( $field['label'] ) . wp_kses_post( apply_filters( 'submit_job_form_required_label', $field['required'] ? '' : ' <small>' . __( '(optional)', 'wp-job-manager' ) . '</small>', $field ) ); ?></label>
+						<div class="field <?php echo $field['required'] ? 'required-field' : ''; ?>">
+							<?php get_job_manager_template( 'form-fields/' . $field['type'] . '-field.php', [ 'key' => $key, 'field' => $field ] ); ?>
+						</div>
+					</fieldset>
+				<?php endforeach; ?>
+
+				<?php do_action( 'submit_job_form_company_fields_end' ); ?>
+			<?php endif; ?>
+
+			<?php do_action( 'submit_job_form_end' ); ?>
+
+			<p>
+				<input type="hidden" name="job_manager_form" value="<?php echo esc_attr( $form ); ?>" />
+				<input type="hidden" name="job_id" value="<?php echo esc_attr( $job_id ); ?>" />
+				<input type="hidden" name="step" value="<?php echo esc_attr( $step ); ?>" />
+				<input type="submit" name="submit_job" class="button"
+				<?php if ('v3' === $captcha_version) echo 'onclick="jm_job_submit_click(event)"'; ?> value="<?php echo esc_attr($submit_button_text); ?>" />
+				<?php
+				if ( isset( $can_continue_later ) && $can_continue_later ) {
+					echo '<input type="submit" name="save_draft" class="button secondary save_draft" value="' . esc_attr__( 'Save Draft', 'wp-job-manager' ) . '" formnovalidate />';
+				}
+				?>
+				<span class="spinner" style="background-image: url(<?php echo esc_url( includes_url( 'images/spinner.gif' ) ); ?>);"></span>
+			</p>
+
+		<?php else : ?>
+
+			<?php do_action( 'submit_job_form_disabled' ); ?>
+
 		<?php endif; ?>
-
-		<?php do_action( 'submit_job_form_end' ); ?>
-
-		<p>
-			<input type="hidden" name="job_manager_form" value="<?php echo esc_attr( $form ); ?>" />
-			<input type="hidden" name="job_id" value="<?php echo esc_attr( $job_id ); ?>" />
-			<input type="hidden" name="step" value="<?php echo esc_attr( $step ); ?>" />
-			<input type="submit" name="submit_job" class="button"
-    		<?php if ('v3' === $captcha_version) echo 'onclick="jm_job_submit_click(event)"'; ?> value="<?php echo esc_attr($submit_button_text); ?>" />
-			<?php
-			if ( isset( $can_continue_later ) && $can_continue_later ) {
-				echo '<input type="submit" name="save_draft" class="button secondary save_draft" value="' . esc_attr__( 'Save Draft', 'wp-job-manager' ) . '" formnovalidate />';
-			}
-			?>
-			<span class="spinner" style="background-image: url(<?php echo esc_url( includes_url( 'images/spinner.gif' ) ); ?>);"></span>
-		</p>
-
-	<?php else : ?>
-
-		<?php do_action( 'submit_job_form_disabled' ); ?>
-
-	<?php endif; ?>
-</form>
+	</form>
+<?php else : ?>
+	<?php get_job_manager_template_part( 'access-denied', 'submit-job_listing' ); ?>
+<?php endif; ?>

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1822,14 +1822,11 @@ function job_manager_user_can_view_job_listing( $job_id ) {
  *
  * @since $$next_version$$
  *
- * @param  int $job_id
  * @return bool
  */
-function job_manager_user_can_view_submit_job_listing( $job_id ) {
+function job_manager_user_can_view_submit_job_listing() {
 	$can_view = true;
-	$job      = get_post( $job_id );
-
-	$caps = get_option( 'job_manager_submit_job_listing_capability' );
+	$caps     = get_option( 'job_manager_submit_job_listing_capability' );
 
 	if ( $caps ) {
 		$can_view = false;
@@ -1841,19 +1838,14 @@ function job_manager_user_can_view_submit_job_listing( $job_id ) {
 		}
 	}
 
-	if ( $job->post_author > 0 && absint( $job->post_author ) === get_current_user_id() ) {
-		$can_view = true;
-	}
-
 	/**
 	 * Filter if the current user can or cannot view job submission
 	 *
 	 * @since $$next_version$$
 	 *
 	 * @param boolean $can_view
-	 * @param int     $job_id
 	 */
-	return apply_filters( 'job_manager_user_can_view_submit_job', $can_view, $job_id );
+	return apply_filters( 'job_manager_user_can_view_submit_job', $can_view );
 }
 
 /**

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1745,7 +1745,7 @@ function job_manager_count_user_job_listings( $user_id = 0 ) {
 }
 
 /**
- * True if an the user can browse resumes.
+ * True if an the user can browse job listings.
  *
  * @return bool
  */
@@ -1774,7 +1774,7 @@ function job_manager_user_can_browse_job_listings() {
 }
 
 /**
- * True if an the user can view a resume.
+ * True if an the user can view a job listing.
  *
  * @since 1.37.0
  *
@@ -1815,6 +1815,45 @@ function job_manager_user_can_view_job_listing( $job_id ) {
 	 * @param int     $job_id
 	 */
 	return apply_filters( 'job_manager_user_can_view_job', $can_view, $job_id );
+}
+
+/**
+ * True if an the user can view submit job listing.
+ *
+ * @since $$next_version$$
+ *
+ * @param  int $job_id
+ * @return bool
+ */
+function job_manager_user_can_view_submit_job_listing( $job_id ) {
+	$can_view = true;
+	$job      = get_post( $job_id );
+
+	$caps = get_option( 'job_manager_submit_job_listing_capability' );
+
+	if ( $caps ) {
+		$can_view = false;
+		foreach ( $caps as $cap ) {
+			if ( current_user_can( $cap ) ) {
+				$can_view = true;
+				break;
+			}
+		}
+	}
+
+	if ( $job->post_author > 0 && absint( $job->post_author ) === get_current_user_id() ) {
+		$can_view = true;
+	}
+
+	/**
+	 * Filter if the current user can or cannot view job submission
+	 *
+	 * @since $$next_version$$
+	 *
+	 * @param boolean $can_view
+	 * @param int     $job_id
+	 */
+	return apply_filters( 'job_manager_user_can_view_submit_job', $can_view, $job_id );
 }
 
 /**


### PR DESCRIPTION

### Changes Proposed in this Pull Request

I've received numerous requests from users for visibility options on the job submission page. Currently, most users manage this through third-party plugins, but since WPJM already offers visibility options for "Browse Jobs" and "View Job," I thought it would be beneficial to add similar options for "Job Submission" as well.

### Testing Instructions

* Go to "Job Manager -> Settings -> Job Visibility" 
* Add a role to "Submit Job Capability"
* Visit the job submission as a not logged in user

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* New filter: `job_manager_user_can_view_submit_job`
* New template: access-denied-submit-job_listing.php
