### PR TITLE
In get_the_company_logo(): make sure $post exists

### DIFF
--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -900,6 +900,11 @@ function the_company_logo( $size = 'thumbnail', $default = null, $post = null ) 
 function get_the_company_logo( $post = null, $size = 'thumbnail' ) {
 	$post = get_post( $post );
 
+	// Called with invalid post ID or without post ID outside the loop.
+	if ( ! $post ) {
+		return '';
+	}
+
 	if ( has_post_thumbnail( $post->ID ) ) {
 		$src = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), $size );
 		return $src ? $src[0] : '';


### PR DESCRIPTION
Fixes #2894.

### Changes Proposed in this Pull Request

Ensure `$post` exists before using it in `get_the_company_logo()`. It may not exist if an invalid post ID was passed, or when the function was called without a post ID outside the loop.
