### PR TITLE
integrate settings link to wp-job-manager

### DIFF
--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -138,7 +138,6 @@ class WP_Job_Manager {
 		add_action( 'plugins_loaded', [ $this, 'include_admin_files' ] );
 
 		// Filters.
-		add_filter( 'plugin_action_links_' . JOB_MANAGER_PLUGIN_BASENAME, [ $this, 'plugin_action_links' ] );
 		add_filter( 'wp_privacy_personal_data_exporters', [ 'WP_Job_Manager_Data_Exporter', 'register_wpjm_user_data_exporter' ] );
 		add_filter( 'allowed_redirect_hosts', [ $this, 'add_to_allowed_redirect_hosts' ] );
 
@@ -157,18 +156,6 @@ class WP_Job_Manager {
 	public function add_to_allowed_redirect_hosts( $hosts ) {
 		$hosts[] = wp_parse_url( WP_Job_Manager_Helper_API::get_wpjmcom_url(), PHP_URL_HOST );
 		return $hosts;
-	}
-
-	/**
-	 * Adds a Settings link to the plugin action links on the Plugins screen.
-	 *
-	 * @param array $links Existing plugin action links.
-	 * @return array Plugin action links with Settings prepended.
-	 */
-	public function plugin_action_links( $links ) {
-		$settings_link = '<a href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-settings#settings-general' ) ) . '">' . esc_html__( 'Settings', 'wp-job-manager' ) . '</a>';
-		array_unshift( $links, $settings_link );
-		return $links;
 	}
 
 	/**

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -138,6 +138,7 @@ class WP_Job_Manager {
 		add_action( 'plugins_loaded', [ $this, 'include_admin_files' ] );
 
 		// Filters.
+		add_filter( 'plugin_action_links_' . JOB_MANAGER_PLUGIN_BASENAME, [ $this, 'plugin_action_links' ] );
 		add_filter( 'wp_privacy_personal_data_exporters', [ 'WP_Job_Manager_Data_Exporter', 'register_wpjm_user_data_exporter' ] );
 		add_filter( 'allowed_redirect_hosts', [ $this, 'add_to_allowed_redirect_hosts' ] );
 
@@ -156,6 +157,18 @@ class WP_Job_Manager {
 	public function add_to_allowed_redirect_hosts( $hosts ) {
 		$hosts[] = wp_parse_url( WP_Job_Manager_Helper_API::get_wpjmcom_url(), PHP_URL_HOST );
 		return $hosts;
+	}
+
+	/**
+	 * Adds a Settings link to the plugin action links on the Plugins screen.
+	 *
+	 * @param array $links Existing plugin action links.
+	 * @return array Plugin action links with Settings prepended.
+	 */
+	public function plugin_action_links( $links ) {
+		$settings_link = '<a href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-settings#settings-general' ) ) . '">' . esc_html__( 'Settings', 'wp-job-manager' ) . '</a>';
+		array_unshift( $links, $settings_link );
+		return $links;
 	}
 
 	/**

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -485,16 +485,16 @@ class WP_Job_Manager_Helper {
 	 */
 	public function plugin_links( $actions, $plugin_filename ) {
 		if ( plugin_basename( JOB_MANAGER_PLUGIN_DIR . '/wp-job-manager.php' ) === $plugin_filename
-        && current_user_can( 'manage_options' )
-	    ) {
-	        array_unshift(
-	            $actions,
-	            '<a href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-settings' ) ) . '">'
-	                . esc_html__( 'Settings', 'wp-job-manager' )
-	            . '</a>'
-	        );
-	    }
-		
+			&& current_user_can( 'manage_options' )
+		) {
+			array_unshift(
+				$actions,
+				'<a href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-settings' ) ) . '">'
+					. esc_html__( 'Settings', 'wp-job-manager' )
+				. '</a>'
+			);
+		}
+
 		$plugin = $this->get_license_managed_plugin( $plugin_filename );
 		if ( ! $plugin || ! current_user_can( 'update_plugins' ) ) {
 			return $actions;

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -484,6 +484,17 @@ class WP_Job_Manager_Helper {
 	 * @return array
 	 */
 	public function plugin_links( $actions, $plugin_filename ) {
+		if ( plugin_basename( JOB_MANAGER_PLUGIN_DIR . '/wp-job-manager.php' ) === $plugin_filename
+        && current_user_can( 'manage_options' )
+	    ) {
+	        array_unshift(
+	            $actions,
+	            '<a href="' . esc_url( admin_url( 'edit.php?post_type=job_listing&page=job-manager-settings' ) ) . '">'
+	                . esc_html__( 'Settings', 'wp-job-manager' )
+	            . '</a>'
+	        );
+	    }
+		
 		$plugin = $this->get_license_managed_plugin( $plugin_filename );
 		if ( ! $plugin || ! current_user_can( 'update_plugins' ) ) {
 			return $actions;


### PR DESCRIPTION
**Fixes #**

*(No issue — minor UX improvement)*

### Changes Proposed in this Pull Request

* Adds a **Settings** link to the WP Job Manager entry on the Plugins screen (plugins.php), pointing directly to the General settings tab (`wp-admin/edit.php?post_type=job_listing&page=job-manager-settings#settings-general`).

### Testing Instructions

1. Activate WP Job Manager.
2. Navigate to **Plugins → Installed Plugins**.
3. Locate **WP Job Manager** in the list.
4. Confirm a **Settings** link appears in the action links row (alongside Deactivate, etc.).
5. Click the **Settings** link and confirm it redirects to the Job Manager → Settings page with the General tab active.

### Release Notes

* Added a Settings link to the plugin action links on the Plugins screen for quicker access to plugin settings.

### New or Updated Hooks and Templates

*None.*

### Deprecated Code

*None.*

### Screenshot / Video
<img width="1831" height="311" alt="image" src="https://github.com/user-attachments/assets/1838e460-3050-40c1-a52e-4dd018777aeb" />

*(Settings link visible in the Plugins list)*