### PR TITLE
Fix hardcoded dashboard expiration date format

### DIFF
--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -594,14 +594,15 @@ class Job_Dashboard_Shortcode {
 	}
 
 	/**
-	 * Show job title.
+	 * Show the job date
 	 *
 	 * @param \WP_Post $job
 	 *
 	 * @output string
 	 */
 	public static function the_date( $job ) {
-		echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', get_option( 'date_format' ) ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
+		$date_format = get_option( 'date_format' ) ?: 'M d, Y';
+		echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', $date_format ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
 	}
 
 	/**

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -601,7 +601,7 @@ class Job_Dashboard_Shortcode {
 	 * @output string
 	 */
 	public static function the_date( $job ) {
-		echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', 'M d, Y' ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
+		echo '<div>' . esc_html( wp_date( apply_filters( 'job_manager_get_dashboard_date_format', get_option( 'date_format' ) ), get_post_datetime( $job )->getTimestamp() ) ) . '</div>';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2890

### Changes Proposed in this Pull Request
* We should change the hardcoded dateformat for the Job Dashboard Shortcode. Currently it displays the date format hardcoded in the format 'M d, Y'. Now it will respect the settings set in WordPress.

### Testing Instructions
* open /job-dashboard/ page. without the fix it will be displayed like this
<img width="1610" height="365" alt="image" src="https://github.com/user-attachments/assets/d19f4eea-b87c-4064-8c9d-73fb3e506969" />

After the fix it will be displayed according to your settings, in my example "j. F Y".
<img width="1616" height="273" alt="image" src="https://github.com/user-attachments/assets/5cbdf6e0-f68a-43c7-93a3-1d0ac98f9ca6" />

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes
* fix hardcoded dashboard expiration date format

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
* -

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code
* -

### Screenshot / Video
-