### PR TITLE
Release WP Job Manager 2.4.2

### DIFF
--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 2.4.1\n"
+"Project-Id-Version: WP Job Manager 2.4.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-02-24T15:29:38+00:00\n"
+"POT-Creation-Date: 2026-05-12T10:37:06+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: wp-job-manager\n"
@@ -50,7 +50,7 @@ msgid "The license is not activated. Click on the following button to activate i
 msgstr ""
 
 #: includes/3rd-party/wpcom.php:103
-#: includes/helper/class-wp-job-manager-helper.php:502
+#: includes/helper/class-wp-job-manager-helper.php:513
 #: includes/helper/views/html-licenses.php:44
 #: includes/helper/views/html-licenses.php:171
 msgid "Activate License"
@@ -66,17 +66,17 @@ msgstr ""
 msgid "<a href=\"%s\">Switch to primary language</a> to edit this setting."
 msgstr ""
 
-#: includes/abstracts/abstract-wp-job-manager-form.php:372
+#: includes/abstracts/abstract-wp-job-manager-form.php:382
 msgid "Terms and Conditions"
 msgstr ""
 
 #. translators: Placeholder %s is the Terms and Conditions placeholder.
-#: includes/abstracts/abstract-wp-job-manager-form.php:383
+#: includes/abstracts/abstract-wp-job-manager-form.php:393
 #, php-format
 msgid "I accept the %s."
 msgstr ""
 
-#: includes/abstracts/abstract-wp-job-manager-form.php:423
+#: includes/abstracts/abstract-wp-job-manager-form.php:433
 msgid "Terms and Conditions is a required field"
 msgstr ""
 
@@ -198,7 +198,7 @@ msgstr ""
 
 #: includes/admin/class-wp-job-manager-addons.php:189
 #: includes/admin/class-wp-job-manager-settings.php:1414
-#: includes/class-wp-job-manager-post-types.php:458
+#: includes/class-wp-job-manager-post-types.php:459
 msgid "Job Manager"
 msgstr ""
 
@@ -330,11 +330,12 @@ msgstr ""
 
 #: includes/admin/class-wp-job-manager-admin.php:200
 #: includes/admin/class-wp-job-manager-settings.php:171
-#: includes/class-wp-job-manager-post-types.php:589
+#: includes/class-wp-job-manager-post-types.php:590
 msgid "Job Listings"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-admin.php:201
+#: includes/helper/class-wp-job-manager-helper.php:493
 msgid "Settings"
 msgstr ""
 
@@ -488,8 +489,8 @@ msgstr ""
 
 #: includes/admin/class-wp-job-manager-cpt.php:499
 #: includes/class-wp-job-manager-email-notifications.php:274
-#: includes/class-wp-job-manager-post-types.php:1658
-#: includes/forms/class-wp-job-manager-form-submit-job.php:233
+#: includes/class-wp-job-manager-post-types.php:1715
+#: includes/forms/class-wp-job-manager-form-submit-job.php:241
 #: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:46
 #: templates/job-filters.php:35
 #: templates/job-filters.php:36
@@ -513,7 +514,7 @@ msgstr ""
 
 #: includes/admin/class-wp-job-manager-cpt.php:503
 #: includes/admin/class-wp-job-manager-settings.php:227
-#: includes/class-wp-job-manager-post-types.php:311
+#: includes/class-wp-job-manager-post-types.php:312
 msgid "Categories"
 msgstr ""
 
@@ -539,7 +540,7 @@ msgstr ""
 #: includes/admin/class-wp-job-manager-cpt.php:586
 #: includes/class-job-dashboard-shortcode.php:208
 #: includes/class-job-dashboard-shortcode.php:247
-#: includes/class-wp-job-manager-post-types.php:464
+#: includes/class-wp-job-manager-post-types.php:465
 msgid "Edit"
 msgstr ""
 
@@ -586,19 +587,19 @@ msgid "Job listing archive page"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:108
-#: includes/class-wp-job-manager-post-types.php:1339
+#: includes/class-wp-job-manager-post-types.php:1396
 msgctxt "Job permalink - resave permalinks after changing this"
 msgid "job"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:117
-#: includes/class-wp-job-manager-post-types.php:1340
+#: includes/class-wp-job-manager-post-types.php:1397
 msgctxt "Job category slug - resave permalinks after changing this"
 msgid "job-category"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:126
-#: includes/class-wp-job-manager-post-types.php:1341
+#: includes/class-wp-job-manager-post-types.php:1398
 msgctxt "Job type slug - resave permalinks after changing this"
 msgid "job-type"
 msgstr ""
@@ -852,7 +853,7 @@ msgid "Jobs will be shown if within ALL selected categories"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:259
-#: includes/class-wp-job-manager-post-types.php:374
+#: includes/class-wp-job-manager-post-types.php:375
 msgid "Types"
 msgstr ""
 
@@ -877,8 +878,8 @@ msgid "This allows users to select more than one type when submitting a job. The
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:279
-#: includes/class-wp-job-manager-post-types.php:1751
-#: includes/forms/class-wp-job-manager-form-submit-job.php:241
+#: includes/class-wp-job-manager-post-types.php:1808
+#: includes/forms/class-wp-job-manager-form-submit-job.php:249
 msgid "Remote Position"
 msgstr ""
 
