### PR TITLE
add featured support to RSS

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -728,6 +728,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
+		$input_featured      = isset( $_GET['featured'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['featured'] ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$query_args = [
@@ -759,6 +760,13 @@ class WP_Job_Manager_Post_Types {
 				}
 			}
 			$query_args['meta_query'][] = $location_search;
+		}
+
+		if ( $input_featured ) {
+			$query_args['meta_query'][] = [
+				'key'   => '_featured',
+				'value' => '1',
+			];
 		}
 
 		// Hide filled positions from the job feed.

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -728,7 +728,7 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
-		$input_featured      = isset( $_GET['featured'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['featured'] ) );
+		$input_featured      = isset( $_GET['featured'] ) ? sanitize_text_field( wp_unslash( $_GET['featured'] ) ) : null;
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$query_args = [
@@ -762,10 +762,10 @@ class WP_Job_Manager_Post_Types {
 			$query_args['meta_query'][] = $location_search;
 		}
 
-		if ( $input_featured ) {
+		if ( null !== $input_featured ) {
 			$query_args['meta_query'][] = [
 				'key'   => '_featured',
-				'value' => '1',
+				'value' => '1' === $input_featured ? '1' : '0',
 			];
 		}
 


### PR DESCRIPTION
Fixes #2341

### Changes Proposed in this Pull Request

* Added support for filtering the job RSS feed by featured status using the `featured=true` query parameter

### Testing Instructions

1. Mark one or more job listings as "Featured" in WP Admin.
2. Visit `/?feed=job_feed` — confirm all published jobs appear.
3. Visit `/?feed=job_feed&featured=true` — confirm only featured jobs appear.
4. Combine with other filters, e.g. `/?feed=job_feed&featured=true&search_location=London` — confirm both filters are applied correctly.

### Release Notes

* Added `featured=true` query parameter support to the job RSS feed to allow filtering by featured listings only.

### New or Updated Hooks and Templates
-

### Deprecated Code
-

### Screenshot / Video
-