### PR TITLE
Add Makefile release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,17 @@ lint-fix: ## Auto-fix PHP CodeSniffer issues
 build: ## Build plugin zip
 	npm run build
 
+## Release
+release: ## Prepare release PR (usage: make release VERSION=2.4.2)
+	$(check_node)
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make release VERSION=2.4.2"; \
+		exit 1; \
+	fi
+	npm run release $(VERSION)
+
 ## Help
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: install up down destroy logs test-up test-down test lint lint-fix build help
+.PHONY: install up down destroy logs test-up test-down test lint lint-fix build release help


### PR DESCRIPTION
## Summary

Adds a `release` target to the Makefile that wraps `npm run release`, so the release entry point is discoverable via `make help` alongside the other workflows (build, test, lint, env).

Usage:

```
make release VERSION=2.4.2
```

The target errors out with a usage message if `VERSION` is missing, and runs the same Node-version check as the other targets.

## Test plan

- [x] `make help` lists `release` under a `Release` section
- [x] `make release` (no `VERSION`) prints usage and exits non-zero
- [ ] `make release VERSION=…` invokes `npm run release …` and hands off to `scripts/prepare-release.mjs` interactively

<!-- wpjm:plugin-zip -->
----

| Plugin build for 1b4ec265b60cbb8b7fc4b729e6bcf27ecd076e96 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2948-1b4ec265.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2948-1b4ec265)             |

<!-- /wpjm:plugin-zip -->
