### PR TITLE
Author filter follow-up: centralize parsing, close AJAX array bypass

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -136,7 +136,14 @@ class WP_Job_Manager_Ajax {
 		$remote_position    = isset( $_REQUEST['remote_position'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['remote_position'] ) ) : null;
 		$show_pagination    = isset( $_REQUEST['show_pagination'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['show_pagination'] ) ) : null;
 		$featured_first     = isset( $_REQUEST['featured_first'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured_first'] ) ) : null;
-		$author             = ( isset( $_REQUEST['author'] ) && ! is_array( $_REQUEST['author'] ) ) ? sanitize_text_field( wp_unslash( $_REQUEST['author'] ) ) : '';
+		if ( ! isset( $_REQUEST['author'] ) ) {
+			$author = '';
+		} elseif ( is_array( $_REQUEST['author'] ) ) {
+			// Array-shaped input is not supported via AJAX - fails closed (passes '0' so get_job_listings returns zero results).
+			$author = '0';
+		} else {
+			$author = sanitize_text_field( wp_unslash( $_REQUEST['author'] ) );
+		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( is_array( $search_categories ) ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -746,31 +746,13 @@ class WP_Job_Manager_Post_Types {
 
 		if ( isset( $_GET['author'] ) ) {
 			if ( is_array( $_GET['author'] ) ) {
-				// Array-shaped input (?author[]=1) is not a supported format - fails-closed.
+				// Array-shaped query string (?author[]=1) is not a supported format - fails closed.
 				$input_author = [ 0 ];
 			} else {
-				$sanitized_author = sanitize_text_field( wp_unslash( $_GET['author'] ) );
-				// Note: '' === '' is false, so empty string = unset (no filter).
-				if ( '' === $sanitized_author ) {
-					$input_author = false;
-				} else {
-					$input_author = array_values(
-						array_filter(
-							array_map(
-								fn( $v ) => ctype_digit( trim( $v ) ) && (int) trim( $v ) > 0 ? (int) trim( $v ) : 0,
-								explode( ',', $sanitized_author )
-							),
-							fn( $v ) => $v > 0
-						)
-					);
-					// Fails-closed: author was supplied but yielded no valid IDs (e.g. '0', 'abc') -> force empty results.
-					if ( empty( $input_author ) ) {
-						$input_author = [ 0 ];
-					}
-				}
+				$input_author = _wpjm_parse_author_ids( sanitize_text_field( wp_unslash( $_GET['author'] ) ) );
 			}
 		} else {
-			$input_author = false;
+			$input_author = null;
 		}
 
 		$job_manager_keyword = isset( $_GET['search_keywords'] ) ? sanitize_text_field( wp_unslash( $_GET['search_keywords'] ) ) : '';
@@ -845,7 +827,8 @@ class WP_Job_Manager_Post_Types {
 			];
 		}
 
-		if ( ! empty( $input_author ) ) {
+		if ( null !== $input_author ) {
+			// [0] is the fail-closed sentinel: no real post_author equals 0.
 			$query_args['author__in'] = $input_author;
 		}
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
@@ -292,6 +292,38 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		return $args;
 	}
 
+	/**
+	 * Regression: array-shaped author input (?author[]=N) must fail closed and not bypass the author filter.
+	 *
+	 * @since $$next-version$$
+	 * @covers WP_Job_Manager_Ajax::get_listings
+	 */
+	public function test_get_listings_author_array_input_fails_closed() {
+		$user_a = $this->factory->user->create();
+		$this->factory->job_listing->create_many( 3, [ 'post_author' => $user_a ] );
+
+		$this->set_up_job_listing_search_request();
+		$_REQUEST['author'] = [ (string) $user_a ];
+
+		add_filter( 'job_manager_ajax_get_jobs_html_results', '__return_false' );
+		add_filter( 'job_manager_get_listings_result', [ $this, 'load_last_jobs_result' ], 10, 2 );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		ob_start();
+		WP_Job_Manager_Ajax::instance()->get_listings();
+		$result = json_decode( ob_get_clean(), true );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		remove_filter( 'job_manager_get_listings_result', [ $this, 'load_last_jobs_result' ], 10 );
+		remove_filter( 'job_manager_ajax_get_jobs_html_results', '__return_false' );
+
+		unset( $_REQUEST['author'] );
+		$this->tear_down_job_listing_search_request();
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['found_jobs'], 'Array-shaped author must fail closed, not silently disable the filter.' );
+		$this->assertArrayHasKey( '_jobs', $result );
+		$this->assertCount( 0, $result['_jobs'] );
+	}
+
 	private function set_up_job_listing_search_request() {
 		$_REQUEST['search_location']   = null;
 		$_REQUEST['search_keywords']   = null;

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -1085,7 +1085,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		$jobs_a = $this->factory->job_listing->create_many( 2, [ 'post_author' => $user_a ] );
 		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_b ] );
 
-		// 'abc' parses to 0 and should be dropped; only $user_a's listings are returned.
+		// 'abc' fails ctype_digit and is dropped; only $user_a's listings are returned.
 		$result = get_job_listings( [ 'author' => $user_a . ',abc' ] );
 
 		$this->assertEqualSets( $jobs_a, wp_list_pluck( $result->posts, 'ID' ) );
@@ -1109,5 +1109,109 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		$result = get_job_listings( [ 'author' => [ $user_a, $user_b ] ] );
 
 		$this->assertEqualSets( array_merge( $jobs_a, $jobs_b ), wp_list_pluck( $result->posts, 'ID' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_null_returns_null() {
+		$this->assertNull( _wpjm_parse_author_ids( null ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_empty_string_returns_null() {
+		$this->assertNull( _wpjm_parse_author_ids( '' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_single_numeric_string() {
+		$this->assertSame( [ 5 ], _wpjm_parse_author_ids( '5' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_comma_separated() {
+		$this->assertSame( [ 1, 2, 3 ], _wpjm_parse_author_ids( '1,2,3' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_whitespace_tolerated() {
+		$this->assertSame( [ 1, 2, 3 ], _wpjm_parse_author_ids( '1, 2 , 3' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_non_numeric_fails_closed() {
+		$this->assertSame( [ 0 ], _wpjm_parse_author_ids( 'abc' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_zero_fails_closed() {
+		$this->assertSame( [ 0 ], _wpjm_parse_author_ids( '0' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_negative_fails_closed() {
+		$this->assertSame( [ 0 ], _wpjm_parse_author_ids( '-5' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_mixed_drops_invalid_tokens() {
+		$this->assertSame( [ 1, 2 ], _wpjm_parse_author_ids( '1,abc,2' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_array_of_ints() {
+		$this->assertSame( [ 1, 2 ], _wpjm_parse_author_ids( [ 1, 2 ] ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_array_mixed_drops_invalid() {
+		$this->assertSame( [ 1, 2 ], _wpjm_parse_author_ids( [ 1, 'abc', 2, '-5', 0 ] ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_empty_array_fails_closed() {
+		$this->assertSame( [ 0 ], _wpjm_parse_author_ids( [] ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::_wpjm_parse_author_ids
+	 */
+	public function test_parse_author_ids_integer_input() {
+		$this->assertSame( [ 7 ], _wpjm_parse_author_ids( 7 ) );
 	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 	 * @param string|array|object $args {
 	 *     Arguments used to retrieve job listings.
 	 *
-	 *     @type int|string|int[] $author Optional. User ID, comma-separated user IDs, or array of user IDs to filter listings by author. Default 0 (no filter).
+	 *     @type int|string|int[] $author Optional. User ID, comma-separated user IDs, or array of user IDs to filter listings by author. Omit or pass an empty string for no filter. A supplied value that yields no valid positive integer IDs (e.g. `'0'`, `'abc'`, `[]`) fails closed and returns zero results. Added in $$next-version$$.
 	 * }
 	 * @return WP_Query
 	 */
@@ -197,20 +197,12 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			];
 		}
 
-		if ( isset( $args['author'] ) && ( is_array( $args['author'] ) || '' !== $args['author'] ) ) {
-			$raw_author = $args['author'];
-			$tokens     = is_array( $raw_author ) ? $raw_author : explode( ',', (string) $raw_author );
-			$author_ids = array_values(
-				array_filter(
-					array_map(
-						fn( $v ) => ctype_digit( trim( $v ) ) && (int) trim( $v ) > 0 ? (int) trim( $v ) : 0,
-						$tokens
-					),
-					fn( $v ) => $v > 0
-				)
-			);
-			// Fails-closed: if author was supplied but yielded no valid IDs, return zero results.
-			$query_args['author__in'] = ! empty( $author_ids ) ? $author_ids : [ 0 ];
+		if ( isset( $args['author'] ) ) {
+			$author_ids = _wpjm_parse_author_ids( $args['author'] );
+			if ( null !== $author_ids ) {
+				// [0] is the fail-closed sentinel: no real post_author equals 0.
+				$query_args['author__in'] = $author_ids;
+			}
 		}
 
 		$job_manager_keyword = sanitize_text_field( $args['search_keywords'] );
@@ -291,6 +283,52 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		remove_filter( 'posts_search', 'get_job_listings_keyword_search', 10 );
 
 		return $result;
+	}
+endif;
+
+if ( ! function_exists( '_wpjm_parse_author_ids' ) ) :
+	/**
+	 * Parse a raw author input (string, comma-separated string, integer, or array) into a list of positive user IDs.
+	 *
+	 * Returns `null` when the input represents "no filter" (the input was unset or an empty string).
+	 * Returns `[0]` as a fail-closed sentinel when the input was supplied but yielded no valid positive IDs
+	 * (e.g. `'0'`, `'abc'`, `[]`, `'-5'`). `[0]` is safe in `author__in` because no real `post_author` equals 0.
+	 *
+	 * @since $$next-version$$
+	 * @access private
+	 *
+	 * @param mixed $raw Raw author input.
+	 * @return array|null Array of positive integer user IDs, `[0]` sentinel, or null for "no filter".
+	 */
+	function _wpjm_parse_author_ids( $raw ) {
+		if ( null === $raw ) {
+			return null;
+		}
+
+		if ( is_array( $raw ) ) {
+			$tokens = $raw;
+		} else {
+			$raw = (string) $raw;
+			if ( '' === $raw ) {
+				return null;
+			}
+			$tokens = explode( ',', $raw );
+		}
+
+		$author_ids = array_values(
+			array_filter(
+				array_map(
+					static function ( $v ) {
+						$s = trim( (string) $v );
+						return ctype_digit( $s ) && (int) $s > 0 ? (int) $s : 0;
+					},
+					$tokens
+				),
+				static fn( $v ) => $v > 0
+			)
+		);
+
+		return ! empty( $author_ids ) ? $author_ids : [ 0 ];
 	}
 endif;
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -15,7 +15,8 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 	 * @param string|array|object $args {
 	 *     Arguments used to retrieve job listings.
 	 *
-	 *     @type int|string|int[] $author Optional. User ID, comma-separated user IDs, or array of user IDs to filter listings by author. Omit or pass an empty string for no filter. A supplied value that yields no valid positive integer IDs (e.g. `'0'`, `'abc'`, `[]`) fails closed and returns zero results. Added in $$next-version$$.
+	 *     @type int|string|int[] $author Optional. User ID, comma-separated user IDs, or array of user IDs to filter listings by author. Omit or pass an empty string for no filter. A supplied value that yields no valid positive integer IDs (e.g. `'0'`, `'abc'`, `[]`) fails closed and returns zero results.
+	 *                                    @since $$next-version$$
 	 * }
 	 * @return WP_Query
 	 */


### PR DESCRIPTION
Follow-up to #2935 addressing the warnings raised in code review.

## Summary

* **Centralized parsing.** Extracted `_wpjm_parse_author_ids()` in `wp-job-manager-functions.php`. `get_job_listings()`, `WP_Job_Manager_Post_Types::job_feed()`, and `WP_Job_Manager_Ajax::get_listings()` now all delegate to it instead of carrying near-identical inline parsers that could drift independently.
* **Closed the AJAX array-bypass bug.** The AJAX `get_listings` handler previously fell back to `''` (silent no-filter) when `$_REQUEST['author']` was array-shaped, so a crafted `?author[]=9999` request bypassed the author filter entirely. It now fails closed with `'0'`, matching the behaviour `job_feed()` already had for array-shaped query strings. A PHPUnit regression test covers this.
* **Documented the `[0]` sentinel in `job_feed()`.** `get_job_listings()` had a comment explaining why `author__in => [0]` is the fail-closed value (no real `post_author` equals 0); `job_feed()` did not. Comment added.
* **Tightened the new `@type` PHPDoc on `get_job_listings`.** The previous "Default 0 (no filter)" wording was inaccurate — runtime default is omitted/empty-string. Reworded and added a `$$next-version$$` since marker.
* **Fixed a stale test comment.** `test_get_job_listings_author_mixed_valid_and_invalid` said `'abc' parses to 0`; with `ctype_digit` it's dropped before the integer cast.

## Test plan

- [ ] CI runs the new direct unit tests for `_wpjm_parse_author_ids` (null, empty string, single ID, comma-separated, whitespace, non-numeric, zero, negative, mixed valid/invalid, array variants, empty array, integer input).
- [ ] CI runs the new AJAX regression test `test_get_listings_author_array_input_fails_closed` confirming that `?author[]=N` returns zero jobs rather than silently disabling the filter.
- [ ] CI runs the pre-existing `get_job_listings()` author tests — these still cover the behaviour transitively via the new helper.
- [ ] PHPCS clean locally (`make lint`).
- [ ] Manual smoke (any reviewer): `[jobs author="1"]`, `[jobs author="1,2"]`, `[jobs author="abc"]` (zero results), `[jobs]` (no filter), `?author=1` and `?author=1,2` on the job archive feed.

## Out of scope / parallel work

These came up in the review but are deliberately not in this PR:

- **External shortcode reference docs.** `readme.txt` mentions the `[jobs]` shortcode but doesn't carry a full attribute reference. The user-facing shortcode reference at wpjobmanager.com needs an `author` entry — that's a docs-team task and lives outside this repo.
- **Reset link UX in `job_manager_get_filtered_links()`.** It doesn't treat a page-scoped `author` as an active filter, so author-only pages may still show Reset. Matches how `featured` / `filled` are handled today; low priority.
- **"Search completed" AJAX copy.** Not set for author changes either; consistent with other shortcode-scoped attrs. Defer until product wants the change.
- **Changelog entry for the `author` attribute.** #2935 didn't add one; not adding here either — keeping this PR scoped to the review fixes.

Refs #2935


<!-- wpjm:plugin-zip -->
----

| Plugin build for 57422ed06c54d34db88ff0401a19b991f81578fd <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/05/wp-job-manager-zip-2958-57422ed0.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/05/2958-57422ed0)             |

<!-- /wpjm:plugin-zip -->


