### PR TITLE
Apply the View Job Capability to core search, search feeds, and oEmbed

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -977,14 +977,15 @@ class WP_Job_Manager_Post_Types {
 	 * Gates the oEmbed response (`/wp-json/oembed/1.0/embed?url=...`) for a single listing.
 	 *
 	 * The oEmbed endpoint exposes a published listing's title and author identity as
-	 * machine-readable data without reaching the single-listing view or the single-item
-	 * REST route, so a denied viewer could read restricted listing metadata through it.
-	 * Returning empty data makes the endpoint fail closed (a 404), matching the single-item
-	 * REST route ({@see WP_Job_Manager_REST_API::gate_view_capability_for_single()}).
+	 * machine-readable data without reaching the browse gate, single-listing view, or
+	 * single-item REST route, so a denied viewer could read restricted listing metadata
+	 * through it. Returning empty data makes the endpoint fail closed (a 404), matching
+	 * the single-item REST route ({@see WP_Job_Manager_REST_API::gate_view_capability_for_single()}).
 	 *
 	 * oEmbed is a single-item endpoint, so the per-listing {@see job_manager_user_can_view_job_listing()}
 	 * check, which lets an author reach their own listing and honours the `preview` bypass,
-	 * is the correct boundary here, unlike the query-level search and feed gates.
+	 * is part of the boundary here. The browse capability is also enforced because oEmbed
+	 * is a public discovery/reference surface.
 	 *
 	 * @param array   $data The response data.
 	 * @param WP_Post $post The post object.
@@ -993,7 +994,7 @@ class WP_Job_Manager_Post_Types {
 	public function gate_oembed_response_for_listings( $data, $post ) {
 		if ( $post instanceof WP_Post
 			&& self::PT_LISTING === $post->post_type
-			&& ! job_manager_user_can_view_job_listing( $post->ID ) ) {
+			&& ( ! job_manager_user_can_browse_job_listings() || ! job_manager_user_can_view_job_listing( $post->ID ) ) ) {
 			return [];
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -712,7 +712,7 @@ class WP_Job_Manager_Post_Types {
 	public function job_feed() {
 		global $job_manager_keyword;
 
-		// Browse-capability gate: emit an empty feed (matching the [jobs] shortcode denial)
+		// Browse-capability gate — emit an empty feed (matching the [jobs] shortcode denial)
 		// rather than 404 / 403, so feed readers don't error on a configured-private site.
 		if ( ! job_manager_user_can_browse_job_listings() ) {
 			// phpcs:ignore WordPress.WP.DiscouragedFunctions
@@ -838,7 +838,7 @@ class WP_Job_Manager_Post_Types {
 			$query_args['author__in'] = $input_author;
 		}
 
-		// View-capability gate: when the configured View Job Capability denies the current
+		// View-capability gate — when the configured View Job Capability denies the current
 		// viewer, limit the feed to their own listings, mirroring the per-listing gate
 		// enforced by the single listing view and REST API. This overrides any requested
 		// author filter: a denied viewer may only ever see their own listings.
@@ -848,7 +848,7 @@ class WP_Job_Manager_Post_Types {
 				$query_args['author__in'] = [ $viewer_id ];
 			} else {
 				// Anonymous: no listings. Post IDs are never 0, so this is a safe empty
-				// sentinel, unlike author__in, since a listing can have post_author 0.
+				// sentinel — unlike author__in, since a listing can have post_author 0.
 				$query_args['post__in'] = [ 0 ];
 			}
 		}
@@ -877,7 +877,7 @@ class WP_Job_Manager_Post_Types {
 	/**
 	 * Gates core feed queries for the job_listing post type so the default RSS / Atom
 	 * endpoints (?feed=rss2&post_type=job_listing, etc.) honor the browse capability and
-	 * exclude password-protected listings, matching the hardening applied to the custom
+	 * exclude password-protected listings — matching the hardening applied to the custom
 	 * job_feed and AJAX / REST paths.
 	 *
 	 * @param WP_Query $query The query.
@@ -899,7 +899,7 @@ class WP_Job_Manager_Post_Types {
 
 		$query->set( 'has_password', false );
 
-		// View-capability gate: see job_feed(): restrict a denied viewer to their own
+		// View-capability gate — see job_feed(): restrict a denied viewer to their own
 		// listings (none for anonymous) so the default RSS / Atom endpoints do not expose
 		// details the single listing view and REST API withhold.
 		if ( self::viewer_denied_by_view_cap() ) {
@@ -979,13 +979,18 @@ class WP_Job_Manager_Post_Types {
 	 * The oEmbed endpoint exposes a published listing's title and author identity as
 	 * machine-readable data without reaching the browse gate, single-listing view, or
 	 * single-item REST route, so a denied viewer could read restricted listing metadata
-	 * through it. Returning empty data makes the endpoint fail closed (a 404), matching
-	 * the single-item REST route ({@see WP_Job_Manager_REST_API::gate_view_capability_for_single()}).
+	 * through it. Returning empty data makes the endpoint fail closed with a 404, the same
+	 * response shape as the single-item REST route
+	 * ({@see WP_Job_Manager_REST_API::gate_view_capability_for_single()}).
 	 *
-	 * oEmbed is a single-item endpoint, so the per-listing {@see job_manager_user_can_view_job_listing()}
-	 * check, which lets an author reach their own listing and honours the `preview` bypass,
-	 * is part of the boundary here. The browse capability is also enforced because oEmbed
-	 * is a public discovery/reference surface.
+	 * The per-listing {@see job_manager_user_can_view_job_listing()} check — which lets an
+	 * author reach their own listing and honours the `preview` bypass — is part of the
+	 * boundary. This gate is intentionally *stricter* than the single-item REST route and the
+	 * single-listing view, which enforce the view capability only: oEmbed is a public
+	 * discovery/reference surface, fetched unsolicited by embedding clients, so the browse
+	 * capability is enforced too. A consequence is that a browse-denied author cannot reach
+	 * even their own listing's oEmbed, unlike the single-item route; their own listings remain
+	 * reachable via the job dashboard and the single listing view.
 	 *
 	 * @param array   $data The response data.
 	 * @param WP_Post $post The post object.
@@ -2246,7 +2251,7 @@ class WP_Job_Manager_Post_Types {
 	 * the site's view-capability gate denies the viewer. Used as the default `auth_view_callback`
 	 * for job listing meta fields, consumed by `WP_Job_Manager_REST_API::prepare_job_listing()`.
 	 *
-	 * @param bool   $allowed   Ignored; `prepare_job_listing()` always passes false.
+	 * @param bool   $allowed   Ignored — `prepare_job_listing()` always passes false.
 	 * @param string $meta_key  The meta key.
 	 * @param int    $post_id   Job listing's post ID.
 	 * @param int    $user_id   User ID.
@@ -2263,9 +2268,9 @@ class WP_Job_Manager_Post_Types {
 
 		// Mirror the bypass in WP_Job_Manager_REST_API::prepare_job_listing(): a user with
 		// edit_post on a *password-only* protected listing legitimately needs meta access
-		// to drive Gutenberg; without this, saving the post in the editor overwrites
+		// to drive Gutenberg — without this, saving the post in the editor overwrites
 		// `_company_name`, `_job_location`, `_application`, etc. with empty values.
-		// View-capability denials do NOT get this bypass; they remain the harder gate.
+		// View-capability denials do NOT get this bypass — they remain the harder gate.
 		if ( $is_password_blocked && ! $is_viewcap_blocked && user_can( $user_id, 'edit_post', $post_id ) ) {
 			return true;
 		}

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -212,6 +212,8 @@ class WP_Job_Manager_Post_Types {
 
 		add_action( 'parse_query', [ $this, 'add_feed_query_args' ] );
 		add_action( 'pre_get_posts', [ $this, 'gate_feed_query_for_listings' ] );
+		add_action( 'pre_get_posts', [ $this, 'gate_search_query_for_listings' ] );
+		add_filter( 'oembed_response_data', [ $this, 'gate_oembed_response_for_listings' ], 10, 2 );
 
 		// Single job content.
 		$this->job_content_filter( true );
@@ -710,7 +712,7 @@ class WP_Job_Manager_Post_Types {
 	public function job_feed() {
 		global $job_manager_keyword;
 
-		// Browse-capability gate — emit an empty feed (matching the [jobs] shortcode denial)
+		// Browse-capability gate: emit an empty feed (matching the [jobs] shortcode denial)
 		// rather than 404 / 403, so feed readers don't error on a configured-private site.
 		if ( ! job_manager_user_can_browse_job_listings() ) {
 			// phpcs:ignore WordPress.WP.DiscouragedFunctions
@@ -836,7 +838,7 @@ class WP_Job_Manager_Post_Types {
 			$query_args['author__in'] = $input_author;
 		}
 
-		// View-capability gate — when the configured View Job Capability denies the current
+		// View-capability gate: when the configured View Job Capability denies the current
 		// viewer, limit the feed to their own listings, mirroring the per-listing gate
 		// enforced by the single listing view and REST API. This overrides any requested
 		// author filter: a denied viewer may only ever see their own listings.
@@ -846,7 +848,7 @@ class WP_Job_Manager_Post_Types {
 				$query_args['author__in'] = [ $viewer_id ];
 			} else {
 				// Anonymous: no listings. Post IDs are never 0, so this is a safe empty
-				// sentinel — unlike author__in, since a listing can have post_author 0.
+				// sentinel, unlike author__in, since a listing can have post_author 0.
 				$query_args['post__in'] = [ 0 ];
 			}
 		}
@@ -875,7 +877,7 @@ class WP_Job_Manager_Post_Types {
 	/**
 	 * Gates core feed queries for the job_listing post type so the default RSS / Atom
 	 * endpoints (?feed=rss2&post_type=job_listing, etc.) honor the browse capability and
-	 * exclude password-protected listings — matching the hardening applied to the custom
+	 * exclude password-protected listings, matching the hardening applied to the custom
 	 * job_feed and AJAX / REST paths.
 	 *
 	 * @param WP_Query $query The query.
@@ -897,7 +899,7 @@ class WP_Job_Manager_Post_Types {
 
 		$query->set( 'has_password', false );
 
-		// View-capability gate — see job_feed(): restrict a denied viewer to their own
+		// View-capability gate: see job_feed(): restrict a denied viewer to their own
 		// listings (none for anonymous) so the default RSS / Atom endpoints do not expose
 		// details the single listing view and REST API withhold.
 		if ( self::viewer_denied_by_view_cap() ) {
@@ -909,6 +911,93 @@ class WP_Job_Manager_Post_Types {
 				$query->set( 'post__in', [ 0 ] );
 			}
 		}
+	}
+
+	/**
+	 * Gates the core front-end search query - and search feeds - so that restricted
+	 * job_listing posts are not disclosed through ordinary WordPress search.
+	 *
+	 * The job_listing post type is registered with `exclude_from_search => false`, so the
+	 * default search query (`/?s=...`, and its `&feed=rss2` variant) spans every searchable
+	 * post type and renders listing titles and full bodies. That query never reaches the
+	 * [jobs] shortcode, AJAX, REST, or single-listing gates, so without this a denied
+	 * viewer can read restricted listing bodies through site search and search feeds.
+	 *
+	 * When the viewer cannot browse listings, or the configured View Job Capability denies
+	 * them, job_listing is dropped from the set of searched post types so other types
+	 * (posts, pages) are unaffected; if it was the only searched type the query is forced to
+	 * return nothing. Mirrors the REST search gate
+	 * ({@see WP_Job_Manager_REST_API::gate_search_query_for_listings()}).
+	 *
+	 * Note: this is intentionally stricter than the single-listing view and the feed gate,
+	 * which let a denied *author* still reach their own listings. The search query runs
+	 * across every searchable post type, so an `author__in` constraint would also restrict
+	 * the viewer's posts and pages. A denied author therefore does not see their own listings
+	 * through site search; they remain reachable via the job dashboard and single listing view.
+	 *
+	 * Password-protected listings are already withheld from search by WP core, so only the
+	 * capability boundary is handled here.
+	 *
+	 * @param WP_Query $query The query.
+	 */
+	public function gate_search_query_for_listings( $query ) {
+		if ( is_admin() || ! $query->is_main_query() || ! $query->is_search() ) {
+			return;
+		}
+
+		if ( job_manager_user_can_browse_job_listings() && ! self::viewer_denied_by_view_cap() ) {
+			return;
+		}
+
+		$requested = $query->get( 'post_type' );
+		if ( empty( $requested ) || 'any' === $requested ) {
+			// No explicit post type: WordPress searches every type with exclude_from_search => false.
+			$searched = array_values( get_post_types( [ 'exclude_from_search' => false ] ) );
+		} else {
+			$searched = array_values( (array) $requested );
+		}
+
+		if ( ! in_array( self::PT_LISTING, $searched, true ) ) {
+			return;
+		}
+
+		$remaining = array_values( array_diff( $searched, [ self::PT_LISTING ] ) );
+		if ( $remaining ) {
+			// Other types were searched too; keep those, just not listings.
+			$query->set( 'post_type', $remaining );
+		} else {
+			// Listings were the only searched type. Force no results rather than letting
+			// WP_Query fall back to the default 'post' type. Post IDs are never 0.
+			$query->set( 'post_type', self::PT_LISTING );
+			$query->set( 'post__in', [ 0 ] );
+		}
+	}
+
+	/**
+	 * Gates the oEmbed response (`/wp-json/oembed/1.0/embed?url=...`) for a single listing.
+	 *
+	 * The oEmbed endpoint exposes a published listing's title and author identity as
+	 * machine-readable data without reaching the single-listing view or the single-item
+	 * REST route, so a denied viewer could read restricted listing metadata through it.
+	 * Returning empty data makes the endpoint fail closed (a 404), matching the single-item
+	 * REST route ({@see WP_Job_Manager_REST_API::gate_view_capability_for_single()}).
+	 *
+	 * oEmbed is a single-item endpoint, so the per-listing {@see job_manager_user_can_view_job_listing()}
+	 * check, which lets an author reach their own listing and honours the `preview` bypass,
+	 * is the correct boundary here, unlike the query-level search and feed gates.
+	 *
+	 * @param array   $data The response data.
+	 * @param WP_Post $post The post object.
+	 * @return array
+	 */
+	public function gate_oembed_response_for_listings( $data, $post ) {
+		if ( $post instanceof WP_Post
+			&& self::PT_LISTING === $post->post_type
+			&& ! job_manager_user_can_view_job_listing( $post->ID ) ) {
+			return [];
+		}
+
+		return $data;
 	}
 
 	/**
@@ -2156,7 +2245,7 @@ class WP_Job_Manager_Post_Types {
 	 * the site's view-capability gate denies the viewer. Used as the default `auth_view_callback`
 	 * for job listing meta fields, consumed by `WP_Job_Manager_REST_API::prepare_job_listing()`.
 	 *
-	 * @param bool   $allowed   Ignored — `prepare_job_listing()` always passes false.
+	 * @param bool   $allowed   Ignored; `prepare_job_listing()` always passes false.
 	 * @param string $meta_key  The meta key.
 	 * @param int    $post_id   Job listing's post ID.
 	 * @param int    $user_id   User ID.
@@ -2173,9 +2262,9 @@ class WP_Job_Manager_Post_Types {
 
 		// Mirror the bypass in WP_Job_Manager_REST_API::prepare_job_listing(): a user with
 		// edit_post on a *password-only* protected listing legitimately needs meta access
-		// to drive Gutenberg — without this, saving the post in the editor overwrites
+		// to drive Gutenberg; without this, saving the post in the editor overwrites
 		// `_company_name`, `_job_location`, `_application`, etc. with empty values.
-		// View-capability denials do NOT get this bypass — they remain the harder gate.
+		// View-capability denials do NOT get this bypass; they remain the harder gate.
 		if ( $is_password_blocked && ! $is_viewcap_blocked && user_can( $user_id, 'edit_post', $post_id ) ) {
 			return true;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,7 @@ You can view (and contribute) translations via the [translate.wordpress.org](htt
 * Apply the listing submission limit as an inclusive maximum.
 * Apply the View Job Capability to RSS and Atom feeds.
 * Apply the View Job Capability to the REST search endpoint.
+* Apply the View Job Capability to WordPress search and oEmbed output.
 * Fix author filtering on job listing queries and feeds.
 
 ### 2.4.1 - 2026-02-24

--- a/tests/php/tests/security/test_class.core-search-view-capability.php
+++ b/tests/php/tests/security/test_class.core-search-view-capability.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Regression tests for the View Job Capability gate on the core WordPress search
+ * query (`/?s=...`) and search feeds (`/?s=...&feed=rss2`).
+ *
+ * The `job_listing` post type is registered with `exclude_from_search => false`, so
+ * the default WordPress search query, which spans every searchable post type,
+ * includes listings and renders their title and full body. That path never reaches
+ * the [jobs] shortcode, the AJAX handler, the REST collection/search gates, or the
+ * single-listing view, so without a dedicated gate a denied viewer can read
+ * restricted listing bodies through ordinary site search and its RSS/Atom feeds.
+ *
+ * Covers the configuration where anonymous users may browse listing indexes
+ * (`job_manager_browse_job_listings_capability` empty) but must satisfy a
+ * capability to view individual listing details
+ * (`job_manager_view_job_listing_capability` set).
+ *
+ * @package wp-job-manager/tests
+ */
+class Tests_Core_Search_View_Capability extends WPJM_BaseTest {
+
+	const SENTINEL = 'SENTINELCORESEARCHVIEWCAP';
+
+	public function setUp(): void {
+		parent::setUp();
+		// Browsing is open to everyone; viewing details requires the `read` capability,
+		// which anonymous users do not have.
+		delete_option( 'job_manager_browse_job_listings_capability' );
+		update_option( 'job_manager_view_job_listing_capability', [ 'read' ] );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		delete_option( 'job_manager_browse_job_listings_capability' );
+		parent::tearDown();
+	}
+
+	private function create_restricted_listing( $args = [] ) {
+		return $this->factory->job_listing->create(
+			array_merge(
+				[
+					'post_title'   => self::SENTINEL . ' title',
+					'post_content' => self::SENTINEL . ' body token',
+				],
+				$args
+			)
+		);
+	}
+
+	/**
+	 * Runs a front-end search as the main query and returns the selected post IDs.
+	 *
+	 * go_to() parses the URL into query vars and runs it as the global main query,
+	 * which fires the pre_get_posts gate under test exactly as a real request would.
+	 */
+	private function search_post_ids( $url ) {
+		$this->go_to( $url );
+		global $wp_query;
+
+		return wp_list_pluck( $wp_query->posts, 'ID' );
+	}
+
+	/**
+	 * A view-restricted (non-password) listing must not appear in core search for an
+	 * anonymous viewer.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_search_excludes_restricted_listing_for_anonymous() {
+		$post_id = $this->create_restricted_listing();
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_post_ids( home_url( '/?s=' . self::SENTINEL ) ),
+			'A view-restricted listing must not appear in core search for a denied viewer.'
+		);
+	}
+
+	/**
+	 * Positive control: a viewer who satisfies the view capability still finds the
+	 * listing, so the gate does not over-block.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_search_includes_listing_for_capable_viewer() {
+		$post_id = $this->create_restricted_listing();
+		$this->login_as_admin();
+
+		$this->assertContains(
+			$post_id,
+			$this->search_post_ids( home_url( '/?s=' . self::SENTINEL ) ),
+			'A capable viewer must still find the listing in core search.'
+		);
+	}
+
+	/**
+	 * When listings are unrestricted (the default), core search is left untouched.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_search_includes_listing_when_unrestricted() {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		$post_id = $this->create_restricted_listing();
+		$this->logout();
+
+		$this->assertContains(
+			$post_id,
+			$this->search_post_ids( home_url( '/?s=' . self::SENTINEL ) ),
+			'With no view capability configured, listings remain searchable by everyone.'
+		);
+	}
+
+	/**
+	 * A mixed search by a denied viewer still returns other post types; only the
+	 * listing is withheld.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_search_preserves_other_post_types_for_denied_viewer() {
+		$listing_id = $this->create_restricted_listing();
+		$post_id    = $this->factory->post->create(
+			[ 'post_title' => self::SENTINEL . ' ordinary post', 'post_status' => 'publish' ]
+		);
+		$this->logout();
+
+		$ids = $this->search_post_ids( home_url( '/?s=' . self::SENTINEL ) );
+
+		$this->assertContains( $post_id, $ids, 'An ordinary post must still be searchable for a denied viewer.' );
+		$this->assertNotContains( $listing_id, $ids, 'The restricted listing must be withheld from the search.' );
+	}
+
+	/**
+	 * The search RSS feed (`/?s=...&feed=rss2`) is also a search query and must withhold
+	 * restricted listings from a denied viewer.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_search_feed_excludes_restricted_listing_for_anonymous() {
+		$post_id = $this->create_restricted_listing();
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_post_ids( home_url( '/?s=' . self::SENTINEL . '&feed=rss2' ) ),
+			'A view-restricted listing must not appear in the search RSS feed for a denied viewer.'
+		);
+	}
+
+	/**
+	 * An explicit listing-only core search must fail closed rather than falling back to
+	 * ordinary posts when the listing post type is removed.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_explicit_listing_search_excludes_restricted_listing_for_anonymous() {
+		$post_id = $this->create_restricted_listing();
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_post_ids( home_url( '/?s=' . self::SENTINEL . '&post_type=job_listing' ) ),
+			'A listing-only search must fail closed for a denied viewer.'
+		);
+	}
+
+	/**
+	 * A signed-in author denied by the view capability does NOT get their own listing
+	 * back from core search. Intentionally stricter than the single-item route and feed
+	 * gate, mirroring the REST search gate: the search query spans every searchable post
+	 * type, so honouring author ownership cannot be done without affecting other types.
+	 * Their own listings stay reachable via the job dashboard and the single-item view.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_search_excludes_own_listing_for_denied_signed_in_author() {
+		// Require a capability the author does not hold, so they are denied by the view cap
+		// yet still own the listing (the `read` cap from setUp is held by every logged-in user).
+		update_option( 'job_manager_view_job_listing_capability', [ 'manage_options' ] );
+
+		$author_id = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$post_id   = $this->create_restricted_listing( [ 'post_author' => $author_id ] );
+		wp_set_current_user( $author_id );
+
+		$this->assertTrue(
+			job_manager_user_can_view_job_listing( $post_id ),
+			'The author should still be permitted to view their own listing individually.'
+		);
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_post_ids( home_url( '/?s=' . self::SENTINEL ) ),
+			'Core search intentionally fails closed: a denied author does not get own listings here.'
+		);
+	}
+
+	/**
+	 * When browsing itself is gated, a denied viewer gets no listings from search.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_search_query_for_listings
+	 */
+	public function test_search_excludes_listing_when_browse_denied() {
+		update_option( 'job_manager_browse_job_listings_capability', [ 'read' ] );
+		$post_id = $this->create_restricted_listing();
+		$this->logout();
+
+		$this->assertNotContains(
+			$post_id,
+			$this->search_post_ids( home_url( '/?s=' . self::SENTINEL ) ),
+			'A browse-denied viewer must not enumerate listings via core search.'
+		);
+	}
+}

--- a/tests/php/tests/security/test_class.oembed-view-capability.php
+++ b/tests/php/tests/security/test_class.oembed-view-capability.php
@@ -4,16 +4,16 @@
  * (`/wp-json/oembed/1.0/embed?url=...`).
  *
  * The oEmbed endpoint returns a published listing's title and author identity as
- * machine-readable data without reaching the single-listing view or the single-item
- * REST route. For a viewer the View Job Capability denies, it must fail closed,
- * matching the single-item REST route, which returns 404.
+ * machine-readable data without reaching the browse gate, single-listing view, or
+ * single-item REST route. For a viewer denied by browse or View Job Capability, it
+ * must fail closed, matching the single-item REST route, which returns 404.
  *
  * Unlike core search, oEmbed is a single-item endpoint, so the per-listing check
- * (which lets an author reach their own listing) is the correct boundary here.
+ * (which lets an author reach their own listing) remains part of the boundary.
  *
  * @package wp-job-manager/tests
  */
-class Tests_oEmbed_View_Capability extends WPJM_BaseTest {
+class Tests_oEmbed_View_Capability extends WPJM_REST_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
@@ -23,7 +23,15 @@ class Tests_oEmbed_View_Capability extends WPJM_BaseTest {
 
 	public function tearDown(): void {
 		delete_option( 'job_manager_view_job_listing_capability' );
+		delete_option( 'job_manager_browse_job_listings_capability' );
 		parent::tearDown();
+	}
+
+	private function get_oembed_endpoint_response( $post_id ) {
+		return $this->get(
+			'/oembed/1.0/embed',
+			[ 'url' => home_url( '/?post_type=job_listing&p=' . $post_id ) ]
+		);
 	}
 
 	/**
@@ -42,6 +50,44 @@ class Tests_oEmbed_View_Capability extends WPJM_BaseTest {
 	}
 
 	/**
+	 * A browse-restricted listing must produce no oEmbed data even when viewing is
+	 * otherwise unrestricted.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_excludes_listing_when_browse_denied() {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		update_option( 'job_manager_browse_job_listings_capability', [ 'read' ] );
+		$post_id = $this->factory->job_listing->create();
+		$this->logout();
+
+		$this->assertEmpty(
+			get_oembed_response_data( get_post( $post_id ), 600 ),
+			'A browse-restricted listing must not expose oEmbed data to a denied viewer.'
+		);
+	}
+
+	/**
+	 * The public oEmbed REST endpoint must fail closed for a restricted listing.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_endpoint_returns_not_found_for_restricted_listing() {
+		$post_id = $this->factory->job_listing->create(
+			[ 'post_title' => 'OEMBED_RESTRICTED_LISTING_TITLE' ]
+		);
+		$this->logout();
+
+		$response = $this->get_oembed_endpoint_response( $post_id );
+		$this->assertResponseStatus( $response, 404 );
+		$this->assertStringNotContainsString(
+			'OEMBED_RESTRICTED_LISTING_TITLE',
+			wp_json_encode( $response->get_data() ),
+			'The oEmbed REST endpoint must not serialize restricted listing metadata.'
+		);
+	}
+
+	/**
 	 * Positive control: a capable viewer still gets oEmbed data, so the gate does not over-block.
 	 *
 	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
@@ -52,6 +98,26 @@ class Tests_oEmbed_View_Capability extends WPJM_BaseTest {
 
 		$data = get_oembed_response_data( get_post( $post_id ), 600 );
 		$this->assertNotEmpty( $data, 'A capable viewer must still receive oEmbed data.' );
+	}
+
+	/**
+	 * Positive control for the public oEmbed REST endpoint.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_endpoint_includes_listing_for_capable_viewer() {
+		$post_id = $this->factory->job_listing->create(
+			[ 'post_title' => 'OEMBED_VISIBLE_LISTING_TITLE' ]
+		);
+		$this->login_as_admin();
+
+		$response = $this->get_oembed_endpoint_response( $post_id );
+		$this->assertResponseStatus( $response, 200 );
+		$this->assertStringContainsString(
+			'OEMBED_VISIBLE_LISTING_TITLE',
+			wp_json_encode( $response->get_data() ),
+			'A capable viewer must still receive listing metadata from the oEmbed REST endpoint.'
+		);
 	}
 
 	/**

--- a/tests/php/tests/security/test_class.oembed-view-capability.php
+++ b/tests/php/tests/security/test_class.oembed-view-capability.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Regression tests for the View Job Capability gate on the oEmbed response data
+ * (`/wp-json/oembed/1.0/embed?url=...`).
+ *
+ * The oEmbed endpoint returns a published listing's title and author identity as
+ * machine-readable data without reaching the single-listing view or the single-item
+ * REST route. For a viewer the View Job Capability denies, it must fail closed,
+ * matching the single-item REST route, which returns 404.
+ *
+ * Unlike core search, oEmbed is a single-item endpoint, so the per-listing check
+ * (which lets an author reach their own listing) is the correct boundary here.
+ *
+ * @package wp-job-manager/tests
+ */
+class Tests_oEmbed_View_Capability extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		delete_option( 'job_manager_browse_job_listings_capability' );
+		update_option( 'job_manager_view_job_listing_capability', [ 'read' ] );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		parent::tearDown();
+	}
+
+	/**
+	 * A view-restricted listing must produce no oEmbed data for an anonymous viewer.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_excludes_restricted_listing_for_anonymous() {
+		$post_id = $this->factory->job_listing->create();
+		$this->logout();
+
+		$this->assertEmpty(
+			get_oembed_response_data( get_post( $post_id ), 600 ),
+			'A view-restricted listing must not expose oEmbed data to a denied viewer.'
+		);
+	}
+
+	/**
+	 * Positive control: a capable viewer still gets oEmbed data, so the gate does not over-block.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_includes_listing_for_capable_viewer() {
+		$post_id = $this->factory->job_listing->create();
+		$this->login_as_admin();
+
+		$data = get_oembed_response_data( get_post( $post_id ), 600 );
+		$this->assertNotEmpty( $data, 'A capable viewer must still receive oEmbed data.' );
+	}
+
+	/**
+	 * The per-listing check lets a denied author reach their own listing's oEmbed data,
+	 * matching the single-listing view and single-item REST route.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_includes_own_listing_for_denied_author() {
+		update_option( 'job_manager_view_job_listing_capability', [ 'manage_options' ] );
+		$author_id = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$post_id   = $this->factory->job_listing->create( [ 'post_author' => $author_id ] );
+		wp_set_current_user( $author_id );
+
+		$this->assertNotEmpty(
+			get_oembed_response_data( get_post( $post_id ), 600 ),
+			'An author must still reach their own listing oEmbed data.'
+		);
+	}
+
+	/**
+	 * When listings are unrestricted (the default), oEmbed is left untouched.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_includes_listing_when_unrestricted() {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		$post_id = $this->factory->job_listing->create();
+		$this->logout();
+
+		$this->assertNotEmpty(
+			get_oembed_response_data( get_post( $post_id ), 600 ),
+			'With no view capability configured, listing oEmbed remains available.'
+		);
+	}
+
+	/**
+	 * The gate must not affect oEmbed for ordinary post types.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_unaffected_for_ordinary_post() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$this->logout();
+
+		$this->assertNotEmpty(
+			get_oembed_response_data( get_post( $post_id ), 600 ),
+			'An ordinary post must still expose oEmbed data regardless of the listing view capability.'
+		);
+	}
+}


### PR DESCRIPTION
### Changes Proposed in this Pull Request

Extends the View Job Capability enforcement (already applied to the custom job feed, the default RSS/Atom feeds, AJAX, and the REST collection/search endpoints in #2982 and #2984) to the remaining default output paths that surface `job_listing` content:

* **Core WordPress search** (`/?s=…`) and **search feeds** (`/?s=…&feed=rss2`). The `job_listing` post type is registered with `exclude_from_search => false`, so the default search query spans it and renders listing titles and bodies without passing through any of the plugin's existing gates. A new `pre_get_posts` gate (`gate_search_query_for_listings()`) drops `job_listing` from the searched post types when the viewer cannot browse listings or is denied by the View Job Capability — leaving other post types untouched — and forces an empty result when listings were the only searched type.
* **oEmbed** (`/wp-json/oembed/1.0/embed?url=…`). A new `oembed_response_data` gate (`gate_oembed_response_for_listings()`) returns empty data (a 404) for a listing the viewer is not permitted to see. This surface is intentionally stricter than the single-listing view and single-item REST route — it also enforces the browse capability, since oEmbed is a public discovery/reference surface fetched unsolicited by embedding clients.

When no capability is configured (the default), all of these paths behave exactly as before.

Consistent with the prior work, generic search fails closed strictly: a denied author does not get their own listings back from search (the query spans every searchable post type, so author-scoping cannot be applied without affecting other types). Their own listings remain reachable via the job dashboard and the single listing view.

### Testing Instructions

1. Set both visibility options to require a capability anonymous users lack:
   ```php
   update_option( 'job_manager_view_job_listing_capability', [ 'read' ] );
   ```
2. Publish a job listing with a recognisable title/body.
3. As a logged-out visitor:
   * `/?s=<term>` and `/?s=<term>&feed=rss2` must **not** return the listing (ordinary posts/pages still appear).
   * `/wp-json/oembed/1.0/embed?url=<listing-url>` must return **404**.
4. As an administrator (or any capable viewer), confirm the listing still appears in search and its oEmbed still resolves.
5. Remove the option and confirm default behaviour is unchanged.
6. `vendor/bin/phpunit --filter 'Tests_Core_Search_View_Capability|Tests_oEmbed_View_Capability'`

### Release Notes

* Apply the View Job Capability to WordPress search and oEmbed output.

### New or Updated Hooks and Templates

* None.

### Deprecated Code

* None.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 4a63dc03dbe7aeb790caae36e9aca8b228809c6c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2985-4a63dc03.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2985-4a63dc03)             |

<!-- /wpjm:plugin-zip -->
