### PR TITLE
Fix release build dropping assets/dist from the plugin zip

### DIFF
--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -1,12 +1,29 @@
 #!/usr/bin/env bash
 
+# Fail loudly on any error or unset variable so a broken build never produces a zip.
+set -euo pipefail
+
 # Step 1: Clean and create build folder
 rm -rf build
 mkdir -p build/wp-job-manager
 
-# Step 2: Copy the current folder to the build folder, excluding undesired directories
-# Strip the wp-job-manager/ prefix from exclude.lst so rsync can use it too
-# Keep package.json/composer.* — they're needed for build:assets and composer install
+# Step 2: Build assets at the repo root.
+# wp-scripts needs webpack.config.js, node_modules and the assets/{js,css} sources,
+# none of which are copied into the build folder (they're excluded from the release).
+# Building here ensures assets/dist is freshly generated before it is staged.
+npm run build:assets
+
+# Step 3: Verify the asset build actually produced output before continuing.
+# wp-scripts exits 0 even when it builds nothing, so check explicitly.
+if ! ls assets/dist/css/*.css >/dev/null 2>&1; then
+	echo "ERROR: asset build produced no assets/dist/css/*.css; aborting release build." >&2
+	exit 1
+fi
+
+# Step 4: Copy the current folder to the build folder, excluding undesired directories.
+# Strip the wp-job-manager/ prefix from exclude.lst so rsync can use it too.
+# Keep package.json/composer.* — they're needed for composer install.
+# The freshly built assets/dist is copied as part of this step.
 sed 's|^wp-job-manager/||' scripts/exclude.lst | grep -v -E '^(package\.json|package-lock\.json|composer\.\*)$' > /tmp/rsync-exclude.lst
 rsync -av --progress . build/wp-job-manager --exclude build --exclude vendor --exclude-from /tmp/rsync-exclude.lst
 rm -f /tmp/rsync-exclude.lst
@@ -14,18 +31,21 @@ rm -f /tmp/rsync-exclude.lst
 # Navigate to build directory
 cd build/wp-job-manager
 
-# Step 3: Build assets
-npm run build:assets
-
-# Step 4: Run composer install without development dependencies
+# Step 5: Run composer install without development dependencies
 composer install --no-dev
 
-# Step 5: Zip the entire contents of the build folder into `wp-job-manager.zip` excluding the files from the exclude.lst file
+# Step 6: Verify the staged plugin contains the built assets before zipping.
+if ! ls assets/dist/css/*.css >/dev/null 2>&1; then
+	echo "ERROR: assets/dist/css/*.css missing from staged plugin; aborting release build." >&2
+	exit 1
+fi
+
+# Step 7: Zip the entire contents of the build folder into `wp-job-manager.zip` excluding the files from the exclude.lst file
 # Navigate one level up, so the zip command includes the build directory content
 cd ..
 zip -r wp-job-manager.zip wp-job-manager -x@../scripts/exclude.lst
 
-# Step 6: Remove the contents of the build folder except the new zip file
+# Step 8: Remove the contents of the build folder except the new zip file
 rm -rf wp-job-manager
 
 echo "Build process complete. The wp-job-manager.zip file is ready in the /build folder."


### PR DESCRIPTION
## Problem

The 2.4.3 release shipped to WordPress.org with **no `assets/dist/` directory** — the entire built CSS/JS is missing from the zip. Confirmed by inspecting the live artifact (`downloads.wordpress.org/plugin/wp-job-manager.2.4.3.zip` → 0 `assets/dist` entries).

Because `register_style()`/`register_script()` return `false` when the built file's `.asset.php` companion is absent, **every** built asset silently fails to enqueue (no PHP error). Result on released 2.4.3:

- Employer Job Dashboard renders as raw stacked divs (no `frontend.css`/`ui.css`/`job-dashboard.css`).
- The "Apply for job" application box shows un-hidden, and the toggle is dead (`job-application.js` missing — it hides `.application_details` on load; CSS does not).
- Other built JS (overlay, ajax filters, submission) is also absent.

`assets/lib/*` (select2 etc.) and `assets/images/` still load because they are git-committed and referenced by direct path.

## Root cause

`scripts/build-plugin.sh` ran `wp-scripts build` **inside** `build/wp-job-manager`, but `webpack.config.js` and the `assets/{js,css}` sources are excluded from the rsync copy. With no config present, wp-scripts looked for a default `src/` dir, found none, built nothing — and **still exited 0**, so the script zipped a dist-less plugin (no `set -e`, no verification).

Build log proof:
```
> wp-scripts build
Source directory "src" was not found...
webpack 5.77.0 compiled successfully in 46 ms
```

A clean CI checkout has no pre-existing `assets/dist` to mask this (it's gitignored). Local builds passed only because the dev working tree already contained `dist`. Regression introduced in `9cb805ab` ("Consolidate build exclusions").

## Fix

- Build assets at the **repo root**, where `webpack.config.js`, `node_modules` and the sources live, before staging. The freshly built `assets/dist` is then copied in by rsync.
- Add `set -euo pipefail` so a failed step aborts.
- Verify `assets/dist/css/*.css` exists both after the build and in the staged plugin, aborting if empty — so a broken build can never ship again.

## Verification

Clean-room reproduction (local `dist` hidden to simulate a fresh CI checkout):

- **Before:** `npm run build` exits 0, produced zip has **0** dist CSS files.
- **After:** build freshly generates all 11 dist CSS files; zip contains them (`frontend.css`, `ui.css`, `job-dashboard.css` confirmed present).

## Note

This repairs **future** builds only. 2.4.3 is already live and broken for all installs — it needs a re-release (2.4.4) built with this fix.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 6556476122feb68896aecd58a08ef83f965752b4 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2990-65564761.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2990-65564761)             |

<!-- /wpjm:plugin-zip -->
