### PR TITLE
[jobs] shortcode: add author attribute to filter listings by user ID

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -316,6 +316,7 @@ jQuery( document ).ready( function( $ ) {
 			var remote_position = $target.data( 'remote_position' );
 			var job_types = $target.data( 'job_types' );
 			var post_status = $target.data( 'post_status' );
+			var author = $target.data( 'author' );
 			var index = $( 'div.job_listings' ).index( this );
 			var categories, keywords, location;
 
@@ -387,6 +388,7 @@ jQuery( document ).ready( function( $ ) {
 					featured: featured,
 					filled: filled,
 					remote_position: remote_position,
+					author: author,
 					show_pagination: $target.data( 'show_pagination' ),
 					form_data: $form.serialize(),
 				};
@@ -416,6 +418,7 @@ jQuery( document ).ready( function( $ ) {
 					featured: featured,
 					filled: filled,
 					remote_position: remote_position,
+					author: author,
 					show_pagination: $target.data( 'show_pagination' ),
 				};
 			}

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -136,6 +136,7 @@ class WP_Job_Manager_Ajax {
 		$remote_position    = isset( $_REQUEST['remote_position'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['remote_position'] ) ) : null;
 		$show_pagination    = isset( $_REQUEST['show_pagination'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['show_pagination'] ) ) : null;
 		$featured_first     = isset( $_REQUEST['featured_first'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured_first'] ) ) : null;
+		$author             = isset( $_REQUEST['author'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['author'] ) ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( is_array( $search_categories ) ) {
@@ -161,6 +162,7 @@ class WP_Job_Manager_Ajax {
 			'orderby'           => $orderby,
 			'order'             => $order,
 			'featured_first'    => $featured_first,
+			'author'            => $author,
 			'offset'            => ( $page - 1 ) * $per_page,
 			'posts_per_page'    => max( 1, $per_page ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Known slow query.
 		];

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -136,7 +136,7 @@ class WP_Job_Manager_Ajax {
 		$remote_position    = isset( $_REQUEST['remote_position'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['remote_position'] ) ) : null;
 		$show_pagination    = isset( $_REQUEST['show_pagination'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['show_pagination'] ) ) : null;
 		$featured_first     = isset( $_REQUEST['featured_first'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured_first'] ) ) : null;
-		$author             = isset( $_REQUEST['author'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['author'] ) ) : '';
+		$author             = ( isset( $_REQUEST['author'] ) && ! is_array( $_REQUEST['author'] ) ) ? sanitize_text_field( wp_unslash( $_REQUEST['author'] ) ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( is_array( $search_categories ) ) {
@@ -247,6 +247,7 @@ class WP_Job_Manager_Ajax {
 				'search_location'   => $search_location,
 				'search_categories' => $search_categories,
 				'search_keywords'   => $search_keywords,
+				'author'            => $author,
 			]
 		);
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -744,9 +744,13 @@ class WP_Job_Manager_Post_Types {
 			$input_job_categories = false;
 		}
 
-		if ( isset( $_GET['author'] ) ) {
+		if ( isset( $_GET['author'] ) && ! is_array( $_GET['author'] ) ) {
 			$sanitized_author = sanitize_text_field( wp_unslash( $_GET['author'] ) );
-			$input_author     = empty( $sanitized_author ) ? false : array_filter( array_map( 'absint', explode( ',', $sanitized_author ) ) );
+			$input_author     = empty( $sanitized_author ) ? false : array_values( array_filter( array_map( 'intval', explode( ',', $sanitized_author ) ), fn( $v ) => $v > 0 ) );
+			// Fails-closed: author was supplied but yielded no valid IDs → force empty results.
+			if ( false !== $input_author && empty( $input_author ) ) {
+				$input_author = [ 0 ];
+			}
 		} else {
 			$input_author = false;
 		}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -745,32 +745,32 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		if ( isset( $_GET['author'] ) ) {
-		    if ( is_array( $_GET['author'] ) ) {
-		        // Array-shaped input (?author[]=1) is not a supported format - fails-closed.
-		        $input_author = [ 0 ];
-		    } else {
-		        $sanitized_author = sanitize_text_field( wp_unslash( $_GET['author'] ) );
-		        // Note: '' === '' is false, so empty string = unset (no filter).
-		        if ( '' === $sanitized_author ) {
-		            $input_author = false;
-		        } else {
-		            $input_author = array_values(
-		                array_filter(
-		                    array_map(
-		                        fn( $v ) => ctype_digit( trim( $v ) ) && (int) trim( $v ) > 0 ? (int) trim( $v ) : 0,
-		                        explode( ',', $sanitized_author )
-		                    ),
-		                    fn( $v ) => $v > 0
-		                )
-		            );
-		            // Fails-closed: author was supplied but yielded no valid IDs (e.g. '0', 'abc') -> force empty results.
-		            if ( empty( $input_author ) ) {
-		                $input_author = [ 0 ];
-		            }
-		        }
-		    }
+			if ( is_array( $_GET['author'] ) ) {
+				// Array-shaped input (?author[]=1) is not a supported format - fails-closed.
+				$input_author = [ 0 ];
+			} else {
+				$sanitized_author = sanitize_text_field( wp_unslash( $_GET['author'] ) );
+				// Note: '' === '' is false, so empty string = unset (no filter).
+				if ( '' === $sanitized_author ) {
+					$input_author = false;
+				} else {
+					$input_author = array_values(
+						array_filter(
+							array_map(
+								fn( $v ) => ctype_digit( trim( $v ) ) && (int) trim( $v ) > 0 ? (int) trim( $v ) : 0,
+								explode( ',', $sanitized_author )
+							),
+							fn( $v ) => $v > 0
+						)
+					);
+					// Fails-closed: author was supplied but yielded no valid IDs (e.g. '0', 'abc') -> force empty results.
+					if ( empty( $input_author ) ) {
+						$input_author = [ 0 ];
+					}
+				}
+			}
 		} else {
-		    $input_author = false;
+			$input_author = false;
 		}
 
 		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -744,15 +744,33 @@ class WP_Job_Manager_Post_Types {
 			$input_job_categories = false;
 		}
 
-		if ( isset( $_GET['author'] ) && ! is_array( $_GET['author'] ) ) {
-			$sanitized_author = sanitize_text_field( wp_unslash( $_GET['author'] ) );
-			$input_author     = empty( $sanitized_author ) ? false : array_values( array_filter( array_map( 'intval', explode( ',', $sanitized_author ) ), fn( $v ) => $v > 0 ) );
-			// Fails-closed: author was supplied but yielded no valid IDs → force empty results.
-			if ( false !== $input_author && empty( $input_author ) ) {
-				$input_author = [ 0 ];
-			}
+		if ( isset( $_GET['author'] ) ) {
+		    if ( is_array( $_GET['author'] ) ) {
+		        // Array-shaped input (?author[]=1) is not a supported format - fails-closed.
+		        $input_author = [ 0 ];
+		    } else {
+		        $sanitized_author = sanitize_text_field( wp_unslash( $_GET['author'] ) );
+		        // Note: '' === '' is false, so empty string = unset (no filter).
+		        if ( '' === $sanitized_author ) {
+		            $input_author = false;
+		        } else {
+		            $input_author = array_values(
+		                array_filter(
+		                    array_map(
+		                        fn( $v ) => ctype_digit( trim( $v ) ) && (int) trim( $v ) > 0 ? (int) trim( $v ) : 0,
+		                        explode( ',', $sanitized_author )
+		                    ),
+		                    fn( $v ) => $v > 0
+		                )
+		            );
+		            // Fails-closed: author was supplied but yielded no valid IDs (e.g. '0', 'abc') -> force empty results.
+		            if ( empty( $input_author ) ) {
+		                $input_author = [ 0 ];
+		            }
+		        }
+		    }
 		} else {
-			$input_author = false;
+		    $input_author = false;
 		}
 
 		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -727,6 +727,13 @@ class WP_Job_Manager_Post_Types {
 			$input_job_categories = false;
 		}
 
+		if ( isset( $_GET['author'] ) ) {
+			$sanitized_author = sanitize_text_field( wp_unslash( $_GET['author'] ) );
+			$input_author     = empty( $sanitized_author ) ? false : array_filter( array_map( 'absint', explode( ',', $sanitized_author ) ) );
+		} else {
+			$input_author = false;
+		}
+
 		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
@@ -788,6 +795,10 @@ class WP_Job_Manager_Post_Types {
 				'include_children' => 'AND' !== $operator,
 				'operator'         => $operator,
 			];
+		}
+
+		if ( ! empty( $input_author ) ) {
+			$query_args['author__in'] = $input_author;
 		}
 
 		if ( ! empty( $job_manager_keyword ) ) {

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -215,7 +215,7 @@ class WP_Job_Manager_Shortcodes {
 					'filled'                    => null, // True to show only filled, false to hide filled, leave null to show both/use the settings.
 					'remote_position'           => null, // True to show only remote, false to hide remote, leave null to show both.
 					'featured_first'            => false, // True to show featured first, false to show in default order.
-					'author'                    => 0, // Limit listings to a specific author by user ID. 0 shows all.
+					'author'                    => '', // Limit listings to a specific author by user ID. Empty string shows all.
 
 					// Default values for filters.
 					'location'                  => '',

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -215,6 +215,7 @@ class WP_Job_Manager_Shortcodes {
 					'filled'                    => null, // True to show only filled, false to hide filled, leave null to show both/use the settings.
 					'remote_position'           => null, // True to show only remote, false to hide remote, leave null to show both.
 					'featured_first'            => false, // True to show featured first, false to show in default order.
+					'author'                    => 0, // Limit listings to a specific author by user ID. 0 shows all.
 
 					// Default values for filters.
 					'location'                  => '',
@@ -237,6 +238,7 @@ class WP_Job_Manager_Shortcodes {
 		$atts['show_more']                 = $this->string_to_bool( $atts['show_more'] );
 		$atts['show_pagination']           = $this->string_to_bool( $atts['show_pagination'] );
 		$atts['featured_first']            = $this->string_to_bool( $atts['featured_first'] );
+		$atts['author']                    = sanitize_text_field( $atts['author'] );
 
 		if ( ! is_null( $atts['featured'] ) ) {
 			$atts['featured'] = ( is_bool( $atts['featured'] ) && $atts['featured'] ) || in_array( $atts['featured'], [ 1, '1', 'true', 'yes' ], true );
@@ -349,6 +351,7 @@ class WP_Job_Manager_Shortcodes {
 						'filled'            => $atts['filled'],
 						'remote_position'   => $atts['remote_position'],
 						'featured_first'    => $atts['featured_first'],
+						'author'            => $atts['author'],
 					]
 				)
 			);
@@ -391,6 +394,9 @@ class WP_Job_Manager_Shortcodes {
 		}
 		if ( ! empty( $atts['post_status'] ) ) {
 			$data_attributes['post_status'] = implode( ',', $atts['post_status'] );
+		}
+		if ( ! empty( $atts['author'] ) ) {
+			$data_attributes['author'] = $atts['author'];
 		}
 
 		$data_attributes['post_id'] = isset( $GLOBALS['post'] ) ? $GLOBALS['post']->ID : 0;

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -986,32 +986,128 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_single_id() {
-	    $user_a = $this->factory->user->create();
-	    $user_b = $this->factory->user->create();
-	
-	    $jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
-	    $jobs_b = $this->factory->job_listing->create_many( 3, [ 'post_author' => $user_b ] );
-	
-	    $result = get_job_listings( [ 'author' => (string) $user_a ] );
-	
-	    $this->assertEqualSets( $jobs_a, wp_list_pluck( $result->posts, 'ID' ) );
+		$user_a = $this->factory->user->create();
+		$user_b = $this->factory->user->create();
+
+		$jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+		$jobs_b = $this->factory->job_listing->create_many( 3, [ 'post_author' => $user_b ] );
+
+		$result = get_job_listings( [ 'author' => (string) $user_a ] );
+
+		$this->assertEqualSets( $jobs_a, wp_list_pluck( $result->posts, 'ID' ) );
 	}
-	
+
 	/**
 	 * @since 2.5.0
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_multiple_ids() {
-	    $user_a = $this->factory->user->create();
-	    $user_b = $this->factory->user->create();
-	    $user_c = $this->factory->user->create();
-	
-	    $jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
-	    $jobs_b = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_b ] );
-	    $jobs_c = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_c ] );
-	
-	    $result = get_job_listings( [ 'author' => $user_a . ',' . $user_b ] );
-	
-	    $this->assertEqualSets( array_merge( $jobs_a, $jobs_b ), wp_list_pluck( $result->posts, 'ID' ) );
+		$user_a = $this->factory->user->create();
+		$user_b = $this->factory->user->create();
+		$user_c = $this->factory->user->create();
+
+		$jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+		$jobs_b = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_b ] );
+		$jobs_c = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_c ] );
+
+		$result = get_job_listings( [ 'author' => $user_a . ',' . $user_b ] );
+
+		$this->assertEqualSets( array_merge( $jobs_a, $jobs_b ), wp_list_pluck( $result->posts, 'ID' ) );
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_empty_string_shows_no_filter() {
+		$user_a = $this->factory->user->create();
+		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+
+		$result = get_job_listings( [ 'author' => '' ] );
+
+		// Empty string means no filter — all listings are returned.
+		$this->assertGreaterThanOrEqual( 2, $result->found_posts );
+	}
+
+	/**
+	 * Non-numeric input should return zero results (fails-closed).
+	 *
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_non_numeric_returns_no_results() {
+		$user_a = $this->factory->user->create();
+		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+
+		$result = get_job_listings( [ 'author' => 'abc' ] );
+
+		$this->assertSame( 0, $result->found_posts );
+	}
+
+	/**
+	 * Negative IDs should not be converted to positive via absint and must return zero results.
+	 *
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_negative_id_returns_no_results() {
+		$user_a = $this->factory->user->create();
+		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+
+		$result = get_job_listings( [ 'author' => '-5' ] );
+
+		$this->assertSame( 0, $result->found_posts );
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_zero_returns_no_results() {
+		$user_a = $this->factory->user->create();
+		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+
+		$result = get_job_listings( [ 'author' => '0' ] );
+
+		$this->assertSame( 0, $result->found_posts );
+	}
+
+	/**
+	 * Mixed valid and invalid IDs: only valid IDs should be used.
+	 *
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_mixed_valid_and_invalid() {
+		$user_a = $this->factory->user->create();
+		$user_b = $this->factory->user->create();
+
+		$jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_b ] );
+
+		// 'abc' parses to 0 and should be dropped; only $user_a's listings are returned.
+		$result = get_job_listings( [ 'author' => $user_a . ',abc' ] );
+
+		$this->assertEqualSets( $jobs_a, wp_list_pluck( $result->posts, 'ID' ) );
+	}
+
+	/**
+	 * Array input with valid user IDs should work.
+	 *
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_array_input() {
+		$user_a = $this->factory->user->create();
+		$user_b = $this->factory->user->create();
+		$user_c = $this->factory->user->create();
+
+		$jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+		$jobs_b = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_b ] );
+		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_c ] );
+
+		$result = get_job_listings( [ 'author' => [ $user_a, $user_b ] ] );
+
+		$this->assertEqualSets( array_merge( $jobs_a, $jobs_b ), wp_list_pluck( $result->posts, 'ID' ) );
 	}
 }

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -980,4 +980,38 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		WP_Job_Manager_Helper_Renewals::renew_job_listing( get_post( $job_listing_id ) );
 		$this->assertFalse( WP_Job_Manager_Helper_Renewals::job_can_be_renewed( $job_listing ) );
 	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_single_id() {
+	    $user_a = $this->factory->user->create();
+	    $user_b = $this->factory->user->create();
+	
+	    $jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+	    $jobs_b = $this->factory->job_listing->create_many( 3, [ 'post_author' => $user_b ] );
+	
+	    $result = get_job_listings( [ 'author' => (string) $user_a ] );
+	
+	    $this->assertEqualSets( $jobs_a, wp_list_pluck( $result->posts, 'ID' ) );
+	}
+	
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_author_multiple_ids() {
+	    $user_a = $this->factory->user->create();
+	    $user_b = $this->factory->user->create();
+	    $user_c = $this->factory->user->create();
+	
+	    $jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
+	    $jobs_b = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_b ] );
+	    $jobs_c = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_c ] );
+	
+	    $result = get_job_listings( [ 'author' => $user_a . ',' . $user_b ] );
+	
+	    $this->assertEqualSets( array_merge( $jobs_a, $jobs_b ), wp_list_pluck( $result->posts, 'ID' ) );
+	}
 }

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -982,7 +982,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_single_id() {
@@ -998,7 +998,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_multiple_ids() {
@@ -1016,7 +1016,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_empty_string_shows_no_filter() {
@@ -1032,7 +1032,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	/**
 	 * Non-numeric input should return zero results (fails-closed).
 	 *
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_non_numeric_returns_no_results() {
@@ -1047,7 +1047,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	/**
 	 * Negative IDs should not be converted to positive via absint and must return zero results.
 	 *
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_negative_id_returns_no_results() {
@@ -1060,7 +1060,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_zero_returns_no_results() {
@@ -1075,7 +1075,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	/**
 	 * Mixed valid and invalid IDs: only valid IDs should be used.
 	 *
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_mixed_valid_and_invalid() {
@@ -1094,7 +1094,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	/**
 	 * Array input with valid user IDs should work.
 	 *
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_author_array_input() {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -197,7 +197,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			];
 		}
 
-		if ( isset( $args['author'] ) && '' !== (string) $args['author'] ) {
+		if ( isset( $args['author'] ) && ( is_array( $args['author'] ) || '' !== $args['author'] ) ) {
 			$raw_author = $args['author'];
 			$author_ids = is_array( $raw_author )
 				? array_values( array_filter( array_map( 'intval', $raw_author ), fn( $v ) => $v > 0 ) )

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -195,7 +195,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		if ( ! empty( $args['author'] ) ) {
 			$author_ids = is_array( $args['author'] )
 				? array_filter( array_map( 'absint', $args['author'] ) )
-				: array_filter( array_map( 'absint', explode( ',', $args['author'] ) ) );
+				: array_filter( array_map( 'absint', explode( ',', (string) $args['author'] ) ) );
 			if ( ! empty( $author_ids ) ) {
 				$query_args['author__in'] = $author_ids;
 			}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -192,6 +192,15 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			];
 		}
 
+		if ( ! empty( $args['author'] ) ) {
+			$author_ids = is_array( $args['author'] )
+				? array_filter( array_map( 'absint', $args['author'] ) )
+				: array_filter( array_map( 'absint', explode( ',', $args['author'] ) ) );
+			if ( ! empty( $author_ids ) ) {
+				$query_args['author__in'] = $author_ids;
+			}
+		}
+
 		$job_manager_keyword = sanitize_text_field( $args['search_keywords'] );
 
 		if ( ! empty( $job_manager_keyword ) && strlen( $job_manager_keyword ) >= apply_filters( 'job_manager_get_listings_keyword_length_threshold', 2 ) ) {
@@ -218,6 +227,11 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		do_action( 'before_get_job_listings', $query_args, $args );
 
 		$should_cache = 'rand_featured' !== $args['orderby'] && 'rand' !== $args['orderby'];
+
+		// Bypass cache when author filter is active to avoid stale results.
+		if ( ! empty( $query_args['author__in'] ) ) {
+			$should_cache = false;
+		}
 
 		// Cache results.
 		if ( apply_filters( 'get_job_listings_cache_results', $should_cache ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -199,9 +199,16 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		if ( isset( $args['author'] ) && ( is_array( $args['author'] ) || '' !== $args['author'] ) ) {
 			$raw_author = $args['author'];
-			$author_ids = is_array( $raw_author )
-				? array_values( array_filter( array_map( 'intval', $raw_author ), fn( $v ) => $v > 0 ) )
-				: array_values( array_filter( array_map( 'intval', explode( ',', (string) $raw_author ) ), fn( $v ) => $v > 0 ) );
+			$tokens     = is_array( $raw_author ) ? $raw_author : explode( ',', (string) $raw_author );
+			$author_ids = array_values(
+				array_filter(
+					array_map(
+						fn( $v ) => ctype_digit( trim( $v ) ) && (int) trim( $v ) > 0 ? (int) trim( $v ) : 0,
+						$tokens
+					),
+					fn( $v ) => $v > 0
+				)
+			);
 			// Fails-closed: if author was supplied but yielded no valid IDs, return zero results.
 			$query_args['author__in'] = ! empty( $author_ids ) ? $author_ids : [ 0 ];
 		}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -12,7 +12,11 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 	 * Queries job listings with certain criteria and returns them.
 	 *
 	 * @since 1.0.5
-	 * @param string|array|object $args Arguments used to retrieve job listings.
+	 * @param string|array|object $args {
+	 *     Arguments used to retrieve job listings.
+	 *
+	 *     @type int|string|int[] $author Optional. User ID, comma-separated user IDs, or array of user IDs to filter listings by author. Default 0 (no filter).
+	 * }
 	 * @return WP_Query
 	 */
 	function get_job_listings( $args = [] ) {
@@ -194,12 +198,12 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		}
 
 		if ( ! empty( $args['author'] ) ) {
-			$author_ids = is_array( $args['author'] )
-				? array_filter( array_map( 'absint', $args['author'] ) )
-				: array_filter( array_map( 'absint', explode( ',', (string) $args['author'] ) ) );
-			if ( ! empty( $author_ids ) ) {
-				$query_args['author__in'] = $author_ids;
-			}
+			$raw_author = $args['author'];
+			$author_ids = is_array( $raw_author )
+				? array_values( array_filter( array_map( 'intval', $raw_author ), fn( $v ) => $v > 0 ) )
+				: array_values( array_filter( array_map( 'intval', explode( ',', (string) $raw_author ) ), fn( $v ) => $v > 0 ) );
+			// Fails-closed: if author was supplied but yielded no valid IDs, return zero results.
+			$query_args['author__in'] = ! empty( $author_ids ) ? $author_ids : [ 0 ];
 		}
 
 		$job_manager_keyword = sanitize_text_field( $args['search_keywords'] );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -228,11 +228,6 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		$should_cache = 'rand_featured' !== $args['orderby'] && 'rand' !== $args['orderby'];
 
-		// Bypass cache when author filter is active to avoid stale results.
-		if ( ! empty( $query_args['author__in'] ) ) {
-			$should_cache = false;
-		}
-
 		// Cache results.
 		if ( apply_filters( 'get_job_listings_cache_results', $should_cache ) ) {
 			$to_hash            = wp_json_encode( $query_args );

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -197,7 +197,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			];
 		}
 
-		if ( ! empty( $args['author'] ) ) {
+		if ( isset( $args['author'] ) && '' !== (string) $args['author'] ) {
 			$raw_author = $args['author'];
 			$author_ids = is_array( $raw_author )
 				? array_values( array_filter( array_map( 'intval', $raw_author ), fn( $v ) => $v > 0 ) )

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -644,6 +644,7 @@ if ( ! function_exists( 'job_manager_get_filtered_links' ) ) :
 								'search_location' => $args['search_location'],
 								'job_categories'  => implode( ',', $job_categories ),
 								'search_keywords' => $args['search_keywords'],
+								'author'          => ! empty( $args['author'] ) ? $args['author'] : '',
 							]
 						)
 					),


### PR DESCRIPTION
Fixes #1892

### Changes Proposed in this Pull Request

* Added `author` attribute to the `[jobs]` shortcode, allowing job listings to be filtered by one or more WordPress user IDs
* Supports a single ID (`[jobs author="1"]`) or comma-separated multiple IDs (`[jobs author="1,3,5"]`)
* Passes the author filter through all three query paths: direct PHP rendering (no-filters), AJAX with filters form, and AJAX without filters form
* Added `author__in` support to `get_job_listings()` (available to all callers, not just the shortcode)

### Testing Instructions

1. Create two or more job listings owned by different users
2. Add `[jobs author="X"]` to a page (where X is a user ID) — verify only that user's listings appear
3. Add `[jobs author="X,Y"]` — verify listings from both users appear
4. With `show_filters="true"` (default), interact with the filter form and verify the author restriction is preserved across AJAX requests
5. Verify that `[jobs]` without the `author` attribute continues to show all listings as before

### Release Notes

* New: The `[jobs]` shortcode now supports an `author` attribute to filter listings by user ID (e.g. `[jobs author="42"]` or `[jobs author="1,2,3"]`)

### New or Updated Hooks and Templates

* No new hooks or templates. The `author` argument is now accepted by `get_job_listings()` and will be respected by any code that calls it directly.

### Important
Make sure to update [WPJM Documentation for Shortcode](https://wpjobmanager.com/document/advanced-usage/shortcode-reference/) as well and include the new feature!

### Deprecated Code
-

### Screenshot / Video
-