### PR TITLE
Job Statistics Banner: remove see whats new link

### DIFF
--- a/includes/admin/class-release-notice.php
+++ b/includes/admin/class-release-notice.php
@@ -73,11 +73,6 @@ class Release_Notice {
 					'url'     => \WP_Job_Manager_Admin_Notices::get_dismiss_url( self::NOTICE_ID ),
 					'primary' => false,
 				],
-				[
-					'label' => __( 'See what\'s new in 2.3', 'wp-job-manager' ),
-					'url'   => 'https://wpjobmanager.com/2024/04/29/new-in-2-3-job-statistics/',
-					'class' => 'is-link',
-				],
 			],
 			'icon'          => false,
 			'level'         => 'landing',

--- a/includes/admin/class-release-notice.php
+++ b/includes/admin/class-release-notice.php
@@ -48,7 +48,6 @@ class Release_Notice {
 		$action_url                 = \WP_Job_Manager_Admin_Notices::get_action_url( 'enable_stats', self::NOTICE_ID );
 		$notices[ self::NOTICE_ID ] = [
 			'type'          => 'site-wide',
-			'label'         => 'New',
 			'heading'       => 'Job Statistics',
 			'message'       => '<div>' . __(
 				'


### PR DESCRIPTION
Fixes #2943

### Changes Proposed in this Pull Request
* Removed the outdated "See what's new in 2.3" action link from the Job Statistics release notice, as the 2.3 release is two years old.

### Testing Instructions
* Navigate to the Job Listings screen in WP Admin and confirm the Job Statistics banner no longer displays a "See what's new in 2.3" link, while the Enable and Dismiss actions remain intact.
* if you dont see the notice at the beginning remove option_name "release_notice_2_3_0" from wp_options

### Release Notes
* "Remove "See what's new in 2.3" from Job Statistics Banner"

### New or Updated Hooks and Templates
-

### Deprecated Code
-

### Screenshot / Video

**BEFORE**
<img width="2297" height="623" alt="image" src="https://github.com/user-attachments/assets/d0121b0d-be09-47e7-ba5e-bbec2a805cdc" />

**AFTER**
<img width="2291" height="620" alt="image" src="https://github.com/user-attachments/assets/9896f79d-5b5f-4643-b7ae-a3c9ece792ec" />
