### PR TITLE
Exclude AGENTS.md, CLAUDE.md, and vendored tests from WP.org build

### DIFF
--- a/scripts/exclude.lst
+++ b/scripts/exclude.lst
@@ -20,6 +20,7 @@ wp-job-manager/.psalm/*
 wp-job-manager/psalm.xml
 wp-job-manager/scripts/*
 wp-job-manager/tests/*
+wp-job-manager/lib/usage-tracking/tests
 wp-job-manager/.git/*
 wp-job-manager/.github/*
 wp-job-manager/readme.md
@@ -36,3 +37,5 @@ wp-job-manager/.wp-env.json
 wp-job-manager/.wp-env.tests.json
 wp-job-manager/blueprint.json
 wp-job-manager/Makefile
+wp-job-manager/CLAUDE.md
+wp-job-manager/AGENTS.md


### PR DESCRIPTION
## Summary

The 2.4.2 deploy run (#2951) showed three paths being copied to `plugins.svn.wordpress.org/wp-job-manager/` that aren't intended for end users:

- `AGENTS.md` and `CLAUDE.md` — repo-level instruction files for AI coding agents.
- `lib/usage-tracking/tests` — vendored test directory from the usage tracking library.

The 2.4.2 SVN commit failed for an unrelated auth reason, so none of these actually shipped — but with the auth issue fixed, the next release would have published them. This PR adds the three paths to `scripts/exclude.lst` so the build artifact uploaded to WP.org no longer contains them.

## Test plan

- [x] Trigger a build of the plugin zip (`make build` or the `Plugin Build` workflow) on this PR and confirm the resulting `wp-job-manager.zip` does not contain `AGENTS.md`, `CLAUDE.md`, or `lib/usage-tracking/tests/`.
- [x] On the next real release, eyeball the SVN status output in the deploy job to confirm none of the three paths appear in the changeset.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 1ca1b846b42e67745ded9439539228e962ee86ae <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2952-1ca1b846.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2952-1ca1b846)             |

<!-- /wpjm:plugin-zip -->
