### PR TITLE
Harden public output paths for password-protected and capability-restricted listings

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -149,6 +149,21 @@ class WP_Job_Manager_Ajax {
 			$filter_post_status = null;
 		}
 
+		// Browse-capability gate — match the [jobs] shortcode denial without surfacing partial results.
+		if ( ! job_manager_user_can_browse_job_listings() ) {
+			wp_send_json(
+				[
+					'found_jobs'    => false,
+					'showing'       => '',
+					'showing_all'   => false,
+					'showing_links' => '',
+					'max_num_pages' => 0,
+					'html'          => '',
+				]
+			);
+			return;
+		}
+
 		$types              = get_job_listing_types();
 		$job_types_filtered = ! is_null( $filter_job_types ) && count( $types ) !== count( $filter_job_types );
 

--- a/includes/class-wp-job-manager-cache-helper.php
+++ b/includes/class-wp-job-manager-cache-helper.php
@@ -31,6 +31,20 @@ class WP_Job_Manager_Cache_Helper {
 		add_action( 'create_term', [ __CLASS__, 'edited_term' ], 10, 3 );
 		add_action( 'delete_term', [ __CLASS__, 'edited_term' ], 10, 3 );
 		add_action( 'transition_post_status', [ __CLASS__, 'maybe_clear_count_transients' ], 10, 3 );
+
+		// Bump the listings cache when capability gates change so cached results don't outlive the policy that produced them.
+		foreach ( [ 'job_manager_browse_job_listings_capability', 'job_manager_view_job_listing_capability' ] as $option ) {
+			add_action( "add_option_{$option}", [ __CLASS__, 'flush_get_job_listings_transient_version' ] );
+			add_action( "update_option_{$option}", [ __CLASS__, 'flush_get_job_listings_transient_version' ] );
+			add_action( "delete_option_{$option}", [ __CLASS__, 'flush_get_job_listings_transient_version' ] );
+		}
+	}
+
+	/**
+	 * Bumps the get_job_listings transient version unconditionally.
+	 */
+	public static function flush_get_job_listings_transient_version() {
+		self::get_transient_version( 'get_job_listings', true );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -211,6 +211,7 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'transition_post_status', [ $this, 'track_job_submission' ], 10, 3 );
 
 		add_action( 'parse_query', [ $this, 'add_feed_query_args' ] );
+		add_action( 'pre_get_posts', [ $this, 'gate_feed_query_for_listings' ] );
 
 		// Single job content.
 		$this->job_content_filter( true );
@@ -834,6 +835,32 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'rss2_item', [ $this, 'job_feed_item' ] );
 		do_action( 'do_feed_rss2', false );
 		remove_filter( 'posts_search', 'get_job_listings_keyword_search', 10 );
