### PR TITLE
Exclude .out-of-scope/ from release zip

### DIFF
--- a/scripts/exclude.lst
+++ b/scripts/exclude.lst
@@ -32,6 +32,7 @@ wp-job-manager/renovate.json
 wp-job-manager/webpack.config.js
 wp-job-manager/.husky/*
 wp-job-manager/.claude/*
+wp-job-manager/.out-of-scope/*
 wp-job-manager/.phpunit.result.cache
 wp-job-manager/.wp-env.json
 wp-job-manager/.wp-env.tests.json


### PR DESCRIPTION
Follow-up to #2978. The `.out-of-scope/` knowledge base added there is maintainer-facing triage documentation — it documents *why* certain feature requests are rejected so future triage doesn't re-litigate them. It has no value (and arguably negative value) inside a deployed plugin zip.

Adds `wp-job-manager/.out-of-scope/*` to `scripts/exclude.lst`, alongside the other maintainer-facing dot-directory exclusions (`.claude/`, `.github/`, etc.).

No functional change. The first release built after this lands won't ship the `.out-of-scope/` directory to WordPress.org.


<!-- wpjm:plugin-zip -->
----

| Plugin build for f19f4fe8555e30010691c4eecc9ba989376fec31 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2979-f19f4fe8.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2979-f19f4fe8)             |

<!-- /wpjm:plugin-zip -->
