### PR TITLE
loading do_feed_rss2 function with do_action

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -807,7 +807,7 @@ class WP_Job_Manager_Post_Types {
 		query_posts( apply_filters( 'job_feed_args', $query_args ) );
 		add_action( 'rss2_ns', [ $this, 'job_feed_namespace' ] );
 		add_action( 'rss2_item', [ $this, 'job_feed_item' ] );
-		do_feed_rss2( false );
+		do_action( 'do_feed_rss2', false );
 		remove_filter( 'posts_search', 'get_job_listings_keyword_search', 10 );
 	}
 


### PR DESCRIPTION
Fixes #2854

### Changes Proposed in this Pull Request
* add a additional action to the do_feed_rss2 action so users can add extra actions to the feed

### Testing Instructions
* Add a do_action behavior to do_feed_rss2
* Call the /?feed=job_feed page and you will notice your custom action is not activated.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes
* add a additional action to the do_feed_rss2

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
-

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code
-

### Screenshot / Video
-