@@ -891,8 +892,8 @@ msgid "This lets users select if the listing is a remote position when submittin
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:289
-#: includes/class-wp-job-manager-post-types.php:1760
-#: includes/forms/class-wp-job-manager-form-submit-job.php:280
+#: includes/class-wp-job-manager-post-types.php:1817
+#: includes/forms/class-wp-job-manager-form-submit-job.php:288
 msgid "Salary"
 msgstr ""
 
@@ -905,8 +906,8 @@ msgid "This lets users add a salary when submitting a job."
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:299
-#: includes/class-wp-job-manager-post-types.php:1770
-#: includes/forms/class-wp-job-manager-form-submit-job.php:287
+#: includes/class-wp-job-manager-post-types.php:1827
+#: includes/forms/class-wp-job-manager-form-submit-job.php:295
 msgid "Salary Currency"
 msgstr ""
 
@@ -931,14 +932,14 @@ msgid "Sets the default currency used by salaries"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:313
-#: includes/class-wp-job-manager-post-types.php:1773
-#: includes/forms/class-wp-job-manager-form-submit-job.php:290
+#: includes/class-wp-job-manager-post-types.php:1830
+#: includes/forms/class-wp-job-manager-form-submit-job.php:223
 msgid "e.g. USD"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:320
-#: includes/class-wp-job-manager-post-types.php:1781
-#: includes/forms/class-wp-job-manager-form-submit-job.php:295
+#: includes/class-wp-job-manager-post-types.php:1838
+#: includes/forms/class-wp-job-manager-form-submit-job.php:303
 msgid "Salary Unit"
 msgstr ""
 
@@ -1323,7 +1324,7 @@ msgstr ""
 #: includes/admin/class-wp-job-manager-taxonomy-meta.php:87
 #: includes/admin/class-wp-job-manager-taxonomy-meta.php:110
 #: includes/admin/class-wp-job-manager-taxonomy-meta.php:129
-#: includes/class-wp-job-manager-post-types.php:417
+#: includes/class-wp-job-manager-post-types.php:418
 msgid "Employment Type"
 msgstr ""
 
@@ -1354,7 +1355,7 @@ msgstr ""
 
 #. translators: Used in user select. %1$s is the user's display name; #%2$s is the user ID; %3$s is the user email.
 #: includes/admin/class-wp-job-manager-writepanels.php:532
-#: includes/class-wp-job-manager-ajax.php:431
+#: includes/class-wp-job-manager-ajax.php:446
 #, php-format
 msgid "%1$s (#%2$s – %3$s)"
 msgstr ""
@@ -1670,6 +1671,7 @@ msgid "Expires in %s"
 msgstr ""
 
 #: includes/class-job-overlay.php:49
+#: includes/class-stats-script.php:69
 msgid "Invalid request."
 msgstr ""
 
@@ -1744,45 +1746,62 @@ msgstr ""
 msgid "Repeat Views"
 msgstr ""
 
+#: includes/class-stats-script.php:74
+msgid "Too many requests."
+msgstr ""
+
+#: includes/class-stats-script.php:80
+#: includes/class-stats-script.php:85
+msgid "Invalid payload."
+msgstr ""
+
+#: includes/class-stats-script.php:89
+msgid "No stats to log."
+msgstr ""
+
+#: includes/class-stats-script.php:142
+msgid "Unable to log stats."
+msgstr ""
+
 #. translators: Placeholder %d is the number of found search results.
-#: includes/class-wp-job-manager-ajax.php:198
+#: includes/class-wp-job-manager-ajax.php:213
 #, php-format
 msgid "Search completed. Found %d matching record."
 msgid_plural "Search completed. Found %d matching records."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-wp-job-manager-ajax.php:296
+#: includes/class-wp-job-manager-ajax.php:311
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:51
-#: includes/class-wp-job-manager-post-types.php:481
+#: includes/class-wp-job-manager-post-types.php:482
 msgid "Company Logo"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:52
-#: includes/class-wp-job-manager-post-types.php:1677
+#: includes/class-wp-job-manager-post-types.php:1734
 msgid "Company Name"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:53
-#: includes/class-wp-job-manager-post-types.php:1685
+#: includes/class-wp-job-manager-post-types.php:1742
 msgid "Company Website"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:54
-#: includes/class-wp-job-manager-post-types.php:1694
+#: includes/class-wp-job-manager-post-types.php:1751
 msgid "Company Tagline"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:55
-#: includes/class-wp-job-manager-post-types.php:1702
-msgid "Company Twitter"
+#: includes/class-wp-job-manager-post-types.php:1759
+msgid "Company X / Twitter"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:56
-#: includes/class-wp-job-manager-post-types.php:1710
+#: includes/class-wp-job-manager-post-types.php:1767
 msgid "Company Video"
 msgstr ""
 
@@ -1825,19 +1844,19 @@ msgid "Job title"
 msgstr ""
 
 #: includes/class-wp-job-manager-email-notifications.php:283
