### PR TITLE
Update actions/cache to use v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         id: npm-cache
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
@@ -27,7 +27,7 @@ jobs:
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,11 +18,11 @@ jobs:
           fetch-depth: 0
 
       - name: Get cached composer directories
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: vendor/
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -72,11 +72,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get cached composer directories
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: vendor/
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -111,11 +111,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get cached composer directories
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: vendor/
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}


### PR DESCRIPTION
Fixes failed building when testing on GH with: "Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2". 

According to https://github.com/actions/toolkit/blob/main/packages/cache/README.md the switch from v2 to v4 should not break anything :) 
