### PR TITLE
Fix typo in field type check for wp_editor

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1902,7 +1902,7 @@ class WP_Job_Manager_Post_Types {
 			$type = $fields[ $meta_key ]['type'];
 		}
 
-		if ( 'textarea' === $type || 'wp_editor' === $type ) {
+		if ( 'textarea' === $type || 'wp-editor' === $type ) {
 			return wp_kses_post( wp_unslash( $meta_value ) );
 		}
 


### PR DESCRIPTION
Looks like anytime someone has a custom WP Editor field type, the type check for field sanitation is checking for `wp_editor` when the actual field type is `wp-editor`, this causes any custom WP Editor fields when saved to lose all formatting.

### Changes Proposed in this Pull Request

* Fix incorrect field type check for `wp_editor` which should be `wp-editor` (to match the actual field type value)

### Testing Instructions

* Create a custom WP Editor field, save, it strips all formatting.  Change this value to `wp_editor` try again, and it works correctly.