-#: includes/class-wp-job-manager-post-types.php:348
-#: includes/forms/class-wp-job-manager-form-submit-job.php:248
+#: includes/class-wp-job-manager-post-types.php:349
+#: includes/forms/class-wp-job-manager-form-submit-job.php:256
 msgid "Job type"
 msgstr ""
 
 #: includes/class-wp-job-manager-email-notifications.php:293
-#: includes/class-wp-job-manager-post-types.php:284
-#: includes/forms/class-wp-job-manager-form-submit-job.php:257
+#: includes/class-wp-job-manager-post-types.php:285
+#: includes/forms/class-wp-job-manager-form-submit-job.php:265
 msgid "Job category"
 msgstr ""
 
 #: includes/class-wp-job-manager-email-notifications.php:302
-#: includes/forms/class-wp-job-manager-form-submit-job.php:305
+#: includes/forms/class-wp-job-manager-form-submit-job.php:313
 msgid "Company name"
 msgstr ""
 
@@ -1890,16 +1909,16 @@ msgstr ""
 msgid "Employer"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:285
+#: includes/class-wp-job-manager-post-types.php:286
 msgid "Job categories"
 msgstr ""
 
 #. translators: Placeholder %s is the plural label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the plural label of the job listing job type taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:313
-#: includes/class-wp-job-manager-post-types.php:376
-#: includes/class-wp-job-manager-post-types.php:474
+#: includes/class-wp-job-manager-post-types.php:314
+#: includes/class-wp-job-manager-post-types.php:377
+#: includes/class-wp-job-manager-post-types.php:475
 #, php-format
 msgid "Search %s"
 msgstr ""
@@ -1907,9 +1926,9 @@ msgstr ""
 #. translators: Placeholder %s is the plural label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the plural label of the job listing job type taxonomy type.
 #. translators: Placeholder %s is the plural label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:315
-#: includes/class-wp-job-manager-post-types.php:378
-#: includes/class-wp-job-manager-post-types.php:460
+#: includes/class-wp-job-manager-post-types.php:316
+#: includes/class-wp-job-manager-post-types.php:379
+#: includes/class-wp-job-manager-post-types.php:461
 #, php-format
 msgid "All %s"
 msgstr ""
@@ -1917,17 +1936,17 @@ msgstr ""
 #. translators: Placeholder %s is the singular label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:317
-#: includes/class-wp-job-manager-post-types.php:380
-#: includes/class-wp-job-manager-post-types.php:480
+#: includes/class-wp-job-manager-post-types.php:318
+#: includes/class-wp-job-manager-post-types.php:381
+#: includes/class-wp-job-manager-post-types.php:481
 #, php-format
 msgid "Parent %s"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
-#: includes/class-wp-job-manager-post-types.php:319
-#: includes/class-wp-job-manager-post-types.php:382
+#: includes/class-wp-job-manager-post-types.php:320
+#: includes/class-wp-job-manager-post-types.php:383
 #, php-format
 msgid "Parent %s:"
 msgstr ""
@@ -1935,239 +1954,239 @@ msgstr ""
 #. translators: Placeholder %s is the singular label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:321
-#: includes/class-wp-job-manager-post-types.php:384
-#: includes/class-wp-job-manager-post-types.php:466
+#: includes/class-wp-job-manager-post-types.php:322
+#: includes/class-wp-job-manager-post-types.php:385
+#: includes/class-wp-job-manager-post-types.php:467
 #, php-format
 msgid "Edit %s"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
-#: includes/class-wp-job-manager-post-types.php:323
-#: includes/class-wp-job-manager-post-types.php:386
+#: includes/class-wp-job-manager-post-types.php:324
+#: includes/class-wp-job-manager-post-types.php:387
 #, php-format
 msgid "Update %s"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
-#: includes/class-wp-job-manager-post-types.php:325
-#: includes/class-wp-job-manager-post-types.php:388
+#: includes/class-wp-job-manager-post-types.php:326
+#: includes/class-wp-job-manager-post-types.php:389
 #, php-format
 msgid "Add New %s"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing category taxonomy type.
 #. translators: Placeholder %s is the singular label of the job listing job type taxonomy type.
-#: includes/class-wp-job-manager-post-types.php:327
-#: includes/class-wp-job-manager-post-types.php:390
+#: includes/class-wp-job-manager-post-types.php:328
+#: includes/class-wp-job-manager-post-types.php:391
 #, php-format
 msgid "New %s Name"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:349
+#: includes/class-wp-job-manager-post-types.php:350
 msgid "Job types"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:427
+#: includes/class-wp-job-manager-post-types.php:428
 msgid "Job"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:428
+#: includes/class-wp-job-manager-post-types.php:429
 msgid "Jobs"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:461
+#: includes/class-wp-job-manager-post-types.php:462
 msgid "Add New"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:463
+#: includes/class-wp-job-manager-post-types.php:464
 #, php-format
 msgid "Add %s"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:468
+#: includes/class-wp-job-manager-post-types.php:469
 #, php-format
 msgid "New %s"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:470
