### PR TITLE
Fix release script bugs and trim CI test matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -53,7 +53,7 @@ jobs:
         # plugin's declared floor; 8.0–8.2 are dropped as they're either EOL
         # or security-only and a break on those would also surface against
         # 7.4 or 8.3. PHP 8.4 coverage is pending bootstrap modernisation —
-        # see the follow-up issue.
+        # see https://github.com/Automattic/WP-Job-Manager/issues/2950.
         include:
           - { wp: '6.4', php: '7.4', wpmu: 0 }
           - { wp: '6.9', php: '8.3', wpmu: 0 }

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,15 +48,15 @@ jobs:
       max-parallel: 10
       matrix:
         # Targeted matrix rather than full WP × PHP cartesian product. Covers
-        # the declared compatibility floor, the WP-recommended PHP version,
-        # and the newest actively-supported PHP release. PHP 7.4 (EOL Nov 2022)
-        # is kept only as a smoke test against the plugin's declared floor;
-        # 8.0–8.2 are dropped as they're either EOL or security-only and a
-        # break on those would also surface against 7.4 or 8.3.
+        # the declared compatibility floor and the WP-recommended PHP version.
+        # PHP 7.4 (EOL Nov 2022) is kept only as a smoke test against the
+        # plugin's declared floor; 8.0–8.2 are dropped as they're either EOL
+        # or security-only and a break on those would also surface against
+        # 7.4 or 8.3. PHP 8.4 coverage is pending bootstrap modernisation —
+        # see the follow-up issue.
         include:
           - { wp: '6.4', php: '7.4', wpmu: 0 }
           - { wp: '6.9', php: '8.3', wpmu: 0 }
-          - { wp: '6.9', php: '8.4', wpmu: 0 }
     env:
       WP_VERSION: ${{ matrix.wp }}
       PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,9 +47,16 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        wp: [ '6.4', '6.5', '6.6', '6.7', '6.8', '6.9' ]
