### PR TITLE
feat: make rel attribute filterable on company website, Twitter, and apply URL links

### DIFF
--- a/templates/content-single-job_listing-company.php
+++ b/templates/content-single-job_listing-company.php
@@ -28,7 +28,10 @@ if ( ! get_the_company_name() ) {
 	<div class="company_header">
 		<p class="name">
 			<?php if ( $website = get_the_company_website() ) : ?>
-				<a class="website" href="<?php echo esc_url( $website ); ?>" rel="nofollow"><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
+				$_rel      = apply_filters( 'job_manager_company_link_rel', 'nofollow', 'website', get_post() );
+				$_rel_attr = $_rel ? ' rel="' . esc_attr( $_rel ) . '"' : '';
+				?>
+				<a class="website" href="<?php echo esc_url( $website ); ?>"<?php echo $_rel_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?>><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
 			<?php endif; ?>
 			<?php the_company_twitter(); ?>
 			<?php the_company_name( '<strong>', '</strong>' ); ?>

--- a/templates/content-single-job_listing-company.php
+++ b/templates/content-single-job_listing-company.php
@@ -27,10 +27,10 @@ if ( ! get_the_company_name() ) {
 
 	<div class="company_header">
 		<p class="name">
-			<?php if ( $website = get_the_company_website() ) : ?>
+			<?php if ( $website = get_the_company_website() ) :
 				$_rel      = apply_filters( 'job_manager_company_link_rel', 'nofollow', 'website', get_post() );
 				$_rel_attr = $_rel ? ' rel="' . esc_attr( $_rel ) . '"' : '';
-				?>
+			?>
 				<a class="website" href="<?php echo esc_url( $website ); ?>"<?php echo $_rel_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?>><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
 			<?php endif; ?>
 			<?php the_company_twitter(); ?>

--- a/templates/job-application-url.php
+++ b/templates/job-application-url.php
@@ -14,5 +14,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+$apply_rel = apply_filters( 'job_manager_application_url_rel', 'nofollow', $apply );
 ?>
-<p><?php esc_html_e( 'To apply for this job please visit', 'wp-job-manager' ); ?> <a href="<?php echo esc_url( $apply->url ); ?>" rel="nofollow"><?php echo esc_html( wp_parse_url( $apply->url, PHP_URL_HOST ) ); ?></a>.</p>
+<p><?php esc_html_e( 'To apply for this job please visit', 'wp-job-manager' ); ?> <a href="<?php echo esc_url( $apply->url ); ?>"<?php echo $apply_rel ? ' rel="' . esc_attr( $apply_rel ) . '"' : ''; ?>><?php echo esc_html( wp_parse_url( $apply->url, PHP_URL_HOST ) ); ?></a>.</p>

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1162,7 +1162,7 @@ function the_company_twitter( $before = '', $after = '', $echo = true, $post = n
 
 	$_rel            = apply_filters( 'job_manager_company_link_rel', 'nofollow', 'twitter', get_post() );
 	$_rel_attr       = $_rel ? ' rel="' . esc_attr( $_rel ) . '"' : '';
-  $company_twitter = $before . '<a href="' . esc_url( 'https://x.com/' . $company_twitter ) . '" class="company_twitter"' . $_rel_attr . '>' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
+	$company_twitter = $before . '<a href="' . esc_url( 'https://x.com/' . $company_twitter ) . '" class="company_twitter"' . $_rel_attr . '>' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
 
 	if ( $echo ) {
 		echo wp_kses_post( $company_twitter );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1155,7 +1155,9 @@ function the_company_twitter( $before = '', $after = '', $echo = true, $post = n
 		return null;
 	}
 
-	$company_twitter = $before . '<a href="' . esc_url( 'https://twitter.com/' . $company_twitter ) . '" class="company_twitter">' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
+	$_rel            = apply_filters( 'job_manager_company_link_rel', 'nofollow', 'twitter', get_post() );
+	$_rel_attr       = $_rel ? ' rel="' . esc_attr( $_rel ) . '"' : '';
+	$company_twitter = $before . '<a href="' . esc_url( 'https://twitter.com/' . $company_twitter ) . '" class="company_twitter"' . $_rel_attr . '>' . esc_html( wp_strip_all_tags( $company_twitter ) ) . '</a>' . $after;
 
 	if ( $echo ) {
 		echo wp_kses_post( $company_twitter );


### PR DESCRIPTION
Fixes #1497

### Changes Proposed in this Pull Request

* The `rel` attribute on the **company website** link (single job listing view) is now controlled by the `job_manager_company_link_rel` filter. Default remains `nofollow` (no behaviour change).
* The `rel` attribute on the **company Twitter** link is now controlled by the same `job_manager_company_link_rel` filter, with `nofollow` as the default. Previously this link had no `rel` attribute.
* The `rel` attribute on the **apply via URL** link is now controlled by a dedicated `job_manager_application_url_rel` filter. Default remains `nofollow` (no behaviour change).

### Testing Instructions

1. Visit a single job listing page that has a company website, Twitter handle, and an apply-by-URL set.
2. Confirm all three links render with `rel="nofollow"` — identical to previous behaviour.
3. Add the following to your theme's `functions.php` and repeat step 2:

```php
// Make company website and Twitter dofollow
add_filter( 'job_manager_company_link_rel', '__return_empty_string' );
```
4. Confirm neither the website nor the Twitter link has a `rel` attribute.

5. Replace with a type-specific override and repeat:
```php
// Website dofollow, Twitter stays nofollow
add_filter( 'job_manager_company_link_rel', function( $rel, $type ) {
    return 'website' === $type ? '' : $rel;
}, 10, 2 );
```
6. Confirm the website link has no `rel` and the Twitter link retains `rel="nofollow"`.

7. Test the apply URL filter:
```php
// Apply link dofollow
add_filter( 'job_manager_application_url_rel', '__return_empty_string' );
```
8. Confirm the apply link renders without a `rel` attribute.

9. Test full security attributes:
```php
add_filter( 'job_manager_company_link_rel', function() {
    return 'nofollow noopener noreferrer';
} );
```
10. Confirm all company links render with `rel="nofollow noopener noreferrer"`.

### Release Notes

* Company website, Twitter, and apply URL links now have a filterable `rel` attribute, allowing site owners to control nofollow/dofollow behaviour without overriding templates.

### New or Updated Hooks and Templates

| Hook | Type | Description |
|---|---|---|
| `job_manager_company_link_rel` | filter | Controls `rel` on company website and Twitter links. Args: `$rel` (string), `$type` (`'website'`\|`'twitter'`), `$post` (WP_Post). |
| `job_manager_application_url_rel` | filter | Controls `rel` on the apply-by-URL link. Args: `$rel` (string), `$apply` (object). |

**Modified templates** (child theme overrides of these will need updating):
- `templates/content-single-job_listing-company.php`
- `templates/job-application-url.php`

### Deprecated Code
-

### Screenshot / Video
-