-#: includes/class-wp-job-manager-post-types.php:472
+#: includes/class-wp-job-manager-post-types.php:471
+#: includes/class-wp-job-manager-post-types.php:473
 #, php-format
 msgid "View %s"
 msgstr ""
 
 #. translators: Placeholder %s is the singular label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:476
+#: includes/class-wp-job-manager-post-types.php:477
 #, php-format
 msgid "No %s found"
 msgstr ""
 
 #. translators: Placeholder %s is the plural label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:478
+#: includes/class-wp-job-manager-post-types.php:479
 #, php-format
 msgid "No %s found in trash"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:482
+#: includes/class-wp-job-manager-post-types.php:483
 msgid "Set company logo"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:483
+#: includes/class-wp-job-manager-post-types.php:484
 msgid "Remove company logo"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:484
+#: includes/class-wp-job-manager-post-types.php:485
 msgid "Use as company logo"
 msgstr ""
 
 #. translators: Placeholder %s is the plural label of the job listing post type.
-#: includes/class-wp-job-manager-post-types.php:487
+#: includes/class-wp-job-manager-post-types.php:488
 #, php-format
 msgid "This is where you can create and manage %s."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:522
-#: wp-job-manager-functions.php:494
+#: includes/class-wp-job-manager-post-types.php:523
+#: wp-job-manager-functions.php:493
 msgctxt "post status"
 msgid "Expired"
 msgstr ""
 
 #. translators: Placeholder %s is the number of expired posts of this type.
-#: includes/class-wp-job-manager-post-types.php:529
+#: includes/class-wp-job-manager-post-types.php:530
 #, php-format
 msgid "Expired <span class=\"count\">(%s)</span>"
 msgid_plural "Expired <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-wp-job-manager-post-types.php:535
-#: wp-job-manager-functions.php:495
+#: includes/class-wp-job-manager-post-types.php:536
+#: wp-job-manager-functions.php:494
 msgctxt "post status"
 msgid "Preview"
 msgstr ""
 
 #. translators: Placeholder %s is the number of posts in a preview state.
-#: includes/class-wp-job-manager-post-types.php:541
+#: includes/class-wp-job-manager-post-types.php:542
 #, php-format
 msgid "Preview <span class=\"count\">(%s)</span>"
 msgid_plural "Preview <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-wp-job-manager-post-types.php:554
+#: includes/class-wp-job-manager-post-types.php:555
 msgid "This is where guest user data is stored."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1323
+#: includes/class-wp-job-manager-post-types.php:1380
 msgctxt "Post type archive slug - resave permalinks after changing this"
 msgid "jobs"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1640
+#: includes/class-wp-job-manager-post-types.php:1697
 #: includes/forms/class-wp-job-manager-form-submit-job.php:210
 msgid "Application email/URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1641
+#: includes/class-wp-job-manager-post-types.php:1698
 #: includes/forms/class-wp-job-manager-form-submit-job.php:211
 msgid "Enter an email address or website URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1644
+#: includes/class-wp-job-manager-post-types.php:1701
 #: includes/forms/class-wp-job-manager-form-submit-job.php:200
 msgid "Application email"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1645
+#: includes/class-wp-job-manager-post-types.php:1702
 #: includes/forms/class-wp-job-manager-form-submit-job.php:201
 msgid "you@example.com"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1647
+#: includes/class-wp-job-manager-post-types.php:1704
 #: includes/forms/class-wp-job-manager-form-submit-job.php:205
 msgid "Application URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1648
+#: includes/class-wp-job-manager-post-types.php:1705
 #: includes/forms/class-wp-job-manager-form-submit-job.php:206
 msgid "https://"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1651
+#: includes/class-wp-job-manager-post-types.php:1708
 msgid "Job listing expires at the end of the day."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1653
+#: includes/class-wp-job-manager-post-types.php:1710
 msgid "Job listing expires at the start of the day."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1659
-#: includes/forms/class-wp-job-manager-form-submit-job.php:237
+#: includes/class-wp-job-manager-post-types.php:1716
+#: includes/forms/class-wp-job-manager-form-submit-job.php:245
 msgid "e.g. \"London\""
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1660
+#: includes/class-wp-job-manager-post-types.php:1717
 msgid "Leave this blank if the location is not important."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1669
+#: includes/class-wp-job-manager-post-types.php:1726
 msgid "This field is required for the \"application\" area to appear beneath the listing."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1695
+#: includes/class-wp-job-manager-post-types.php:1752
 msgid "Brief description about the company"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1711
+#: includes/class-wp-job-manager-post-types.php:1768
 msgid "URL to the company video"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1720
+#: includes/class-wp-job-manager-post-types.php:1777
 msgid "Position Filled"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1726
+#: includes/class-wp-job-manager-post-types.php:1783
 msgid "Filled listings will no longer accept applications."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1729
+#: includes/class-wp-job-manager-post-types.php:1786
 msgid "Featured Listing"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1731
+#: includes/class-wp-job-manager-post-types.php:1788
 msgid "Featured listings will be sticky during searches, and can be styled differently."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1739
