### PR TITLE
Fix: Salary currency field placeholder and description reflect the configured default currency

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -218,6 +218,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		} else {
 			$job_type = 'term-select';
 		}
+
+		$default_salary_currency = get_option( 'job_manager_default_salary_currency' );
+		$salary_currency_placeholder = $default_salary_currency ?: __( 'e.g. USD', 'wp-job-manager' );
+		$salary_currency_description = $default_salary_currency
+			// translators: %s is the default salary currency code (e.g. USD).
+			? sprintf( __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency (%s).', 'wp-job-manager' ), $default_salary_currency )
+			: __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency.', 'wp-job-manager' );
+
 		$this->fields = apply_filters(
 			'submit_job_form_fields',
 			[
@@ -287,8 +295,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'label'       => __( 'Salary Currency', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
-						'placeholder' => __( 'e.g. USD', 'wp-job-manager' ),
-						'description' => __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency.', 'wp-job-manager' ),
+						'placeholder' => $salary_currency_placeholder,
+						'description' => $salary_currency_description,
 						'priority'    => 9,
 					],
 					'job_salary_unit'     => [

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -219,7 +219,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$job_type = 'term-select';
 		}
 
-		$default_salary_currency = get_option( 'job_manager_default_salary_currency' );
+		$default_salary_currency     = get_option( 'job_manager_default_salary_currency' );
 		$salary_currency_placeholder = $default_salary_currency ?: __( 'e.g. USD', 'wp-job-manager' );
 		$salary_currency_description = $default_salary_currency
 			// translators: %s is the default salary currency code (e.g. USD).


### PR DESCRIPTION
Fixes #2300

### Changes Proposed in this Pull Request

* The salary currency field on the frontend job submission form now uses the configured **Default Salary Currency** setting as its placeholder instead of the hardcoded `e.g. USD`.
* The field description now also displays the configured default currency code, making it clear to submitters what currency will be applied if the field is left empty.
* When no default currency is configured, the placeholder falls back to `e.g. USD` and the description remains generic.

### Testing Instructions

1. Go to **Job Listings → Settings** and set the **Default Salary Currency** to a non-USD value (e.g. `EUR` or `CHF`). Ensure **Job Salary Unit Customization** is enabled.
2. Visit the frontend job submission form.
3. Confirm the **Salary Currency** field placeholder shows the configured currency (e.g. `EUR`).
4. Confirm the field description reads: *"…Leave it empty to use the default salary currency (EUR)."*
5. Clear the **Default Salary Currency** setting.
6. Confirm the placeholder falls back to `e.g. USD` and the description no longer mentions a specific currency.

### Release Notes

* The salary currency field on the job submission form now correctly reflects the configured default currency in its placeholder and helper text.

### New or Updated Hooks and Templates
-

### Deprecated Code
-

### Screenshot / Video

Currency set in settings:
<img width="1193" height="227" alt="image" src="https://github.com/user-attachments/assets/112384f4-25f0-4cd3-9fa3-22411ffccf08" />
<img width="1340" height="260" alt="image" src="https://github.com/user-attachments/assets/da020f70-f11a-4502-a45e-710fef789b2a" />

Currency not set in settings:
<img width="1398" height="239" alt="image" src="https://github.com/user-attachments/assets/e02c1de8-ff1e-4536-8aea-f88414e4223e" />
<img width="1326" height="338" alt="image" src="https://github.com/user-attachments/assets/3d312e1e-5aa1-4c45-855a-dd0d3d517c53" />