-        wpmu: [ 0 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        # Targeted matrix rather than full WP × PHP cartesian product. Covers
+        # the declared compatibility floor, the WP-recommended PHP version,
+        # and the newest actively-supported PHP release. PHP 7.4 (EOL Nov 2022)
+        # is kept only as a smoke test against the plugin's declared floor;
+        # 8.0–8.2 are dropped as they're either EOL or security-only and a
+        # break on those would also surface against 7.4 or 8.3.
+        include:
+          - { wp: '6.4', php: '7.4', wpmu: 0 }
+          - { wp: '6.9', php: '8.3', wpmu: 0 }
+          - { wp: '6.9', php: '8.4', wpmu: 0 }
     env:
       WP_VERSION: ${{ matrix.wp }}
       PHP_VERSION: ${{ matrix.php }}

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -3,6 +3,8 @@
  */
 import { config } from 'dotenv';
 import fs from 'fs';
+import os from 'node:os';
+import path from 'node:path';
 import process from 'node:process';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
@@ -228,8 +230,11 @@ function updateVersionInFile( filename ) {
 function replaceNextVersionPlaceholder() {
 	console.log( `Replacing next version placeholder with ${ version } ...` );
 	execSync( `bash scripts/replace-next-version-tag.sh ${ version }` );
+	// Stage only modifications to tracked files. The replacer rewrites existing source
+	// files in place, so `git add -u` is sufficient and avoids sweeping in unrelated
+	// untracked files that may be in the working tree.
 	execSync(
-		`git add .`,
+		`git add -u`,
 	);
 }
 
@@ -278,7 +283,7 @@ function buildReleaseNotes() {
 
 	let changelog = prs.map( ( pr ) => {
 		const body              = pr.body;
-		const changelogSections = body.match( /### Release Notes([\S\s]*?)(?:###|<!--|$)/ );
+		const changelogSections = body.match( /### Release Notes([\S\s]*?)(?:\n#{1,6} |\n<!--|$)/ );
 
 		if ( ! changelogSections ) {
 			return `* ${ pr.title } (#${ pr.number })`;
@@ -311,14 +316,20 @@ function createPR( changelog ) {
 
 	const title = `Release ${ pluginName } ${ version }`;
 
-	let body = prTemplate( { changelog, version } );
-	body     = body
-		.replace( '"', '\"' )
-		.replace( '`', '\`' )
+	const body = prTemplate( { changelog, version } );
 
-	const prLink = execSync( `gh pr create -R ${ plugin.repo } -B trunk -H ${ releaseBranch } --assignee @me --base trunk --title "${ title }" --body "${ body }"` );
-	execSync( `open ${ prLink }` );
-	console.log( `PR: ${ prLink }` );
+	// Pass the body via a temp file so backticks, quotes and other shell metacharacters
+	// inside changelog entries can't be interpreted by the shell when invoking gh.
+	const bodyFile = path.join( os.tmpdir(), `release-pr-body-${ pluginSlug }-${ version }.md` );
+	fs.writeFileSync( bodyFile, body, 'utf-8' );
+
+	try {
+		const prLink = execSync( `gh pr create -R ${ plugin.repo } -B trunk -H ${ releaseBranch } --assignee @me --base trunk --title "${ title }" --body-file "${ bodyFile }"` );
+		execSync( `open ${ prLink }` );
+		console.log( `PR: ${ prLink }` );
+	} finally {
+		fs.unlinkSync( bodyFile );
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related cleanups surfaced while preparing the 2.4.2 release.

### 1. `scripts/prepare-release.mjs` bugs

Three bugs hit when preparing the 2.4.2 branch:

- **`git add .` swept in untracked files.** After running `replace-next-version-tag.sh`, the script did `git add .`, which staged everything in the working tree — including unrelated local notes and screenshots — and committed them into the release branch. Fixed by switching to `git add -u`. The next-version replacer only rewrites already-tracked files in place, so staging only modifications is sufficient.
- **Changelog regex terminated on `###` only.** The release-notes extractor used `/### Release Notes([\S\s]*?)(?:###|<!--|$)/`. A PR whose release notes were followed by a `## Test plan` heading had its entire test plan section leaked into the generated changelog. The regex now terminates on a newline followed by any markdown heading (`#` through `######`) or an HTML comment.
- **PR body shell-interpolation.** `gh pr create --body "${ body }"` exposed the body to the shell. Backticks inside code spans were executed as command substitutions, and the pre-existing single-shot `.replace()` escaping calls only escaped the first occurrence in each case. The body is now written to a temp file and passed via `--body-file`, so the shell never sees the content.

### 2. CI test matrix trim

The previous PHP test matrix ran 30 jobs per PR (6 WP × 5 PHP), four-fifths of which targeted PHP versions that are EOL or security-only.

Replaced with two targeted combinations:

- WP 6.4 × PHP 7.4 — declared compatibility floor.
- WP 6.9 × PHP 8.3 — current WP × WordPress-recommended PHP.

PHP 8.4 was briefly added and reverted in this PR — the test bootstrap promotes every PHP error level (including `E_DEPRECATED`) to a fatal exception, and PHPUnit 9.6.8's own internals emit nullable-parameter deprecations on PHP 8.4, killing the run before any test executes. Restoring 8.4 coverage tracked in #2950.

The plugin's declared `Requires PHP: 7.2` is intentionally left in place — Jetpack still declares 7.2 and bumping the floor is a separate discussion.

## Test plan

- [x] Regex change sanity-checked against six representative cases — `## Test plan` terminator, `### Test plan` terminator, EOF terminator, HTML comment terminator, mid-line `##` (correctly ignored), `#` heading terminator.
- [x] CI on this PR now runs 2 jobs in the test matrix instead of 30.
- [ ] End-to-end verified by re-running `make release VERSION=2.4.2` once this lands.

## Follow-ups

- #2950 — restore PHP 8.4 coverage after modernising `tests/php/bootstrap.php`.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 7001b998fdb91c1f314ee547fea5d08482216d2b <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2949-7001b998.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2949-7001b998)             |

<!-- /wpjm:plugin-zip -->