+#: includes/class-wp-job-manager-post-types.php:1796
 msgid "Listing Expiry Date"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1752
-#: includes/forms/class-wp-job-manager-form-submit-job.php:242
+#: includes/class-wp-job-manager-post-types.php:1809
+#: includes/forms/class-wp-job-manager-form-submit-job.php:250
 msgid "Select if this is a remote position."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1762
-#: includes/forms/class-wp-job-manager-form-submit-job.php:283
+#: includes/class-wp-job-manager-post-types.php:1819
+#: includes/forms/class-wp-job-manager-form-submit-job.php:291
 msgid "e.g. 20000"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1764
+#: includes/class-wp-job-manager-post-types.php:1821
 msgid "Add a salary field, this field is optional."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1775
-#: includes/forms/class-wp-job-manager-form-submit-job.php:291
+#: includes/class-wp-job-manager-post-types.php:1832
+#: includes/forms/class-wp-job-manager-form-submit-job.php:227
 msgid "Add a salary currency, this field is optional. Leave it empty to use the default salary currency."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1786
-#: includes/forms/class-wp-job-manager-form-submit-job.php:298
+#: includes/class-wp-job-manager-post-types.php:1843
+#: includes/forms/class-wp-job-manager-form-submit-job.php:306
 msgid "Add a salary period unit, this field is optional. Leave it empty to use the default salary unit, if one is defined."
 msgstr ""
 
@@ -2212,26 +2231,26 @@ msgid ""
 "\t\t\t\thave started but have not completed: %1$s and %2$s"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:421
+#: includes/class-wp-job-manager.php:430
 msgid "Load previous listings"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:548
+#: includes/class-wp-job-manager.php:557
 msgid "Invalid file type. Accepted types:"
 msgstr ""
 
-#: includes/class-wp-job-manager.php:565
+#: includes/class-wp-job-manager.php:574
 msgid "Any Category"
 msgstr ""
 
 #. translators: Placeholder %d is the number of files to that users are limited to.
-#: includes/class-wp-job-manager.php:581
-#: includes/forms/class-wp-job-manager-form-submit-job.php:516
+#: includes/class-wp-job-manager.php:590
+#: includes/forms/class-wp-job-manager-form-submit-job.php:528
 #, php-format
 msgid "You are only allowed to upload a maximum of %d files."
 msgstr ""
 
-#: includes/class-wp-job-manager.php:589
+#: includes/class-wp-job-manager.php:598
 msgid "This field is required."
 msgstr ""
 
@@ -2322,7 +2341,7 @@ msgid "Submit Details"
 msgstr ""
 
 #: includes/forms/class-wp-job-manager-form-submit-job.php:104
-#: includes/forms/class-wp-job-manager-form-submit-job.php:682
+#: includes/forms/class-wp-job-manager-form-submit-job.php:694
 #: templates/job-preview.php:32
 msgid "Preview"
 msgstr ""
@@ -2331,143 +2350,149 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
+#. translators: %s is the default salary currency code (e.g. USD).
 #: includes/forms/class-wp-job-manager-form-submit-job.php:226
-msgid "Job Title"
+#, php-format
+msgid "Add a salary currency, this field is optional. Leave it empty to use the default salary currency (%s)."
 msgstr ""
 
 #: includes/forms/class-wp-job-manager-form-submit-job.php:234
+msgid "Job Title"
+msgstr ""
+
+#: includes/forms/class-wp-job-manager-form-submit-job.php:242
 msgid "Leave this blank if the location is not important"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:251
+#: includes/forms/class-wp-job-manager-form-submit-job.php:259
 msgid "Choose job type&hellip;"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:266
+#: includes/forms/class-wp-job-manager-form-submit-job.php:274
 msgid "Description"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:308
+#: includes/forms/class-wp-job-manager-form-submit-job.php:316
 msgid "Enter the name of the company"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:312
+#: includes/forms/class-wp-job-manager-form-submit-job.php:320
 #: templates/content-single-job_listing-company.php:31
 msgid "Website"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:316
+#: includes/forms/class-wp-job-manager-form-submit-job.php:324
 msgid "http://"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:320
+#: includes/forms/class-wp-job-manager-form-submit-job.php:328
 msgid "Tagline"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:323
+#: includes/forms/class-wp-job-manager-form-submit-job.php:331
 msgid "Briefly describe your company"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:328
+#: includes/forms/class-wp-job-manager-form-submit-job.php:336
 msgid "Video"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:332
+#: includes/forms/class-wp-job-manager-form-submit-job.php:340
 msgid "A link to a video about your company"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:336
-msgid "Twitter username"
+#: includes/forms/class-wp-job-manager-form-submit-job.php:344
+msgid "X / Twitter username"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:339
+#: includes/forms/class-wp-job-manager-form-submit-job.php:347
 msgid "@yourcompany"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:343
+#: includes/forms/class-wp-job-manager-form-submit-job.php:351
 msgid "Logo"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:383
+#: includes/forms/class-wp-job-manager-form-submit-job.php:395
 msgid "Scheduled Date"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:384
