### PR TITLE
Add permission check to listing query parameters

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -144,6 +144,11 @@ class WP_Job_Manager_Ajax {
 			$search_categories = array_filter( [ sanitize_text_field( wp_unslash( $search_categories ) ) ] );
 		}
 
+		// Ensure the current user can filter by post_status.
+		if ( is_array( $filter_post_status ) && ! current_user_can( \WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS ) ) {
+			$filter_post_status = null;
+		}
+
 		$types              = get_job_listing_types();
 		$job_types_filtered = ! is_null( $filter_job_types ) && count( $types ) !== count( $filter_job_types );
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
@@ -71,6 +71,13 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 				'meta_input'  => [],
 			]
 		);
+		$private   = $this->factory->job_listing->create_many(
+			2,
+			[
+				'post_status' => 'private',
+				'meta_input'  => [],
+			]
+		);
 		$instance  = WP_Job_Manager_Ajax::instance();
 
 		// Run the action.
@@ -95,6 +102,12 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 
 		// Make sure the HTML does NOT contain any of the draft post titles.
 		foreach ( $draft as $post_id ) {
+			$post = get_post( $post_id );
+			$this->assertStringNotContainsString( $post->post_title, $result['html'] );
+		}
+
+		// Make sure the HTML does NOT contain any of the private post titles.
+		foreach ( $private as $post_id ) {
 			$post = get_post( $post_id );
 			$this->assertStringNotContainsString( $post->post_title, $result['html'] );
 		}


### PR DESCRIPTION
## Summary

- Adds a capability check for certain query parameters in the AJAX listings endpoint

## Test plan

- Verify listing queries return expected results for both authenticated and unauthenticated users


<!-- wpjm:plugin-zip -->
----

| Plugin build for 2ed939f108f68d78d13a24df1cdbf498a42bfa66 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/02/wp-job-manager-zip-2914-2ed939f1.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/02/2914-2ed939f1)             |

<!-- /wpjm:plugin-zip -->


