### PR TITLE
Harden submit-form session cookies

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -50,8 +50,6 @@
     </NullableReturnStatement>
     <UndefinedConstant>
       <code>COOKIEPATH</code>
-      <code>COOKIEPATH</code>
-      <code>COOKIE_DOMAIN</code>
       <code>COOKIE_DOMAIN</code>
     </UndefinedConstant>
   </file>
@@ -279,8 +277,6 @@
   <file src="includes/class-wp-job-manager.php">
     <UndefinedConstant>
       <code>COOKIEPATH</code>
-      <code>COOKIEPATH</code>
-      <code>COOKIE_DOMAIN</code>
       <code>COOKIE_DOMAIN</code>
       <code>WP_LANG_DIR</code>
     </UndefinedConstant>
@@ -318,8 +314,6 @@
       <code><![CDATA['post_parent=' . $this->job_id . '&post_type=attachment&fields=ids&numberposts=-1']]></code>
       <code>\WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY</code>
       <code>\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE</code>
-      <code>false</code>
-      <code>false</code>
     </InvalidArgument>
     <InvalidDocblock>
       <code>class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {</code>
@@ -333,8 +327,6 @@
     </TypeDoesNotContainType>
     <UndefinedConstant>
       <code>COOKIEPATH</code>
-      <code>COOKIEPATH</code>
-      <code>COOKIE_DOMAIN</code>
       <code>COOKIE_DOMAIN</code>
       <code>WP_CONTENT_DIR</code>
       <code>WP_CONTENT_URL</code>

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -100,8 +100,18 @@ abstract class WP_Job_Manager_Form {
 			get_post_meta( sanitize_text_field( wp_unslash( $_COOKIE['wp-job-manager-submitting-job-id'] ) ), '_submitting_key', true ) === $_COOKIE['wp-job-manager-submitting-job-key']
 		) {
 			delete_post_meta( sanitize_text_field( wp_unslash( $_COOKIE['wp-job-manager-submitting-job-id'] ) ), '_submitting_key' );
-			setcookie( 'wp-job-manager-submitting-job-id', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-			setcookie( 'wp-job-manager-submitting-job-key', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+
+			$cookie_options = [
+				'expires'  => time() - 3600,
+				'path'     => COOKIEPATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => is_ssl(),
+				'httponly' => true,
+				'samesite' => 'Lax',
+			];
+
+			setcookie( 'wp-job-manager-submitting-job-id', '', $cookie_options );
+			setcookie( 'wp-job-manager-submitting-job-key', '', $cookie_options );
 			wp_safe_redirect( remove_query_arg( [ 'new', 'key', 'job_manager_form' ] ) );
 			exit;
 		}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -297,11 +297,20 @@ class WP_Job_Manager {
 	 * Cleanup job posting cookies.
 	 */
 	public function cleanup_job_posting_cookies() {
+		$cookie_options = [
+			'expires'  => 0,
+			'path'     => COOKIEPATH,
+			'domain'   => COOKIE_DOMAIN,
+			'secure'   => is_ssl(),
+			'httponly' => true,
+			'samesite' => 'Lax',
+		];
+
 		if ( isset( $_COOKIE['wp-job-manager-submitting-job-id'] ) ) {
-			setcookie( 'wp-job-manager-submitting-job-id', '', 0, COOKIEPATH, COOKIE_DOMAIN, false );
+			setcookie( 'wp-job-manager-submitting-job-id', '', $cookie_options );
 		}
 		if ( isset( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
-			setcookie( 'wp-job-manager-submitting-job-key', '', 0, COOKIEPATH, COOKIE_DOMAIN, false );
+			setcookie( 'wp-job-manager-submitting-job-key', '', $cookie_options );
 		}
 	}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -913,10 +913,19 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$this->job_id = wp_insert_post( $job_data );
 
 			if ( ! headers_sent() ) {
-				$submitting_key = uniqid();
+				$submitting_key = wp_generate_password( 32, false );
 
-				setcookie( 'wp-job-manager-submitting-job-id', $this->job_id, false, COOKIEPATH, COOKIE_DOMAIN, false );
-				setcookie( 'wp-job-manager-submitting-job-key', $submitting_key, false, COOKIEPATH, COOKIE_DOMAIN, false );
+				$cookie_options = [
+					'expires'  => 0,
+					'path'     => COOKIEPATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => is_ssl(),
+					'httponly' => true,
+					'samesite' => 'Lax',
+				];
+
+				setcookie( 'wp-job-manager-submitting-job-id', $this->job_id, $cookie_options );
+				setcookie( 'wp-job-manager-submitting-job-key', $submitting_key, $cookie_options );
 
 				update_post_meta( $this->job_id, '_submitting_key', $submitting_key );
 			}


### PR DESCRIPTION
## Summary

Hardening for the cookie-based "resume an in-progress submission" flow on the frontend job submission form.

- Strengthen the random token used for resuming a draft.
- Set `HttpOnly`, `SameSite=Lax`, and `Secure` (under HTTPS) on the related cookies.
- Apply matching attributes at the cookie-deletion sites so deletion still takes effect.

Details intentionally omitted; happy to discuss privately.

## Test plan

- [ ] Start a fresh guest submission; verify both `Set-Cookie` headers include `HttpOnly` and `SameSite=Lax` (and `Secure` over HTTPS).
- [ ] Token cookie value is 32 alphanumerics and matches the `_submitting_key` post meta.
- [ ] Closing the tab and revisiting the submission page still resumes the draft.
- [ ] Visiting the submission page with `?new=1` clears both cookies from the browser.
- [ ] Cross-origin POST to the submission endpoint does not carry the resume cookies (browser strips them due to `SameSite=Lax`); existing draft is not modified.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 6750502dbf2e9f4df6fc0dc64ed7168ee02a403e <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2945-6750502d.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2945-6750502d)             |

<!-- /wpjm:plugin-zip -->