+#: includes/forms/class-wp-job-manager-form-submit-job.php:396
 msgid "Optionally set the date when this listing will be published."
 msgstr ""
 
 #. translators: Placeholder %s is the label for the required field.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:437
+#: includes/forms/class-wp-job-manager-form-submit-job.php:449
 #, php-format
 msgid "%s is a required field"
 msgstr ""
 
 #. translators: Placeholder %s is the field label that is did not validate.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:448
+#: includes/forms/class-wp-job-manager-form-submit-job.php:460
 #, php-format
 msgid "%s is invalid"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:478
+#: includes/forms/class-wp-job-manager-form-submit-job.php:490
 msgid "Invalid image path."
 msgstr ""
 
 #. translators: Placeholder %1$s is field label; %2$s is the file mime type; %3$s is the allowed mime-types.
 #. translators: %1$s is the file field label; %2$s is the file type; %3$s is the list of allowed file types.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:489
-#: wp-job-manager-functions.php:1529
+#: includes/forms/class-wp-job-manager-form-submit-job.php:501
+#: wp-job-manager-functions.php:1528
 #, php-format
 msgid "\"%1$s\" (filetype %2$s) needs to be one of the following file types: %3$s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:499
+#: includes/forms/class-wp-job-manager-form-submit-job.php:511
 msgid "Invalid attachment provided."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:545
+#: includes/forms/class-wp-job-manager-form-submit-job.php:557
 msgid "Please enter a valid application email address"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:550
+#: includes/forms/class-wp-job-manager-form-submit-job.php:562
 msgid "Please enter a valid application URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:556
+#: includes/forms/class-wp-job-manager-form-submit-job.php:568
 msgid "Please enter a valid application email address or URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:741
+#: includes/forms/class-wp-job-manager-form-submit-job.php:753
 msgid "Please enter a username."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:745
+#: includes/forms/class-wp-job-manager-form-submit-job.php:757
 msgid "Please enter a password."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:749
+#: includes/forms/class-wp-job-manager-form-submit-job.php:761
 msgid "Please enter your email address."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:755
+#: includes/forms/class-wp-job-manager-form-submit-job.php:767
 msgid "Passwords must match."
 msgstr ""
 
 #. translators: Placeholder %s is the password hint.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:761
+#: includes/forms/class-wp-job-manager-form-submit-job.php:773
 #, php-format
 msgid "Invalid Password: %s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:763
+#: includes/forms/class-wp-job-manager-form-submit-job.php:775
 msgid "Password is not valid."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:795
+#: includes/forms/class-wp-job-manager-form-submit-job.php:807
 msgid "You must be signed in to post a new listing."
 msgstr ""
 
 #. translators: placeholder is the URL to the job dashboard page.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:821
+#: includes/forms/class-wp-job-manager-form-submit-job.php:833
 #, php-format
 msgid "Draft was saved. Job listing drafts can be resumed from the <a href=\"%s\">job dashboard</a>."
 msgstr ""
@@ -2512,75 +2537,75 @@ msgstr ""
 msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> is expiring soon. Please <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">renew your license</a> to continue receiving updates and support."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:496
+#: includes/helper/class-wp-job-manager-helper.php:507
 msgid "Manage License (Requires Attention)"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:499
+#: includes/helper/class-wp-job-manager-helper.php:510
 msgid "Manage License"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:816
+#: includes/helper/class-wp-job-manager-helper.php:827
 msgid "Please enter a valid license key in order to activate this plugin's license."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:849
+#: includes/helper/class-wp-job-manager-helper.php:860
 msgid "Please enter a valid license key in order to activate the licenses of the plugins."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:878
+#: includes/helper/class-wp-job-manager-helper.php:889
 msgid "There was an error activating your license key. Please try again later."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:934
+#: includes/helper/class-wp-job-manager-helper.php:945
 msgid "license is not active."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:947
+#: includes/helper/class-wp-job-manager-helper.php:958
 msgid "There was an error while deactivating the plugin."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:961
+#: includes/helper/class-wp-job-manager-helper.php:972
 msgid "Plugin license has been deactivated."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:987
+#: includes/helper/class-wp-job-manager-helper.php:998
 msgid "The license has been synced properly."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:992
+#: includes/helper/class-wp-job-manager-helper.php:1003
 msgid "There was an error while syncing the license."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1081
+#: includes/helper/class-wp-job-manager-helper.php:1092
 msgid "Connection failed to the License Key API server - possible server issue."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1090
+#: includes/helper/class-wp-job-manager-helper.php:1101
 msgid "Plugin license has been activated."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1094
+#: includes/helper/class-wp-job-manager-helper.php:1105
 msgid "An unknown error occurred while attempting to activate the license"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1132
+#: includes/helper/class-wp-job-manager-helper.php:1143
 msgid "Job Manager: License required"
 msgid_plural "Job Manager: Licenses required"
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %1$s is the URL to the license key page.
-#: includes/helper/class-wp-job-manager-helper.php:1136
+#: includes/helper/class-wp-job-manager-helper.php:1147
 #, php-format
 msgid "<a href=\"%1$s\">Please add or review your license keys</a> to get updates for the following extensions:"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1143
