### PR TITLE
Apply the View Job Capability to the REST search endpoint

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -840,7 +840,7 @@ class WP_Job_Manager_Post_Types {
 		// viewer, limit the feed to their own listings, mirroring the per-listing gate
 		// enforced by the single listing view and REST API. This overrides any requested
 		// author filter: a denied viewer may only ever see their own listings.
-		if ( self::feed_viewer_denied_by_view_cap() ) {
+		if ( self::viewer_denied_by_view_cap() ) {
 			$viewer_id = get_current_user_id();
 			if ( $viewer_id ) {
 				$query_args['author__in'] = [ $viewer_id ];
@@ -900,7 +900,7 @@ class WP_Job_Manager_Post_Types {
 		// View-capability gate — see job_feed(): restrict a denied viewer to their own
 		// listings (none for anonymous) so the default RSS / Atom endpoints do not expose
 		// details the single listing view and REST API withhold.
-		if ( self::feed_viewer_denied_by_view_cap() ) {
+		if ( self::viewer_denied_by_view_cap() ) {
 			$viewer_id = get_current_user_id();
 			if ( $viewer_id ) {
 				$query->set( 'author__in', [ $viewer_id ] );
@@ -914,15 +914,15 @@ class WP_Job_Manager_Post_Types {
 	/**
 	 * Whether the configured View Job Capability denies the current viewer.
 	 *
-	 * Used to gate feed queries at the query level. Mirrors the capability check in
-	 * {@see job_manager_user_can_view_job_listing()}; the per-listing author-owns-it and
-	 * `preview` bypasses there are handled here by restricting the query to the viewer's
-	 * own listings rather than excluding them. When the option is empty (the default),
-	 * viewing is unrestricted and this returns false.
+	 * Used to gate listing queries at the query level (feeds, REST search). Mirrors the
+	 * capability check in {@see job_manager_user_can_view_job_listing()}; the per-listing
+	 * author-owns-it and `preview` bypasses there are handled by callers, by restricting
+	 * the query to the viewer's own listings rather than excluding them. When the option is
+	 * empty (the default), viewing is unrestricted and this returns false.
 	 *
 	 * @return bool True when the viewer cannot satisfy the configured view capability.
 	 */
-	private static function feed_viewer_denied_by_view_cap() {
+	public static function viewer_denied_by_view_cap() {
 		$caps = get_option( 'job_manager_view_job_listing_capability' );
 
 		if ( empty( $caps ) ) {

--- a/includes/class-wp-job-manager-rest-api.php
+++ b/includes/class-wp-job-manager-rest-api.php
@@ -42,6 +42,15 @@ class WP_Job_Manager_REST_API {
 	 * already excluded from search by WP core, so only the view-capability boundary is
 	 * handled here.
 	 *
+	 * Note: this is intentionally stricter than the single-item route and the feed gate. Both
+	 * of those let a denied *author* still reach their own listings — the single route via
+	 * {@see job_manager_user_can_view_job_listing()}, the feed via `author__in => [ user_id ]`.
+	 * That cannot be mirrored here: the search handler runs one WP_Query across every requested
+	 * subtype, so an `author__in` constraint would also restrict the viewer's posts and pages,
+	 * and per-listing filtering of the results would desync the handler's `found_posts` pagination
+	 * (itself an oracle). A denied author therefore does not see their own listings through generic
+	 * search; their own listings remain reachable via the job dashboard and the single-item route.
+	 *
 	 * @param array           $query_args WP_Query args the search handler will run.
 	 * @param WP_REST_Request $request    The REST search request.
 	 * @return array

--- a/includes/class-wp-job-manager-rest-api.php
+++ b/includes/class-wp-job-manager-rest-api.php
@@ -24,6 +24,51 @@ class WP_Job_Manager_REST_API {
 		add_filter( 'rest_prepare_job_listing', [ __CLASS__, 'prepare_job_listing' ], 10, 2 );
 		add_filter( 'rest_job_listing_query', [ __CLASS__, 'exclude_filled_from_query' ], 10, 2 );
 		add_filter( 'rest_request_before_callbacks', [ __CLASS__, 'gate_view_capability_for_single' ], 10, 3 );
+		add_filter( 'rest_post_search_query', [ __CLASS__, 'gate_search_query_for_listings' ], 10, 2 );
+	}
+
+	/**
+	 * Withholds `job_listing` results from the generic WordPress REST Search endpoint
+	 * (`/wp/v2/search`) for a viewer denied by the browse or View Job Capability options.
+	 *
+	 * The search controller runs its own query and never reaches the single-item route
+	 * gate ({@see gate_view_capability_for_single()}) or the job_listing collection gate
+	 * ({@see exclude_filled_from_query()}), so without this a denied viewer can enumerate
+	 * restricted listings — id, title, url — and use the search term as a content oracle.
+	 *
+	 * When the viewer is denied, the `job_listing` post type is dropped from the searched
+	 * types so other requested subtypes (posts, pages) are unaffected; if it was the only
+	 * requested type the query is forced to return nothing. Password-protected listings are
+	 * already excluded from search by WP core, so only the view-capability boundary is
+	 * handled here.
+	 *
+	 * @param array           $query_args WP_Query args the search handler will run.
+	 * @param WP_REST_Request $request    The REST search request.
+	 * @return array
+	 */
+	public static function gate_search_query_for_listings( $query_args, $request ) {
+		$post_types = isset( $query_args['post_type'] ) ? (array) $query_args['post_type'] : [];
+		if ( ! in_array( WP_Job_Manager_Post_Types::PT_LISTING, $post_types, true ) ) {
+			return $query_args;
+		}
+
+		$denied = ! job_manager_user_can_browse_job_listings()
+			|| WP_Job_Manager_Post_Types::viewer_denied_by_view_cap();
+		if ( ! $denied ) {
+			return $query_args;
+		}
+
+		$remaining = array_values( array_diff( $post_types, [ WP_Job_Manager_Post_Types::PT_LISTING ] ) );
+		if ( $remaining ) {
+			// Other subtypes were requested too — keep searching those, just not listings.
+			$query_args['post_type'] = $remaining;
+		} else {
+			// Listings were the only requested type. Post IDs are never 0, so this is a safe
+			// empty sentinel.
+			$query_args['post__in'] = [ 0 ];
+		}
+
+		return $query_args;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,7 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 * Fix enforcement of the listing submission limit.
 * Apply the listing submission limit as an inclusive maximum.
 * Apply the View Job Capability to RSS and Atom feeds.
+* Apply the View Job Capability to the REST search endpoint.
 * Fix author filtering on job listing queries and feeds.
 
 ### 2.4.1 - 2026-02-24

--- a/tests/php/tests/security/test_class.rest-search-view-capability.php
+++ b/tests/php/tests/security/test_class.rest-search-view-capability.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Regression tests for the View Job Capability gate on the generic WordPress REST
+ * Search endpoint (`/wp/v2/search`).
+ *
+ * Covers the configuration where anonymous users may browse listing indexes
+ * (`job_manager_browse_job_listings_capability` empty) but must satisfy a
+ * capability to view individual listing details
+ * (`job_manager_view_job_listing_capability` set). The generic search controller
+ * must not surface `job_listing` results — id, title, url — that the single-item
+ * route and feeds already withhold from a denied viewer.
+ *
+ * @package wp-job-manager/tests
+ */
+class Tests_REST_Search_View_Capability extends WPJM_REST_TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		// Browsing is open to everyone; viewing details requires the `read` capability,
+		// which anonymous users do not have.
+		delete_option( 'job_manager_browse_job_listings_capability' );
+		update_option( 'job_manager_view_job_listing_capability', [ 'read' ] );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Returns the IDs the REST search endpoint surfaced for the given args.
+	 */
+	private function search_ids( $args ) {
+		$response = $this->get( '/wp/v2/search', $args );
+
+		return wp_list_pluck( (array) $response->get_data(), 'id' );
+	}
+
+	/**
+	 * A view-restricted (non-password) listing must not appear in search for an
+	 * anonymous viewer.
+	 *
+	 * @covers WP_Job_Manager_REST_API::gate_search_query_for_listings
+	 */
+	public function test_search_excludes_restricted_listing_for_anonymous() {
+		$post_id = $this->factory->job_listing->create(
+			[ 'post_title' => 'SEARCHTOKEN restricted listing' ]
+		);
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_ids( [ 'subtype' => 'job_listing', 'search' => 'SEARCHTOKEN' ] ),
+			'A view-restricted listing must not appear in REST search for a denied viewer.'
+		);
+	}
+
+	/**
+	 * Positive control: a viewer who satisfies the view capability still finds the
+	 * listing, so the gate does not over-block.
+	 *
+	 * @covers WP_Job_Manager_REST_API::gate_search_query_for_listings
+	 */
+	public function test_search_includes_listing_for_capable_viewer() {
+		$post_id = $this->factory->job_listing->create(
+			[ 'post_title' => 'SEARCHTOKEN visible listing' ]
+		);
+		$this->login_as_admin();
+
+		$this->assertContains(
+			$post_id,
+			$this->search_ids( [ 'subtype' => 'job_listing', 'search' => 'SEARCHTOKEN' ] ),
+			'A capable viewer must still find the listing in REST search.'
+		);
+	}
+
+	/**
+	 * A mixed-subtype search by a denied viewer must still return other post types;
+	 * only the listing is withheld.
+	 *
+	 * @covers WP_Job_Manager_REST_API::gate_search_query_for_listings
+	 */
+	public function test_search_preserves_other_post_types_for_denied_viewer() {
+		$listing_id = $this->factory->job_listing->create(
+			[ 'post_title' => 'SEARCHTOKEN restricted listing' ]
+		);
+		$post_id = $this->factory->post->create(
+			[ 'post_title' => 'SEARCHTOKEN ordinary post', 'post_status' => 'publish' ]
+		);
+		$this->logout();
+
+		$ids = $this->search_ids( [ 'subtype' => [ 'post', 'job_listing' ], 'search' => 'SEARCHTOKEN' ] );
+
+		$this->assertContains( $post_id, $ids, 'An ordinary post must still be searchable for a denied viewer.' );
+		$this->assertNotContains( $listing_id, $ids, 'The restricted listing must be withheld from the mixed search.' );
+	}
+
+	/**
+	 * When browsing itself is gated, a denied viewer gets no listings from search.
+	 *
+	 * @covers WP_Job_Manager_REST_API::gate_search_query_for_listings
+	 */
+	public function test_search_excludes_listing_when_browse_denied() {
+		update_option( 'job_manager_browse_job_listings_capability', [ 'read' ] );
+		$post_id = $this->factory->job_listing->create(
+			[ 'post_title' => 'SEARCHTOKEN restricted listing' ]
+		);
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_ids( [ 'subtype' => 'job_listing', 'search' => 'SEARCHTOKEN' ] ),
+			'A browse-denied viewer must not enumerate listings via REST search.'
+		);
+
+		delete_option( 'job_manager_browse_job_listings_capability' );
+	}
+}

--- a/tests/php/tests/security/test_class.rest-search-view-capability.php
+++ b/tests/php/tests/security/test_class.rest-search-view-capability.php
@@ -96,6 +96,40 @@ class Tests_REST_Search_View_Capability extends WPJM_REST_TestCase {
 	}
 
 	/**
+	 * A signed-in author denied by the view capability does NOT get their own listing
+	 * back from generic search. This is intentionally stricter than the single-item route
+	 * and the feed gate (see gate_search_query_for_listings()): the search handler runs one
+	 * query across every requested subtype, so honouring author ownership would either leak
+	 * other contributors' content or desync the handler's pagination counts. Their own
+	 * listings stay reachable via the job dashboard and the single-item route.
+	 *
+	 * @covers WP_Job_Manager_REST_API::gate_search_query_for_listings
+	 */
+	public function test_search_excludes_own_listing_for_denied_signed_in_author() {
+		// Require a capability the author does not hold, so they are denied by the view cap
+		// yet still own the listing (the `read` cap from setUp is held by every logged-in user).
+		update_option( 'job_manager_view_job_listing_capability', [ 'manage_options' ] );
+
+		$author_id = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$post_id   = $this->factory->job_listing->create(
+			[ 'post_author' => $author_id, 'post_title' => 'SEARCHTOKEN own listing' ]
+		);
+		// Sanity check: the author can still view their own listing via the per-listing gate,
+		// so the exclusion below is specific to generic search, not a loss of access overall.
+		wp_set_current_user( $author_id );
+		$this->assertTrue(
+			job_manager_user_can_view_job_listing( $post_id ),
+			'The author should still be permitted to view their own listing individually.'
+		);
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_ids( [ 'subtype' => 'job_listing', 'search' => 'SEARCHTOKEN' ] ),
+			'Generic search intentionally fails closed: a denied author does not get own listings here.'
+		);
+	}
+
+	/**
 	 * When browsing itself is gated, a denied viewer gets no listings from search.
 	 *
 	 * @covers WP_Job_Manager_REST_API::gate_search_query_for_listings


### PR DESCRIPTION
## What

The generic WordPress REST Search endpoint (`/wp-json/wp/v2/search?subtype=job_listing&search=...`) runs its own query through `WP_REST_Post_Search_Handler` and never reaches the existing job-listing gates:

- the single-item route gate (`gate_view_capability_for_single`, which 404s restricted listings), nor
- the job-listing collection query gate (`exclude_filled_from_query`).

So with the View Job Capability feature configured (anonymous browsing open, viewing details gated), a denied viewer could enumerate restricted listings — `id`, `title`, `url` — and use the search term as a content oracle, even though the single-item route returns 404 for the very same listing.

## Change

Hook `rest_post_search_query`: when the viewer is denied (by the browse cap or the View Job Capability) and `job_listing` is among the searched post types, drop `job_listing` from the searched types so other requested subtypes (posts, pages) are unaffected — or force an empty result set when listings were the only requested type.

Password-protected listings are already excluded from REST search by WP core, so only the view-capability boundary is handled here.

The view-capability predicate previously private to the feed gate is promoted to a public, generally-named helper (`WP_Job_Manager_Post_Types::viewer_denied_by_view_cap()`), now shared by the feed and search gates.

## Testing

New `Tests_REST_Search_View_Capability` covers:
- a denied anonymous viewer gets no restricted listing in search,
- a capable viewer still finds the listing (no over-block),
- a mixed-subtype search still returns other post types while withholding the listing,
- the browse-denied path returns no listings.

New tests fail on `trunk` and pass with this change. Full REST, feed, and post-types suites pass (99 tests). Lint clean. Also verified manually against a local site with anonymous `curl`.


<!-- wpjm:plugin-zip -->
----

| Plugin build for f2dabc74bd3b2f67db99769dc55a66e4e36f0e17 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2984-f2dabc74.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2984-f2dabc74)             |

<!-- /wpjm:plugin-zip -->


