### PR TITLE
Ship blueprint.json in release zip so WP.org preview works

### DIFF
--- a/scripts/exclude.lst
+++ b/scripts/exclude.lst
@@ -35,7 +35,6 @@ wp-job-manager/.claude/*
 wp-job-manager/.phpunit.result.cache
 wp-job-manager/.wp-env.json
 wp-job-manager/.wp-env.tests.json
-wp-job-manager/blueprint.json
 wp-job-manager/Makefile
 wp-job-manager/CLAUDE.md
 wp-job-manager/AGENTS.md


### PR DESCRIPTION
Fixes #2861.

`blueprint.json` was added to the repo in f9e33563 to fix the WordPress.org plugin preview, but `scripts/exclude.lst` listed it as a release-zip exclusion. The release pipeline stripped the file from the WP.org-deployed plugin, so the directory's preview endpoint kept serving the prior (broken) blueprint that references the missing `https://wpjobmanager.com/wp-content/uploads/2024/03/playground-5.zip`.

This removes the exclusion so the trunk blueprint ships in the next release.

## Verifying

After the next release reaches WP.org, the preview blueprint at
https://wordpress.org/plugins/wp-json/plugins/v1/plugin/wp-job-manager/blueprint.json
should match `blueprint.json` in this repo (landing page on the job listings admin screen, login, install-plugin from `wordpress.org/plugins`).

## Possible WP.org-side caveat

If the WP.org SVN `assets/` directory contains its own `blueprint.json` from earlier work, that copy may take precedence over the trunk-shipped one. If the preview is still broken after the release lands, the SVN `assets/blueprint.json` likely needs to be updated or removed manually (out of repo).


<!-- wpjm:plugin-zip -->
----

| Plugin build for 88e1fe7944ec714f9e6e830353a3da4b7c057697 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2975-88e1fe79.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2975-88e1fe79)             |

<!-- /wpjm:plugin-zip -->
