### PR TITLE
Fix: quote data-href attribute and add esc_js() in promoted jobs admin

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -172,7 +172,7 @@ class WP_Job_Manager_Admin {
 
 				wp_add_inline_script(
 					'job_manager_job_editor_js',
-					sprintf( 'window.wpjm = window.wpjm || {}; window.wpjm.promoteUrl = "%s";', esc_js( esc_url( WP_Job_Manager_Promoted_Jobs_Admin::get_promote_url( $post->ID ) ) ) ),
+					sprintf( 'window.wpjm = window.wpjm || {}; window.wpjm.promoteUrl = %s;', wp_json_encode( esc_url_raw( WP_Job_Manager_Promoted_Jobs_Admin::get_promote_url( $post->ID ) ) ) ),
 					'before'
 				);
 			}

--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -172,7 +172,7 @@ class WP_Job_Manager_Admin {
 
 				wp_add_inline_script(
 					'job_manager_job_editor_js',
-					sprintf( 'window.wpjm = window.wpjm || {}; window.wpjm.promoteUrl = "%s";', WP_Job_Manager_Promoted_Jobs_Admin::get_promote_url( $post->ID ) ),
+					sprintf( 'window.wpjm = window.wpjm || {}; window.wpjm.promoteUrl = "%s";', esc_js( esc_url( WP_Job_Manager_Promoted_Jobs_Admin::get_promote_url( $post->ID ) ) ) ),
 					'before'
 				);
 			}

--- a/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
+++ b/includes/admin/class-wp-job-manager-promoted-jobs-admin.php
@@ -268,7 +268,7 @@ class WP_Job_Manager_Promoted_Jobs_Admin {
 			</div>
 			';
 		} elseif ( 'publish' === $post->post_status ) {
-			echo '<button class="promote_job button button-primary" data-href=' . esc_url( $promote_url ) . '>' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
+			echo '<button class="promote_job button button-primary" data-href="' . esc_url( $promote_url ) . '">' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';
 		} else {
 			$title = __( 'The job needs to be published in order to be promoted.', 'wp-job-manager' );
 			echo '<button type="button" class="button button-primary tips disabled" aria-disabled="true" title="' . esc_attr( $title ) . '" data-tip="' . esc_attr( $title ) . '">' . esc_html__( 'Promote', 'wp-job-manager' ) . '</button>';


### PR DESCRIPTION
Fixes #2966

### Changes Proposed in this Pull Request

Two small fixes in the Promoted Jobs admin area:

1. **`class-wp-job-manager-promoted-jobs-admin.php`** — The Promote button's `data-href` attribute was unquoted: `data-href=VALUE` instead of `data-href="VALUE"`. The Deactivate link directly above it in the same function correctly quotes its `data-href`. Adds the missing double-quotes for valid HTML.

2. **`class-wp-job-manager-admin.php`** — The promote URL passed to `wp_add_inline_script()` via `sprintf()` was not wrapped in `esc_js()`. URL values written into JS string literals need both `esc_url()` (URL integrity) and `esc_js()` (JS context safety). Added `esc_js( esc_url( ... ) )`.

### Testing Instructions

1. Create a published job listing as an admin.
2. In the job listings table, confirm the **Promote** button renders with a properly quoted `data-href` attribute (inspect element).
3. Open the job editor for a published listing. Confirm `window.wpjm.promoteUrl` is correctly set in the page source without breakage.
4. Click Promote — confirm the flow works as before.

### Release Notes

* Fix: Promote button `data-href` attribute now correctly quoted in job listings table.
* Fix: Promote URL in inline script now escaped with `esc_js()`.

### New or Updated Hooks and Templates

*None.*

### Deprecated Code

*None.*

---
*Developed with AI assistance (Claude). Manually reviewed.*