+	}
+
+	/**
+	 * Gates core feed queries for the job_listing post type so the default RSS / Atom
+	 * endpoints (?feed=rss2&post_type=job_listing, etc.) honor the browse capability and
+	 * exclude password-protected listings — matching the hardening applied to the custom
+	 * job_feed and AJAX / REST paths.
+	 *
+	 * @param WP_Query $query The query.
+	 */
+	public function gate_feed_query_for_listings( $query ) {
+		if ( ! $query->is_feed() || ! $query->is_main_query() ) {
+			return;
+		}
+
+		$post_types = (array) $query->get( 'post_type' );
+		if ( ! in_array( self::PT_LISTING, $post_types, true ) ) {
+			return;
+		}
+
+		if ( ! job_manager_user_can_browse_job_listings() ) {
+			$query->set( 'post__in', [ 0 ] );
+			return;
+		}
+
+		$query->set( 'has_password', false );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -709,6 +709,22 @@ class WP_Job_Manager_Post_Types {
 	public function job_feed() {
 		global $job_manager_keyword;
 
+		// Browse-capability gate — emit an empty feed (matching the [jobs] shortcode denial)
+		// rather than 404 / 403, so feed readers don't error on a configured-private site.
+		if ( ! job_manager_user_can_browse_job_listings() ) {
+			// phpcs:ignore WordPress.WP.DiscouragedFunctions
+			query_posts(
+				[
+					'post__in'  => [ 0 ],
+					'post_type' => self::PT_LISTING,
+				]
+			);
+			add_action( 'rss2_ns', [ $this, 'job_feed_namespace' ] );
+			add_action( 'rss2_item', [ $this, 'job_feed_item' ] );
+			do_action( 'do_feed_rss2', false );
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Input used to filter public data in feed.
 		$input_posts_per_page  = isset( $_GET['posts_per_page'] ) ? absint( $_GET['posts_per_page'] ) : 10;
 		$input_search_location = isset( $_GET['search_location'] ) ? sanitize_text_field( wp_unslash( $_GET['search_location'] ) ) : false;
@@ -739,6 +755,7 @@ class WP_Job_Manager_Post_Types {
 			'paged'               => absint( get_query_var( 'paged', 1 ) ),
 			'tax_query'           => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Empty.
 			'meta_query'          => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Empty.
+			'has_password'        => false,
 		];
 
 		if ( ! empty( $input_search_location ) ) {
@@ -1645,7 +1662,7 @@ class WP_Job_Manager_Post_Types {
 			'show_in_admin'      => true,
 			'show_in_rest'       => false,
 			'auth_edit_callback' => [ __CLASS__, 'auth_check_can_edit_job_listings' ],
-			'auth_view_callback' => null,
+			'auth_view_callback' => [ __CLASS__, 'auth_check_can_view_job_listing' ],
 			'sanitize_callback'  => [ __CLASS__, 'sanitize_meta_field_based_on_input_type' ],
 		];
 
@@ -2028,6 +2045,36 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		return job_manager_user_can_edit_job( $post_id );
+	}
+
+	/**
+	 * Checks if a user can view a job listing's meta in REST responses.
+	 *
+	 * Hides meta when the listing is password-protected (and the viewer hasn't unlocked it) or when
+	 * the site's view-capability gate denies the viewer. Used as the default `auth_view_callback`
+	 * for job listing meta fields, consumed by `WP_Job_Manager_REST_API::prepare_job_listing()`.
+	 *
+	 * @param bool   $allowed   Ignored — `prepare_job_listing()` always passes false.
+	 * @param string $meta_key  The meta key.
+	 * @param int    $post_id   Job listing's post ID.
+	 * @param int    $user_id   User ID.
+	 *
+	 * @return bool True if the meta value can be exposed to the viewer.
+	 */
+	public static function auth_check_can_view_job_listing( $allowed, $meta_key, $post_id, $user_id ) {
+		if ( empty( $post_id ) ) {
+			return true;
+		}
+
+		if ( post_password_required( $post_id ) ) {
+			return false;
+		}
+
+		if ( ! job_manager_user_can_view_job_listing( $post_id ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-rest-api.php
+++ b/includes/class-wp-job-manager-rest-api.php
@@ -26,13 +26,23 @@ class WP_Job_Manager_REST_API {
 	}
 
 	/**
-	 * Excludes filled job listings from REST API query results.
+	 * Excludes filled job listings from REST API query results, and short-circuits the query when
+	 * the requester does not have the browse-listings capability.
 	 *
 	 * @param array           $args    Array of query arguments.
 	 * @param WP_REST_Request $request The REST API request.
 	 * @return array
 	 */
 	public static function exclude_filled_from_query( $args, $request ) {
+		// Browse-capability gate — match the same denial the [jobs] shortcode applies, but without surfacing a 403.
+		if ( ! job_manager_user_can_browse_job_listings() ) {
+			$args['post__in'] = [ 0 ];
+			return $args;
+		}
+
+		// Password-protected listings are excluded from REST collections regardless of post-type config.
+		$args['has_password'] = false;
+
 		if ( 1 !== absint( get_option( 'job_manager_hide_filled_positions' ) ) ) {
 			return $args;
 		}
@@ -71,6 +81,36 @@ class WP_Job_Manager_REST_API {
 
 		if ( ! isset( $data['meta'] ) ) {
 			$data['meta'] = [];
+		}
+
+		// When the listing is password-protected (and the viewer hasn't unlocked it) or the
+		// view-capability gate denies the viewer, blank out the identifying top-level fields too. WP core
+		// only gates `content.rendered` / `excerpt.rendered`; for job listings the title / link /
+		// slug / featured-media references can themselves carry sensitive information.
+		$is_blocked = post_password_required( $post ) || ! job_manager_user_can_view_job_listing( $post->ID );
+
+		if ( $is_blocked ) {
+			if ( isset( $data['title']['rendered'] ) ) {
+				$data['title']['rendered'] = '';
+			}
+			if ( array_key_exists( 'link', $data ) ) {
+				unset( $data['link'] );
+			}
+			if ( array_key_exists( 'slug', $data ) ) {
+				$data['slug'] = '';
+			}
+			if ( array_key_exists( 'featured_media', $data ) ) {
+				$data['featured_media'] = 0;
+			}
+			// Links live on WP_REST_Response's private $links property and are merged into the
+			// serialized `_links` block later by WP_REST_Server::response_to_data(); they are not
+			// present in $data at this point, so remove_link() is the only effective way to drop
+			// the featured-media link before serialization.
+			$response->remove_link( 'https://api.w.org/featuredmedia' );
+			$data['meta'] = [];
+			$response->set_data( $data );
+
+			return $response;
 		}
 
 		foreach ( $data['meta'] as $meta_key => $meta_value ) {

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -80,6 +80,11 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 	 * @param array $instance
 	 */
 	public function widget( $args, $instance ) {
+		// Browse-capability gate — match the [jobs] shortcode denial without rendering a partial widget.
+		if ( ! job_manager_user_can_browse_job_listings() ) {
+			return;
+		}
+
 		wp_enqueue_style( 'wp-job-manager-job-listings' );
 
 		if ( $this->get_cached_widget( $args ) ) {

--- a/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-featured-jobs.php
@@ -87,7 +87,12 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 		wp_enqueue_style( 'wp-job-manager-job-listings' );
 
-		if ( $this->get_cached_widget( $args ) ) {
+		// Skip the shared widget cache when view capability is configured: the per-listing template
+		// gate in `content-widget-job_listing.php` makes output viewer-dependent, and the base
+		// cache is keyed only by widget instance id (no auth partition).
+		$view_cap_can_filter = ! empty( get_option( 'job_manager_view_job_listing_capability' ) );
+
+		if ( ! $view_cap_can_filter && $this->get_cached_widget( $args ) ) {
 			return;
 		}
 
@@ -148,7 +153,9 @@ class WP_Job_Manager_Widget_Featured_Jobs extends WP_Job_Manager_Widget {
 
 		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		$this->cache_widget( $args, $content );
+		if ( ! $view_cap_can_filter ) {
+			$this->cache_widget( $args, $content );
+		}
 	}
 }
 

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -85,6 +85,11 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 	 * @param array $instance
 	 */
 	public function widget( $args, $instance ) {
+		// Browse-capability gate — match the [jobs] shortcode denial without rendering a partial widget.
+		if ( ! job_manager_user_can_browse_job_listings() ) {
+			return;
+		}
+
 		wp_enqueue_style( 'wp-job-manager-job-listings' );
 
 		if ( $this->get_cached_widget( $args ) ) {

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -92,7 +92,12 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		wp_enqueue_style( 'wp-job-manager-job-listings' );
 
-		if ( $this->get_cached_widget( $args ) ) {
+		// Skip the shared widget cache when view capability is configured: the per-listing template
+		// gate in `content-widget-job_listing.php` makes output viewer-dependent, and the base
+		// cache is keyed only by widget instance id (no auth partition).
+		$view_cap_can_filter = ! empty( get_option( 'job_manager_view_job_listing_capability' ) );
+
+		if ( ! $view_cap_can_filter && $this->get_cached_widget( $args ) ) {
 			return;
 		}
 
@@ -174,7 +179,9 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		$this->cache_widget( $args, $content );
+		if ( ! $view_cap_can_filter ) {
+			$this->cache_widget( $args, $content );
+		}
 	}
 }
 

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -17,6 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 global $post;
+
+// Defense in depth: the listings query in get_job_listings() already excludes password-protected
+// posts and the AJAX/RSS dispatchers gate on browse capability, but theme overrides of this
+// template would bypass those checks. Re-assert here so any direct WP_Query consumer that picks
+// up this template can't surface protected or capability-restricted listings.
+if ( post_password_required( $post ) || ! job_manager_user_can_view_job_listing( $post->ID ) ) {
+	return;
+}
 ?>
 <li <?php job_listing_class(); ?> data-longitude="<?php echo esc_attr( $post->geolocation_long ); ?>" data-latitude="<?php echo esc_attr( $post->geolocation_lat ); ?>">
 	<a href="<?php the_job_permalink(); ?>">

--- a/templates/content-summary-job_listing.php
+++ b/templates/content-summary-job_listing.php
@@ -15,7 +15,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-global $job_manager;
+global $job_manager, $post;
+
+// Defense in depth — see content-job_listing.php for rationale.
+if ( post_password_required( $post ) || ! job_manager_user_can_view_job_listing( $post->ID ) ) {
+	return;
+}
 ?>
 
 <a href="<?php the_permalink(); ?>">

--- a/templates/content-widget-job_listing.php
+++ b/templates/content-widget-job_listing.php
@@ -14,6 +14,13 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+
+global $post;
+
+// Defense in depth — see content-job_listing.php for rationale.
+if ( post_password_required( $post ) || ! job_manager_user_can_view_job_listing( $post->ID ) ) {
+	return;
+}
 ?>
 <li <?php job_listing_class(); ?>>
 	<a href="<?php the_job_permalink(); ?>">

--- a/tests/php/tests/security/test_class.capability-restricted-listing-output.php
+++ b/tests/php/tests/security/test_class.capability-restricted-listing-output.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Regression tests covering AJAX, REST, RSS, and JSON-LD output paths when
+ * `job_manager_browse_job_listings_capability` / `job_manager_view_job_listing_capability`
+ * are configured: capability denial must apply to every public output path, not only the
+ * visible templates.
+ *
+ * @package wp-job-manager/tests
+ */
+
+class Tests_Capability_Restricted_Listing_Output extends WPJM_REST_TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		// Restrict browse + view to the `read` capability — anonymous users have no caps,
+		// so they must be denied across every public output path.
+		update_option( 'job_manager_browse_job_listings_capability', [ 'read' ] );
+		update_option( 'job_manager_view_job_listing_capability', [ 'read' ] );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_browse_job_listings_capability' );
+		delete_option( 'job_manager_view_job_listing_capability' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Ajax::get_listings
+	 */
+	public function test_ajax_get_listings_denies_anonymous_when_browse_cap_set() {
+		$this->factory->job_listing->create_many( 2 );
+		$this->logout();
+
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		ob_start();
+		WP_Job_Manager_Ajax::instance()->get_listings();
+		$payload = json_decode( (string) ob_get_clean(), true );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+
+		$this->assertIsArray( $payload );
+		$this->assertFalse( $payload['found_jobs'] );
+		$this->assertSame( '', $payload['html'] );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_REST_API::exclude_filled_from_query
+	 */
+	public function test_rest_collection_denies_anonymous_when_browse_cap_set() {
+		$this->factory->job_listing->create_many( 2 );
+		$this->logout();
+
+		$response = $this->get( '/wp/v2/job-listings' );
+		$this->assertResponseStatus( $response, 200 );
+		$this->assertSame( [], $response->get_data() );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_rss_feed_denies_anonymous_when_browse_cap_set() {
+		$this->factory->job_listing->create_many( 2 );
+		$this->logout();
+
+		$feed = $this->capture_job_feed();
+		$this->assertStringNotContainsString( '<item>', $feed );
+	}
+
+	/**
+	 * @covers ::wpjm_output_job_listing_structured_data
+	 *
+	 * The JSON-LD emitter runs from `wp_footer` and must honor the view-capability check
+	 * the visible template applies.
+	 */
+	public function test_jsonld_suppressed_when_view_cap_denies() {
+		$post_id = $this->factory->job_listing->create();
+		$this->logout();
+
+		$this->assertFalse( wpjm_output_job_listing_structured_data( $post_id ) );
+	}
+
+	/**
+	 * @covers ::wpjm_output_job_listing_structured_data
+	 *
+	 * Sanity: when capabilities allow the viewer (admin), structured data still emits.
+	 */
+	public function test_jsonld_still_emits_for_capable_viewer() {
+		$post_id = $this->factory->job_listing->create();
+		$this->login_as_admin();
+
+		$this->assertTrue( wpjm_output_job_listing_structured_data( $post_id ) );
+	}
+
+	/**
+	 * Captures the RSS feed output for the job_feed handler.
+	 *
+	 * Mirrors the helper in test_class.wp-job-manager-post-types.php.
+	 */
+	private function capture_job_feed() {
+		ob_start();
+		try {
+			@WP_Job_Manager_Post_Types::instance()->job_feed();
+			$out = ob_get_clean();
+		} catch ( Exception $e ) {
+			$out = ob_get_clean();
+			throw $e;
+		}
+		return (string) $out;
+	}
+}

--- a/tests/php/tests/security/test_class.password-protected-listing-rest.php
+++ b/tests/php/tests/security/test_class.password-protected-listing-rest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Regression tests covering the REST `job_listing` endpoints and the AJAX listing endpoint
+ * for password-protected listings: meta and identifying top-level fields must not surface,
+ * and the AJAX/REST collections must exclude protected listings.
+ *
+ * @package wp-job-manager/tests
+ */
+
+class Tests_Password_Protected_Listing_REST extends WPJM_REST_TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		// `WPJM_REST_TestCase::setUp` re-registers the post type but not its meta fields,
+		// which leaves $wp_meta_keys without the job_listing meta entries — REST then
+		// returns an empty `meta` block. Mirror the workaround used by
+		// tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php.
+		global $wp_meta_keys;
+		unset( $wp_meta_keys['post'][ \WP_Job_Manager_Post_Types::PT_LISTING ] );
+		WP_Job_Manager_Post_Types::instance()->register_meta_fields();
+	}
+
+	/**
+	 * @covers WP_Job_Manager_REST_API::prepare_job_listing
+	 */
+	public function test_rest_single_blanks_top_level_fields_for_password_protected() {
+		$post_id       = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'post_title'    => '[CONFIDENTIAL] Senior Engineer at InsiderCo',
+			]
+		);
+		// Attach a dummy thumbnail so core's REST controller emits the `wp:featuredmedia` link;
+		// without it the link is never registered and the assertion below would pass trivially.
+		$attachment_id = $this->factory->post->create( [ 'post_type' => 'attachment' ] );
+		set_post_thumbnail( $post_id, $attachment_id );
+		$this->logout();
+
+		$response = $this->get( "/wp/v2/job-listings/{$post_id}" );
+		$this->assertResponseStatus( $response, 200 );
+		$data = $response->get_data();
+
+		$this->assertSame( '', $data['title']['rendered'], 'Title must be blanked.' );
+		$this->assertArrayNotHasKey( 'link', $data, 'Link must be removed.' );
+		$this->assertSame( '', $data['slug'] ?? '', 'Slug must be blanked.' );
+		$this->assertSame( 0, (int) ( $data['featured_media'] ?? 0 ), 'Featured media must be cleared.' );
+		$this->assertArrayNotHasKey(
+			'https://api.w.org/featuredmedia',
+			$response->get_links(),
+			'Featured-media link relation must be removed so ?_embed cannot leak the attachment.'
+		);
+		$this->assertTrue( $data['content']['protected'] );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_REST_API::prepare_job_listing
+	 * @covers WP_Job_Manager_Post_Types::auth_check_can_view_job_listing
+	 */
+	public function test_rest_single_strips_sensitive_meta_for_password_protected() {
+		$post_id = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'meta_input'    => [
+					'_application'      => 'ceo-secret@insiderco.example',
+					'_company_name'     => 'InsiderCo Holdings',
+					'_company_tagline'  => 'private-tagline-PROJECT-MAGENTA',
+					'_company_website'  => 'https://insiderco.example/private-portal',
+					'_job_location'     => 'San Francisco - SECRET-WAREHOUSE-7',
+				],
+			]
+		);
+		$this->logout();
+
+		$response = $this->get( "/wp/v2/job-listings/{$post_id}" );
+		$this->assertResponseStatus( $response, 200 );
+		$meta = $response->get_data()['meta'] ?? [ 'unset' => true ];
+
+		// `prepare_job_listing` short-circuits the entire meta block when the listing is
+		// password-protected; an empty array is the contract.
+		$this->assertSame( [], $meta, 'All meta must be stripped for password-protected listings.' );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_REST_API::exclude_filled_from_query
+	 *
+	 * The REST collection must not return password-protected listings to anonymous viewers,
+	 * regardless of whether browse capability is configured.
+	 */
+	public function test_rest_collection_excludes_password_protected() {
+		$protected = $this->factory->job_listing->create( [ 'post_password' => 'secret' ] );
+		$public    = $this->factory->job_listing->create();
+		$this->logout();
+
+		$response = $this->get( '/wp/v2/job-listings' );
+		$ids      = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertNotContains( $protected, $ids );
+		$this->assertContains( $public, $ids );
+	}
+
+	/**
+	 * @covers ::get_job_listings
+	 * @covers WP_Job_Manager_Ajax::get_listings
+	 *
+	 * The AJAX endpoint must not surface password-protected listings even when called
+	 * with no keyword.
+	 */
+	public function test_ajax_no_keyword_excludes_password_protected() {
+		$protected = $this->factory->job_listing->create( [ 'post_password' => 'secret' ] );
+		$public    = $this->factory->job_listing->create();
+		$this->logout();
+
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		ob_start();
+		WP_Job_Manager_Ajax::instance()->get_listings();
+		$payload = json_decode( (string) ob_get_clean(), true );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+
+		$this->assertIsArray( $payload );
+		$html = (string) ( $payload['html'] ?? '' );
+		$this->assertStringNotContainsString( "post-{$protected}", $html );
+		$this->assertStringContainsString( "post-{$public}", $html );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_REST_API::prepare_job_listing
+	 *
+	 * Sanity / no regression: a normal published listing returns its title, link and a
+	 * populated meta block when the viewer is authorized. Mirrors the meta-presence pattern
+	 * used by tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php.
+	 */
+	public function test_rest_single_returns_full_data_for_normal_listing() {
+		$post_id = $this->factory->job_listing->create(
+			[ 'post_title' => 'Public Junior Coffee Taster' ]
+		);
+		$this->login_as_admin();
+
+		$response = $this->get( "/wp/v2/job-listings/{$post_id}" );
+		$this->assertResponseStatus( $response, 200 );
+		$data = $response->get_data();
+
+		$this->assertSame( 'Public Junior Coffee Taster', $data['title']['rendered'] );
+		$this->assertArrayHasKey( 'link', $data );
+		$this->assertNotEmpty( $data['meta'], 'Normal listings must still expose meta to authorized viewers.' );
+		$this->assertArrayHasKey( '_company_name', $data['meta'] );
+		$this->assertArrayHasKey( '_job_location', $data['meta'] );
+	}
+}

--- a/tests/php/tests/security/test_class.password-protected-listing-rest.php
+++ b/tests/php/tests/security/test_class.password-protected-listing-rest.php
@@ -145,4 +145,69 @@ class Tests_Password_Protected_Listing_REST extends WPJM_REST_TestCase {
 		$this->assertArrayHasKey( '_company_name', $data['meta'] );
 		$this->assertArrayHasKey( '_job_location', $data['meta'] );
 	}
+
+	/**
+	 * @covers WP_Job_Manager_Post_Types::gate_feed_query_for_listings
+	 *
+	 * The default core RSS feed scoped to `post_type=job_listing` (distinct from the custom
+	 * `job_feed` slug) must exclude password-protected listings. The custom job_feed already
+	 * sets `has_password=false` explicitly; this test covers the `pre_get_posts` gate that
+	 * applies to every other core feed slug routed at the post type.
+	 */
+	public function test_default_feed_query_excludes_password_protected() {
+		$query              = new \WP_Query();
+		$query->is_feed     = true;
+		$query->set( 'post_type', \WP_Job_Manager_Post_Types::PT_LISTING );
+		// `is_main_query()` returns true only when $query === $wp_the_query.
+		$GLOBALS['wp_the_query'] = $query;
+
+		\WP_Job_Manager_Post_Types::instance()->gate_feed_query_for_listings( $query );
+
+		$this->assertFalse(
+			$query->get( 'has_password' ),
+			'Default feed query for job_listing must set has_password=false.'
+		);
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Post_Types::gate_feed_query_for_listings
+	 *
+	 * When browse capability denies the viewer, the default feed query for `job_listing`
+	 * must short-circuit to an empty result (matching the AJAX / REST / job_feed gate).
+	 */
+	public function test_default_feed_query_short_circuits_when_browse_cap_denies() {
+		update_option( 'job_manager_browse_job_listings_capability', [ 'manage_options' ] );
+		$this->logout();
+
+		$query              = new \WP_Query();
+		$query->is_feed     = true;
+		$query->set( 'post_type', \WP_Job_Manager_Post_Types::PT_LISTING );
+		$GLOBALS['wp_the_query'] = $query;
+
+		\WP_Job_Manager_Post_Types::instance()->gate_feed_query_for_listings( $query );
+
+		$this->assertSame(
+			[ 0 ],
+			$query->get( 'post__in' ),
+			'Browse-cap-denied feed query must be forced to an empty result-set.'
+		);
+
+		delete_option( 'job_manager_browse_job_listings_capability' );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Post_Types::gate_feed_query_for_listings
+	 *
+	 * Sanity: non-job-listing feed queries (e.g. the standard post feed) are not touched.
+	 */
+	public function test_default_feed_query_leaves_non_job_listing_queries_alone() {
+		$query              = new \WP_Query();
+		$query->is_feed     = true;
+		$query->set( 'post_type', 'post' );
+		$GLOBALS['wp_the_query'] = $query;
+
+		\WP_Job_Manager_Post_Types::instance()->gate_feed_query_for_listings( $query );
+
+		$this->assertNotSame( false, $query->get( 'has_password' ) );
+	}
 }

--- a/tests/php/tests/security/test_class.password-protected-listing-search.php
+++ b/tests/php/tests/security/test_class.password-protected-listing-search.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Regression tests covering keyword search and the listings transient cache:
+ * password-protected listings must not surface to keyword search regardless of viewer
+ * auth state, and cached results must not cross auth boundaries.
+ *
+ * @package wp-job-manager/tests
+ */
+
+class Tests_Password_Protected_Listing_Search extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->disable_job_listing_cache();
+	}
+
+	public function tearDown(): void {
+		$this->disable_job_listing_cache();
+		parent::tearDown();
+	}
+
+	protected function disable_job_listing_cache() {
+		remove_filter( 'get_job_listings_cache_results', '__return_true' );
+		remove_filter( 'get_job_listings_cache_results', '__return_false' );
+		add_filter( 'get_job_listings_cache_results', '__return_false' );
+	}
+
+	protected function enable_job_listing_cache() {
+		remove_filter( 'get_job_listings_cache_results', '__return_false' );
+		remove_filter( 'get_job_listings_cache_results', '__return_true' );
+		add_filter( 'get_job_listings_cache_results', '__return_true' );
+	}
+
+	/**
+	 * @covers ::get_job_listings
+	 * @covers ::get_job_listings_keyword_search
+	 */
+	public function test_subscriber_keyword_search_excludes_password_protected() {
+		$protected = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'post_content'  => 'sentinel-ULTRAVIOLET protected description',
+			]
+		);
+		$public = $this->factory->job_listing->create(
+			[
+				'post_content' => 'sentinel-VANILLA public description',
+			]
+		);
+
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$this->login_as( $subscriber_id );
+
+		$results = get_job_listings( [ 'search_keywords' => 'ULTRAVIOLET' ] );
+		$ids     = wp_list_pluck( $results->posts, 'ID' );
+
+		$this->assertNotContains(
+			$protected,
+			$ids,
+			'Subscriber keyword search must not surface password-protected listings.'
+		);
+	}
+
+	/**
+	 * @covers ::get_job_listings
+	 * @covers ::get_job_listings_keyword_search
+	 */
+	public function test_anonymous_keyword_search_excludes_password_protected() {
+		$protected = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'post_content'  => 'sentinel-INDIGO protected description',
+			]
+		);
+		$this->logout();
+
+		$results = get_job_listings( [ 'search_keywords' => 'INDIGO' ] );
+		$ids     = wp_list_pluck( $results->posts, 'ID' );
+
+		$this->assertNotContains( $protected, $ids );
+	}
+
+	/**
+	 * @covers ::get_job_listings
+	 *
+	 * Sanity / no-regression: public listings still match by keyword.
+	 */
+	public function test_keyword_search_still_returns_public_listings() {
+		$public = $this->factory->job_listing->create(
+			[
+				'post_content' => 'sentinel-CITRINE public description',
+			]
+		);
+		$this->logout();
+
+		$results = get_job_listings( [ 'search_keywords' => 'CITRINE' ] );
+		$ids     = wp_list_pluck( $results->posts, 'ID' );
+
+		$this->assertContains( $public, $ids );
+	}
+
+	/**
+	 * @covers ::get_job_listings
+	 *
+	 * Sanity / no-regression: a search with no matching keyword returns an empty result-set.
+	 */
+	public function test_keyword_search_with_no_match_returns_empty() {
+		$this->factory->job_listing->create();
+		$this->logout();
+
+		$results = get_job_listings( [ 'search_keywords' => 'never-going-to-match-MOSS' ] );
+
+		$this->assertEmpty( wp_list_pluck( $results->posts, 'ID' ) );
+	}
+
+	/**
+	 * @covers ::get_job_listings
+	 *
+	 * Cache amplification: when an authenticated user populates the cache for a keyword,
+	 * a subsequent anonymous request for the same keyword must not read the authed result.
+	 */
+	public function test_cache_key_per_user_blocks_amplification() {
+		$protected = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'post_content'  => 'sentinel-MERIDIAN protected description',
+			]
+		);
+
+		$this->enable_job_listing_cache();
+
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$this->login_as( $subscriber_id );
+		// Prime the cache as the subscriber.
+		get_job_listings( [ 'search_keywords' => 'MERIDIAN' ] );
+
+		// Read as anonymous on the same keyword.
+		$this->logout();
+		$anon_results = get_job_listings( [ 'search_keywords' => 'MERIDIAN' ] );
+		$anon_ids     = wp_list_pluck( $anon_results->posts, 'ID' );
+
+		$this->assertNotContains(
+			$protected,
+			$anon_ids,
+			'Anonymous request must not read a cached result populated by a different user.'
+		);
+	}
+}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -69,6 +69,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			'update_post_meta_cache' => false,
 			'cache_results'          => false,
 			'fields'                 => $args['fields'],
+			'has_password'           => false,
 		];
 
 		if ( $args['posts_per_page'] < 0 ) {
@@ -222,7 +223,8 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		// Cache results.
 		if ( apply_filters( 'get_job_listings_cache_results', $should_cache ) ) {
 			$to_hash            = wp_json_encode( $query_args );
-			$query_args_hash    = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
+			$auth_state         = is_user_logged_in() ? 'u' . get_current_user_id() : 'anon';
+			$query_args_hash    = 'jm_' . md5( $to_hash . JOB_MANAGER_VERSION . $auth_state ) . WP_Job_Manager_Cache_Helper::get_transient_version( 'get_job_listings' );
 			$result             = false;
 			$cached_query_posts = get_transient( $query_args_hash );
 			if ( is_string( $cached_query_posts ) ) {
@@ -468,9 +470,6 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 
 		if ( ! empty( $new_search ) ) {
 			$new_search = " AND ({$new_search}) ";
-			if ( ! is_user_logged_in() ) {
-				$new_search .= " AND ({$wpdb->posts}.post_password = '') ";
-			}
 		} else {
 			return $search;
 		}

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -337,10 +337,13 @@ function wpjm_output_job_listing_structured_data( $post = null ) {
 		return false;
 	}
 
-	// Only show structured data for un-filled, published, and non-password-protected job listings.
+	// Only show structured data for un-filled, published, non-password-protected listings the
+	// viewer is allowed to see; the JSON-LD emitter must honor the same view-capability check
+	// the visible template applies.
 	$output_structured_data = ! is_position_filled( $post )
 		&& 'publish' === $post->post_status
-		&& ! post_password_required( $post );
+		&& ! post_password_required( $post )
+		&& job_manager_user_can_view_job_listing( $post->ID );
 
 	/**
 	 * Filter if we should output structured data.


### PR DESCRIPTION
## Summary

Tightens password-protected and capability-restricted enforcement across the public output paths that produce job listing data: AJAX, REST, RSS (custom and core), JSON-LD, the listing-card templates, and the Recent / Featured Jobs widgets. Previously these paths could surface listing data the visible templates already denied.

## Changes

**`wp-job-manager-functions.php`**
- `get_job_listings()` now adds `'has_password' => false` to its default `$query_args`, so password-protected listings are excluded at the WP_Query layer for every consumer.
- The listings transient cache key now folds in viewer auth state (`'u' . get_current_user_id()` for logged-in users, `'anon'` otherwise) so cached payloads don't cross auth boundaries.
- `get_job_listings_keyword_search()` no longer adds a duplicative `post_password = ''` SQL clause — the query-level `has_password=false` covers all viewers.

**`includes/class-wp-job-manager-cache-helper.php`**
- Adds option-event hooks (add/update/delete) on `job_manager_browse_job_listings_capability` and `job_manager_view_job_listing_capability` that bump the `get_job_listings` transient version, so cached listings don't outlive the policy that produced them.

**`includes/class-wp-job-manager-post-types.php`**
- `job_feed()` (custom RSS) gates on browse capability with an empty feed, and adds `has_password=false` to its query.
- New `gate_feed_query_for_listings()` on `pre_get_posts` extends the same gate to every core feed slug scoped to `post_type=job_listing` (`?feed=rss2&post_type=job_listing`, `?feed=atom&post_type=job_listing`, etc.). Without this, anonymous viewers could see a password-protected listing's title, permalink, slug, and pubdate via the default RSS feed even with the browse-capability option configured.
- `get_job_listing_fields()` default `auth_view_callback` swaps from `null` to a new `auth_check_can_view_job_listing` static method that returns false on password-protected or view-cap-denied listings; meta fields without an explicit override now flow through this gate.

**`includes/class-wp-job-manager-rest-api.php`**
- `prepare_job_listing()` blanks top-level fields (`title.rendered`, `link`, `slug`, `featured_media`) and removes the `wp:featuredmedia` link relation when the viewer can't unlock the listing or is denied by view capability. The `meta` block is emptied in the same path.
- `exclude_filled_from_query()` short-circuits the REST collection (`post__in = [0]`) when browse capability denies the viewer, and adds `has_password=false` unconditionally.

**`includes/class-wp-job-manager-ajax.php`**
- `get_listings()` returns a success-shaped empty JSON payload when browse capability denies the viewer, matching what the JS client expects.

**`includes/widgets/class-wp-job-manager-widget-recent-jobs.php`, `…-widget-featured-jobs.php`**
- Both widgets now early-return from `widget()` ahead of `get_cached_widget()` when `job_manager_user_can_browse_job_listings()` denies the viewer. Without this, the widgets bypassed the browse-capability gate the AJAX / REST / RSS paths apply, and could be served from `WP_Widget`'s built-in cache after a policy change.

**`wp-job-manager-template.php`**
- `wpjm_output_job_listing_structured_data()` now also requires `job_manager_user_can_view_job_listing()`; the `wp_footer` JSON-LD emitter honors the same view-capability check the visible template applies.

**`templates/content-*-job_listing.php`**
- Adds a defense-in-depth password + view-capability gate at the top of each listing-card template so theme overrides can't bypass the per-post checks.

**`tests/php/tests/security/`** (new + extended)
- Test classes covering: keyword search + transient cache for password-protected listings, AJAX/REST/RSS/JSON-LD denial under browse / view capability configuration, REST single + collection behavior for password-protected listings (including verification that the `wp:featuredmedia` link relation is removed), and the new `pre_get_posts` feed gate (default feed excludes password-protected, browse-cap-denied feed short-circuits, non-job-listing feed queries are not affected).

## Manual test results

Verified against `make up` / wp-env at `http://localhost:8888` with subscriber registration enabled:

- Original PoC closed: subscriber AJAX `?jm-ajax=get_listings&search_keywords=ULTRAVIOLET` → `found_jobs=False`; all six oracle tokens (`ULTRAVIOLET`, `InsiderCo`, `MAGENTA`, `WAREHOUSE-7`, `ceo-secret`, `tagline`) return `ok`.
- Custom `?feed=job_feed&search_keywords=ULTRAVIOLET` → 0 items.
- Default `?feed=rss2&post_type=job_listing` → public listings present, password-protected listings absent.
- REST single (`/wp/v2/job-listings/<protected_id>?_embed=1`) returns blanked title/link/slug/featured_media/meta and no `wp:featuredmedia` link relation.
- REST collection excludes password-protected, includes public.
- With `job_manager_browse_job_listings_capability=["read"]`: anonymous AJAX, REST collection, custom `job_feed`, default `rss2&post_type=job_listing`, and Recent Jobs widget all return empty / no output. Subscriber Alice (has `read`) still sees listings.
- Cache amplification fixed: subscriber priming the cache for a keyword does not surface password-protected listings on a subsequent anonymous request (separate transient slots verified in `wp_options`).

## Known follow-ups

- #2941 — REST `content.rendered` / `excerpt.rendered` are not blanked for view-capability-denied (non-password-protected) listings. Pre-existing on trunk; this PR closes most of the gap but leaves the body fields for a follow-up.

### Release Notes

* Fixes a series of information disclosure issues affecting password-protected and capability-restricted job listings.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 463 tests, 1891 assertions, 3 skipped (geocode, same as baseline)
- [x] Manual: REST single endpoint for a password-protected listing returns blanked title/link/slug/featured_media and empty meta; `?_embed=1` does not surface the attachment.
- [x] Manual: with browse capability set, AJAX `get_listings`, REST collection, RSS `job_feed`, default `?feed=rss2&post_type=job_listing`, and Recent Jobs widget return empty payloads to denied viewers; JSON-LD does not emit on the single-listing footer.
- [x] Manual: with no capability config (default), public listings still surface to anonymous viewers in AJAX / REST / RSS (custom and default) / JSON-LD / widgets, and the keyword search returns public listings.
- [x] Manual: cached listings populated by an authenticated user do not surface to a subsequent anonymous request on the same query.



<!-- wpjm:plugin-zip -->
----

| Plugin build for cc2d8a0c66103cb1d74cf0572e4a25fbad7f2982 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2940-cc2d8a0c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2940-cc2d8a0c)             |

<!-- /wpjm:plugin-zip -->



