### PR TITLE
Set usage-tracking deprecation version to 2.0.0

### DIFF
--- a/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
+++ b/lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php
@@ -566,7 +566,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @deprecated since 2.0.0
 	 **/
 	public function enqueue_script_deps() {
-		_deprecated_function( __METHOD__, '$$next-version' );
+		_deprecated_function( __METHOD__, '2.0.0' );
 	}
 
 	/**
@@ -576,7 +576,7 @@ abstract class WP_Job_Manager_Usage_Tracking_Base {
 	 * @deprecated since 2.0.0
 	 **/
 	public function output_opt_in_js() {
-		_deprecated_function( __METHOD__, '$$next-version' );
+		_deprecated_function( __METHOD__, '2.0.0' );
 		?>
 		<?php
 	}


### PR DESCRIPTION
The two `_deprecated_function()` calls in `lib/usage-tracking/class-wp-job-manager-usage-tracking-base.php` used a malformed `'$$next-version'` placeholder (missing the trailing `$$`), so `scripts/replace-next-version-tag.sh` never substituted it and the literal `$$next-version` would ship as the deprecation version.

These methods (`enqueue_script_deps`, `output_opt_in_js`) were deprecated in **2.0.0** per their `@deprecated since 2.0.0` docblocks, so this hardcodes `'2.0.0'` rather than completing the placeholder — completing it would substitute the *current* release (e.g. 2.4.3) and misreport the deprecation version.

History: the `_deprecated_function()` calls were added 2023-10-16 (`00d97eb2`); the `@deprecated since 2.0.0` docblocks were added 2023-11-17 (`6905bf27`).

### Changes Proposed in this Pull Request
* Set the deprecation version on the two usage-tracking `_deprecated_function()` calls to `2.0.0`, matching their `@deprecated` docblocks.

### Release Notes
* None (developer-facing fix; corrects the version reported in two deprecation notices).

<!-- wpjm:plugin-zip -->
----

| Plugin build for 7c50f2f0181ad8511b863de27491e09b4d8a38b4 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2987-7c50f2f0.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2987-7c50f2f0)             |

<!-- /wpjm:plugin-zip -->
