### PR TITLE
Apply the View Job Capability to job listing feeds

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -832,6 +832,14 @@ class WP_Job_Manager_Post_Types {
 			$query_args['author__in'] = $input_author;
 		}
 
+		// View-capability gate — when the configured View Job Capability denies the current
+		// viewer, limit the feed to their own listings ([0] / none for anonymous), mirroring
+		// the per-listing gate enforced by the single listing view and REST API. This overrides
+		// any requested author filter: a denied viewer may only ever see their own listings.
+		if ( self::feed_viewer_denied_by_view_cap() ) {
+			$query_args['author__in'] = [ get_current_user_id() ];
+		}
+
 		if ( ! empty( $job_manager_keyword ) ) {
 			$query_args['s'] = $job_manager_keyword;
 			add_filter( 'posts_search', 'get_job_listings_keyword_search', 10, 2 );
@@ -877,6 +885,40 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		$query->set( 'has_password', false );
+
+		// View-capability gate — see job_feed(): restrict a denied viewer to their own
+		// listings ([0] / none for anonymous) so the default RSS / Atom endpoints do not
+		// expose details the single listing view and REST API withhold.
+		if ( self::feed_viewer_denied_by_view_cap() ) {
+			$query->set( 'author__in', [ get_current_user_id() ] );
+		}
+	}
+
+	/**
+	 * Whether the configured View Job Capability denies the current viewer.
+	 *
+	 * Used to gate feed queries at the query level. Mirrors the capability check in
+	 * {@see job_manager_user_can_view_job_listing()}; the per-listing author-owns-it and
+	 * `preview` bypasses there are handled here by restricting the query to the viewer's
+	 * own listings rather than excluding them. When the option is empty (the default),
+	 * viewing is unrestricted and this returns false.
+	 *
+	 * @return bool True when the viewer cannot satisfy the configured view capability.
+	 */
+	private static function feed_viewer_denied_by_view_cap() {
+		$caps = get_option( 'job_manager_view_job_listing_capability' );
+
+		if ( empty( $caps ) ) {
+			return false;
+		}
+
+		foreach ( (array) $caps as $cap ) {
+			if ( current_user_can( $cap ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -833,11 +833,18 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		// View-capability gate — when the configured View Job Capability denies the current
-		// viewer, limit the feed to their own listings ([0] / none for anonymous), mirroring
-		// the per-listing gate enforced by the single listing view and REST API. This overrides
-		// any requested author filter: a denied viewer may only ever see their own listings.
+		// viewer, limit the feed to their own listings, mirroring the per-listing gate
+		// enforced by the single listing view and REST API. This overrides any requested
+		// author filter: a denied viewer may only ever see their own listings.
 		if ( self::feed_viewer_denied_by_view_cap() ) {
-			$query_args['author__in'] = [ get_current_user_id() ];
+			$viewer_id = get_current_user_id();
+			if ( $viewer_id ) {
+				$query_args['author__in'] = [ $viewer_id ];
+			} else {
+				// Anonymous: no listings. Post IDs are never 0, so this is a safe empty
+				// sentinel — unlike author__in, since a listing can have post_author 0.
+				$query_args['post__in'] = [ 0 ];
+			}
 		}
 
 		if ( ! empty( $job_manager_keyword ) ) {
@@ -887,10 +894,16 @@ class WP_Job_Manager_Post_Types {
 		$query->set( 'has_password', false );
 
 		// View-capability gate — see job_feed(): restrict a denied viewer to their own
-		// listings ([0] / none for anonymous) so the default RSS / Atom endpoints do not
-		// expose details the single listing view and REST API withhold.
+		// listings (none for anonymous) so the default RSS / Atom endpoints do not expose
+		// details the single listing view and REST API withhold.
 		if ( self::feed_viewer_denied_by_view_cap() ) {
-			$query->set( 'author__in', [ get_current_user_id() ] );
+			$viewer_id = get_current_user_id();
+			if ( $viewer_id ) {
+				$query->set( 'author__in', [ $viewer_id ] );
+			} else {
+				// Anonymous: no listings. Post IDs are never 0 (safe sentinel); author 0 is not.
+				$query->set( 'post__in', [ 0 ] );
+			}
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,7 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 ### 2.4.3
 * Fix enforcement of the listing submission limit.
 * Apply the listing submission limit as an inclusive maximum.
+* Apply the View Job Capability to RSS and Atom feeds.
 
 ### 2.4.1 - 2026-02-24
 * Add permission check to listing query parameters (#2914)

--- a/tests/php/tests/security/test_class.feed-view-capability.php
+++ b/tests/php/tests/security/test_class.feed-view-capability.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Regression tests for the View Job Capability gate on RSS / Atom feeds.
+ *
+ * Covers the configuration where anonymous users may browse listing indexes
+ * (`job_manager_browse_job_listings_capability` empty) but must satisfy a
+ * capability to view individual listing details
+ * (`job_manager_view_job_listing_capability` set). The feeds must withhold
+ * listing details from a denied viewer, consistently with the single listing
+ * view and the REST single-item route.
+ *
+ * @package wp-job-manager/tests
+ */
+class Tests_Feed_View_Capability extends WPJM_BaseTest {
+
+	const SENTINEL = 'SENTINEL_FEED_VIEWCAP_LEAK';
+
+	private $author_id;
+
+	public function setUp(): void {
+		parent::setUp();
+		// Browsing is open to everyone; viewing details requires the `read` capability,
+		// which anonymous users do not have.
+		delete_option( 'job_manager_browse_job_listings_capability' );
+		update_option( 'job_manager_view_job_listing_capability', [ 'read' ] );
+
+		// Listings must have a real (non-zero) author: the feed gate restricts denied
+		// viewers via `author__in => [0]`, the fail-closed sentinel used throughout the
+		// feed code. Production listings always have a submitter, so an author-0 post
+		// (the factory default) would not reflect a real listing.
+		$this->author_id = $this->factory->user->create( [ 'role' => 'employer' ] );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		parent::tearDown();
+	}
+
+	private function create_restricted_listing() {
+		$post_id = $this->factory->job_listing->create(
+			[
+				'post_author'  => $this->author_id,
+				'post_content' => self::SENTINEL,
+				'post_title'   => self::SENTINEL . ' title',
+			]
+		);
+		update_post_meta( $post_id, '_company_name', self::SENTINEL . ' company' );
+		update_post_meta( $post_id, '_job_location', self::SENTINEL . ' location' );
+
+		return $post_id;
+	}
+
+	/**
+	 * Captures the custom job_feed output.
+	 *
+	 * Mirrors the helper in test_class.capability-restricted-listing-output.php.
+	 */
+	private function capture_job_feed() {
+		ob_start();
+		try {
+			@WP_Job_Manager_Post_Types::instance()->job_feed();
+			$out = ob_get_clean();
+		} catch ( Exception $e ) {
+			$out = ob_get_clean();
+			throw $e;
+		}
+
+		return (string) $out;
+	}
+
+	/**
+	 * Returns the post IDs the job_feed query selected, after rendering the feed.
+	 *
+	 * Asserting on the resulting query (rather than the rendered RSS string) tests the
+	 * gate directly and is immune to the feed template's once-per-process rendering
+	 * behaviour: query_posts() populates the global query before the body is rendered.
+	 */
+	private function job_feed_post_ids() {
+		$this->capture_job_feed();
+		global $wp_query;
+
+		return wp_list_pluck( $wp_query->posts, 'ID' );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_omits_restricted_listing_for_anonymous() {
+		$post_id = $this->create_restricted_listing();
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->job_feed_post_ids(),
+			'Restricted listing must be excluded from the feed for a denied viewer.'
+		);
+	}
+
+	/**
+	 * Positive control: a viewer who satisfies the view capability still receives the listing,
+	 * so the gate does not over-block.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_includes_restricted_listing_for_capable_viewer() {
+		$post_id = $this->create_restricted_listing();
+		$this->login_as_admin();
+
+		$this->assertContains(
+			$post_id,
+			$this->job_feed_post_ids(),
+			'A capable viewer must still receive the listing in the feed.'
+		);
+	}
+
+	/**
+	 * The core feed gate restricts a denied viewer to their own listings.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_feed_query_for_listings
+	 */
+	public function test_core_feed_query_restricts_denied_anonymous_viewer() {
+		$this->logout();
+
+		$previous_main_query = isset( $GLOBALS['wp_the_query'] ) ? $GLOBALS['wp_the_query'] : null;
+
+		$query           = new WP_Query();
+		$query->is_feed  = true;
+		$query->set( 'post_type', WP_Job_Manager_Post_Types::PT_LISTING );
+		// is_main_query() compares identity against the global query.
+		$GLOBALS['wp_the_query'] = $query;
+
+		try {
+			WP_Job_Manager_Post_Types::instance()->gate_feed_query_for_listings( $query );
+		} finally {
+			$GLOBALS['wp_the_query'] = $previous_main_query;
+		}
+
+		// Anonymous viewer (user id 0) is fail-closed to no author.
+		$this->assertSame( [ 0 ], $query->get( 'author__in' ) );
+	}
+}

--- a/tests/php/tests/security/test_class.feed-view-capability.php
+++ b/tests/php/tests/security/test_class.feed-view-capability.php
@@ -135,7 +135,32 @@ class Tests_Feed_View_Capability extends WPJM_BaseTest {
 			$GLOBALS['wp_the_query'] = $previous_main_query;
 		}
 
-		// Anonymous viewer (user id 0) is fail-closed to no author.
-		$this->assertSame( [ 0 ], $query->get( 'author__in' ) );
+		// Anonymous viewer is fail-closed via post__in (post IDs are never 0), not via
+		// author__in — a listing can have post_author 0, which author__in => [0] would match.
+		$this->assertSame( [ 0 ], $query->get( 'post__in' ) );
+	}
+
+	/**
+	 * A listing with no author (post_author 0) must still be excluded for a denied
+	 * anonymous viewer. Regression for the author__in => [0] sentinel matching author-0
+	 * listings instead of excluding them.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_omits_author_zero_listing_for_anonymous() {
+		$post_id = $this->factory->job_listing->create(
+			[
+				'post_author'  => 0,
+				'post_content' => self::SENTINEL,
+				'post_title'   => self::SENTINEL . ' orphan',
+			]
+		);
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->job_feed_post_ids(),
+			'An author-0 listing must be excluded from the feed for a denied viewer.'
+		);
 	}
 }


### PR DESCRIPTION
## Summary

The RSS / Atom feed paths applied only the **browse** capability gate, not the per-listing **View Job Capability**. On a site where browsing is open but viewing details requires a capability, a denied viewer could retrieve listing details (title, content, company, location, salary) through the feeds — details that the single listing view and the REST single-item route already withhold. This aligns the feeds with those paths.

## Changes

- Added a shared `feed_viewer_denied_by_view_cap()` check (mirrors the capability check in `job_manager_user_can_view_job_listing()`).
- `job_feed()` (custom `job_feed`) and `gate_feed_query_for_listings()` (core `?feed=rss2&post_type=job_listing`) now restrict a denied viewer to their own listings:
  - anonymous viewers are failed closed with `post__in => [0]` (post IDs are never 0), so they receive no listings;
  - logged-in denied viewers are restricted to their real author id.
  - `author__in` is deliberately **not** used for the empty case, because a listing can have `post_author` 0 (e.g. created via WP-CLI or import) and `author__in => [0]` would match those rather than exclude them.
- No change to the default configuration: when the View Job Capability option is empty, feeds behave as before.
- Adds regression tests: denied-viewer exclusion, capable-viewer positive control, the core-feed query gate, and an author-0 listing.

## Testing

- `vendor/bin/phpunit --filter "Tests_Feed_View_Capability|test_job_feed"` — passing (new tests + existing feed tests).
- Manually verified on a dev site (browse open, view = `read`): both `/?feed=job_feed` and `/?feed=rss2&post_type=job_listing` return no listing items for an anonymous viewer, including listings with `post_author` 0.
- `php -l` and `phpcs` clean (pre-commit hook).

<!-- wpjm:plugin-zip -->
----

| Plugin build for f85e9adf582820d4097f88cf6d536891858ac65a <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2982-f85e9adf.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2982-f85e9adf)             |

<!-- /wpjm:plugin-zip -->
