### PR TITLE
Fix dashboard edit action for scheduled listings

### DIFF
--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -242,6 +242,7 @@ class Job_Dashboard_Shortcode {
 				break;
 			case 'pending_payment':
 			case 'pending':
+			case 'future':
 				if ( \WP_Job_Manager_Post_Types::job_is_editable( $job->ID ) ) {
 					$actions['edit'] = [
 						'label' => __( 'Edit', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1243,9 +1243,11 @@ class WP_Job_Manager_Post_Types {
 		$job_is_editable = true;
 		$post_status     = get_post_status( $job_id );
 
+		$published = in_array( $post_status, [ 'future', 'publish' ], true );
+
 		if (
-			( 'publish' === $post_status && ! wpjm_user_can_edit_published_submissions() )
-			|| ( 'publish' !== $post_status && ! job_manager_user_can_edit_pending_submissions() )
+			( $published && ! wpjm_user_can_edit_published_submissions() )
+			|| ( ! $published && ! job_manager_user_can_edit_pending_submissions() )
 		) {
 			$job_is_editable = false;
 		}


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Handle the `future` post status in the job dashboard, show the "Edit" action can show up for scheduled listings
* Use the "Allow published edits" settings instead of "Allow editing of pending listings" for deciding if a scheduled job should be editable

### Testing Instructions

* Make sure Settings → Submissions → Allow Published Edits is enabled (with or without re-approval)
* Create a new listing, set a scheduled date
* Approve it as admin
* Check that it's editable in the job dashboard

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/86fe931c-0f63-4e5c-bf0c-3c1aa336a16b" />


<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Fix: Enable editing of scheduled listings if published/approved listings are editable


### Screenshot / Video


<!-- wpjm:plugin-zip -->
----

| Plugin build for 76d5226ba871a9b715a660b10356a24bd69de241 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2025/01/wp-job-manager-zip-2872-76d5226b.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2025/01/2872-76d5226b)             |

<!-- /wpjm:plugin-zip -->
