### PR TITLE
Add WebP support and dedicated filter for company logo uploads

### DIFF
--- a/assets/js/ajax-file-upload.js
+++ b/assets/js/ajax-file-upload.js
@@ -85,7 +85,7 @@ jQuery(function($) {
 				var $form           = $file_field.closest( 'form' );
 				var $uploaded_files = $file_field.parent().find('.job-manager-uploaded-files');
 				var multiple        = $file_field.attr( 'multiple' ) ? 1 : 0;
-				var image_types     = [ 'jpg', 'gif', 'png', 'jpeg', 'jpe' ];
+				var image_types     = [ 'jpg', 'gif', 'png', 'jpeg', 'jpe', 'webp' ];
 
 				data.context.remove();
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -347,12 +347,16 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'priority'           => 6,
 						'ajax'               => true,
 						'multiple'           => false,
-						'allowed_mime_types' => [
-							'jpg'  => 'image/jpeg',
-							'jpeg' => 'image/jpeg',
-							'gif'  => 'image/gif',
-							'png'  => 'image/png',
-						],
+						'allowed_mime_types' => apply_filters(
+							'job_manager_company_logo_allowed_mime_types',
+							[
+								'jpg'  => 'image/jpeg',
+								'jpeg' => 'image/jpeg',
+								'gif'  => 'image/gif',
+								'png'  => 'image/png',
+								'webp' => 'image/webp',
+							]
+						),
 					],
 				],
 			]

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1560,11 +1560,15 @@ function job_manager_upload_file( $file, $args = [] ) {
  */
 function job_manager_get_allowed_mime_types( $field = '' ) {
 	if ( 'company_logo' === $field ) {
-		$allowed_mime_types = [
-			'jpg|jpeg|jpe' => 'image/jpeg',
-			'gif'          => 'image/gif',
-			'png'          => 'image/png',
-		];
+		$allowed_mime_types = apply_filters(
+			'job_manager_company_logo_allowed_mime_types',
+			[
+				'jpg|jpeg|jpe' => 'image/jpeg',
+				'gif'          => 'image/gif',
+				'png'          => 'image/png',
+				'webp'         => 'image/webp',
+			]
+		);
 	} else {
 		$allowed_mime_types = [
 			'jpg|jpeg|jpe' => 'image/jpeg',


### PR DESCRIPTION
**Fixes #2932**

### Changes Proposed in this Pull Request

* Added `webp` as a default allowed mime type for company logo uploads
* Added `job_manager_company_logo_allowed_mime_types` filter so developers can customize allowed mime types for company logos without affecting other file fields
* Applied the same filter to both the form validation path and the Ajax uploader path (`job_manager_get_allowed_mime_types()`) so they stay in sync
* Fixed the frontend Ajax upload preview not showing an image thumbnail for `.webp` files

### Testing Instructions

* Submit a job listing and upload a `.webp` file as the company logo — it should upload successfully and show an image preview
* Confirm non-image file types still trigger the correct error
* Add the filter below and confirm a custom type (e.g. SVG) is accepted in both the drag-and-drop Ajax uploader and on form validation:
```php
add_filter( 'job_manager_company_logo_allowed_mime_types', function( $types ) {
    $types['svg'] = 'image/svg+xml';
    return $types;
} );
```

### Release Notes

* Company logo uploads now accept WebP images by default
* New filter `job_manager_company_logo_allowed_mime_types` allows customizing allowed file types for the company logo field

### New or Updated Hooks and Templates

* **Filter: `job_manager_company_logo_allowed_mime_types`** — Filters the allowed mime types for the company logo upload field. Applies to both the form validation and the Ajax file uploader. Receives an array of `extension => mime_type` pairs. Note: the form validation path uses plain extension keys (e.g. `'webp'`), while the Ajax uploader uses pipe-separated keys (e.g. `'jpg|jpeg|jpe'`) — both are passed through this same filter.

### Deprecated Code

*

### Screenshot / Video