### PR TITLE
Fix structured data output for password-protected listings

### DIFF
--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -1000,6 +1000,23 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		}
 	}
 
+	/**
+	 * Test that structured data is turned off for password-protected job listings.
+	 *
+	 * @since 1.28.0
+	 * @covers ::wpjm_output_job_listing_structured_data
+	 */
+	public function test_password_protected_no_structured_data() {
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_password' => 'test123',
+				'post_status'   => 'publish',
+			]
+		);
+
+		$this->assertFalse( wpjm_output_job_listing_structured_data( $job_id ) );
+	}
+
 	protected function get_wp_no_robots() {
 		ob_start();
 		wp_no_robots();

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -337,8 +337,10 @@ function wpjm_output_job_listing_structured_data( $post = null ) {
 		return false;
 	}
 
-	// Only show structured data for un-filled and published job listings.
-	$output_structured_data = ! is_position_filled( $post ) && 'publish' === $post->post_status;
+	// Only show structured data for un-filled, published, and non-password-protected job listings.
+	$output_structured_data = ! is_position_filled( $post )
+		&& 'publish' === $post->post_status
+		&& ! post_password_required( $post );
 
 	/**
 	 * Filter if we should output structured data.
@@ -353,6 +355,10 @@ function wpjm_output_job_listing_structured_data( $post = null ) {
 
 /**
  * Gets the structured data for the job listing.
+ *
+ * Note: This function does not check if the job listing is published, filled,
+ * password-protected, or otherwise hidden. Use wpjm_output_job_listing_structured_data()
+ * to check if structured data should be output for a given job listing.
  *
  * @since 1.28.0
  * @see https://developers.google.com/search/docs/data-types/job-postings


### PR DESCRIPTION
## Summary
- Fix structured data output for password-protected job listings.
- Add test coverage.

## Test plan
- [ ] Verify password-protected listings no longer output structured data.
- [ ] Verify non-password-protected listings still output structured data as before.


<!-- wpjm:plugin-zip -->
----

| Plugin build for b171b31f51c3acb43bb7630feb83c470ee672ff9 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/02/wp-job-manager-zip-2913-b171b31f.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/02/2913-b171b31f)             |

<!-- /wpjm:plugin-zip -->


