### PR TITLE
Add test for browse-denied author oEmbed enforcement

### DIFF
--- a/tests/php/tests/security/test_class.oembed-view-capability.php
+++ b/tests/php/tests/security/test_class.oembed-view-capability.php
@@ -139,6 +139,25 @@ class Tests_oEmbed_View_Capability extends WPJM_REST_TestCase {
 	}
 
 	/**
+	 * The oEmbed gate is intentionally stricter than the single-item route: it also enforces the
+	 * browse capability, so a browse-denied author cannot reach even their own listing's oEmbed.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings
+	 */
+	public function test_oembed_excludes_own_listing_for_browse_denied_author() {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		update_option( 'job_manager_browse_job_listings_capability', [ 'manage_options' ] );
+		$author_id = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$post_id   = $this->factory->job_listing->create( [ 'post_author' => $author_id ] );
+		wp_set_current_user( $author_id );
+
+		$this->assertEmpty(
+			get_oembed_response_data( get_post( $post_id ), 600 ),
+			'A browse-denied author must not reach their own listing oEmbed; the gate enforces the browse capability.'
+		);
+	}
+
+	/**
 	 * When listings are unrestricted (the default), oEmbed is left untouched.
 	 *
 	 * @covers WP_Job_Manager_Post_Types::gate_oembed_response_for_listings


### PR DESCRIPTION
### Changes Proposed in this Pull Request

* Adds one regression test (`Tests_oEmbed_View_Capability::test_oembed_excludes_own_listing_for_browse_denied_author`) covering shipped behavior that previously had no explicit coverage: the oEmbed gate is intentionally stricter than the single-listing view and the single-item REST route — it also enforces the browse capability, so a browse-denied author cannot reach even their own listing's oEmbed.

Test only; no behavior change. Follows up Automattic/WP-Job-Manager#2985.

### Testing Instructions

* `vendor/bin/phpunit --filter 'Tests_oEmbed_View_Capability'` — 9 tests pass.

### Release Notes

* N/A (test only).


<!-- wpjm:plugin-zip -->
----

| Plugin build for 9dc61a60d66889e3f010a334a12c2282e0fa2f46 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2986-9dc61a60.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2986-9dc61a60)             |

<!-- /wpjm:plugin-zip -->
