### PR TITLE
Fix: Exclude filled job listings from REST API collection responses

### DIFF
--- a/includes/class-wp-job-manager-rest-api.php
+++ b/includes/class-wp-job-manager-rest-api.php
@@ -33,6 +33,10 @@ class WP_Job_Manager_REST_API {
 	 * @return array
 	 */
 	public static function exclude_filled_from_query( $args, $request ) {
+		if ( 1 !== absint( get_option( 'job_manager_hide_filled_positions' ) ) ) {
+			return $args;
+		}
+
 		if ( ! isset( $args['meta_query'] ) ) {
 			$args['meta_query'] = []; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
 		}

--- a/includes/class-wp-job-manager-rest-api.php
+++ b/includes/class-wp-job-manager-rest-api.php
@@ -22,6 +22,35 @@ class WP_Job_Manager_REST_API {
 	 */
 	public static function init() {
 		add_filter( 'rest_prepare_job_listing', [ __CLASS__, 'prepare_job_listing' ], 10, 2 );
+		add_filter( 'rest_job_listing_query', [ __CLASS__, 'exclude_filled_from_query' ], 10, 2 );
+	}
+
+	/**
+	 * Excludes filled job listings from REST API query results.
+	 *
+	 * @param array           $args    Array of query arguments.
+	 * @param WP_REST_Request $request The REST API request.
+	 * @return array
+	 */
+	public static function exclude_filled_from_query( $args, $request ) {
+		if ( ! isset( $args['meta_query'] ) ) {
+			$args['meta_query'] = []; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
+		}
+
+		$args['meta_query'][] = [
+			'relation' => 'OR',
+			[
+				'key'     => '_filled',
+				'value'   => '1',
+				'compare' => '!=',
+			],
+			[
+				'key'     => '_filled',
+				'compare' => 'NOT EXISTS',
+			],
+		];
+
+		return $args;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1855

### Changes Proposed in this Pull Request
* Filled job listings are now excluded from the job listings collection endpoint (`GET /wp-json/wp/v2/job-listings`) via the `rest_job_listing_query` filter.

### Testing Instructions

1. Mark one or more job listings as **Position Filled** in the WP admin.
2. Make a request to `GET /wp-json/wp/v2/job-listings` and confirm filled listings are absent from the results.
4. Confirm non-filled listings are still returned as expected in both cases.

### Release Notes
* Filled job listings are no longer exposed via the REST API.

### New or Updated Hooks and Templates
-

### Deprecated Code
-

### Screenshot / Video
-