+#: includes/helper/class-wp-job-manager-helper.php:1154
 msgid "Manage Licenses"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:1148
+#: includes/helper/class-wp-job-manager-helper.php:1159
 msgid "My Account"
 msgstr ""
 
@@ -2943,12 +2968,12 @@ msgid "Maximum file size: %s."
 msgstr ""
 
 #: templates/form-fields/multiselect-field.php:20
-#: wp-job-manager-functions.php:1296
+#: wp-job-manager-functions.php:1295
 msgid "No results match"
 msgstr ""
 
 #: templates/form-fields/multiselect-field.php:20
-#: wp-job-manager-functions.php:1297
+#: wp-job-manager-functions.php:1296
 msgid "Select Some Options"
 msgstr ""
 
@@ -3030,6 +3055,10 @@ msgstr ""
 msgid "Daily Views"
 msgstr ""
 
+#: templates/job-stats.php:91
+msgid "Statistics reflect visitor activity on public pages and may include approximate counts."
+msgstr ""
+
 #: templates/job-submit.php:25
 #, php-format
 msgid "You are editing an existing job. %s"
@@ -3075,118 +3104,118 @@ msgstr ""
 msgid "%1$s submitted successfully."
 msgstr ""
 
-#: wp-job-manager-functions.php:493
+#: wp-job-manager-functions.php:492
 msgctxt "post status"
 msgid "Draft"
 msgstr ""
 
-#: wp-job-manager-functions.php:496
+#: wp-job-manager-functions.php:495
 msgctxt "post status"
 msgid "Pending approval"
 msgstr ""
 
-#: wp-job-manager-functions.php:497
+#: wp-job-manager-functions.php:496
 msgctxt "post status"
 msgid "Pending payment"
 msgstr ""
 
-#: wp-job-manager-functions.php:498
+#: wp-job-manager-functions.php:497
 msgctxt "post status"
 msgid "Active"
 msgstr ""
 
-#: wp-job-manager-functions.php:499
+#: wp-job-manager-functions.php:498
 msgctxt "post status"
 msgid "Scheduled"
 msgstr ""
 
-#: wp-job-manager-functions.php:620
+#: wp-job-manager-functions.php:619
 msgid "Reset"
 msgstr ""
 
-#: wp-job-manager-functions.php:624
+#: wp-job-manager-functions.php:623
 msgid "RSS"
 msgstr ""
 
-#: wp-job-manager-functions.php:733
+#: wp-job-manager-functions.php:732
 msgid "Invalid email address."
 msgstr ""
 
-#: wp-job-manager-functions.php:741
+#: wp-job-manager-functions.php:740
 msgid "Your email address isn&#8217;t correct."
 msgstr ""
 
-#: wp-job-manager-functions.php:745
+#: wp-job-manager-functions.php:744
 msgid "This email is already registered, please choose another one."
 msgstr ""
 
-#: wp-job-manager-functions.php:1056
+#: wp-job-manager-functions.php:1055
 msgid "Full Time"
 msgstr ""
 
-#: wp-job-manager-functions.php:1057
+#: wp-job-manager-functions.php:1056
 msgid "Part Time"
 msgstr ""
 
-#: wp-job-manager-functions.php:1058
+#: wp-job-manager-functions.php:1057
 msgid "Contractor"
 msgstr ""
 
-#: wp-job-manager-functions.php:1059
+#: wp-job-manager-functions.php:1058
 msgid "Temporary"
 msgstr ""
 
-#: wp-job-manager-functions.php:1060
+#: wp-job-manager-functions.php:1059
 msgid "Intern"
 msgstr ""
 
-#: wp-job-manager-functions.php:1061
+#: wp-job-manager-functions.php:1060
 msgid "Volunteer"
 msgstr ""
 
-#: wp-job-manager-functions.php:1062
+#: wp-job-manager-functions.php:1061
 msgid "Per Diem"
 msgstr ""
 
-#: wp-job-manager-functions.php:1063
+#: wp-job-manager-functions.php:1062
 msgid "Other"
 msgstr ""
 
-#: wp-job-manager-functions.php:1130
+#: wp-job-manager-functions.php:1129
 msgid "Passwords must be at least 8 characters long."
 msgstr ""
 
-#: wp-job-manager-functions.php:1295
+#: wp-job-manager-functions.php:1294
 msgid "Choose a category&hellip;"
 msgstr ""
 
 #. translators: %s is the list of allowed file types.
-#: wp-job-manager-functions.php:1532
+#: wp-job-manager-functions.php:1531
 #, php-format
 msgid "Uploaded files need to be one of the following file types: %s"
 msgstr ""
 
-#: wp-job-manager-functions.php:1828
+#: wp-job-manager-functions.php:1831
 msgid "--"
 msgstr ""
 
-#: wp-job-manager-functions.php:1829
+#: wp-job-manager-functions.php:1832
 msgid "Year"
 msgstr ""
 
-#: wp-job-manager-functions.php:1830
+#: wp-job-manager-functions.php:1833
 msgid "Month"
 msgstr ""
 
