### PR TITLE
add categories to feed

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -847,11 +847,12 @@ class WP_Job_Manager_Post_Types {
 	 * Adds custom data to the job feed.
 	 */
 	public function job_feed_item() {
-		$post_id   = get_the_ID();
-		$location  = get_the_job_location( $post_id );
-		$company   = get_the_company_name( $post_id );
-		$job_types = wpjm_get_the_job_types( $post_id );
-		$salary    = get_the_job_salary( $post_id );
+		$post_id        = get_the_ID();
+		$location       = get_the_job_location( $post_id );
+		$company        = get_the_company_name( $post_id );
+		$job_types      = wpjm_get_the_job_types( $post_id );
+		$job_categories = wpjm_get_the_job_categories( $post_id );
+		$salary         = get_the_job_salary( $post_id );
 
 		if ( $location ) {
 			echo '<job_listing:location><![CDATA[' . esc_html( $location ) . "]]></job_listing:location>\n";
@@ -860,6 +861,11 @@ class WP_Job_Manager_Post_Types {
 			$job_types_names = implode( ', ', wp_list_pluck( $job_types, 'name' ) );
 			echo '<job_listing:job_type><![CDATA[' . esc_html( $job_types_names ) . "]]></job_listing:job_type>\n";
 		}
+		if ( ! empty( $job_categories ) ) {
+			$job_categories_names = implode( ', ', wp_list_pluck( $job_categories, 'name' ) );
+			echo '<job_listing:job_category><![CDATA[' . esc_html( $job_categories_names ) . "]]></job_listing:job_category>\n";
+		}
+		
 		if ( $company ) {
 			echo '<job_listing:company><![CDATA[' . esc_html( $company ) . "]]></job_listing:company>\n";
 		}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -865,7 +865,6 @@ class WP_Job_Manager_Post_Types {
 			$job_categories_names = implode( ', ', wp_list_pluck( $job_categories, 'name' ) );
 			echo '<job_listing:job_category><![CDATA[' . esc_html( $job_categories_names ) . "]]></job_listing:job_category>\n";
 		}
-		
 		if ( $company ) {
 			echo '<job_listing:company><![CDATA[' . esc_html( $company ) . "]]></job_listing:company>\n";
 		}

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -340,7 +340,8 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 			$result_arr = xml_to_array( $result );
 			$this->assertNotEmpty( $result_arr );
 			$this->assertTrue( isset( $result_arr[0]['child'] ) );
-			$this->assertCount( 3, $result_arr[0]['child'] );
+			$expected_count = (int) $has_location + (int) $has_job_type + (int) $has_job_category + (int) $has_company;
+			$this->assertCount( $expected_count, $result_arr[0]['child'] );
 
 			if ( $has_location ) {
 				$job_location = get_the_job_location( $post );

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -340,7 +340,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 			$result_arr = xml_to_array( $result );
 			$this->assertNotEmpty( $result_arr );
 			$this->assertTrue( isset( $result_arr[0]['child'] ) );
-			$this->assertCount( 2, $result_arr[0]['child'] );
+			$this->assertCount( 3, $result_arr[0]['child'] );
 
 			if ( $has_location ) {
 				$job_location = get_the_job_location( $post );

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -283,6 +283,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		$new_jobs       = [];
 		$type_a         = wp_create_term( 'Job Type A', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
 		$type_b         = wp_create_term( 'Job Type B', \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
+		$category_a     = wp_create_term( 'Job Category A', \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY );
 		$new_job_args   = [];
 		$new_job_args[] = [
 			'meta_input' => [
@@ -290,6 +291,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 			],
 			'tax_input'  => [
 				\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => $type_a['term_id'],
+				\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY => $category_a['term_id'],
 			],
 		];
 		$new_job_args[] = [
@@ -325,6 +327,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 			$has_location = ! empty( $new_job_args[ $index ]['meta_input']['_job_location'] );
 			$has_company  = ! empty( $new_job_args[ $index ]['meta_input']['_company_name'] );
 			$has_job_type = ! empty( $new_job_args[ $index ]['tax_input'][\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE] );
+			$has_job_category = ! empty( $new_job_args[ $index ]['tax_input'][\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY] );
 			$index++;
 
 			$jobs->the_post();
@@ -353,6 +356,14 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				$this->assertStringContainsString( $job_type->name, $result );
 			} else {
 				$this->assertStringNotContainsString( 'job_listing:job_type', $result );
+			}
+
+			if ( $has_job_category ) {
+				$job_category = current( wpjm_get_the_job_categories( $post ) );
+				$this->assertStringContainsString( 'job_listing:job_category', $result );
+				$this->assertStringContainsString( $job_category->name, $result );
+			} else {
+				$this->assertStringNotContainsString( 'job_listing:job_category', $result );
 			}
 
 			if ( $has_company ) {


### PR DESCRIPTION
Fixes #1910

### Changes Proposed in this Pull Request

* Added `job_category` to the job RSS feed XML output in `job_feed_item()`, consistent with how `job_type` is already included.
* Job categories are comma-separated when multiple categories are assigned to a listing.

### Testing Instructions

1. Ensure at least one job listing has a category assigned.
2. Visit the job RSS feed URL (e.g. `/?feed=job_feed`).
3. Confirm each feed item that has categories now includes a `<job_listing:job_category>` element, e.g.:
   ```xml
   <job_listing:job_category><![CDATA[Engineering, Design]]></job_listing:job_category>
   ```
4. Confirm feed items without a category omit the element entirely.
5. Confirm existing feed elements (`location`, `job_type`, `company`, `salary`) are unaffected.

### Release Notes

* Job categories are now included in the job RSS feed XML output.

### New or Updated Hooks and Templates

*

### Deprecated Code

*

### Screenshot / Video