### PR TITLE
Add square-format hint and configurable max size for company logo uploads

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -499,17 +499,18 @@ class WP_Job_Manager_Settings {
 							'track'   => 'value',
 						],
 						[
-							'name'        => 'job_manager_company_logo_max_size',
-							'std'         => '',
-							'placeholder' => '',
-							'label'       => __( 'Company Logo Max Size', 'wp-job-manager' ),
-							'desc'        => __( 'Maximum file size for company logo uploads, in kilobytes. Leave blank to use the server default.', 'wp-job-manager' ),
-							'type'        => 'text',
-							'attributes'  => [
-								'type' => 'number',
+							'name'              => 'job_manager_company_logo_max_size',
+							'std'               => '',
+							'placeholder'       => __( 'No limit', 'wp-job-manager' ),
+							'label'             => __( 'Company Logo Max Size', 'wp-job-manager' ),
+							'desc'              => __( 'Maximum file size for company logo uploads, in kilobytes. Leave blank to use the server default.', 'wp-job-manager' ),
+							'type'              => 'number',
+							'attributes'        => [
 								'min'  => '0',
 								'step' => '1',
 							],
+							'sanitize_callback' => [ $this, 'sanitize_company_logo_max_size' ],
+							'track'             => 'value',
 						],
 						[
 							'name'       => 'job_manager_show_agreement_job_submission',
@@ -1389,6 +1390,18 @@ class WP_Job_Manager_Settings {
 	 * @return string|int
 	 */
 	public function sanitize_submission_limit( $value ) {
+		return $this->sanitize_numeric_boundaries( $value, 0, self::MAX_ALLOWED_SUBMISSION_LIMIT );
+	}
+
+	/**
+	 * Sanitize the company logo max size (in KB) between 0 and MAX_ALLOWED_SUBMISSION_LIMIT.
+	 *
+	 * A blank (non-numeric) value is preserved so uploads fall back to the server default.
+	 *
+	 * @param string|int $value
+	 * @return string|int
+	 */
+	public function sanitize_company_logo_max_size( $value ) {
 		return $this->sanitize_numeric_boundaries( $value, 0, self::MAX_ALLOWED_SUBMISSION_LIMIT );
 	}
 

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -499,6 +499,19 @@ class WP_Job_Manager_Settings {
 							'track'   => 'value',
 						],
 						[
+							'name'        => 'job_manager_company_logo_max_size',
+							'std'         => '',
+							'placeholder' => '',
+							'label'       => __( 'Company Logo Max Size', 'wp-job-manager' ),
+							'desc'        => __( 'Maximum file size for company logo uploads, in kilobytes. Leave blank to use the server default.', 'wp-job-manager' ),
+							'type'        => 'text',
+							'attributes'  => [
+								'type' => 'number',
+								'min'  => '0',
+								'step' => '1',
+							],
+						],
+						[
 							'name'       => 'job_manager_show_agreement_job_submission',
 							'std'        => '0',
 							'label'      => __( 'Terms and Conditions Checkbox', 'wp-job-manager' ),

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -355,6 +355,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'priority'           => 6,
 						'ajax'               => true,
 						'multiple'           => false,
+						'description'        => __( 'Square format recommended (1:1 ratio).', 'wp-job-manager' ),
+						'max_size'           => job_manager_get_company_logo_max_size(),
 						'allowed_mime_types' => apply_filters(
 							'job_manager_company_logo_allowed_mime_types',
 							[

--- a/readme.txt
+++ b/readme.txt
@@ -147,6 +147,9 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 
 == Changelog ==
 
+### 2.4.3
+* Add a square format hint and a configurable maximum upload size for company logos.
+
 ### 2.4.1 - 2026-02-24
 * Add permission check to listing query parameters (#2914)
 * Fix structured data output for password-protected listings (#2913)

--- a/templates/form-fields/file-field.php
+++ b/templates/form-fields/file-field.php
@@ -56,8 +56,10 @@ if ( ! empty( $field['ajax'] ) && job_manager_user_can_upload_file_via_ajax() ) 
 />
 <small class="description">
 	<?php if ( ! empty( $field['description'] ) ) : ?>
-		<?php echo wp_kses_post( $field['description'] ); ?>
-	<?php else : ?>
-		<?php printf( esc_html__( 'Maximum file size: %s.', 'wp-job-manager' ), size_format( wp_max_upload_size() ) ); ?>
+		<?php echo wp_kses_post( $field['description'] ); ?><br>
 	<?php endif; ?>
+	<?php
+	$max_size = ! empty( $field['max_size'] ) ? (int) $field['max_size'] : wp_max_upload_size();
+	printf( esc_html__( 'Maximum file size: %s.', 'wp-job-manager' ), size_format( $max_size ) );
+	?>
 </small>

--- a/templates/form-fields/file-field.php
+++ b/templates/form-fields/file-field.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.33.0
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -890,6 +890,57 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		);
 	}
 
+	/**
+	 * A configured logo max size (in KB) is returned in bytes.
+	 *
+	 * @covers ::job_manager_get_company_logo_max_size
+	 */
+	public function test_company_logo_max_size_uses_configured_value() {
+		update_option( 'job_manager_company_logo_max_size', 50 );
+
+		$this->assertSame(
+			50 * KB_IN_BYTES,
+			job_manager_get_company_logo_max_size(),
+			'A configured size in KB should be returned converted to bytes.'
+		);
+	}
+
+	/**
+	 * A blank value falls back to the server upload limit.
+	 *
+	 * @covers ::job_manager_get_company_logo_max_size
+	 */
+	public function test_company_logo_max_size_falls_back_when_blank() {
+		update_option( 'job_manager_company_logo_max_size', '' );
+
+		$this->assertSame(
+			wp_max_upload_size(),
+			job_manager_get_company_logo_max_size(),
+			'A blank value should fall back to the server upload limit.'
+		);
+	}
+
+	/**
+	 * Zero and negative values fall back to the server upload limit rather than blocking all uploads.
+	 *
+	 * @covers ::job_manager_get_company_logo_max_size
+	 */
+	public function test_company_logo_max_size_falls_back_for_zero_and_negative() {
+		update_option( 'job_manager_company_logo_max_size', 0 );
+		$this->assertSame(
+			wp_max_upload_size(),
+			job_manager_get_company_logo_max_size(),
+			'A zero value should fall back to the server upload limit.'
+		);
+
+		update_option( 'job_manager_company_logo_max_size', -5 );
+		$this->assertSame(
+			wp_max_upload_size(),
+			job_manager_get_company_logo_max_size(),
+			'A negative value should fall back to the server upload limit.'
+		);
+	}
+
 	protected function set_up_request_page() {
 		$this->go_to( get_post_type_archive_link( \WP_Job_Manager_Post_Types::PT_LISTING ) );
 	}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1470,6 +1470,20 @@ function job_manager_prepare_uploaded_files( $file_data ) {
 }
 
 /**
+ * Returns the maximum allowed file size for company logo uploads, in bytes.
+ *
+ * Returns the value configured in settings (converted from KB), or falls back
+ * to the server's upload limit when no custom value is set.
+ *
+ * @since n.e.x.t
+ * @return int Maximum file size in bytes.
+ */
+function job_manager_get_company_logo_max_size(): int {
+	$max_size_kb = (int) get_option( 'job_manager_company_logo_max_size', 0 );
+	return $max_size_kb > 0 ? $max_size_kb * KB_IN_BYTES : wp_max_upload_size();
+}
+
+/**
  * Uploads a file using WordPress file API.
  *
  * @since 1.21.0
@@ -1517,6 +1531,20 @@ function job_manager_upload_file( $file, $args = [] ) {
 
 	if ( is_wp_error( $file ) ) {
 		return $file;
+	}
+
+	if ( 'company_logo' === $args['file_key'] ) {
+		$max_size = job_manager_get_company_logo_max_size();
+		if ( $file['size'] > $max_size ) {
+			return new WP_Error(
+				'upload',
+				sprintf(
+					// translators: %s is the maximum allowed file size.
+					__( 'The company logo exceeds the maximum allowed file size of %s.', 'wp-job-manager' ),
+					size_format( $max_size )
+				)
+			);
+		}
 	}
 
 	if ( ! in_array( $file['type'], $allowed_mime_types, true ) ) {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1475,7 +1475,7 @@ function job_manager_prepare_uploaded_files( $file_data ) {
  * Returns the value configured in settings (converted from KB), or falls back
  * to the server's upload limit when no custom value is set.
  *
- * @since n.e.x.t
+ * @since $$next-version$$
  * @return int Maximum file size in bytes.
  */
 function job_manager_get_company_logo_max_size(): int {


### PR DESCRIPTION
## Summary

Addresses the two items from #1361:

1. **Square format hint** — adds "Square format recommended (1:1 ratio)." below the logo upload field so employers know what shape to use before uploading.

2. **Configurable max upload size** — adds a **Company Logo Max Size** field (in KB) to the Job Submission settings tab. When set, it's enforced server-side during upload with a clear error message, and displayed in the frontend hint below the field. Leaving it blank falls back to the server default (`wp_max_upload_size()`).

## Changes

| File | What changed |
|------|-------------|
| `includes/admin/class-wp-job-manager-settings.php` | New `job_manager_company_logo_max_size` number input in the Job Submission section |
| `wp-job-manager-functions.php` | New `job_manager_get_company_logo_max_size()` helper; size check in `job_manager_upload_file()` |
| `includes/forms/class-wp-job-manager-form-submit-job.php` | `description` and `max_size` keys added to the `company_logo` field config |
| `templates/form-fields/file-field.php` | Renders `description` (if set) above the max-size line instead of replacing it |

## Test plan

- [ ] Submit a job listing and verify the logo field shows "Square format recommended (1:1 ratio)." and the max size line beneath it
- [ ] Set **Company Logo Max Size** to e.g. `50` (KB) in settings; upload a logo larger than 50 KB — should get an error
- [ ] Upload a logo smaller than the configured limit — should succeed
- [ ] Leave **Company Logo Max Size** blank — upload limit should fall back to the PHP/Apache server default
- [ ] Other file upload fields (e.g. any non-logo fields) should be unaffected

Fixes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)