### PR TITLE
reCaptcha script not being loaded

### DIFF
--- a/includes/class-wp-job-manager-recaptcha.php
+++ b/includes/class-wp-job-manager-recaptcha.php
@@ -77,7 +77,11 @@ class WP_Job_Manager_Recaptcha {
 				add_filter( $validate_hook, [ $this, 'validate_recaptcha_field' ] );
 			}
 
-			add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+			if ( did_action( 'wp_enqueue_scripts' ) ) {
+				$this->enqueue_scripts();
+			} else {
+				add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/WP-Job-Manager/issues/2850

### Changes Proposed in this Pull Request

The reCAPTCHA scripts aren't being loaded on any themes other than the default ones.

### Testing Instructions

* Setup reCaptcha
* Switch to a non default theme
* Go to the job submission