-#: wp-job-manager-functions.php:1831
+#: wp-job-manager-functions.php:1834
 msgid "Week"
 msgstr ""
 
-#: wp-job-manager-functions.php:1832
+#: wp-job-manager-functions.php:1835
 msgid "Day"
 msgstr ""
 
-#: wp-job-manager-functions.php:1833
+#: wp-job-manager-functions.php:1836
 msgid "Hour"
 msgstr ""
 
@@ -3200,47 +3229,47 @@ msgstr ""
 msgid "Application via %1$s listing on %2$s"
 msgstr ""
 
-#: wp-job-manager-template.php:715
+#: wp-job-manager-template.php:718
 msgid "Your email"
 msgstr ""
 
-#: wp-job-manager-template.php:716
+#: wp-job-manager-template.php:719
 msgid "you@yourdomain.com"
 msgstr ""
 
-#: wp-job-manager-template.php:724
+#: wp-job-manager-template.php:727
 msgid "Username"
 msgstr ""
 
-#: wp-job-manager-template.php:733
+#: wp-job-manager-template.php:736
 msgid "Password"
 msgstr ""
 
-#: wp-job-manager-template.php:743
+#: wp-job-manager-template.php:746
 msgid "Verify Password"
 msgstr ""
 
-#: wp-job-manager-template.php:771
+#: wp-job-manager-template.php:774
 msgid "Posted on "
 msgstr ""
 
 #. translators: Placeholder %s is the relative, human readable time since the job listing was posted.
-#: wp-job-manager-template.php:777
-#: wp-job-manager-template.php:803
+#: wp-job-manager-template.php:780
+#: wp-job-manager-template.php:806
 #, php-format
 msgid "Posted %s ago"
 msgstr ""
 
 #. translators: Placeholder %s is the relative, human readable time the job listing is scheduled to be published.
-#: wp-job-manager-template.php:780
+#: wp-job-manager-template.php:783
 #, php-format
 msgid "Scheduled to publish in %s"
 msgstr ""
 
-#: wp-job-manager-template.php:818
+#: wp-job-manager-template.php:821
 msgid "Remote"
 msgstr ""
 
-#: wp-job-manager-template.php:842
+#: wp-job-manager-template.php:845
 msgid "Anywhere"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: mikejolley, automattic, adamkheckler, alexsanford1, annezazu, cena, chaselivingston, csonnek, davor.altman, donnapep, donncha, drawmyface, erania-pinnera, fjorgemota, jacobshere, jakeom, jeherve, jenhooks, jgs, jonryan, kraftbj, lamdayap, lschuyler, macmanx, nancythanki, orangesareorange, rachelsquirrel, renathoc, ryancowles, richardmtl, scarstocea
 Tags: jobs, careers, company, hiring, job board
 Requires at least: 6.4
-Tested up to: 6.6
-Requires PHP: 7.2
+Tested up to: 6.9
+Requires PHP: 7.4
 Stable tag: 2.4.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jobs, careers, company, hiring, job board
 Requires at least: 6.4
 Tested up to: 6.6
 Requires PHP: 7.2
-Stable tag: 2.4.1
+Stable tag: 2.4.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 2.4.1
+ * Version: 2.4.2
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '2.4.1' );
+define( 'JOB_MANAGER_VERSION', '2.4.2' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.4
- * Tested up to: 6.6
+ * Tested up to: 6.9
  * Requires PHP: 7.4
  * Text Domain: wp-job-manager
  * Domain Path: /languages/


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## WP Job Manager 2.4.2

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Fix Job Dashboard actions menu on Safari (#2947)
* Harden submit-form session cookies (#2945)
* Fixes a REST API information disclosure where the body, excerpt, and existence of listings restricted by view-capability were exposed to denied viewers. Restricted listings now return 404 indistinguishable from a missing post, including HEAD probes and listings that are also password-protected.
* Fixes a data-loss bug where editors opening a password-protected listing in the block editor would save empty meta values (location, company name, application target).
* Fixes a series of information disclosure issues affecting password-protected and capability-restricted job listings.
* Harden stats AJAX endpoint input validation and rate limiting (#2938)
* Company logo uploads now accept WebP images by default
* New filter `job_manager_company_logo_allowed_mime_types` allows customizing allowed file types for the company logo field
* The salary currency field on the job submission form now correctly reflects the configured default currency in its placeholder and helper text.
* Filled job listings are no longer exposed via the REST API.
* Job categories are now included in the job RSS feed XML output.
* Added `featured=true` query parameter support to the job RSS feed to allow filtering by featured listings only.
* Fixed PHP 8+ undefined array key warning in the widget caching methods.
* Updated Twitter profile links to use the new `x.com` domain and updated related labels to "X / Twitter" to reflect the platform rebrand.
* Added a Settings link to the plugin action links on the Plugins screen for quicker access to plugin settings.
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org



<!-- wpjm:plugin-zip -->
----

| Plugin build for 757943bcae695afda51e82defae84b9f5c635561 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2951-757943bc.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2951-757943bc)             |

<!-- /wpjm:plugin-zip -->


