### PR TITLE
Update Twitter Labels and URL to X

### DIFF
--- a/includes/class-wp-job-manager-data-exporter.php
+++ b/includes/class-wp-job-manager-data-exporter.php
@@ -52,7 +52,7 @@ class WP_Job_Manager_Data_Exporter {
 			'_company_name'    => __( 'Company Name', 'wp-job-manager' ),
 			'_company_website' => __( 'Company Website', 'wp-job-manager' ),
 			'_company_tagline' => __( 'Company Tagline', 'wp-job-manager' ),
-			'_company_twitter' => __( 'Company Twitter', 'wp-job-manager' ),
+			'_company_twitter' => __( 'Company X / Twitter', 'wp-job-manager' ),
 			'_company_video'   => __( 'Company Video', 'wp-job-manager' ),
 		];
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1699,7 +1699,7 @@ class WP_Job_Manager_Post_Types {
 				'show_in_rest'  => true,
 			],
 			'_company_twitter'     => [
-				'label'         => __( 'Company Twitter', 'wp-job-manager' ),
+				'label'         => __( 'Company X / Twitter', 'wp-job-manager' ),
 				'placeholder'   => '@yourcompany',
 				'priority'      => 6,
 				'data_type'     => 'string',

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -333,7 +333,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'priority'    => 4,
 					],
 					'company_twitter' => [
-						'label'       => __( 'Twitter username', 'wp-job-manager' ),
+						'label'       => __( 'X / Twitter username', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
 						'placeholder' => __( '@yourcompany', 'wp-job-manager' ),

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
@@ -104,7 +104,7 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 					'_company_name'    => 'Example',
 					'_company_website' => 'https://example.com/',
 					'_company_tagline' => 'Just another tagline',
-					'_company_twitter' => 'https://twitter.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
+					'_company_twitter' => 'https://x.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
 					'_company_video'   => 'https://example.com/company/video',
 				],
 				[
@@ -131,8 +131,8 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 									'value' => 'Just another tagline',
 								],
 								[
-									'name'  => 'Company Twitter',
-									'value' => 'https://twitter.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
+									'name'  => 'Company X / Twitter',
+									'value' => 'https://x.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
 								],
 								[
 									'name'  => 'Company Video',

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1139,7 +1139,7 @@ function get_the_company_tagline( $post = null ) {
 }
 
 /**
- * Displays or retrieves the current company Twitter link with optional content.
+ * Displays or retrieves the current company X / Twitter link with optional content.
  *
  * @since 1.0.0
  * @param string           $before (default: '').
@@ -1155,7 +1155,7 @@ function the_company_twitter( $before = '', $after = '', $echo = true, $post = n
 		return null;
 	}
 
-	$company_twitter = $before . '<a href="' . esc_url( 'https://twitter.com/' . $company_twitter ) . '" class="company_twitter">' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
+	$company_twitter = $before . '<a href="' . esc_url( 'https://x.com/' . $company_twitter ) . '" class="company_twitter">' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
 
 	if ( $echo ) {
 		echo wp_kses_post( $company_twitter );


### PR DESCRIPTION
**Fixes #2918**

*(No linked issue — minor UX/branding update)*

### Changes Proposed in this Pull Request

* Updated the company Twitter profile link URL from `https://twitter.com/` to `https://x.com/` in `the_company_twitter()`.
* Updated user-facing label strings from "Twitter username" to "X / Twitter username" (job submission form) and "Company Twitter" to "Company X / Twitter" (admin meta box, personal data export) to reflect the platform rebrand.

### Testing Instructions

1. Create or edit a job listing and add a value to the **X / Twitter username** field — confirm the label reads "X / Twitter username".
2. Save and view the single job listing on the frontend.
3. Confirm the Twitter/X link in the company info box points to `https://x.com/<username>` rather than `https://twitter.com/<username>`.
4. In wp-admin, open the job listing post editor and confirm the meta field label reads "Company X / Twitter".
5. Go to **Tools → Erase Personal Data**, request an export for a user with a job listing that has a Twitter handle, and confirm the exported label reads "Company X / Twitter".

### Release Notes

* Updated Twitter profile links to use the new `x.com` domain and updated related labels to "X / Twitter" to reflect the platform rebrand.

### New or Updated Hooks and Templates

*None.*

### Deprecated Code

*None.*

### Screenshot / Video

*(Label and link change are text-only — no visual screenshot required)*