### PR TITLE
Fail closed correctly when an author filter resolves to no valid IDs

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -827,8 +827,12 @@ class WP_Job_Manager_Post_Types {
 			];
 		}
 
-		if ( null !== $input_author ) {
-			// [0] is the fail-closed sentinel: no real post_author equals 0.
+		if ( [ 0 ] === $input_author ) {
+			// The author filter was supplied but yielded no valid IDs. Fail closed via
+			// post__in: a listing can legitimately have post_author 0, so author__in => [0]
+			// would match orphaned listings instead of excluding them.
+			$query_args['post__in'] = [ 0 ];
+		} elseif ( null !== $input_author ) {
 			$query_args['author__in'] = $input_author;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,7 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 * Fix enforcement of the listing submission limit.
 * Apply the listing submission limit as an inclusive maximum.
 * Apply the View Job Capability to RSS and Atom feeds.
+* Fix author filtering on job listing queries and feeds.
 
 ### 2.4.1 - 2026-02-24
 * Add permission check to listing query parameters (#2914)

--- a/tests/php/tests/security/test_class.feed-author-filter.php
+++ b/tests/php/tests/security/test_class.feed-author-filter.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Regression tests for the author filter on the RSS / Atom job feed.
+ *
+ * No View Job Capability is configured here: browsing and viewing are both open,
+ * so the only constraint on the feed query is the requested `?author=` filter.
+ * When that filter is supplied but yields no valid IDs (`?author=abc`,
+ * `?author[]=1`), the feed must fail closed without leaking orphaned listings
+ * (post_author 0). Applying the `[0]` sentinel as `author__in => [0]` would match
+ * those orphaned listings instead of excluding them.
+ *
+ * @package wp-job-manager/tests
+ */
+class Tests_Feed_Author_Filter extends WPJM_BaseTest {
+
+	public function tearDown(): void {
+		unset( $_GET['author'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Mirrors the helper in test_class.feed-view-capability.php: captures the
+	 * job_feed output and returns the post IDs its query selected.
+	 */
+	private function job_feed_post_ids() {
+		ob_start();
+		try {
+			@WP_Job_Manager_Post_Types::instance()->job_feed();
+			ob_get_clean();
+		} catch ( Exception $e ) {
+			ob_get_clean();
+			throw $e;
+		}
+
+		global $wp_query;
+
+		return wp_list_pluck( $wp_query->posts, 'ID' );
+	}
+
+	/**
+	 * A scalar author filter that yields no valid IDs must not leak orphaned listings.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_invalid_author_excludes_orphan_listing() {
+		$orphan_id = $this->factory->job_listing->create( [ 'post_author' => 0 ] );
+
+		$_GET['author'] = 'abc';
+
+		$this->assertNotContains(
+			$orphan_id,
+			$this->job_feed_post_ids(),
+			'An orphaned listing must not leak when the author filter yields no valid IDs.'
+		);
+	}
+
+	/**
+	 * An array-shaped author filter (unsupported) fails closed and must not leak orphans.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_array_author_excludes_orphan_listing() {
+		$orphan_id = $this->factory->job_listing->create( [ 'post_author' => 0 ] );
+
+		$_GET['author'] = [ '1' ];
+
+		$this->assertNotContains(
+			$orphan_id,
+			$this->job_feed_post_ids(),
+			'An orphaned listing must not leak when an array-shaped author filter is supplied.'
+		);
+	}
+
+	/**
+	 * Positive control: a valid author filter still returns that author's listing,
+	 * so the fix does not over-block.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_valid_author_returns_listing() {
+		$author_id  = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$listing_id = $this->factory->job_listing->create( [ 'post_author' => $author_id ] );
+
+		$_GET['author'] = (string) $author_id;
+
+		$this->assertContains(
+			$listing_id,
+			$this->job_feed_post_ids(),
+			'A valid author filter must still return that author\'s listing.'
+		);
+	}
+}

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -1073,6 +1073,24 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
+	 * An invalid author filter must not leak orphaned listings (post_author 0).
+	 *
+	 * The parser returns the `[0]` fail-closed sentinel for supplied-but-invalid
+	 * author input. Applied as `author__in => [0]` this would match orphaned
+	 * listings, since a listing can legitimately have post_author 0.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_invalid_author_excludes_orphan_listing() {
+		$this->factory->job_listing->create( [ 'post_author' => 0 ] );
+
+		$result = get_job_listings( [ 'author' => 'abc' ] );
+
+		$this->assertSame( 0, $result->found_posts, 'An orphaned listing must not leak when the author filter yields no valid IDs.' );
+	}
+
+	/**
 	 * Mixed valid and invalid IDs: only valid IDs should be used.
 	 *
 	 * @since $$next-version$$

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -200,8 +200,12 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 
 		if ( isset( $args['author'] ) ) {
 			$author_ids = _wpjm_parse_author_ids( $args['author'] );
-			if ( null !== $author_ids ) {
-				// [0] is the fail-closed sentinel: no real post_author equals 0.
+			if ( [ 0 ] === $author_ids ) {
+				// The author filter was supplied but yielded no valid IDs. Fail closed via
+				// post__in: a listing can legitimately have post_author 0, so author__in => [0]
+				// would match orphaned listings instead of excluding them.
+				$query_args['post__in'] = [ 0 ];
+			} elseif ( null !== $author_ids ) {
 				$query_args['author__in'] = $author_ids;
 			}
 		}
@@ -293,7 +297,9 @@ if ( ! function_exists( '_wpjm_parse_author_ids' ) ) :
 	 *
 	 * Returns `null` when the input represents "no filter" (the input was unset or an empty string).
 	 * Returns `[0]` as a fail-closed sentinel when the input was supplied but yielded no valid positive IDs
-	 * (e.g. `'0'`, `'abc'`, `[]`, `'-5'`). `[0]` is safe in `author__in` because no real `post_author` equals 0.
+	 * (e.g. `'0'`, `'abc'`, `[]`, `'-5'`). Callers must treat the `[0]` sentinel as "match nothing" and fail
+	 * closed via `post__in => [0]`, NOT `author__in => [0]`: a listing can legitimately have `post_author` 0,
+	 * which `author__in => [0]` would match.
 	 *
 	 * @since $$next-version$$
 	 * @access private


### PR DESCRIPTION
## What

When a job listing query or feed receives an `author` filter that resolves to no valid positive user IDs (e.g. `?author=abc`, `?author=0`, `?author[]=1`), the parser returns a `[0]` fail-closed sentinel meaning "match nothing".

Both `job_feed()` and `get_job_listings()` applied that sentinel as `author__in => [0]`. A listing can legitimately have `post_author` 0 (orphaned listings), so `author__in => [0]` matched those listings instead of returning an empty result.

## Change

- Apply the sentinel as `post__in => [0]` instead. Post IDs are never 0, so the query reliably matches nothing.
- Correct the `_wpjm_parse_author_ids()` docblock, which previously asserted `[0]` was safe in `author__in`.
- Add regression tests: an orphaned listing present alongside an invalid author filter must be excluded — covered for both the feed (`job_feed()`) and the listings query (`get_job_listings()`), plus a positive control that a valid author filter still returns its listing.

This mirrors the existing fail-closed-via-`post__in` pattern already used by the feed's view-capability gate for anonymous viewers.

## Testing

`make test` — functions and security suites pass (80 tests). New regression tests fail on `trunk` and pass with this change.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 2ff9c0aa7b8f2a7e0c86d6273520d2c9fb42df20 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2983-2ff9c0aa.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2983-2ff9c0aa)             |

<!-- /wpjm:plugin-zip -->
