### PR TITLE
release: scope gh auth check to github.com

### DIFF
--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -145,7 +145,11 @@ async function askForConfirmation(
 	console.log( `ℹ️️  Make sure a ` + chalk.bold( `milestone ${ newVersion }` ) + ` exists GitHub, and all PRs are assigned to the milestone.` );
 	console.log( `-----------------------------` );
 	console.log( `ℹ️️  Make sure you are logged in to GH CLI with \`gh auth login\`.` );
-	execSync( 'gh auth status' );
+	// Scope the auth check to github.com (where the plugin repo lives). An unrelated
+	// host in `gh` config (e.g. an internal GitHub Enterprise instance that is
+	// unreachable off-VPN) would otherwise make `gh auth status` exit non-zero and
+	// abort the release.
+	execSync( 'gh auth status --hostname github.com' );
 	console.log( `-----------------------------` );
 	console.log( `Pull requests to include (milestone ${ newVersion }):` );
 


### PR DESCRIPTION
The release script (`scripts/prepare-release.mjs`) ran a bare `gh auth status`. `gh auth status` exits non-zero if **any** configured host fails authentication — including an unrelated GitHub Enterprise host (e.g. `github.a8c.com`) that is unreachable off-VPN. Because the call is `execSync(...)`, that non-zero exit throws and aborts the release before it does anything, even when `github.com` auth is perfectly valid.

The release only ever interacts with `github.com` (all other `gh` calls are explicitly `-R Automattic/wp-job-manager`), so this scopes the check to `--hostname github.com`.

### Changes Proposed in this Pull Request
* Scope the `gh auth status` preflight check in `prepare-release.mjs` to `--hostname github.com`.

### Release Notes
* None (release-tooling fix; no user-facing or shipped-code change).


<!-- wpjm:plugin-zip -->
----

| Plugin build for 1b5294710f6d29f4d3a008c79284d37c4602406e <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2988-1b529471.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2988-1b529471)             |

<!-- /wpjm:plugin-zip -->
