### PR TITLE
Add AI agent skills configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,12 @@ Two-axis mapping: `[Status] Accepted` (approved in principle) plus `ready-for-ag
 ### Domain docs
 
 Single-context (`CONTEXT.md` + `docs/adr/` at repo root). See `docs/agents/domain.md`.
+
+## Contributor conventions
+
+For human contributor docs that also bind agents — branch naming, PR style, coding standards, test setup, localisation — read:
+
+- `docs/CONTRIBUTING.md` — getting started, coding guidelines, PR review
+- `readme.md` — WordPress.org-facing plugin readme
+- `tests/README.md` — unit test setup and conventions
+- [Git Flow and PR Review wiki](https://github.com/Automattic/WP-Job-Manager/wiki/Our-Git-Flow-and-PR-Review)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ GitHub Issues on `Automattic/WP-Job-Manager`. See `docs/agents/issue-tracker.md`
 
 ### Triage labels
 
-Default vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+Two-axis mapping: `[Status] Accepted` (approved in principle) plus `ready-for-agent` / `ready-for-human` (verified current and self-contained). See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `Automattic/WP-Job-Manager`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context (`CONTEXT.md` + `docs/adr/` at repo root). See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -15,7 +15,12 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 ## When a skill says "publish to the issue tracker"
 
-Create a GitHub issue.
+Create a GitHub issue. Follow `.github/ISSUE_TEMPLATE.md` — that file is the canonical bug-report shape (Steps to Reproduce, What I Expected, What Happened Instead, PHP / WordPress / WP Job Manager Version, Browser / OS Version, Screenshot / Video, Context / Source). For non-bug issues (proposals, cleanup, questions) the template structure is a useful starting point; drop sections that don't apply.
+
+**Don't file these as issues:**
+
+- **End-user support questions** — direct to https://wordpress.org/support/plugin/wp-job-manager.
+- **Security vulnerabilities** — direct to https://hackerone.com/automattic. Never paste exploit details into a public GitHub issue.
 
 ## When a skill says "fetch the relevant ticket"
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -4,7 +4,7 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 
 | Canonical role    | Label in this repo                       | Notes                                                                                        |
 | ----------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `needs-triage`    | *(no label — unlabeled)*                 | This repo doesn't carry an explicit "needs triage" label. Treat any issue with no `[Status] *` label as needing triage. |
+| `needs-triage`    | `needs-triage` *or* unlabeled            | Apply `needs-triage` to **new** issues only. Old unlabeled issues count as needing triage too but are not retro-labeled (would be too noisy). |
 | `needs-info`      | `[Status] Needs Author Reply`            | Exact fit.                                                                                   |
 | `ready-for-agent` | `ready-for-agent` + `[Status] Accepted`  | Both labels required (see below).                                                            |
 | `ready-for-human` | `ready-for-human` + `[Status] Accepted`  | Both labels required (see below).                                                            |
@@ -43,8 +43,18 @@ The triage skill may also want to apply or read these orthogonal labels:
 
 ## Listing untriaged issues
 
-To find issues that need triage (no `[Status] *` label):
+Two populations to check:
 
-```sh
-gh issue list --state open --search 'no:label OR -label:"[Status] Accepted" -label:"[Status] Needs Author Reply" -label:"[Status] In Progress" -label:"[Status] Won't Fix"'
-```
+1. **New issues explicitly marked for triage** — filter by the `needs-triage` label:
+
+   ```sh
+   gh issue list --state open --label "needs-triage"
+   ```
+
+2. **Old unlabeled issues** — anything open with no `[Status] *` label and no `needs-triage`:
+
+   ```sh
+   gh issue list --state open --search 'no:label OR (-label:"needs-triage" -label:"[Status] Accepted" -label:"[Status] Needs Author Reply" -label:"[Status] In Progress" -label:"[Status] Won't Fix")'
+   ```
+
+   Don't bulk-apply `needs-triage` to these — that generates notification noise on every subscriber.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,15 +1,50 @@
 # Triage Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker (https://github.com/Automattic/WP-Job-Manager/labels).
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+| Canonical role    | Label in this repo                       | Notes                                                                                        |
+| ----------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `needs-triage`    | *(no label — unlabeled)*                 | This repo doesn't carry an explicit "needs triage" label. Treat any issue with no `[Status] *` label as needing triage. |
+| `needs-info`      | `[Status] Needs Author Reply`            | Exact fit.                                                                                   |
+| `ready-for-agent` | `ready-for-agent` + `[Status] Accepted`  | Both labels required (see below).                                                            |
+| `ready-for-human` | `ready-for-human` + `[Status] Accepted`  | Both labels required (see below).                                                            |
+| `wontfix`         | `[Status] Won't Fix`                     | Exact fit.                                                                                   |
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string(s) from this table.
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+## Two-axis readiness
+
+`[Status] Accepted` and the `ready-for-*` labels are **orthogonal**:
+
+- **`[Status] Accepted`** means a maintainer agreed the issue is real and a fix would be merged.
+- **`ready-for-agent` / `ready-for-human`** mean someone has *recently* re-read the issue and confirmed it is:
+  - still relevant (some accepted issues are years old and stale),
+  - self-contained in the issue body (context not spread across long comment threads),
+  - actionable as written.
+
+An accepted issue is **not** ready to pick up until one of the `ready-for-*` labels is added.
+
+| Apply when                                                                       | Use                |
+| -------------------------------------------------------------------------------- | ------------------ |
+| Issue body fully summarises scope; minimal code-archaeology needed                | `ready-for-agent`  |
+| Implementation needs human judgement (UX, edge cases, customer-facing decisions)  | `ready-for-human`  |
+
+If an accepted issue can't be brought up to either bar (stale, vague, scope drifted), leave it without a `ready-for-*` label and add a comment explaining why — or close it.
+
+## Other labels worth knowing
+
+The triage skill may also want to apply or read these orthogonal labels:
+
+- **Priority**: `[Pri] Critical`, `[Pri] High`, `[Pri] Normal`, `[Pri] Low`
+- **Type**: `Bug`, `Enhancement`, `[Type] Proposal`, `[Type] Question`, `[Type] Cleanup and Documentation`, `[Type] Maintenance`, `[Type] Good First Bug`
+- **Source**: `Customer Report` (issues reported via Happiness)
+- **Status (additional)**: `[Status] In Progress`, `[Status] Needs Documentation`, `[Status] Needs Design`
+- **Area**: `Hooks`, `Templates`, `Addon`, `Third-party Conflict`, `Promoted Jobs`, `Stats`
+
+## Listing untriaged issues
+
+To find issues that need triage (no `[Status] *` label):
+
+```sh
+gh issue list --state open --search 'no:label OR -label:"[Status] Accepted" -label:"[Status] Needs Author Reply" -label:"[Status] In Progress" -label:"[Status] Won't Fix"'
+```


