### PR TITLE
Enforce listing submission limit when publishing a previewed listing

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1163,6 +1163,17 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$job = get_post( $this->job_id );
 
 			if ( in_array( $job->post_status, [ 'preview', 'expired' ], true ) ) {
+				// Re-validate the submission limit before promoting a listing for the
+				// first time. A `preview` listing is not yet counted, so the page-load
+				// check in WP_Job_Manager_Shortcodes::handle_redirects() is not enough on
+				// its own. Renewals of already-counted listings (e.g. `expired`) are
+				// exempt because publishing them does not increase the user's count.
+				if ( 'preview' === $job->post_status && ! job_manager_user_can_submit_job_listing() ) {
+					$this->add_error( __( 'You have reached the listing limit for your account and cannot publish this listing.', 'wp-job-manager' ) );
+
+					return;
+				}
+
 				// Reset expiry.
 				delete_post_meta( $job->ID, '_job_expires' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -147,6 +147,9 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 
 == Changelog ==
 
+### 2.4.3
+* Fix enforcement of the listing submission limit.
+
 ### 2.4.1 - 2026-02-24
 * Add permission check to listing query parameters (#2914)
 * Fix structured data output for password-protected listings (#2913)

--- a/readme.txt
+++ b/readme.txt
@@ -149,6 +149,7 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 
 ### 2.4.3
 * Fix enforcement of the listing submission limit.
+* Apply the listing submission limit as an inclusive maximum.
 
 ### 2.4.1 - 2026-02-24
 * Add permission check to listing query parameters (#2914)

--- a/tests/php/tests/includes/test_class.submit-job-submission-limit.php
+++ b/tests/php/tests/includes/test_class.submit-job-submission-limit.php
@@ -84,6 +84,35 @@ class WP_Test_Submit_Job_Submission_Limit extends WPJM_BaseTest {
 	}
 
 	/**
+	 * The limit is inclusive: a user who already has exactly the maximum number
+	 * of listings cannot publish another previewed listing.
+	 */
+	public function test_preview_listing_not_promoted_at_exactly_limit() {
+		$this->login_as_employer();
+		$user_id = get_current_user_id();
+
+		update_option( 'job_manager_submission_limit', 1 );
+
+		// Exactly at the limit of 1.
+		$this->factory->job_listing->create( [ 'post_author' => $user_id ] );
+
+		$preview_id = $this->factory->job_listing->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'preview',
+			]
+		);
+
+		$this->continue_from_preview( $preview_id );
+
+		$this->assertEquals(
+			'preview',
+			get_post_status( $preview_id ),
+			'A user at exactly the limit must not be able to publish another listing.'
+		);
+	}
+
+	/**
 	 * The limit re-check does not interfere with the normal submission flow:
 	 * a user under the limit can publish their previewed listing.
 	 */

--- a/tests/php/tests/includes/test_class.submit-job-submission-limit.php
+++ b/tests/php/tests/includes/test_class.submit-job-submission-limit.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Tests that the submission limit is enforced when a listing is promoted from
+ * the `preview` step to a published status, not only on form page load.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Submit_Job_Submission_Limit extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+
+		// Deterministic promotion target.
+		update_option( 'job_manager_submission_requires_approval', 0 );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_submission_limit' );
+		delete_option( 'job_manager_submission_requires_approval' );
+		unset( $_POST, $_REQUEST );
+		$_POST    = [];
+		$_REQUEST = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Drives WP_Job_Manager_Form_Submit_Job::preview_handler() for the "continue"
+	 * action against a specific job, the way the preview step POST does.
+	 *
+	 * @param int $job_id Job listing to promote.
+	 */
+	private function continue_from_preview( $job_id ) {
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$job_id_prop = $class->getProperty( 'job_id' );
+		$job_id_prop->setAccessible( true );
+		$job_id_prop->setValue( $form, $job_id );
+
+		$step_prop = $class->getProperty( 'step' );
+		$step_prop->setAccessible( true );
+		$step_prop->setValue( $form, 1 );
+
+		$nonce                   = wp_create_nonce( 'preview-job-' . $job_id );
+		$_POST                   = [
+			'continue'    => '1',
+			'job_id'      => $job_id,
+			'_wpjm_nonce' => $nonce,
+		];
+		$_REQUEST['_wpjm_nonce'] = $nonce;
+
+		$form->preview_handler();
+	}
+
+	/**
+	 * A user over the submission limit cannot publish a stockpiled `preview`
+	 * listing by completing the preview step.
+	 */
+	public function test_preview_listing_not_promoted_when_over_limit() {
+		$this->login_as_employer();
+		$user_id = get_current_user_id();
+
+		update_option( 'job_manager_submission_limit', 1 );
+
+		// Two published listings put the user over the limit of 1.
+		$this->factory->job_listing->create_many( 2, [ 'post_author' => $user_id ] );
+
+		$preview_id = $this->factory->job_listing->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'preview',
+			]
+		);
+
+		$this->continue_from_preview( $preview_id );
+
+		$this->assertEquals(
+			'preview',
+			get_post_status( $preview_id ),
+			'Preview listing must not be promoted when the user is over the submission limit.'
+		);
+	}
+
+	/**
+	 * The limit re-check does not interfere with the normal submission flow:
+	 * a user under the limit can publish their previewed listing.
+	 */
+	public function test_preview_listing_promoted_when_under_limit() {
+		$this->login_as_employer();
+		$user_id = get_current_user_id();
+
+		update_option( 'job_manager_submission_limit', 5 );
+
+		$preview_id = $this->factory->job_listing->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'preview',
+			]
+		);
+
+		$this->continue_from_preview( $preview_id );
+
+		$this->assertEquals(
+			'publish',
+			get_post_status( $preview_id ),
+			'Preview listing should publish normally when the user is under the limit.'
+		);
+	}
+
+	/**
+	 * Renewing an already-counted `expired` listing is exempt from the limit,
+	 * since republishing it does not increase the user's listing count.
+	 */
+	public function test_expired_listing_renewal_not_blocked_when_over_limit() {
+		$this->login_as_employer();
+		$user_id = get_current_user_id();
+
+		update_option( 'job_manager_submission_limit', 1 );
+
+		// A published listing plus the expired one puts the user over the limit.
+		$this->factory->job_listing->create( [ 'post_author' => $user_id ] );
+
+		$expired_id = $this->factory->job_listing->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'expired',
+			]
+		);
+
+		$this->continue_from_preview( $expired_id );
+
+		$this->assertEquals(
+			'publish',
+			get_post_status( $expired_id ),
+			'Expired listing renewal must not be blocked by the submission limit.'
+		);
+	}
+}

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1917,7 +1917,7 @@ function job_manager_get_salary_unit_options( $include_empty = true ) {
 function job_manager_user_can_submit_job_listing() {
 	$submission_limit = get_option( 'job_manager_submission_limit', '' );
 	$job_count        = job_manager_count_user_job_listings();
-	$can_submit       = '' === $submission_limit || $submission_limit >= $job_count;
+	$can_submit       = '' === $submission_limit || $submission_limit > $job_count;
 	/**
 	 * Filter if the current user can or cannot submit job listings
 	 *


### PR DESCRIPTION
## Summary

Applies the per-account listing limit (`job_manager_submission_limit`) consistently and as an inclusive maximum, so it is enforced when a previewed listing is published — not only on form page load — and caps the account at exactly the configured number of listings.

## Changes

- `preview_handler()` re-checks `job_manager_user_can_submit_job_listing()` before a `preview` listing is promoted to a published status, surfacing the standard limit message when the account is over its limit.
- `job_manager_user_can_submit_job_listing()` compares the limit to the current count with `>` instead of `>=`, so the limit is an inclusive cap. Previously an account could hold one listing beyond the configured maximum.
- Renewals of already-counted listings (e.g. `expired`) are exempt, since republishing them does not increase the account's listing count.
- Adds regression tests covering the over-limit, exactly-at-limit, under-limit, and expired-renewal cases.

## Note

This makes the limit slightly stricter: sites that currently allow one listing beyond the configured maximum will now cap at exactly that number.

## Testing

- `vendor/bin/phpunit --filter WP_Test_Submit_Job_Submission_Limit` — 4 passing.
- `php -l` and `phpcs` clean (pre-commit hook).

<!-- wpjm:plugin-zip -->
----

| Plugin build for fdbcc922865b3e9ced0a80bec330884e96907544 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2981-fdbcc922.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2981-fdbcc922)             |

<!-- /wpjm:plugin-zip -->
