### PR TITLE
Seed .out-of-scope/ KB with self-service-premium-flags entry

### DIFF
--- a/.out-of-scope/self-service-premium-flags.md
+++ b/.out-of-scope/self-service-premium-flags.md
@@ -1,0 +1,50 @@
+# Self-Service Premium Flags
+
+This project does not, by default, expose premium / paid-tier listing flags (Featured, Promoted, etc.) as toggles on the *frontend* job submission form.
+
+## Why this is out of scope
+
+Premium flags exist in WP Job Manager as plain post-meta in core (e.g. `_featured` on `job_listing`), but the **paid-tier business model is enforced at the UI layer** — by which surfaces expose the toggle to which users. The intended flow is:
+
+- **Backend / `edit_others_posts`-capable users** (site admins, editors) can toggle Featured directly on the post edit screen.
+- **Submitter-facing flows** that need Featured as a *paid* upgrade go through the [WC Paid Listings add-on](https://wpjobmanager.com/add-ons/wc-paid-listings/), which mediates the upgrade as a WooCommerce product purchase.
+
+Adding a default "Featured" checkbox to the frontend submission form would:
+
+1. Let any submitter on a free install get the Featured perk (top-of-list ranking, highlighting) at no cost, undermining the paid-upgrade boundary that the WC Paid Listings add-on depends on.
+2. Conflict with WC Paid Listings on commercial sites — the add-on assumes Featured is something a submitter *purchases*, not something they tick.
+3. Push the premium boundary into core code rather than keeping it as an add-on concern.
+
+The same reasoning applies to other premium flags such as Promoted Jobs — surfacing them as a free toggle on submitter-facing forms would defeat their purpose.
+
+## The supported escape hatch
+
+Sites that legitimately want to expose Featured (or any other field) on the frontend form for *their own* trusted users (e.g. an in-house editorial team submitting via the frontend instead of `/wp-admin/`) can already do this via the `submit_job_form_fields` filter:
+
+```php
+add_filter( 'submit_job_form_fields', function ( $fields ) {
+    $fields['job']['featured'] = [
+        'label'       => __( 'Featured', 'mytheme' ),
+        'type'        => 'checkbox',
+        'required'    => false,
+        'priority'    => 11,
+    ];
+    return $fields;
+} );
+
+// And save it on submission (capability-gated):
+add_action( 'job_manager_update_job_data', function ( $job_id, $values ) {
+    if ( ! current_user_can( 'edit_others_posts' ) ) {
+        return;
+    }
+    if ( ! empty( $values['job']['featured'] ) ) {
+        update_post_meta( $job_id, '_featured', 1 );
+    }
+}, 10, 2 );
+```
+
+Capability-gating the save (as above) is essential — it prevents the free-tier abuse path while supporting the internal-team use case the requesters typically have in mind.
+
+## Prior requests
+
+- [#2327](https://github.com/Automattic/WP-Job-Manager/issues/2327) — "Request Featured Checkbox on the Front End Post Page"

--- a/.out-of-scope/self-service-premium-flags.md
+++ b/.out-of-scope/self-service-premium-flags.md
@@ -17,33 +17,13 @@ Adding a default "Featured" checkbox to the frontend submission form would:
 
 The same reasoning applies to other premium flags such as Promoted Jobs — surfacing them as a free toggle on submitter-facing forms would defeat their purpose.
 
-## The supported escape hatch
+## What we won't ship in core
 
-Sites that legitimately want to expose Featured (or any other field) on the frontend form for *their own* trusted users (e.g. an in-house editorial team submitting via the frontend instead of `/wp-admin/`) can already do this via the `submit_job_form_fields` filter:
+- A built-in Featured (or Promoted) checkbox on the frontend submission form.
+- A core settings toggle that exposes premium flags to submitters.
+- Documentation or examples that help end-users bypass the WC Paid Listings purchase flow.
 
-```php
-add_filter( 'submit_job_form_fields', function ( $fields ) {
-    $fields['job']['featured'] = [
-        'label'       => __( 'Featured', 'mytheme' ),
-        'type'        => 'checkbox',
-        'required'    => false,
-        'priority'    => 11,
-    ];
-    return $fields;
-} );
-
-// And save it on submission (capability-gated):
-add_action( 'job_manager_update_job_data', function ( $job_id, $values ) {
-    if ( ! current_user_can( 'edit_others_posts' ) ) {
-        return;
-    }
-    if ( ! empty( $values['job']['featured'] ) ) {
-        update_post_meta( $job_id, '_featured', 1 );
-    }
-}, 10, 2 );
-```
-
-Capability-gating the save (as above) is essential — it prevents the free-tier abuse path while supporting the internal-team use case the requesters typically have in mind.
+Sites with a *genuine* internal need (e.g. an in-house editorial team submitting jobs via the frontend instead of `/wp-admin/` because they don't have admin access) should add the field themselves with capability checks matched to their team's roles — they don't need it documented here, and we won't ship a recipe for it.
 
 ## Prior requests
 


### PR DESCRIPTION
Adds an `.out-of-scope/` knowledge base used by the triage workflow ([docs](https://github.com/Automattic/WP-Job-Manager/blob/trunk/docs/agents/)) to record rejected feature-request **concepts** durably, so they don't get re-litigated when similar requests come in later. One file per concept, not per issue.

This PR seeds the directory with the first entry:

**`self-service-premium-flags.md`** — documents why front-end self-service toggles for premium flags (Featured, Promoted) are out of scope: the freemium boundary is enforced at the UI surface, and exposing these flags by default on submitter-facing forms would (1) let free-tier users get the perk for free and (2) conflict with the **WC Paid Listings** add-on which mediates Featured as a paid upgrade. Includes the supported developer escape hatch (the `submit_job_form_fields` filter + a capability gate on the save side).

Refs #2327, which will be closed as wontfix once this lands, linking back to the entry as the durable rationale.

No functional change. Maintainer-facing documentation only.



<!-- wpjm:plugin-zip -->
----

| Plugin build for 4abd9807452f96760e5c8601f46b0329a37cd2e0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2978-4abd9807.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2978-4abd9807)             |

<!-- /wpjm:plugin-zip -->


