### PR TITLE
Enable Expiry Date in Frontend Form

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -237,9 +237,6 @@
       <code>false</code>
       <code>string</code>
     </InvalidNullableReturnType>
-    <NullArgument>
-      <code>null</code>
-    </NullArgument>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -390,6 +390,16 @@ class WP_Job_Manager_Settings {
 							'track'      => 'bool',
 						],
 						[
+							'name'       => 'job_manager_enable_expiry_date_field',
+							'std'        => '0',
+							'label'      => __( 'Expiry Date Field', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable expiry date field in frontend form', 'wp-job-manager' ),
+							'desc'       => __( 'Allow employers to set a custom expiry date for their job listings that overrides the default listing duration.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+							'track'      => 'bool',
+						],
+						[
 							'name'       => 'job_manager_generate_username_from_email',
 							'std'        => '1',
 							'label'      => __( 'Account Username', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1169,8 +1169,8 @@ class WP_Job_Manager_Post_Types {
 	/**
 	 * Set the job expiration date.
 	 *
-	 * @param WP_Post|int       $job          Job post object or ID.
-	 * @param DateTimeImmutable $date_expires Date time object for the job expiration date. Null if to be cleared.
+	 * @param WP_Post|int            $job          Job post object or ID.
+	 * @param DateTimeImmutable|null $date_expires Date time object for the job expiration date. Null to clear.
 	 *
 	 * @return false
 	 * @throws TypeError When bad argument is passed to `$date_expires`.

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -591,7 +591,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		// Validate expiry date field if enabled and provided.
 		if ( get_option( 'job_manager_enable_expiry_date_field' ) && ! empty( $values['job']['job_expires'] ) ) {
-			$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values['job']['job_expires'], wp_timezone() );
+			$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d|', $values['job']['job_expires'], wp_timezone() );
 			if ( ! $expires_date ) {
 				throw new Exception( __( 'Please enter a valid expiry date', 'wp-job-manager' ) );
 			}
@@ -1046,7 +1046,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 					// If a date is provided, also set the job expiration.
 					if ( ! empty( $values[ $group_key ][ $key ] ) ) {
-						$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values[ $group_key ][ $key ], wp_timezone() );
+						$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d|', $values[ $group_key ][ $key ], wp_timezone() );
 						if ( $expires_date ) {
 							WP_Job_Manager_Post_Types::instance()->set_job_expiration( $this->job_id, $expires_date );
 						}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -409,10 +409,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				'required'    => false,
 				'placeholder' => '',
 				'priority'    => '6.6',
-				'class'       => 'job-manager-datepicker',
-				'attributes'  => [
-					'min' => current_time( 'Y-m-d' ),
-				],
 			];
 		}
 
@@ -591,14 +587,20 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		// Validate expiry date field if enabled and provided.
 		if ( get_option( 'job_manager_enable_expiry_date_field' ) && ! empty( $values['job']['job_expires'] ) ) {
 			$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d|', $values['job']['job_expires'], wp_timezone() );
-			if ( ! $expires_date ) {
+			$date_errors  = DateTimeImmutable::getLastErrors();
+			if ( ! $expires_date || ( is_array( $date_errors ) && $date_errors['warning_count'] > 0 ) ) {
 				throw new Exception( __( 'Please enter a valid expiry date', 'wp-job-manager' ) );
 			}
 
 			// Check if the date is in the past.
+			// Skip the check when editing an expired listing with an unchanged date — otherwise
+			// owners would be locked out of any unrelated edits on their expired listings.
 			$today = new DateTimeImmutable( 'today', wp_timezone() );
 			if ( $expires_date < $today ) {
-				throw new Exception( __( 'Expiry date cannot be in the past', 'wp-job-manager' ) );
+				$existing_expires = $this->job_id ? get_post_meta( $this->job_id, '_job_expires', true ) : '';
+				if ( $values['job']['job_expires'] !== $existing_expires ) {
+					throw new Exception( __( 'Expiry date cannot be in the past', 'wp-job-manager' ) );
+				}
 			}
 		}
 
@@ -1050,12 +1052,16 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					// Handle custom expiry date field.
 				} elseif ( 'job_expires' === $key ) {
 
-					// If a date is provided, also set the job expiration.
 					if ( ! empty( $values[ $group_key ][ $key ] ) ) {
+						// A date was provided — persist it.
 						$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d|', $values[ $group_key ][ $key ], wp_timezone() );
 						if ( $expires_date ) {
 							WP_Job_Manager_Post_Types::instance()->set_job_expiration( $this->job_id, $expires_date );
 						}
+					} else {
+						// Empty: clear the stored date so the default duration is recomputed on the
+						// next status transition (matches field description "Leave blank to use default duration").
+						WP_Job_Manager_Post_Types::instance()->set_job_expiration( $this->job_id, null );
 					}
 
 					// Save meta data.
@@ -1203,8 +1209,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$job = get_post( $this->job_id );
 
 			if ( in_array( $job->post_status, [ 'preview', 'expired' ], true ) ) {
-				// Reset expiry.
-				delete_post_meta( $job->ID, '_job_expires' );
+				// Reset expiry — but preserve a user-chosen date when the expiry date field is active.
+				$saved_expiry = get_post_meta( $job->ID, '_job_expires', true );
+				if ( ! get_option( 'job_manager_enable_expiry_date_field' ) || empty( $saved_expiry ) ) {
+					delete_post_meta( $job->ID, '_job_expires' );
+				}
 
 				// Update job listing.
 				$update_job                = [];

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -539,19 +539,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			}
 		}
 
-		// Validate expiry date field.
-		if ( get_option( 'job_manager_enable_expiry_date_field' ) && ! empty( $values['job']['job_expires'] ) ) {
-			$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values['job']['job_expires'], wp_timezone() );
-			if ( ! $expires_date ) {
-				return new WP_Error( 'validation-error', __( 'Please enter a valid expiry date.', 'wp-job-manager' ) );
-			}
-
-			$today = new DateTimeImmutable( 'now', wp_timezone() );
-			if ( $expires_date < $today ) {
-				return new WP_Error( 'validation-error', __( 'Expiry date cannot be in the past.', 'wp-job-manager' ) );
-			}
-		}
-
 		// Application method.
 		if ( ! $this->should_application_field_skip_email_url_validation() && isset( $values['job']['application'] ) ) {
 			$allowed_application_method = get_option( 'job_manager_allowed_application_method', '' );

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -399,7 +399,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				'priority'    => '6.6',
 				'class'       => 'job-manager-datepicker',
 				'attributes'  => [
-					'min' => current_time( 'Y-m-d' )
+					'min' => current_time( 'Y-m-d' ),
 				],
 			];
 		}
@@ -545,7 +545,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			if ( ! $expires_date ) {
 				return new WP_Error( 'validation-error', __( 'Please enter a valid expiry date.', 'wp-job-manager' ) );
 			}
-			
+
 			$today = new DateTimeImmutable( 'now', wp_timezone() );
 			if ( $expires_date < $today ) {
 				return new WP_Error( 'validation-error', __( 'Expiry date cannot be in the past.', 'wp-job-manager' ) );
@@ -589,14 +589,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			}
 		}
 
-		// Validate expiry date field if enabled and provided
+		// Validate expiry date field if enabled and provided.
 		if ( get_option( 'job_manager_enable_expiry_date_field' ) && ! empty( $values['job']['job_expires'] ) ) {
 			$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values['job']['job_expires'], wp_timezone() );
 			if ( ! $expires_date ) {
 				throw new Exception( __( 'Please enter a valid expiry date', 'wp-job-manager' ) );
 			}
-			
-			// Check if the date is in the past
+
+			// Check if the date is in the past.
 			$today = new DateTimeImmutable( 'today', wp_timezone() );
 			if ( $expires_date < $today ) {
 				throw new Exception( __( 'Expiry date cannot be in the past', 'wp-job-manager' ) );
@@ -1041,10 +1041,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 					// Handle custom expiry date field.
 				} elseif ( 'job_expires' === $key ) {
-					// Always save the raw value first
+					// Always save the raw value first.
 					update_post_meta( $this->job_id, '_job_expires', $values[ $group_key ][ $key ] );
-					
-					// If a date is provided, also set the job expiration
+
+					// If a date is provided, also set the job expiration.
 					if ( ! empty( $values[ $group_key ][ $key ] ) ) {
 						$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values[ $group_key ][ $key ], wp_timezone() );
 						if ( $expires_date ) {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -389,6 +389,21 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			];
 		}
 
+		if ( get_option( 'job_manager_enable_expiry_date_field' ) ) {
+			$this->fields['job']['job_expires'] = [
+				'label'       => __( 'Expiry Date', 'wp-job-manager' ),
+				'description' => __( 'Optionally set when this job listing will expire. Leave blank to use default duration.', 'wp-job-manager' ),
+				'type'        => 'date',
+				'required'    => false,
+				'placeholder' => '',
+				'priority'    => '6.6',
+				'class'       => 'job-manager-datepicker',
+				'attributes'  => [
+					'min' => current_time( 'Y-m-d' )
+				],
+			];
+		}
+
 		return $this->fields;
 	}
 
@@ -524,6 +539,19 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			}
 		}
 
+		// Validate expiry date field.
+		if ( get_option( 'job_manager_enable_expiry_date_field' ) && ! empty( $values['job']['job_expires'] ) ) {
+			$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values['job']['job_expires'], wp_timezone() );
+			if ( ! $expires_date ) {
+				return new WP_Error( 'validation-error', __( 'Please enter a valid expiry date.', 'wp-job-manager' ) );
+			}
+			
+			$today = new DateTimeImmutable( 'now', wp_timezone() );
+			if ( $expires_date < $today ) {
+				return new WP_Error( 'validation-error', __( 'Expiry date cannot be in the past.', 'wp-job-manager' ) );
+			}
+		}
+
 		// Application method.
 		if ( ! $this->should_application_field_skip_email_url_validation() && isset( $values['job']['application'] ) ) {
 			$allowed_application_method = get_option( 'job_manager_allowed_application_method', '' );
@@ -558,6 +586,20 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						}
 						break;
 				}
+			}
+		}
+
+		// Validate expiry date field if enabled and provided
+		if ( get_option( 'job_manager_enable_expiry_date_field' ) && ! empty( $values['job']['job_expires'] ) ) {
+			$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values['job']['job_expires'], wp_timezone() );
+			if ( ! $expires_date ) {
+				throw new Exception( __( 'Please enter a valid expiry date', 'wp-job-manager' ) );
+			}
+			
+			// Check if the date is in the past
+			$today = new DateTimeImmutable( 'today', wp_timezone() );
+			if ( $expires_date < $today ) {
+				throw new Exception( __( 'Expiry date cannot be in the past', 'wp-job-manager' ) );
 			}
 		}
 
@@ -996,6 +1038,19 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						set_post_thumbnail( $this->job_id, $attachment_id );
 					}
 					update_user_meta( get_current_user_id(), '_company_logo', $attachment_id );
+
+					// Handle custom expiry date field.
+				} elseif ( 'job_expires' === $key ) {
+					// Always save the raw value first
+					update_post_meta( $this->job_id, '_job_expires', $values[ $group_key ][ $key ] );
+					
+					// If a date is provided, also set the job expiration
+					if ( ! empty( $values[ $group_key ][ $key ] ) ) {
+						$expires_date = DateTimeImmutable::createFromFormat( 'Y-m-d', $values[ $group_key ][ $key ], wp_timezone() );
+						if ( $expires_date ) {
+							WP_Job_Manager_Post_Types::instance()->set_job_expiration( $this->job_id, $expires_date );
+						}
+					}
 
 					// Save meta data.
 				} else {

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1028,8 +1028,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 					// Handle custom expiry date field.
 				} elseif ( 'job_expires' === $key ) {
-					// Always save the raw value first.
-					update_post_meta( $this->job_id, '_job_expires', $values[ $group_key ][ $key ] );
 
 					// If a date is provided, also set the job expiration.
 					if ( ! empty( $values[ $group_key ][ $key ] ) ) {


### PR DESCRIPTION
Fixes #2886 

### Changes Proposed in this Pull Request
* Allow Expiry Date to be set in Frontend Form for Job Submissions

### Testing Instructions
* Go to Settings -> Job Submissions and activate "Expiry Date field"
* Visit Job Submissions Frontend Form
* add a new job including an expiry date
* see in wp-admin if the expiry date was set correctly

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes
* Allow Expiry Date to be set in Frontend Form for Job Submissions

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code
*

### Screenshot / Video
<img width="991" height="235" alt="image" src="https://github.com/user-attachments/assets/f516ff07-a56f-4e36-9894-c69a59a2413c" />
