### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '7.4'
           tools: composer

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: gh pr comment ${{ github.event.number }} --body "🚀 **[Release workflow started](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**"
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '7.4'
           tools: composer
@@ -41,7 +41,7 @@ jobs:
       - name: Install SVN
         run: sudo apt-get update && sudo apt-get install -y subversion
       - name: Deploy to WordPress.org
-        uses: 10up/action-wordpress-plugin-deploy@abb939a0d0bfd01063e8d1933833209201557381
+        uses: 10up/action-wordpress-plugin-deploy@abb939a0d0bfd01063e8d1933833209201557381 # 2.2.2
         env:
           SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -22,7 +22,7 @@ jobs:
          node-version: 16
 
      - name: Wait for prior instances of the workflow to finish
-       uses: softprops/turnstyle@v1
+       uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # v0.1.5
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,13 +13,13 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
       - name: Generate Swagger UI
-        uses: Legion2/swagger-ui-action@v1
+        uses: Legion2/swagger-ui-action@eff65dc3f193f0a749872be82f74baa35be0797d # v1.3.0
         with:
           output: swagger-ui
           spec-file: ./docs/api/internal.json
           version: "^4.18.0"
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: swagger-ui

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '7.4'
           tools:       composer
@@ -83,7 +83,7 @@ jobs:
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           extensions: mysql
@@ -122,7 +122,7 @@ jobs:
           path: vendor/
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This PR was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 5
- Repo-level unpinned usage count from the trunk recheck: 8
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Ref adjustment notes:
- .github/workflows/gardening.yml: `softprops/turnstyle@v1` -> `softprops/turnstyle@v0.1.5`

Verification commands:

```bash
# 10up/action-wordpress-plugin-deploy # 2.2.2 -> abb939a0d0bfd01063e8d1933833209201557381
gh api repos/10up/action-wordpress-plugin-deploy/commits/2.2.2 --jq '.sha'
# expected: abb939a0d0bfd01063e8d1933833209201557381

# Legion2/swagger-ui-action # v1.3.0 -> eff65dc3f193f0a749872be82f74baa35be0797d
gh api repos/Legion2/swagger-ui-action/commits/v1.3.0 --jq '.sha'
# expected: eff65dc3f193f0a749872be82f74baa35be0797d

# peaceiris/actions-gh-pages # v3.9.3 -> 373f7f263a76c20808c831209c920827a82a2847
gh api repos/peaceiris/actions-gh-pages/commits/v3.9.3 --jq '.sha'
# expected: 373f7f263a76c20808c831209c920827a82a2847

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# softprops/turnstyle # v0.1.5 -> 8db075d65b19bf94e6e8687b504db69938dc3c65
gh api repos/softprops/turnstyle/commits/v0.1.5 --jq '.sha'
# expected: 8db075d65b19bf94e6e8687b504db69938dc3c65
```


<!-- wpjm:plugin-zip -->
----

| Plugin build for 1a5d8128c3710593255f22c97ce075d2e8d491ec <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2969-1a5d8128.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2969-1a5d8128)             |

<!-- /wpjm:plugin-zip -->
