### PR TITLE
Harden stats AJAX endpoint input validation and rate limiting

### DIFF
--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -298,10 +298,7 @@ class Stats_Script {
 	 * @return string
 	 */
 	private function get_client_ip() {
-		if ( ! isset( $_SERVER['REMOTE_ADDR'] ) || ! is_string( $_SERVER['REMOTE_ADDR'] ) ) {
-			return '';
-		}
-		$ip = filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP );
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP ) : '';
 		return is_string( $ip ) ? $ip : '';
 	}
 

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -41,13 +41,6 @@ class Stats_Script {
 	const AJAX_RATE_LIMIT = 60;
 
 	/**
-	 * Memoized result of the `wpjm_get_registered_stats` filter for the current request.
-	 *
-	 * @var array|null
-	 */
-	private $registered_stats_cache = null;
-
-	/**
 	 * Log multiple stats in one go. Triggered in an ajax call.
 	 *
 	 * @return void
@@ -127,17 +120,22 @@ class Stats_Script {
 		);
 		$stats = array_filter( $stats );
 
-		$registered_stats = $this->get_registered_stat_names();
+		// Snapshot the registered-stats filter result once for this request and thread
+		// it through the filter helpers. Caching this on a singleton property would
+		// break `apply_filters` semantics for callbacks added after the first call
+		// in the same request.
+		$registered_stats = $this->get_registered_stats();
+		$registered_names = array_keys( $registered_stats );
 		$stats            = array_filter(
 			$stats,
-			function ( $stat ) use ( $registered_stats ) {
-				return isset( $stat['name'] ) && in_array( $stat['name'], $registered_stats, true );
+			function ( $stat ) use ( $registered_names ) {
+				return isset( $stat['name'] ) && in_array( $stat['name'], $registered_names, true );
 			}
 		);
 
-		$stats          = $this->filter_by_post_validity( $stats, $post_id );
+		$stats          = $this->filter_by_post_validity( $stats, $post_id, $registered_stats );
 		$pending_unique = [];
-		$stats          = $this->filter_server_unique( $stats, $pending_unique );
+		$stats          = $this->filter_server_unique( $stats, $pending_unique, $registered_stats );
 
 		if ( empty( $stats ) ) {
 			wp_send_json_success();
@@ -180,12 +178,13 @@ class Stats_Script {
 	 *
 	 * @param array $stats            Stat rows.
 	 * @param int   $request_post_id  The page-level post_id the nonce is bound to.
+	 * @param array $registered_stats Snapshot of `wpjm_get_registered_stats` for this request.
 	 * @return array Filtered stat rows.
 	 */
-	private function filter_by_post_validity( $stats, $request_post_id ) {
+	private function filter_by_post_validity( $stats, $request_post_id, array $registered_stats ) {
 		$listing_stat_names    = [];
 		$impression_stat_names = [];
-		foreach ( $this->get_registered_stats() as $name => $def ) {
+		foreach ( $registered_stats as $name => $def ) {
 			$is_listing_page = ( $def['page'] ?? '' ) === 'listing';
 			$is_impression   = ( $def['type'] ?? '' ) === 'impression';
 			if ( $is_listing_page || $is_impression ) {
@@ -249,18 +248,19 @@ class Stats_Script {
 	 * the transient before `batch_log_stats()` ran risked suppressing a legitimate
 	 * retry for 24 hours when the DB write failed.
 	 *
-	 * @param array $stats        Stat rows.
-	 * @param array $pending_keys Out-param: transient keys to set after a successful DB write.
+	 * @param array $stats            Stat rows.
+	 * @param array $pending_keys     Out-param: transient keys to set after a successful DB write.
+	 * @param array $registered_stats Snapshot of `wpjm_get_registered_stats` for this request.
 	 * @return array Filtered stat rows.
 	 */
-	private function filter_server_unique( $stats, array &$pending_keys ) {
+	private function filter_server_unique( $stats, array &$pending_keys, array $registered_stats ) {
 		$client = $this->get_client_ip();
 		if ( '' === $client ) {
 			return $stats;
 		}
 
 		$unique_stat_names = [];
-		foreach ( $this->get_registered_stats() as $name => $def ) {
+		foreach ( $registered_stats as $name => $def ) {
 			if ( ! empty( $def['unique'] ) ) {
 				$unique_stat_names[] = $name;
 			}
@@ -336,15 +336,6 @@ class Stats_Script {
 	private function get_client_ip() {
 		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP ) : '';
 		return is_string( $ip ) ? $ip : '';
-	}
-
-	/**
-	 * Get stat names.
-	 *
-	 * @return int[]|string[]
-	 */
-	private function get_registered_stat_names() {
-		return array_keys( $this->get_registered_stats() );
 	}
 
 	/**
@@ -424,10 +415,7 @@ class Stats_Script {
 	 * @return array
 	 */
 	private function get_registered_stats() {
-		if ( null !== $this->registered_stats_cache ) {
-			return $this->registered_stats_cache;
-		}
-		$this->registered_stats_cache = (array) apply_filters(
+		return (array) apply_filters(
 			'wpjm_get_registered_stats',
 			[
 				Job_Listing_Stats::VIEW              => [
@@ -471,7 +459,6 @@ class Stats_Script {
 				],
 			]
 		);
-		return $this->registered_stats_cache;
 	}
 
 	/**

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -73,7 +73,11 @@ class Stats_Script {
 			return;
 		}
 		$stats = json_decode( $stats_raw, true );
-		if ( empty( $stats ) || ! is_array( $stats ) ) {
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $stats ) ) {
+			wp_send_json_error( __( 'Invalid payload.', 'wp-job-manager' ), 400 );
+			return;
+		}
+		if ( empty( $stats ) ) {
 			wp_send_json_error( __( 'No stats to log.', 'wp-job-manager' ), 400 );
 			return;
 		}
@@ -117,7 +121,10 @@ class Stats_Script {
 			return;
 		}
 
-		Stats::instance()->batch_log_stats( $stats );
+		if ( ! Stats::instance()->batch_log_stats( $stats ) ) {
+			wp_send_json_error( __( 'Unable to log stats.', 'wp-job-manager' ), 500 );
+			return;
+		}
 		wp_send_json_success();
 	}
 

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -115,6 +115,13 @@ class Stats_Script {
 	 * Listing-scope stats (page=listing or type=impression) require a published job_listing.
 	 * Other stats require any published post.
 	 *
+	 * Residual: on a [jobs]-shortcode page the nonce is tied to the page post, but impression
+	 * stats legitimately carry per-listing post_ids. A client with a valid page nonce can
+	 * submit impressions for any published job_listing, not just ones visible on the page.
+	 * Rate limiting + dedup constrain the volume; the dashboard footnote discloses that
+	 * public-page stats are approximate. Eliminating this would require server-side
+	 * impression recording, which is incompatible with full-page caching.
+	 *
 	 * @param array $stats Stat rows.
 	 * @return array Filtered stat rows.
 	 */
@@ -158,7 +165,11 @@ class Stats_Script {
 	}
 
 	/**
-	 * Server-side per-client dedup for "_unique" stats.
+	 * Server-side per-client dedup for stats flagged `unique` in their definition.
+	 *
+	 * Authoritative: reads the `unique` flag from registered-stat definitions rather
+	 * than guessing from the stat name. Covers `*_unique` stats and any other stat
+	 * (e.g. `job_apply_click`) registered with `unique => true`.
 	 *
 	 * @param array $stats Stat rows.
 	 * @return array Filtered stat rows.
@@ -168,15 +179,26 @@ class Stats_Script {
 		if ( '' === $client ) {
 			return $stats;
 		}
+
+		$unique_stat_names = [];
+		foreach ( $this->get_registered_stats() as $name => $def ) {
+			if ( ! empty( $def['unique'] ) ) {
+				$unique_stat_names[] = $name;
+			}
+		}
+		if ( empty( $unique_stat_names ) ) {
+			return $stats;
+		}
+
 		$today = gmdate( 'Y-m-d' );
 		$ttl   = strtotime( 'tomorrow UTC' ) - time();
 		$ttl   = $ttl > 0 ? $ttl : DAY_IN_SECONDS;
 
 		return array_filter(
 			$stats,
-			function ( $stat ) use ( $client, $today, $ttl ) {
+			function ( $stat ) use ( $client, $today, $ttl, $unique_stat_names ) {
 				$name = $stat['name'] ?? '';
-				if ( strlen( $name ) < 7 || '_unique' !== substr( $name, -7 ) ) {
+				if ( ! in_array( $name, $unique_stat_names, true ) ) {
 					return true;
 				}
 				$key = 'wpjm_u_' . md5( $client . '|' . $name . '|' . ( $stat['post_id'] ?? 0 ) . '|' . $today );
@@ -265,6 +287,13 @@ class Stats_Script {
 	 * @return void
 	 */
 	private function enqueue_stats_script( $page = 'listing', $post_id = 0 ) {
+
+		// If a page is both a single job_listing and hosts the [jobs] shortcode,
+		// only the first call wins — double-localizing would overwrite the first
+		// nonce and break listing-page stats.
+		if ( wp_script_is( 'wp-job-manager-stats', 'enqueued' ) ) {
+			return;
+		}
 
 		$script_data = [
 			'ajaxUrl'   => admin_url( 'admin-ajax.php' ),

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -171,6 +171,10 @@ class Stats_Script {
 	 * than guessing from the stat name. Covers `*_unique` stats and any other stat
 	 * (e.g. `job_apply_click`) registered with `unique => true`.
 	 *
+	 * Uses a 24-hour sliding window starting at the first observed click. A calendar-day
+	 * (midnight UTC) boundary would let a visitor near the boundary re-count within
+	 * minutes of their first click.
+	 *
 	 * @param array $stats Stat rows.
 	 * @return array Filtered stat rows.
 	 */
@@ -190,22 +194,18 @@ class Stats_Script {
 			return $stats;
 		}
 
-		$today = gmdate( 'Y-m-d' );
-		$ttl   = strtotime( 'tomorrow UTC' ) - time();
-		$ttl   = $ttl > 0 ? $ttl : DAY_IN_SECONDS;
-
 		return array_filter(
 			$stats,
-			function ( $stat ) use ( $client, $today, $ttl, $unique_stat_names ) {
+			function ( $stat ) use ( $client, $unique_stat_names ) {
 				$name = $stat['name'] ?? '';
 				if ( ! in_array( $name, $unique_stat_names, true ) ) {
 					return true;
 				}
-				$key = 'wpjm_u_' . md5( $client . '|' . $name . '|' . ( $stat['post_id'] ?? 0 ) . '|' . $today );
+				$key = 'wpjm_u_' . md5( $client . '|' . $name . '|' . ( $stat['post_id'] ?? 0 ) );
 				if ( get_transient( $key ) ) {
 					return false;
 				}
-				set_transient( $key, 1, $ttl );
+				set_transient( $key, 1, DAY_IN_SECONDS );
 				return true;
 			}
 		);

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -31,39 +31,191 @@ class Stats_Script {
 	}
 
 	/**
+	 * Max stats accepted in a single AJAX request.
+	 */
+	const AJAX_BATCH_LIMIT = 50;
+
+	/**
+	 * Requests allowed per client per minute.
+	 */
+	const AJAX_RATE_LIMIT = 60;
+
+	/**
 	 * Log multiple stats in one go. Triggered in an ajax call.
 	 *
-	 * @return bool
+	 * @return void
 	 */
 	public function ajax_log_stat() {
 		if ( ! wp_doing_ajax() ) {
-			return false;
+			return;
 		}
 
 		$post_data = stripslashes_deep( $_POST );
+		$post_id   = absint( $post_data['post_id'] ?? 0 );
 
-		if ( ! isset( $post_data['_ajax_nonce'] ) || ! wp_verify_nonce( $post_data['_ajax_nonce'], 'ajax-nonce' ) ) {
-			return false;
+		if (
+			! isset( $post_data['_ajax_nonce'] )
+			|| ! $post_id
+			|| ! wp_verify_nonce( $post_data['_ajax_nonce'], 'wpjm_log_stat_' . $post_id )
+		) {
+			wp_send_json_error( 'Invalid request.', 403 );
+			return;
 		}
 
-		$stats_json = $post_data['stats'] ?? '[]';
-		$stats      = json_decode( $stats_json, true );
-
-		if ( empty( $stats ) ) {
-			return false;
+		if ( $this->is_rate_limited() ) {
+			wp_send_json_error( 'Too many requests.', 429 );
+			return;
 		}
 
-		$errors           = [];
+		$stats = json_decode( $post_data['stats'] ?? '[]', true );
+		if ( empty( $stats ) || ! is_array( $stats ) ) {
+			wp_send_json_error( 'No stats to log.', 400 );
+			return;
+		}
+
+		$stats = array_slice( $stats, 0, self::AJAX_BATCH_LIMIT );
+
+		$today = gmdate( 'Y-m-d' );
+		$stats = array_map(
+			function ( $stat ) use ( $today ) {
+				if ( ! is_array( $stat ) ) {
+					return null;
+				}
+				$stat['count'] = 1;
+				$stat['date']  = $today;
+				return $stat;
+			},
+			$stats
+		);
+		$stats = array_filter( $stats );
+
 		$registered_stats = $this->get_registered_stat_names();
-
-		$stats = array_filter(
+		$stats            = array_filter(
 			$stats,
-			function( $stat ) use ( $registered_stats ) {
-				return in_array( $stat['name'], $registered_stats, true );
+			function ( $stat ) use ( $registered_stats ) {
+				return isset( $stat['name'] ) && in_array( $stat['name'], $registered_stats, true );
 			}
 		);
 
-		return Stats::instance()->batch_log_stats( $stats );
+		$stats = $this->filter_by_post_validity( $stats );
+		$stats = $this->filter_server_unique( $stats );
+
+		if ( empty( $stats ) ) {
+			wp_send_json_success();
+			return;
+		}
+
+		Stats::instance()->batch_log_stats( $stats );
+		wp_send_json_success();
+	}
+
+	/**
+	 * Validate stat post_ids against the expected post type and status.
+	 *
+	 * Listing-scope stats (page=listing or type=impression) require a published job_listing.
+	 * Other stats require any published post.
+	 *
+	 * @param array $stats Stat rows.
+	 * @return array Filtered stat rows.
+	 */
+	private function filter_by_post_validity( $stats ) {
+		$listing_stat_names = [];
+		foreach ( $this->get_registered_stats() as $name => $def ) {
+			$is_listing_page = ( $def['page'] ?? '' ) === 'listing';
+			$is_impression   = ( $def['type'] ?? '' ) === 'impression';
+			if ( $is_listing_page || $is_impression ) {
+				$listing_stat_names[] = $name;
+			}
+		}
+
+		$cache = [];
+		return array_filter(
+			$stats,
+			function ( $stat ) use ( &$cache, $listing_stat_names ) {
+				$post_id = absint( $stat['post_id'] ?? 0 );
+				if ( ! $post_id ) {
+					return false;
+				}
+
+				$requires_listing = in_array( $stat['name'] ?? '', $listing_stat_names, true );
+				$cache_key        = $post_id . '|' . ( $requires_listing ? 'L' : 'P' );
+
+				if ( ! isset( $cache[ $cache_key ] ) ) {
+					$status = get_post_status( $post_id );
+					$type   = get_post_type( $post_id );
+					if ( 'publish' !== $status ) {
+						$cache[ $cache_key ] = false;
+					} elseif ( $requires_listing && \WP_Job_Manager_Post_Types::PT_LISTING !== $type ) {
+						$cache[ $cache_key ] = false;
+					} else {
+						$cache[ $cache_key ] = true;
+					}
+				}
+
+				return $cache[ $cache_key ];
+			}
+		);
+	}
+
+	/**
+	 * Server-side per-client dedup for "_unique" stats.
+	 *
+	 * @param array $stats Stat rows.
+	 * @return array Filtered stat rows.
+	 */
+	private function filter_server_unique( $stats ) {
+		$client = $this->get_client_ip();
+		if ( '' === $client ) {
+			return $stats;
+		}
+		$today = gmdate( 'Y-m-d' );
+		$ttl   = strtotime( 'tomorrow UTC' ) - time();
+		$ttl   = $ttl > 0 ? $ttl : DAY_IN_SECONDS;
+
+		return array_filter(
+			$stats,
+			function ( $stat ) use ( $client, $today, $ttl ) {
+				$name = $stat['name'] ?? '';
+				if ( strlen( $name ) < 7 || '_unique' !== substr( $name, -7 ) ) {
+					return true;
+				}
+				$key = 'wpjm_u_' . md5( $client . '|' . $name . '|' . ( $stat['post_id'] ?? 0 ) . '|' . $today );
+				if ( get_transient( $key ) ) {
+					return false;
+				}
+				set_transient( $key, 1, $ttl );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Soft per-client rate limit. Not an auth boundary — absorbs drive-by abuse.
+	 *
+	 * @return bool
+	 */
+	private function is_rate_limited() {
+		$client = $this->get_client_ip();
+		if ( '' === $client ) {
+			return false;
+		}
+		$key   = 'wpjm_rl_' . md5( $client );
+		$count = (int) get_transient( $key );
+		if ( $count >= self::AJAX_RATE_LIMIT ) {
+			return true;
+		}
+		set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+		return false;
+	}
+
+	/**
+	 * Client IP from REMOTE_ADDR only (X-Forwarded-For is spoofable by design here).
+	 *
+	 * @return string
+	 */
+	private function get_client_ip() {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP ) : '';
+		return is_string( $ip ) ? $ip : '';
 	}
 
 	/**
@@ -116,7 +268,7 @@ class Stats_Script {
 
 		$script_data = [
 			'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
-			'ajaxNonce' => wp_create_nonce( 'ajax-nonce' ),
+			'ajaxNonce' => wp_create_nonce( 'wpjm_log_stat_' . $post_id ),
 			'postId'    => $post_id,
 			'stats'     => $this->get_stats_for_ajax( $post_id, $page ),
 		];

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -100,7 +100,7 @@ class Stats_Script {
 			}
 		);
 
-		$stats = $this->filter_by_post_validity( $stats );
+		$stats = $this->filter_by_post_validity( $stats, $post_id );
 		$stats = $this->filter_server_unique( $stats );
 
 		if ( empty( $stats ) ) {
@@ -113,42 +113,64 @@ class Stats_Script {
 	}
 
 	/**
-	 * Validate stat post_ids against the expected post type and status.
+	 * Validate stat post_ids against expected post type, status, and request scope.
 	 *
-	 * Listing-scope stats (page=listing or type=impression) require a published job_listing.
-	 * Other stats require any published post.
+	 * Two checks are applied per stat row:
 	 *
-	 * Residual: on a [jobs]-shortcode page the nonce is tied to the page post, but impression
-	 * stats legitimately carry per-listing post_ids. A client with a valid page nonce can
-	 * submit impressions for any published job_listing, not just ones visible on the page.
-	 * Rate limiting + dedup constrain the volume; the dashboard footnote discloses that
-	 * public-page stats are approximate. Eliminating this would require server-side
-	 * impression recording, which is incompatible with full-page caching.
+	 * 1. Scope: for non-impression stats the stat's post_id must equal the request-level
+	 *    post_id (the page the client rendered, bound to the nonce). This stops a client
+	 *    with a valid nonce for one published post from logging `job_view`, `job_apply_click`,
+	 *    etc. for a different post.
 	 *
-	 * @param array $stats Stat rows.
+	 * 2. Validity: the target post must be published, and listing-scope stats
+	 *    (page=listing or type=impression) must target a `job_listing`.
+	 *
+	 * Impression stats (type=impression) are exempt from the scope check because the
+	 * `[jobs]` shortcode's JS client posts per-listing post_ids that legitimately differ
+	 * from the page post_id. Residual risk: on a `[jobs]` page a client with a valid page
+	 * nonce can still submit impressions for any published job_listing, not just ones
+	 * visible on the page. Rate limiting + dedup constrain the volume; the dashboard
+	 * footnote discloses that public-page stats are approximate. Eliminating this would
+	 * require server-side impression recording, which is incompatible with full-page
+	 * caching.
+	 *
+	 * @param array $stats            Stat rows.
+	 * @param int   $request_post_id  The page-level post_id the nonce is bound to.
 	 * @return array Filtered stat rows.
 	 */
-	private function filter_by_post_validity( $stats ) {
-		$listing_stat_names = [];
+	private function filter_by_post_validity( $stats, $request_post_id ) {
+		$listing_stat_names    = [];
+		$impression_stat_names = [];
 		foreach ( $this->get_registered_stats() as $name => $def ) {
 			$is_listing_page = ( $def['page'] ?? '' ) === 'listing';
 			$is_impression   = ( $def['type'] ?? '' ) === 'impression';
 			if ( $is_listing_page || $is_impression ) {
 				$listing_stat_names[] = $name;
 			}
+			if ( $is_impression ) {
+				$impression_stat_names[] = $name;
+			}
 		}
 
 		$cache = [];
 		return array_filter(
 			$stats,
-			function ( $stat ) use ( &$cache, $listing_stat_names ) {
+			function ( $stat ) use ( &$cache, $listing_stat_names, $impression_stat_names, $request_post_id ) {
 				$post_id = absint( $stat['post_id'] ?? 0 );
 				if ( ! $post_id ) {
 					return false;
 				}
 
-				$requires_listing = in_array( $stat['name'] ?? '', $listing_stat_names, true );
-				$cache_key        = $post_id . '|' . ( $requires_listing ? 'L' : 'P' );
+				$name             = $stat['name'] ?? '';
+				$is_impression    = in_array( $name, $impression_stat_names, true );
+				$requires_listing = in_array( $name, $listing_stat_names, true );
+
+				// Scope: non-impression stats must target the post the nonce was issued for.
+				if ( ! $is_impression && $post_id !== $request_post_id ) {
+					return false;
+				}
+
+				$cache_key = $post_id . '|' . ( $requires_listing ? 'L' : 'P' );
 
 				if ( ! isset( $cache[ $cache_key ] ) ) {
 					$status = get_post_status( $post_id );

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -298,7 +298,10 @@ class Stats_Script {
 	 * @return string
 	 */
 	private function get_client_ip() {
-		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP ) : '';
+		if ( ! isset( $_SERVER['REMOTE_ADDR'] ) || ! is_string( $_SERVER['REMOTE_ADDR'] ) ) {
+			return '';
+		}
+		$ip = filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP );
 		return is_string( $ip ) ? $ip : '';
 	}
 

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -50,6 +50,14 @@ class Stats_Script {
 			return;
 		}
 
+		// If stats collection has been toggled off (e.g. between page render and
+		// this deferred AJAX call), short-circuit as a no-op so we don't emit 500s
+		// for what is an expected state.
+		if ( ! Stats::is_enabled() ) {
+			wp_send_json_success();
+			return;
+		}
+
 		$post_data = stripslashes_deep( $_POST );
 		$post_id   = absint( $post_data['post_id'] ?? 0 );
 

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -41,6 +41,13 @@ class Stats_Script {
 	const AJAX_RATE_LIMIT = 60;
 
 	/**
+	 * Memoized result of the `wpjm_get_registered_stats` filter for the current request.
+	 *
+	 * @var array|null
+	 */
+	private $registered_stats_cache = null;
+
+	/**
 	 * Log multiple stats in one go. Triggered in an ajax call.
 	 *
 	 * @return void
@@ -107,6 +114,13 @@ class Stats_Script {
 				$stat['group']   = is_string( $stat['group'] ?? null ) ? $stat['group'] : '';
 				$stat['count']   = 1;
 				$stat['date']    = $today;
+				// Mirror Stats::parse_stats() length constraints here so the AJAX handler
+				// never hands batch_log_stats() a row that parse_stats() will reject. That
+				// keeps a `false` return from batch_log_stats unambiguously a DB error,
+				// so clients don't see spurious 500s for valid-but-oversized payloads.
+				if ( strlen( $stat['name'] ) > 50 || strlen( $stat['group'] ) > 50 ) {
+					return null;
+				}
 				return $stat;
 			},
 			$stats
@@ -121,8 +135,9 @@ class Stats_Script {
 			}
 		);
 
-		$stats = $this->filter_by_post_validity( $stats, $post_id );
-		$stats = $this->filter_server_unique( $stats );
+		$stats          = $this->filter_by_post_validity( $stats, $post_id );
+		$pending_unique = [];
+		$stats          = $this->filter_server_unique( $stats, $pending_unique );
 
 		if ( empty( $stats ) ) {
 			wp_send_json_success();
@@ -130,8 +145,13 @@ class Stats_Script {
 		}
 
 		if ( ! Stats::instance()->batch_log_stats( $stats ) ) {
+			// Don't burn the dedup window if the DB write failed — the client should be
+			// able to retry the same unique stat without being silently suppressed for 24h.
 			wp_send_json_error( __( 'Unable to log stats.', 'wp-job-manager' ), 500 );
 			return;
+		}
+		foreach ( $pending_unique as $key ) {
+			set_transient( $key, 1, DAY_IN_SECONDS );
 		}
 		wp_send_json_success();
 	}
@@ -224,10 +244,16 @@ class Stats_Script {
 	 * (midnight UTC) boundary would let a visitor near the boundary re-count within
 	 * minutes of their first click.
 	 *
-	 * @param array $stats Stat rows.
+	 * Dedup transient keys are collected into `$pending_keys` rather than written
+	 * inline, so the caller can commit them only after the DB write succeeds. Writing
+	 * the transient before `batch_log_stats()` ran risked suppressing a legitimate
+	 * retry for 24 hours when the DB write failed.
+	 *
+	 * @param array $stats        Stat rows.
+	 * @param array $pending_keys Out-param: transient keys to set after a successful DB write.
 	 * @return array Filtered stat rows.
 	 */
-	private function filter_server_unique( $stats ) {
+	private function filter_server_unique( $stats, array &$pending_keys ) {
 		$client = $this->get_client_ip();
 		if ( '' === $client ) {
 			return $stats;
@@ -245,16 +271,18 @@ class Stats_Script {
 
 		return array_filter(
 			$stats,
-			function ( $stat ) use ( $client, $unique_stat_names ) {
+			function ( $stat ) use ( $client, $unique_stat_names, &$pending_keys ) {
 				$name = $stat['name'] ?? '';
 				if ( ! in_array( $name, $unique_stat_names, true ) ) {
 					return true;
 				}
 				$key = 'wpjm_u_' . md5( $client . '|' . $name . '|' . ( $stat['post_id'] ?? 0 ) );
-				if ( get_transient( $key ) ) {
+				// Reject duplicates already claimed earlier in the same batch, so an
+				// attacker can't pack 50 identical rows into one request.
+				if ( in_array( $key, $pending_keys, true ) || get_transient( $key ) ) {
 					return false;
 				}
-				set_transient( $key, 1, DAY_IN_SECONDS );
+				$pending_keys[] = $key;
 				return true;
 			}
 		);
@@ -396,7 +424,10 @@ class Stats_Script {
 	 * @return array
 	 */
 	private function get_registered_stats() {
-		return (array) apply_filters(
+		if ( null !== $this->registered_stats_cache ) {
+			return $this->registered_stats_cache;
+		}
+		$this->registered_stats_cache = (array) apply_filters(
 			'wpjm_get_registered_stats',
 			[
 				Job_Listing_Stats::VIEW              => [
@@ -440,6 +471,7 @@ class Stats_Script {
 				],
 			]
 		);
+		return $this->registered_stats_cache;
 	}
 
 	/**

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -58,18 +58,23 @@ class Stats_Script {
 			|| ! $post_id
 			|| ! wp_verify_nonce( $post_data['_ajax_nonce'], 'wpjm_log_stat_' . $post_id )
 		) {
-			wp_send_json_error( 'Invalid request.', 403 );
+			wp_send_json_error( __( 'Invalid request.', 'wp-job-manager' ), 403 );
 			return;
 		}
 
 		if ( $this->is_rate_limited() ) {
-			wp_send_json_error( 'Too many requests.', 429 );
+			wp_send_json_error( __( 'Too many requests.', 'wp-job-manager' ), 429 );
 			return;
 		}
 
-		$stats = json_decode( $post_data['stats'] ?? '[]', true );
+		$stats_raw = $post_data['stats'] ?? '[]';
+		if ( ! is_string( $stats_raw ) ) {
+			wp_send_json_error( __( 'Invalid payload.', 'wp-job-manager' ), 400 );
+			return;
+		}
+		$stats = json_decode( $stats_raw, true );
 		if ( empty( $stats ) || ! is_array( $stats ) ) {
-			wp_send_json_error( 'No stats to log.', 400 );
+			wp_send_json_error( __( 'No stats to log.', 'wp-job-manager' ), 400 );
 			return;
 		}
 
@@ -81,9 +86,13 @@ class Stats_Script {
 				if ( ! is_array( $stat ) ) {
 					return null;
 				}
-				// Canonicalize post_id early so every downstream step (validity
-				// check, dedup keying, DB write) operates on the same integer.
+				// Canonicalize types early so every downstream step (validity check,
+				// dedup keying, DB write) operates on consistent scalars. Without this,
+				// non-string name/group or non-integer post_id can trip strlen()/md5()
+				// later and turn the endpoint into a trivial DoS.
 				$stat['post_id'] = absint( $stat['post_id'] ?? 0 );
+				$stat['name']    = is_string( $stat['name'] ?? null ) ? $stat['name'] : '';
+				$stat['group']   = is_string( $stat['group'] ?? null ) ? $stat['group'] : '';
 				$stat['count']   = 1;
 				$stat['date']    = $today;
 				return $stat;
@@ -239,6 +248,12 @@ class Stats_Script {
 	/**
 	 * Soft per-client rate limit. Not an auth boundary — absorbs drive-by abuse.
 	 *
+	 * Fixed-window implementation: the transient stores `{count, start}` and the
+	 * window resets once `now - start >= MINUTE_IN_SECONDS`. Using just an integer
+	 * counter with `set_transient(..., MINUTE_IN_SECONDS)` would refresh the TTL
+	 * on every call, so a continuous trickle of requests would never let the
+	 * window expire and would eventually falsely block legitimately active users.
+	 *
 	 * @return bool
 	 */
 	private function is_rate_limited() {
@@ -246,12 +261,27 @@ class Stats_Script {
 		if ( '' === $client ) {
 			return false;
 		}
-		$key   = 'wpjm_rl_' . md5( $client );
-		$count = (int) get_transient( $key );
-		if ( $count >= self::AJAX_RATE_LIMIT ) {
+		$key    = 'wpjm_rl_' . md5( $client );
+		$now    = time();
+		$window = get_transient( $key );
+
+		if (
+			! is_array( $window )
+			|| ! isset( $window['count'], $window['start'] )
+			|| $now - (int) $window['start'] >= MINUTE_IN_SECONDS
+		) {
+			$window = [
+				'count' => 0,
+				'start' => $now,
+			];
+		}
+
+		if ( (int) $window['count'] >= self::AJAX_RATE_LIMIT ) {
 			return true;
 		}
-		set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+
+		$window['count']++;
+		set_transient( $key, $window, MINUTE_IN_SECONDS );
 		return false;
 	}
 

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -330,38 +330,47 @@ class Stats_Script {
 
 		global $post;
 
+		$pages = [];
 		if ( is_wpjm_job_listing() ) {
-			$this->enqueue_stats_script( 'listing', $post->ID );
+			$pages[] = 'listing';
 		}
-
 		if ( $this->page_has_jobs_shortcode( $post ) ) {
-			$this->enqueue_stats_script( 'jobs', $post->ID );
+			$pages[] = 'jobs';
 		}
 
+		if ( empty( $pages ) ) {
+			return;
+		}
+
+		$this->enqueue_stats_script( $pages, $post->ID );
 	}
 
 	/**
-	 * Register scripts for given screen.
+	 * Register the stats script for the given page contexts.
 	 *
-	 * @param string $page Which page.
-	 * @param int    $post_id Which id.
+	 * A single request can match more than one context (e.g. a `job_listing`
+	 * post whose content embeds the `[jobs]` shortcode). All applicable stat
+	 * definitions are collected into one `wp_localize_script` call so the
+	 * client receives the union of listing-page and jobs-page stats under a
+	 * single nonce.
+	 *
+	 * @param string[] $pages    Page contexts (`listing`, `jobs`).
+	 * @param int      $post_id  The page-level post_id.
 	 *
 	 * @return void
 	 */
-	private function enqueue_stats_script( $page = 'listing', $post_id = 0 ) {
+	private function enqueue_stats_script( array $pages, $post_id = 0 ) {
 
-		// If a page is both a single job_listing and hosts the [jobs] shortcode,
-		// only the first call wins — double-localizing would overwrite the first
-		// nonce and break listing-page stats.
-		if ( wp_script_is( 'wp-job-manager-stats', 'enqueued' ) ) {
-			return;
+		$stats = [];
+		foreach ( $pages as $page ) {
+			$stats = array_merge( $stats, $this->get_stats_for_ajax( $post_id, $page ) );
 		}
 
 		$script_data = [
 			'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
 			'ajaxNonce' => wp_create_nonce( 'wpjm_log_stat_' . $post_id ),
 			'postId'    => $post_id,
-			'stats'     => $this->get_stats_for_ajax( $post_id, $page ),
+			'stats'     => $stats,
 		];
 
 		wp_enqueue_script( 'wp-job-manager-stats' );

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -98,19 +98,16 @@ class Stats_Script {
 				if ( ! is_array( $stat ) ) {
 					return null;
 				}
-				// Canonicalize types early so every downstream step (validity check,
-				// dedup keying, DB write) operates on consistent scalars. Without this,
-				// non-string name/group or non-integer post_id can trip strlen()/md5()
-				// later and turn the endpoint into a trivial DoS.
+				// Canonicalize types so every downstream step (validity check, dedup
+				// keying, DB write) operates on consistent scalars; strlen()/md5() on
+				// a non-string fatals on PHP 8+.
 				$stat['post_id'] = absint( $stat['post_id'] ?? 0 );
 				$stat['name']    = is_string( $stat['name'] ?? null ) ? $stat['name'] : '';
 				$stat['group']   = is_string( $stat['group'] ?? null ) ? $stat['group'] : '';
 				$stat['count']   = 1;
 				$stat['date']    = $today;
-				// Mirror Stats::parse_stats() length constraints here so the AJAX handler
-				// never hands batch_log_stats() a row that parse_stats() will reject. That
-				// keeps a `false` return from batch_log_stats unambiguously a DB error,
-				// so clients don't see spurious 500s for valid-but-oversized payloads.
+				// Mirror Stats::parse_stats() length constraints so a `false` return
+				// from batch_log_stats() unambiguously means a DB error.
 				if ( strlen( $stat['name'] ) > 50 || strlen( $stat['group'] ) > 50 ) {
 					return null;
 				}
@@ -121,9 +118,8 @@ class Stats_Script {
 		$stats = array_filter( $stats );
 
 		// Snapshot the registered-stats filter result once for this request and thread
-		// it through the filter helpers. Caching this on a singleton property would
-		// break `apply_filters` semantics for callbacks added after the first call
-		// in the same request.
+		// it through the filter helpers so the `wpjm_get_registered_stats` filter fires
+		// once per AJAX request.
 		$registered_stats = $this->get_registered_stats();
 		$registered_names = array_keys( $registered_stats );
 		$stats            = array_filter(
@@ -143,8 +139,6 @@ class Stats_Script {
 		}
 
 		if ( ! Stats::instance()->batch_log_stats( $stats ) ) {
-			// Don't burn the dedup window if the DB write failed — the client should be
-			// able to retry the same unique stat without being silently suppressed for 24h.
 			wp_send_json_error( __( 'Unable to log stats.', 'wp-job-manager' ), 500 );
 			return;
 		}
@@ -244,9 +238,7 @@ class Stats_Script {
 	 * minutes of their first click.
 	 *
 	 * Dedup transient keys are collected into `$pending_keys` rather than written
-	 * inline, so the caller can commit them only after the DB write succeeds. Writing
-	 * the transient before `batch_log_stats()` ran risked suppressing a legitimate
-	 * retry for 24 hours when the DB write failed.
+	 * inline, so the caller can commit them only after the DB write succeeds.
 	 *
 	 * @param array $stats            Stat rows.
 	 * @param array $pending_keys     Out-param: transient keys to set after a successful DB write.
@@ -292,10 +284,8 @@ class Stats_Script {
 	 * Soft per-client rate limit. Not an auth boundary — absorbs drive-by abuse.
 	 *
 	 * Fixed-window implementation: the transient stores `{count, start}` and the
-	 * window resets once `now - start >= MINUTE_IN_SECONDS`. Using just an integer
-	 * counter with `set_transient(..., MINUTE_IN_SECONDS)` would refresh the TTL
-	 * on every call, so a continuous trickle of requests would never let the
-	 * window expire and would eventually falsely block legitimately active users.
+	 * window resets once `now - start >= MINUTE_IN_SECONDS`, so the TTL isn't
+	 * refreshed by each write and an active client isn't falsely blocked.
 	 *
 	 * @return bool
 	 */

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -81,8 +81,11 @@ class Stats_Script {
 				if ( ! is_array( $stat ) ) {
 					return null;
 				}
-				$stat['count'] = 1;
-				$stat['date']  = $today;
+				// Canonicalize post_id early so every downstream step (validity
+				// check, dedup keying, DB write) operates on the same integer.
+				$stat['post_id'] = absint( $stat['post_id'] ?? 0 );
+				$stat['count']   = 1;
+				$stat['date']    = $today;
 				return $stat;
 			},
 			$stats

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -213,6 +213,8 @@ class Stats {
 		$args['post_id'] = absint( $args['post_id'] );
 
 		if (
+			! is_string( $args['name'] ) ||
+			! is_string( $args['group'] ) ||
 			empty( $args['name'] ) ||
 			strlen( $args['name'] ) > 50 ||
 			strlen( $args['group'] ) > 50 ||

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -221,6 +221,15 @@ class Stats {
 			return false;
 		}
 
+		if ( ! is_string( $args['date'] ) || 1 !== preg_match( '/^\d{4}-\d{2}-\d{2}$/', $args['date'] ) ) {
+			return false;
+		}
+
+		$post_status = get_post_status( $args['post_id'] );
+		if ( ! $post_status || 'trash' === $post_status ) {
+			return false;
+		}
+
 		return $args;
 	}
 

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -221,7 +221,10 @@ class Stats {
 			return false;
 		}
 
-		if ( ! is_string( $args['date'] ) || 1 !== preg_match( '/^\d{4}-\d{2}-\d{2}$/', $args['date'] ) ) {
+		if ( ! is_string( $args['date'] ) || 1 !== preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $args['date'], $date_parts ) ) {
+			return false;
+		}
+		if ( ! wp_checkdate( (int) $date_parts[2], (int) $date_parts[3], (int) $date_parts[1], $args['date'] ) ) {
 			return false;
 		}
 

--- a/templates/job-stats.php
+++ b/templates/job-stats.php
@@ -87,6 +87,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</div>
 		</div>
 	</div>
+	<p class="jm-job-stats__footnote">
+		<small><em><?php esc_html_e( 'Statistics reflect visitor activity on public pages and may include approximate counts.', 'wp-job-manager' ); ?></em></small>
+	</p>
 	<div class="jm-job-stat-details jm-ui-row">
 		<?php foreach ( $stats as $column_name => $column ) : ?>
 			<div class="jm-ui-col">

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -637,4 +637,42 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		$this->assertEquals( 1, $stats[0]->count );
 	}
 
+	public function test_ajax_dedup_not_burned_on_db_failure() {
+		// Regression: filter_server_unique used to write the dedup transient
+		// before the DB write ran, so a failed insert silently suppressed the
+		// same (IP, name, post_id) for 24h. The pending-key rollback must keep
+		// the window open so a retry can succeed.
+		global $wpdb;
+		$job_id = $this->factory->job_listing->create();
+
+		$real_table          = $wpdb->wpjm_stats;
+		$wpdb->wpjm_stats    = $wpdb->prefix . 'wpjm_stats_missing_' . wp_rand();
+		$previous_suppress   = $wpdb->suppress_errors( true );
+		$previous_show_errors = $wpdb->hide_errors();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view_unique' ],
+		] );
+		$this->invoke_ajax();
+
+		$wpdb->wpjm_stats = $real_table;
+		$wpdb->suppress_errors( $previous_suppress );
+		if ( $previous_show_errors ) {
+			$wpdb->show_errors();
+		}
+
+		$dedup_key = 'wpjm_u_' . md5( '127.0.0.1|job_view_unique|' . $job_id );
+		$this->assertFalse( get_transient( $dedup_key ), 'Dedup transient must not be set when the DB write failed.' );
+
+		// Retry on the real table must now succeed.
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view_unique' ],
+		] );
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view_unique', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 1, $stats[0]->count );
+	}
+
 }

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -58,11 +58,27 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 
 	private function delete_transients_by_prefix( $prefix ) {
 		global $wpdb;
-		$like = $wpdb->esc_like( '_transient_' . $prefix ) . '%';
+		$value_like   = $wpdb->esc_like( '_transient_' . $prefix ) . '%';
+		$timeout_like = $wpdb->esc_like( '_transient_timeout_' . $prefix ) . '%';
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$names = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s", $like ) );
+		$names = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+				$value_like,
+				$timeout_like
+			)
+		);
+		// Collect the transient name from either the value row or the timeout row so that
+		// an orphaned `_transient_timeout_*` left by a prior run still gets evicted.
+		$transients = [];
 		foreach ( $names as $name ) {
-			$transient = substr( $name, strlen( '_transient_' ) );
+			if ( 0 === strpos( $name, '_transient_timeout_' ) ) {
+				$transients[ substr( $name, strlen( '_transient_timeout_' ) ) ] = true;
+			} elseif ( 0 === strpos( $name, '_transient_' ) ) {
+				$transients[ substr( $name, strlen( '_transient_' ) ) ] = true;
+			}
+		}
+		foreach ( array_keys( $transients ) as $transient ) {
 			delete_transient( $transient );
 		}
 	}

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -322,6 +322,36 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		$this->assertNotEmpty( $stats );
 	}
 
+	public function test_ajax_rejects_cross_post_listing_stat() {
+		// A valid nonce for page A must not allow logging non-impression stats for post B,
+		// even if B is also a published job_listing.
+		$job_a = $this->factory->job_listing->create();
+		$job_b = $this->factory->job_listing->create();
+
+		$this->set_request( $job_a, [
+			[ 'post_id' => $job_b, 'name' => 'job_apply_click' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( 'job_apply_click', $job_b ) );
+	}
+
+	public function test_ajax_allows_per_listing_impression_from_jobs_page() {
+		// Impression stats legitimately carry per-listing post_ids on a [jobs] page,
+		// so the scope check must not block them.
+		$page_id  = $this->factory->post->create( [ 'post_type' => 'page', 'post_status' => 'publish' ] );
+		$job_id   = $this->factory->job_listing->create();
+
+		$this->set_request( $page_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_search_impression' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$this->assertNotEmpty( Stats::instance()->get_stats( 'job_search_impression', $job_id ) );
+	}
+
 	public function test_ajax_rejects_impression_for_non_listing() {
 		$page_id = $this->factory->post->create( [ 'post_type' => 'page', 'post_status' => 'publish' ] );
 
@@ -363,24 +393,24 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	}
 
 	public function test_ajax_caps_batch_size() {
+		// Use impression stats because they're the real-world case for posting many
+		// per-listing stat rows under a single page-level nonce (the [jobs] shortcode).
 		$over_limit = Stats_Script::AJAX_BATCH_LIMIT + 10;
-		$job_ids    = [];
-		for ( $i = 0; $i < $over_limit; $i++ ) {
-			$job_ids[] = $this->factory->job_listing->create();
-		}
-
-		$page_id = $job_ids[0];
+		$page_id    = $this->factory->post->create( [ 'post_type' => 'page', 'post_status' => 'publish' ] );
 
 		$payload = [];
-		foreach ( $job_ids as $id ) {
-			$payload[] = [ 'post_id' => $id, 'name' => 'job_view' ];
+		for ( $i = 0; $i < $over_limit; $i++ ) {
+			$payload[] = [
+				'post_id' => $this->factory->job_listing->create(),
+				'name'    => 'job_search_impression',
+			];
 		}
 
 		$this->set_request( $page_id, $payload );
 
 		$this->invoke_ajax();
 
-		$stats = Stats::instance()->get_stats( 'job_view' );
+		$stats = Stats::instance()->get_stats( 'job_search_impression' );
 		$this->assertCount( Stats_Script::AJAX_BATCH_LIMIT, $stats );
 	}
 

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -9,11 +9,58 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		parent::setUp();
 		update_option( Stats::OPTION_ENABLE_STATS, true );
 		Stats::instance()->migrate_db();
+
+		// WP_UnitTestCase wipes filters between tests; Stats_Script is a singleton
+		// whose constructor only registers hooks once. Re-add the action for each test.
+		add_action( 'wp_ajax_job_manager_log_stat', [ Stats_Script::instance(), 'ajax_log_stat' ] );
+		add_action( 'wp_ajax_nopriv_job_manager_log_stat', [ Stats_Script::instance(), 'ajax_log_stat' ] );
+
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+		$this->clear_stats_transients();
+
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		add_filter( 'wp_doing_ajax', '__return_true' );
 	}
 
 	public function tearDown(): void {
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		$this->clear_stats_transients();
+		$_POST = [];
 		parent::tearDown();
 
+	}
+
+	private function clear_stats_transients() {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_wpjm\_%' OR option_name LIKE '\_transient\_timeout\_wpjm\_%'" );
+		wp_cache_flush();
+	}
+
+	/**
+	 * Helper to build the $_POST payload with a valid nonce tied to a page-level post_id.
+	 *
+	 * @param int   $page_post_id   Page-level post_id used for nonce binding.
+	 * @param array $stats_payload  Array of stat rows to JSON-encode into the `stats` field.
+	 * @return void
+	 */
+	private function set_request( $page_post_id, $stats_payload ) {
+		$_POST = [
+			'post_id'     => $page_post_id,
+			'stats'       => wp_json_encode( $stats_payload ),
+			'_ajax_nonce' => wp_create_nonce( 'wpjm_log_stat_' . $page_post_id ),
+		];
+	}
+
+	private function invoke_ajax() {
+		ob_start();
+		try {
+			do_action( 'wp_ajax_job_manager_log_stat' );
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement
+			// wp_die may throw; swallow to let the test inspect DB state.
+		}
+		ob_end_clean();
 	}
 
 	public function test_log_stat_creates_record() {
@@ -39,11 +86,12 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	}
 
 	public function test_log_stat_increases_count() {
+		$post_id = $this->factory->job_listing->create();
 
-		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => 1, 'count' => 1 ] );
-		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => 1, 'count' => 1 ] );
+		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => $post_id, 'count' => 1 ] );
+		Stats::instance()->log_stat( 'test_stat', [ 'post_id' => $post_id, 'count' => 1 ] );
 
-		$stats = Stats::instance()->get_stats( 'test_stat', 1 );
+		$stats = Stats::instance()->get_stats( 'test_stat', $post_id );
 
 		$this->assertNotEmpty( $stats );
 		$this->assertEquals( 2, $stats[0]->count );
@@ -51,11 +99,13 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	}
 
 	public function test_batch_log_stats_creates_records() {
+		$post_a = $this->factory->job_listing->create();
+		$post_b = $this->factory->job_listing->create();
 
 		$stats = [
-			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
-			[ 'name' => 'test_stat', 'post_id' => 2, 'count' => 2 ],
-			[ 'name' => 'test_stat_2', 'post_id' => 1, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => $post_a, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => $post_b, 'count' => 2 ],
+			[ 'name' => 'test_stat_2', 'post_id' => $post_a, 'count' => 1 ],
 		];
 
 		Stats::instance()->batch_log_stats( $stats );
@@ -67,11 +117,13 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	}
 
 	public function test_batch_log_stats_increases_counts() {
+		$post_a = $this->factory->job_listing->create();
+		$post_b = $this->factory->job_listing->create();
 
 		$stats = [
-			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
-			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
-			[ 'name' => 'test_stat', 'post_id' => 2, 'count' => 2 ],
+			[ 'name' => 'test_stat', 'post_id' => $post_a, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => $post_a, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => $post_b, 'count' => 2 ],
 		];
 
 		Stats::instance()->batch_log_stats( $stats );
@@ -86,18 +138,20 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	}
 
 	public function test_delete_stats_deletes_post_stats() {
+		$post_a = $this->factory->job_listing->create();
+		$post_b = $this->factory->job_listing->create();
 
 		$stats = [
-			[ 'name' => 'test_stat', 'post_id' => 1, 'count' => 1 ],
-			[ 'name' => 'test_stat', 'post_id' => 2, 'count' => 2 ],
-			[ 'name' => 'test_stat_2', 'post_id' => 1, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => $post_a, 'count' => 1 ],
+			[ 'name' => 'test_stat', 'post_id' => $post_b, 'count' => 2 ],
+			[ 'name' => 'test_stat_2', 'post_id' => $post_a, 'count' => 1 ],
 		];
 
 		Stats::instance()->batch_log_stats( $stats );
 
-		Stats::instance()->delete_stats( 1 );
+		Stats::instance()->delete_stats( $post_a );
 
-		$stats = Stats::instance()->get_stats( null, 1 );
+		$stats = Stats::instance()->get_stats( null, $post_a );
 
 		$this->assertEmpty( $stats );
 
@@ -141,31 +195,233 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	}
 
 	public function test_ajax_stats_logged() {
-
-		Stats_Script::instance();
-
 		$job_id = $this->factory->job_listing->create();
 
-		$_POST = [
-			'stats'       => json_encode( [
-				[
-					'post_id' => $job_id,
-					'name'    => 'job_view',
-				],
-				[
-					'post_id' => $job_id,
-					'name'    => 'job_view_unique',
-				],
-			] ),
-			'_ajax_nonce' => wp_create_nonce( 'ajax-nonce' ),
-		];
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view' ],
+			[ 'post_id' => $job_id, 'name' => 'job_view_unique' ],
+		] );
 
-		do_action( 'wp_ajax_job_manager_log_stat' );
+		$this->invoke_ajax();
 
 		$stats = Stats::instance()->get_stats( null, $job_id );
 
 		$this->assertEquals( [ 'job_view', 'job_view_unique' ], wp_list_pluck( $stats, 'name' ) );
+	}
 
+	public function test_ajax_rejects_old_generic_nonce() {
+		$job_id = $this->factory->job_listing->create();
+
+		$_POST = [
+			'post_id'     => $job_id,
+			'stats'       => wp_json_encode( [
+				[ 'post_id' => $job_id, 'name' => 'job_view' ],
+			] ),
+			'_ajax_nonce' => wp_create_nonce( 'ajax-nonce' ),
+		];
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( null, $job_id ) );
+	}
+
+	public function test_ajax_rejects_mismatched_post_id_nonce() {
+		$job_a = $this->factory->job_listing->create();
+		$job_b = $this->factory->job_listing->create();
+
+		// Nonce is tied to job_a, but the request claims to come from the page for job_b.
+		$_POST = [
+			'post_id'     => $job_b,
+			'stats'       => wp_json_encode( [
+				[ 'post_id' => $job_a, 'name' => 'job_view' ],
+			] ),
+			'_ajax_nonce' => wp_create_nonce( 'wpjm_log_stat_' . $job_a ),
+		];
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( null, $job_a ) );
+		$this->assertEmpty( Stats::instance()->get_stats( null, $job_b ) );
+	}
+
+	public function test_ajax_rejects_listing_stat_for_non_listing_post() {
+		$page_id = $this->factory->post->create( [ 'post_type' => 'post', 'post_status' => 'publish' ] );
+
+		$this->set_request( $page_id, [
+			[ 'post_id' => $page_id, 'name' => 'job_view' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( null, $page_id ) );
+	}
+
+	public function test_ajax_rejects_non_published_listing() {
+		$draft_id = $this->factory->job_listing->create( [ 'post_status' => 'draft' ] );
+
+		$this->set_request( $draft_id, [
+			[ 'post_id' => $draft_id, 'name' => 'job_view' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( null, $draft_id ) );
+	}
+
+	public function test_ajax_rejects_nonexistent_post() {
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => 999999, 'name' => 'job_view' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( null, 999999 ) );
+	}
+
+	public function test_ajax_allows_search_view_for_page() {
+		$page_id = $this->factory->post->create( [ 'post_type' => 'page', 'post_status' => 'publish' ] );
+
+		$this->set_request( $page_id, [
+			[ 'post_id' => $page_id, 'name' => 'search_view' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'search_view', $page_id );
+		$this->assertNotEmpty( $stats );
+	}
+
+	public function test_ajax_rejects_impression_for_non_listing() {
+		$page_id = $this->factory->post->create( [ 'post_type' => 'page', 'post_status' => 'publish' ] );
+
+		$this->set_request( $page_id, [
+			[ 'post_id' => $page_id, 'name' => 'job_search_impression' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( 'job_search_impression', $page_id ) );
+	}
+
+	public function test_ajax_clamps_count_to_one() {
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view', 'count' => 999 ],
+		] );
+
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 1, $stats[0]->count );
+	}
+
+	public function test_ajax_forces_server_date() {
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view', 'date' => '2000-01-01' ],
+		] );
+
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( gmdate( 'Y-m-d' ), $stats[0]->date );
+	}
+
+	public function test_ajax_caps_batch_size() {
+		$job_ids = [];
+		for ( $i = 0; $i < 60; $i++ ) {
+			$job_ids[] = $this->factory->job_listing->create();
+		}
+
+		$page_id = $job_ids[0];
+
+		$payload = [];
+		foreach ( $job_ids as $id ) {
+			$payload[] = [ 'post_id' => $id, 'name' => 'job_view' ];
+		}
+
+		$this->set_request( $page_id, $payload );
+
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view' );
+		$this->assertCount( 50, $stats );
+	}
+
+	public function test_ajax_server_dedup_blocks_duplicate_unique() {
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view_unique' ],
+		] );
+		$this->invoke_ajax();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view_unique' ],
+		] );
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view_unique', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 1, $stats[0]->count );
+	}
+
+	public function test_ajax_non_unique_stats_not_deduped() {
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view' ],
+		] );
+		$this->invoke_ajax();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view' ],
+		] );
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 2, $stats[0]->count );
+	}
+
+	public function test_ajax_rate_limit_blocks_excess_requests() {
+		$job_id = $this->factory->job_listing->create();
+
+		// Seed the rate-limit transient near its ceiling so we don't need 60 iterations.
+		set_transient( 'wpjm_rl_' . md5( '127.0.0.1' ), 60, MINUTE_IN_SECONDS );
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view' ],
+		] );
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( 'job_view', $job_id ) );
+	}
+
+	public function test_parse_stats_rejects_trashed_post() {
+		$job_id = $this->factory->job_listing->create();
+		wp_trash_post( $job_id );
+
+		$result = Stats::instance()->log_stat( 'job_view', [ 'post_id' => $job_id, 'count' => 1 ] );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_parse_stats_rejects_malformed_date() {
+		$job_id = $this->factory->job_listing->create();
+
+		$result = Stats::instance()->log_stat(
+			'job_view',
+			[ 'post_id' => $job_id, 'count' => 1, 'date' => 'not-a-date' ]
+		);
+
+		$this->assertFalse( $result );
 	}
 
 }

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -526,6 +526,43 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		$this->assertEmpty( Stats::instance()->get_stats( null, $job_id ) );
 	}
 
+	public function test_parse_stats_rejects_non_string_name_via_batch() {
+		// batch_log_stats() is an array-typed public API: third-party callers can
+		// pass non-string `name`. parse_stats must reject without fatalling on strlen().
+		$job_id = $this->factory->job_listing->create();
+
+		$result = Stats::instance()->batch_log_stats( [
+			[ 'name' => [ 'not', 'a', 'string' ], 'post_id' => $job_id, 'count' => 1 ],
+		] );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_parse_stats_rejects_non_string_group() {
+		$job_id = $this->factory->job_listing->create();
+
+		$result = Stats::instance()->log_stat(
+			'job_view',
+			[ 'post_id' => $job_id, 'count' => 1, 'group' => [ 'not', 'a', 'string' ] ]
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_ajax_noop_when_stats_disabled() {
+		update_option( Stats::OPTION_ENABLE_STATS, false );
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view' ],
+		] );
+		$this->invoke_ajax();
+
+		// No row written and no error surfaced; re-enable for assertion read.
+		update_option( Stats::OPTION_ENABLE_STATS, true );
+		$this->assertEmpty( Stats::instance()->get_stats( null, $job_id ) );
+	}
+
 	public function test_ajax_handles_non_string_group_without_fatal() {
 		// Regression: non-string `group` would later hit strlen() in parse_stats()
 		// and fatal on PHP 8+. Must be normalized before any downstream processing.

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -334,8 +334,9 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	}
 
 	public function test_ajax_caps_batch_size() {
-		$job_ids = [];
-		for ( $i = 0; $i < 60; $i++ ) {
+		$over_limit = Stats_Script::AJAX_BATCH_LIMIT + 10;
+		$job_ids    = [];
+		for ( $i = 0; $i < $over_limit; $i++ ) {
 			$job_ids[] = $this->factory->job_listing->create();
 		}
 
@@ -351,7 +352,7 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		$this->invoke_ajax();
 
 		$stats = Stats::instance()->get_stats( 'job_view' );
-		$this->assertCount( 50, $stats );
+		$this->assertCount( Stats_Script::AJAX_BATCH_LIMIT, $stats );
 	}
 
 	public function test_ajax_server_dedup_blocks_duplicate_unique() {
@@ -368,6 +369,27 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		$this->invoke_ajax();
 
 		$stats = Stats::instance()->get_stats( 'job_view_unique', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 1, $stats[0]->count );
+	}
+
+	public function test_ajax_server_dedup_blocks_apply_click_without_unique_suffix() {
+		// Regression: job_apply_click is registered as unique: true but the name
+		// does not end in "_unique". Dedup must key on the definition flag, not
+		// on the suffix heuristic.
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_apply_click' ],
+		] );
+		$this->invoke_ajax();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_apply_click' ],
+		] );
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_apply_click', $job_id );
 		$this->assertNotEmpty( $stats );
 		$this->assertEquals( 1, $stats[0]->count );
 	}

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -474,8 +474,12 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 	public function test_ajax_rate_limit_blocks_excess_requests() {
 		$job_id = $this->factory->job_listing->create();
 
-		// Seed the rate-limit transient near its ceiling so we don't need 60 iterations.
-		set_transient( 'wpjm_rl_' . md5( '127.0.0.1' ), 60, MINUTE_IN_SECONDS );
+		// Seed the rate-limit window at its ceiling so we don't need 60 iterations.
+		set_transient(
+			'wpjm_rl_' . md5( '127.0.0.1' ),
+			[ 'count' => Stats_Script::AJAX_RATE_LIMIT, 'start' => time() ],
+			MINUTE_IN_SECONDS
+		);
 
 		$this->set_request( $job_id, [
 			[ 'post_id' => $job_id, 'name' => 'job_view' ],
@@ -483,6 +487,63 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		$this->invoke_ajax();
 
 		$this->assertEmpty( Stats::instance()->get_stats( 'job_view', $job_id ) );
+	}
+
+	public function test_ajax_rate_limit_window_resets_after_minute() {
+		// Regression: an integer counter with TTL reset on every write would
+		// climb forever for an actively-browsing client. The fixed window must
+		// reset once start + MINUTE_IN_SECONDS has passed.
+		$job_id = $this->factory->job_listing->create();
+
+		// Window at ceiling but started more than a minute ago: stale, should reset.
+		set_transient(
+			'wpjm_rl_' . md5( '127.0.0.1' ),
+			[ 'count' => Stats_Script::AJAX_RATE_LIMIT, 'start' => time() - ( MINUTE_IN_SECONDS + 10 ) ],
+			MINUTE_IN_SECONDS
+		);
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view' ],
+		] );
+		$this->invoke_ajax();
+
+		$this->assertNotEmpty( Stats::instance()->get_stats( 'job_view', $job_id ) );
+	}
+
+	public function test_ajax_handles_non_string_stats_field_without_fatal() {
+		// Regression: `stats[]=foo` makes $_POST['stats'] an array, and
+		// json_decode(array) fatals on PHP 8+. Endpoint must reject cleanly.
+		$job_id = $this->factory->job_listing->create();
+
+		$_POST = [
+			'post_id'     => $job_id,
+			'stats'       => [ 'not', 'a', 'string' ],
+			'_ajax_nonce' => wp_create_nonce( 'wpjm_log_stat_' . $job_id ),
+		];
+
+		$this->invoke_ajax();
+
+		$this->assertEmpty( Stats::instance()->get_stats( null, $job_id ) );
+	}
+
+	public function test_ajax_handles_non_string_group_without_fatal() {
+		// Regression: non-string `group` would later hit strlen() in parse_stats()
+		// and fatal on PHP 8+. Must be normalized before any downstream processing.
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[
+				'post_id' => $job_id,
+				'name'    => 'job_view',
+				'group'   => [ 'malicious' => 'object' ],
+			],
+		] );
+
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( '', $stats[0]->group );
 	}
 
 	public function test_parse_stats_rejects_trashed_post() {

--- a/tests/php/tests/includes/test_class.stats.php
+++ b/tests/php/tests/includes/test_class.stats.php
@@ -4,6 +4,13 @@ namespace WP_Job_Manager;
 
 class WP_Test_Stats extends \WPJM_BaseTest {
 
+	/**
+	 * Previous REMOTE_ADDR value, restored in tearDown to avoid leaking global state.
+	 *
+	 * @var mixed Original value; null sentinel if the key was unset.
+	 */
+	private $previous_remote_addr;
+
 	//setup
 	public function setUp(): void {
 		parent::setUp();
@@ -15,7 +22,8 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		add_action( 'wp_ajax_job_manager_log_stat', [ Stats_Script::instance(), 'ajax_log_stat' ] );
 		add_action( 'wp_ajax_nopriv_job_manager_log_stat', [ Stats_Script::instance(), 'ajax_log_stat' ] );
 
-		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+		$this->previous_remote_addr = $_SERVER['REMOTE_ADDR'] ?? null;
+		$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
 		$this->clear_stats_transients();
 
 		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
@@ -26,16 +34,37 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 		$this->clear_stats_transients();
+
+		if ( null === $this->previous_remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $this->previous_remote_addr;
+		}
 		$_POST = [];
 		parent::tearDown();
 
 	}
 
+	/**
+	 * Clear the specific transient families the stats endpoint writes, so they don't leak
+	 * across tests. Narrowed to the `wpjm_u_` (unique dedup) and `wpjm_rl_` (rate limit)
+	 * prefixes — `delete_transient()` evicts both the DB row and the object-cache entry,
+	 * so no broad `wp_cache_flush()` is needed.
+	 */
 	private function clear_stats_transients() {
+		$this->delete_transients_by_prefix( 'wpjm_u_' );
+		$this->delete_transients_by_prefix( 'wpjm_rl_' );
+	}
+
+	private function delete_transients_by_prefix( $prefix ) {
 		global $wpdb;
+		$like = $wpdb->esc_like( '_transient_' . $prefix ) . '%';
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_wpjm\_%' OR option_name LIKE '\_transient\_timeout\_wpjm\_%'" );
-		wp_cache_flush();
+		$names = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s", $like ) );
+		foreach ( $names as $name ) {
+			$transient = substr( $name, strlen( '_transient_' ) );
+			delete_transient( $transient );
+		}
 	}
 
 	/**
@@ -444,6 +473,40 @@ class WP_Test_Stats extends \WPJM_BaseTest {
 		);
 
 		$this->assertFalse( $result );
+	}
+
+	public function test_parse_stats_rejects_impossible_calendar_date() {
+		// Regression: the regex would accept any YYYY-MM-DD shape. 2024-02-31 is
+		// not a real date; wp_checkdate() catches it.
+		$job_id = $this->factory->job_listing->create();
+
+		$result = Stats::instance()->log_stat(
+			'job_view',
+			[ 'post_id' => $job_id, 'count' => 1, 'date' => '2024-02-31' ]
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_ajax_dedup_survives_noninteger_post_id() {
+		// Regression: before canonicalization, `post_id: "<int><garbage>"` would
+		// pass filter_by_post_validity (via absint) but produce a distinct
+		// transient key from the plain integer form, bypassing server-side dedup.
+		$job_id = $this->factory->job_listing->create();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id, 'name' => 'job_view_unique' ],
+		] );
+		$this->invoke_ajax();
+
+		$this->set_request( $job_id, [
+			[ 'post_id' => $job_id . 'abc', 'name' => 'job_view_unique' ],
+		] );
+		$this->invoke_ajax();
+
+		$stats = Stats::instance()->get_stats( 'job_view_unique', $job_id );
+		$this->assertNotEmpty( $stats );
+		$this->assertEquals( 1, $stats[0]->count );
 	}
 
 }


### PR DESCRIPTION
## Summary

Tightens input validation, authorization scoping, and abuse mitigations on the stats collection AJAX endpoint (`job_manager_log_stat`). Public-page statistics remain best-effort — the dashboard now says so in a footnote.

Context: [Patchstack advisory](https://patchstack.com/database/Wordpress/Plugin/wp-job-manager/vulnerability/wordpress-wp-job-manager-plugin-2-4-1-broken-access-control-vulnerability).

## Changes

**`includes/class-stats-script.php`**
- Stats nonce is now bound to the page-level `post_id` (`wpjm_log_stat_{post_id}`) rather than a generic action string.
- Non-impression stats must target the nonce-bound `post_id`; impression stats (which legitimately carry per-listing `post_id`s on a `[jobs]` page) retain the broader post-type/status check.
- `post_id` values submitted per stat are validated against expected post type and status: stats whose definition is `page=listing` or `type=impression` require a published `job_listing`; other stats (e.g. `search_view`) require any published post.
- `post_id` is canonicalized with `absint()` up-front so validity-check, dedup-keying, and DB-write all see the same integer.
- `name` and `group` are normalized to strings in the same pass; non-string inputs no longer risk fatal errors in `strlen()` downstream on PHP 8+. Rows whose `name` or `group` exceed `parse_stats()`'s 50-char limit are dropped at the AJAX layer, so a `false` return from `batch_log_stats()` unambiguously means a DB write error rather than an all-filtered payload.
- `count` is clamped to 1, `date` is forced to today (server-side), and the batch is capped at 50 entries per request.
- JSON payload handling distinguishes parse failures (`Invalid payload.`) from empty arrays (`No stats to log.`) and from non-string `stats` fields.
- Per-client request count is soft-rate-limited (60/min) using a fixed `{count, start}` window. A plain integer counter would have its TTL refreshed on every `set_transient()` call, letting a trickle of legitimate traffic eventually hit the ceiling.
- Server-side dedup for any stat registered with `unique => true` uses a 24-hour sliding TTL keyed on client IP + stat name + post_id. The window starts at the first observed event so visitors near midnight UTC can't re-count within minutes; unique counts are effectively "once per visitor per rolling 24 hours."
- Dedup transient keys are collected during filtering and only written after `batch_log_stats()` succeeds, so a failed DB write doesn't silently suppress the same unique stat for 24 hours. Duplicate rows packed into the same batch are also rejected against the in-flight key set, so an attacker can't pack 50 identical rows into one request.
- The `wpjm_get_registered_stats` filter is snapshotted once per AJAX request and threaded through the filter helpers, rather than cached on the singleton (which would mask callbacks added after the first call in the same request).
- When a page is both a single `job_listing` and hosts the `[jobs]` shortcode, both contexts' stats are merged into a single `wp_localize_script` call under one nonce.
- Short-circuits with a success no-op when `Stats::is_enabled()` is false, so toggling stats off between page render and AJAX call doesn't surface as 500s.
- All exit paths return structured `wp_send_json_*` responses with explicit `return` for testability. `batch_log_stats()` failures now surface as 500 so operator tooling sees the DB-write issue.

**`includes/class-stats.php`**
- `parse_stats()` rejects non-existent and trashed posts, malformed date strings, impossible calendar dates (via `wp_checkdate()`), and non-string `name` / `group` values (defense-in-depth for internal callers).

**`templates/job-stats.php`**
- Adds a footnote to the job-stats overlay: *"Statistics reflect visitor activity on public pages and may include approximate counts."*

**`tests/php/tests/includes/test_class.stats.php`**
- 20+ new tests covering nonce binding, cross-post scope rejection, post-type/status validation, count/date clamping, batch cap, rate-limit window reset, server-side dedup (including the `job_apply_click` no-suffix case, the `post_id` canonicalization bypass, and the "dedup window must not burn on DB failure" regression), non-string payload handling, short-circuit when disabled, and `parse_stats()` defense-in-depth rejections.
- Three pre-existing tests updated to use factory-created job listings (prior arbitrary `post_id => 1` values are now legitimately rejected).
- Adds setUp helpers for per-test AJAX hook re-registration (singleton constructor runs once, but `WP_UnitTestCase` wipes filter state between tests), for nonce + `$_POST` payload construction, and for narrowed transient cleanup (both value and timeout rows).

## Expected post-upgrade behaviour (needs release-notes callout)

After upgrading, employers may see small changes in reported apply clicks and unique views. Most sites should see minimal impact because legitimate browser traffic was already being deduped client-side via `localStorage`. This PR moves that enforcement to the server authoritatively.

Two cases where the numbers will shift noticeably:

- **Sites with significant bot or scripted traffic**: totals will drop. Those counts were inflated by traffic that bypassed the client-side dedup; the new totals reflect more accurate counting.
- **Sites where many legitimate visitors share a single IP** (corporate networks behind NAT, carrier-grade NAT on mobile, VPN/proxy exits, public Wi-Fi): totals may also drop, but in this case the dedup is now too *aggressive* — two real candidates applying from the same office within 24 hours of each other will be counted once. This is a known trade-off. A follow-up `wpjm_stats_client_ip` filter is planned so hosts behind a reverse proxy can customise IP detection.

Suggested release-notes language:

> Apply click and unique view statistics are now deduplicated per visitor on a 24-hour sliding window, matching the intent of the `unique` flag. Previously this relied on client-side logic that could be bypassed. Most listings should see little change. Sites where several visitors share a single IP address (office networks, mobile carriers, VPNs) may see lower counts on those stats because the dedup cannot distinguish separate visitors behind the same IP.

## Residual caveats (documented, not fixed here)

- Behind a reverse proxy or CDN, `REMOTE_ADDR` may be the proxy IP — rate-limit and dedup buckets can collide across users. Follow-up: a `wpjm_stats_client_ip` filter.
- Unique-stat dedup transients fall back to `wp_options` without an external object cache; cleanup relies on WP cron.
- Apply-click and search-impression stats remain client-reported; on a `[jobs]` page the nonce is tied to the page post but impression stats legitimately carry per-listing `post_id`s, so a client with a valid page nonce can submit impressions for any published `job_listing`. Rate limiting and post validation constrain the volume but don't structurally prevent fabrication. The UI footnote discloses this.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 445 tests, 1851 assertions, 3 skipped (geocode, same as baseline)
- [x] Manual: legitimate page views, unique views, apply-clicks, and search impressions record correctly on published listings and the `[jobs]` page
- [ ] Manual: stats payloads targeting draft/private/trashed/non-existent posts are silently dropped
- [ ] Manual: stats for a mismatched page-level `post_id` fail nonce verification with \`403\`
- [ ] Manual: the 61st request from one IP within a minute returns \`429\`
- [x] Manual: duplicate `job_apply_click` and `*_unique` stats from the same IP within 24 hours increment only once
- [x] Manual: the footnote renders in the job-stats overlay in the Employer Dashboard





<!-- wpjm:plugin-zip -->
----

| Plugin build for 5771860a60550def9e9f7a2017222bd62e70c90d <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/04/wp-job-manager-zip-2938-5771860a.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/04/2938-5771860a)             |

<!-- /wpjm:plugin-zip -->









