### PR TITLE
defensively checking for a missing widget_id

### DIFF
--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -81,6 +81,10 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	 * @return bool
 	 */
 	public function get_cached_widget( $args ) {
+		if ( empty( $args['widget_id'] ) ) {
+			return false;
+		}
+
 		$cache = wp_cache_get( $this->widget_id, 'widget' );
 
 		if ( ! is_array( $cache ) ) {
@@ -102,6 +106,10 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	 * @param string $content
 	 */
 	public function cache_widget( $args, $content ) {
+		if ( empty( $args['widget_id'] ) ) {
+			return;
+		}
+
 		$cache = wp_cache_get( $this->widget_id, 'widget' );
 
 		if ( ! is_array( $cache ) ) {


### PR DESCRIPTION
**Fixes #2910**

### Changes Proposed in this Pull Request

* Added an `empty()` guard on `$args['widget_id']` in `WP_Job_Manager_Widget::get_cached_widget()` and `cache_widget()` to prevent PHP 8+ undefined array key warnings.
* When `widget_id` is absent, `get_cached_widget()` returns `false` (cache miss) and `cache_widget()` returns early — both fall back gracefully to normal widget rendering without caching.

### Testing Instructions

1. Ensure a PHP 8.0+ environment with error reporting set to `E_ALL`.
2. Add a WP Job Manager widget (e.g. Recent Jobs or Featured Jobs) to a sidebar via **Appearance → Widgets**.
3. Load a frontend page that displays the widget.
4. Confirm no `undefined array key "widget_id"` PHP warnings appear in the error log or on screen.
5. Confirm the widget renders correctly with caching intact under normal conditions (i.e. `$args['widget_id']` is present as expected in a standard WordPress widget context).

### Release Notes

* Fixed PHP 8+ undefined array key warning in the widget caching methods.

### New or Updated Hooks and Templates

*None.*

### Deprecated Code

*None.*

### Screenshot / Video

*N/A — no visual change.*