### PR DESCRIPTION
## Summary

Scaffold the per-repo configuration that AI coding-agent skills expect.

**Files added at the repo root**

- `AGENTS.md` — source of truth for AI agent instructions, with an `## Agent skills` block pointing at the three docs below. Also cross-references `docs/CONTRIBUTING.md`, `readme.md`, `tests/README.md`, and the Git Flow wiki so agents pick up human contributor conventions.
- `CLAUDE.md` — single-line `@AGENTS.md` import shim so Claude Code picks up the same content.

**Files added under `docs/agents/`**

- `issue-tracker.md` — uses the `gh` CLI; new issues follow `.github/ISSUE_TEMPLATE.md`; excludes user-support questions (forum) and security reports (HackerOne) from the GitHub tracker.
- `triage-labels.md` — maps the five canonical triage roles to this repo's actual labels using a **two-axis model**:
  - `[Status] Accepted` (approved in principle) is orthogonal to `ready-for-agent` / `ready-for-human` (verified current, self-contained, actionable). An issue needs both before it should be picked up.
  - `needs-info` → `[Status] Needs Author Reply`
  - `wontfix` → `[Status] Won't Fix`
  - `needs-triage` applies prospectively to new issues; old unlabeled issues are also untriaged but **not retro-labeled** to avoid subscriber notification noise.
- `domain.md` — single-context layout for `CONTEXT.md` / `docs/adr/` (created lazily by `/grill-with-docs` when terms or decisions actually resolve).

## Repo-level changes outside this PR

Three labels created on `Automattic/WP-Job-Manager`:

- `needs-triage` (yellow) — new issue awaiting maintainer evaluation
- `ready-for-agent` (green) — accepted, self-contained, current; AFK agent can pick up
- `ready-for-human` (blue) — accepted, current; needs human judgement during implementation

## Test plan

- [ ] Confirm `CLAUDE.md` / `AGENTS.md` render correctly on GitHub
- [ ] Verify Claude Code resolves `@AGENTS.md` from `CLAUDE.md`
- [ ] Sanity-check the untriaged-issues `gh issue list` query in `docs/agents/triage-labels.md`


<!-- wpjm:plugin-zip -->
----

| Plugin build for 9569cabc065415254917bc6a1ee27eddf2572fa7 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2944-9569cabc.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2944-9569cabc)             |

<!-- /wpjm:plugin-zip -->


