### PR TITLE
Install SVN in release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           node scripts/create-release.mjs wp-job-manager ${{ github.event.number }}
           cd build && unzip -q wp-job-manager.zip
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
       - name: Deploy to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@abb939a0d0bfd01063e8d1933833209201557381
         env:


### PR DESCRIPTION
## Summary
- GitHub Actions runners no longer include SVN by default, breaking the WordPress.org deploy step in the release workflow
- Adds an explicit `apt-get install subversion` step before the deploy action

## Test plan
- [ ] Trigger a release and verify the WordPress.org deploy step succeeds

<!-- wpjm:plugin-zip -->
----

| Plugin build for efdae14984743cc565d170313dc34fa0c1dcc2df <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/02/wp-job-manager-zip-2916-efdae149.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/02/2916-efdae149)             |

<!-- /wpjm:plugin-zip -->
