### PR TITLE
Fix Job Dashboard actions menu on Safari

### DIFF
--- a/assets/js/job-dashboard.js
+++ b/assets/js/job-dashboard.js
@@ -11,6 +11,35 @@ function setupEvents( root ) {
 		.forEach( el => el.addEventListener( 'click', confirmDelete ) );
 }
 
+function setupActionsMenu() {
+	document.addEventListener( 'pointerdown', event => {
+		document.querySelectorAll( 'details.jm-ui-actions-menu[open]' ).forEach( menu => {
+			if ( ! menu.contains( event.target ) ) {
+				menu.open = false;
+			}
+		} );
+	} );
+
+	document.addEventListener( 'keydown', event => {
+		if ( event.key !== 'Escape' ) {
+			return;
+		}
+		document.querySelectorAll( 'details.jm-ui-actions-menu[open]' ).forEach( menu => {
+			menu.open = false;
+			menu.querySelector( 'summary' )?.focus();
+		} );
+	} );
+
+	window.addEventListener( 'pageshow', event => {
+		if ( ! event.persisted ) {
+			return;
+		}
+		document.querySelectorAll( 'details.jm-ui-actions-menu[open]' ).forEach( menu => {
+			menu.open = false;
+		} );
+	} );
+}
+
 function confirmDelete( event ) {
 	// eslint-disable-next-line no-alert
 	if ( ! window.confirm( i18nConfirmDelete ) ) {
@@ -80,6 +109,7 @@ function setupStatsOverlay() {
 
 domReady( () => {
 	setupEvents( document );
+	setupActionsMenu();
 
 	if ( statsEnabled ) {
 		setupStatsOverlay();

--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -154,12 +154,10 @@ class UI_Elements {
 	 * @return string Actions menu HTML.
 	 */
 	public static function actions_menu( $content ) {
-		$label = __( 'Actions', 'wp-job-manager' );
-
-		$close = esc_attr( 'event.currentTarget.contains(event.relatedTarget) || setTimeout(() => this.open = false, 100 )' );
+		$label = esc_attr__( 'Actions', 'wp-job-manager' );
 
 		return <<<HTML
-<details class="jm-ui-actions-menu" onfocusout="{$close}">
+<details class="jm-ui-actions-menu">
 	<summary tabindex="0" class="jm-ui-action-menu__open-button jm-ui-button--icon"
 		aria-label="{$label}">
 		<span class="jm-ui-button__icon"></span>


### PR DESCRIPTION
## Summary

- Drop the inline `onfocusout` + 100 ms setTimeout pattern on the `<details>` actions menu that ate clicks on Safari.
- Close the menu from `job-dashboard.js` instead: outside `pointerdown`, Escape (with focus return), and bfcache restore.

Fixes #2832

## Why this fixes Safari

The previous close was driven by `focusout` on the `<details>`, with a 100 ms timeout to allow a click inside to register first. Safari doesn't reliably focus elements on click (notably `<summary>` and inner `<a>`), so the relatedTarget check failed and the menu closed before the action link's navigation could fire. Replacing it with a document-level `pointerdown` outside-click and an Escape handler removes the focus dependency entirely.

The `pageshow` + `event.persisted` handler covers Safari's bfcache: previously a menu left open before clicking Edit would still be open after pressing Back.

## Test plan

- [x] Safari: open three-dot menu, click each action — Edit / Mark Filled / Duplicate / Renew / Delete fire on first click
- [x] Safari: open menu, click Edit, press Back — menu is closed on return
- [x] Chrome / Firefox: no regression
- [x] Keyboard: Tab focuses summary, Enter opens, Esc closes and returns focus to the toggle
- [x] Click outside the menu closes it
- [x] `make lint` passes

<!-- wpjm:plugin-zip -->
----

| Plugin build for 7d94ea60dcaf94b4ad777bace5f8b48642b531a1 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2947-7d94ea60.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2947-7d94ea60)             |

<!-- /wpjm:plugin-zip -->
