### PR TITLE
Honor restrictive filter_post_status=publish for logged-out visitors

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -152,9 +152,23 @@ class WP_Job_Manager_Ajax {
 			$search_categories = array_filter( [ sanitize_text_field( wp_unslash( $search_categories ) ) ] );
 		}
 
-		// Ensure the current user can filter by post_status.
+		// Ensure the current user can filter by post_status. Users without the capability may only
+		// narrow the query to publicly visible listings (e.g. the `[jobs post_status="publish"]`
+		// shortcode), never request unpublished statuses such as draft, pending, preview or private.
 		if ( is_array( $filter_post_status ) && ! current_user_can( \WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS ) ) {
-			$filter_post_status = null;
+			/**
+			 * Post statuses a visitor without listing-editing capabilities is allowed to filter by.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param string[] $allowed_post_status Allowed post statuses. Defaults to `[ 'publish' ]`.
+			 */
+			$allowed_post_status = apply_filters( 'job_manager_get_listings_public_post_status', [ 'publish' ] );
+			$filter_post_status  = array_values( array_intersect( $filter_post_status, $allowed_post_status ) );
+
+			if ( empty( $filter_post_status ) ) {
+				$filter_post_status = null;
+			}
 		}
 
 		// Browse-capability gate — match the [jobs] shortcode denial without surfacing partial results.

--- a/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
@@ -282,6 +282,108 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		$this->assertArrayHasKey( 'error', $result['files'][0] );
 	}
 
+	/**
+	 * Regression: a logged-out visitor's restrictive `filter_post_status=publish` (emitted by the
+	 * `[jobs post_status="publish"]` shortcode) must be honored, not discarded back to the more
+	 * permissive default which can include expired listings when "Hide expired listings" is off.
+	 *
+	 * @since $$next-version$$
+	 * @covers WP_Job_Manager_Ajax::get_listings
+	 */
+	public function test_get_listings_publish_filter_preserved_for_logged_out() {
+		// Show expired by default, so the fallback would otherwise leak expired listings.
+		update_option( 'job_manager_hide_expired', 0 );
+		wp_set_current_user( 0 );
+
+		$published = $this->factory->job_listing->create_many( 2 );
+		$expired   = $this->factory->job_listing->create_many(
+			2,
+			[
+				'post_status' => 'expired',
+				'meta_input'  => [],
+			]
+		);
+
+		$this->set_up_job_listing_search_request();
+		$_REQUEST['filter_post_status'] = [ 'publish' ];
+
+		add_filter( 'job_manager_ajax_get_jobs_html_results', '__return_false' );
+		add_filter( 'job_manager_get_listings_result', [ $this, 'load_last_jobs_result' ], 10, 2 );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		ob_start();
+		WP_Job_Manager_Ajax::instance()->get_listings();
+		$result = json_decode( ob_get_clean(), true );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		remove_filter( 'job_manager_get_listings_result', [ $this, 'load_last_jobs_result' ], 10 );
+		remove_filter( 'job_manager_ajax_get_jobs_html_results', '__return_false' );
+
+		unset( $_REQUEST['filter_post_status'] );
+		$this->tear_down_job_listing_search_request();
+		delete_option( 'job_manager_hide_expired' );
+
+		$job_ids = wp_list_pluck( $result['_jobs'], 'ID' );
+		sort( $job_ids );
+		sort( $published );
+
+		$this->assertSame( $published, $job_ids, 'Logged-out filter_post_status=publish must return only published listings, not the expired fallback.' );
+		foreach ( $expired as $post_id ) {
+			$this->assertNotContains( $post_id, $job_ids, 'Expired listings must not leak when the publish filter is requested.' );
+		}
+	}
+
+	/**
+	 * Regression: a logged-out visitor must not be able to surface unpublished listings by injecting
+	 * disallowed `filter_post_status` values (the original disclosure vector). Disallowed values are
+	 * stripped and the query falls back to the public default.
+	 *
+	 * @since $$next-version$$
+	 * @covers WP_Job_Manager_Ajax::get_listings
+	 */
+	public function test_get_listings_disallowed_status_filter_stripped_for_logged_out() {
+		wp_set_current_user( 0 );
+
+		$published = $this->factory->job_listing->create_many( 2 );
+		$draft     = $this->factory->job_listing->create_many(
+			2,
+			[
+				'post_status' => 'draft',
+				'meta_input'  => [],
+			]
+		);
+		$private   = $this->factory->job_listing->create_many(
+			2,
+			[
+				'post_status' => 'private',
+				'meta_input'  => [],
+			]
+		);
+
+		$this->set_up_job_listing_search_request();
+		$_REQUEST['filter_post_status'] = [ 'draft', 'private' ];
+
+		add_filter( 'job_manager_ajax_get_jobs_html_results', '__return_false' );
+		add_filter( 'job_manager_get_listings_result', [ $this, 'load_last_jobs_result' ], 10, 2 );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		ob_start();
+		WP_Job_Manager_Ajax::instance()->get_listings();
+		$result = json_decode( ob_get_clean(), true );
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+		remove_filter( 'job_manager_get_listings_result', [ $this, 'load_last_jobs_result' ], 10 );
+		remove_filter( 'job_manager_ajax_get_jobs_html_results', '__return_false' );
+
+		unset( $_REQUEST['filter_post_status'] );
+		$this->tear_down_job_listing_search_request();
+
+		$job_ids = wp_list_pluck( $result['_jobs'], 'ID' );
+		sort( $job_ids );
+		sort( $published );
+
+		$this->assertSame( $published, $job_ids, 'Disallowed statuses must be stripped, returning only published listings.' );
+		foreach ( array_merge( $draft, $private ) as $post_id ) {
+			$this->assertNotContains( $post_id, $job_ids, 'Unpublished listings must never be exposed to logged-out visitors.' );
+		}
+	}
+
 	public function load_last_jobs_result( $result, $jobs ) {
 		$result['_jobs'] = $jobs->get_posts();
 		return $result;


### PR DESCRIPTION
## Problem

The capability guard added in 2.4.1 (commit 2ed939f1) to fix the `filter_post_status` information-disclosure issue is too blunt: for any visitor without `CAP_EDIT_LISTINGS`, it **nullifies the entire `filter_post_status` array**.

That also discards the perfectly benign, *restrictive* value `publish` that the core shortcode itself sends. The chain:

1. `[jobs post_status="publish" show_filters="true" ...]`
2. `output_jobs()` emits `data-post_status="publish"` on the wrapper (`class-wp-job-manager-shortcodes.php:395-396`); with filters on, the list is loaded via AJAX.
3. `assets/js/ajax-filters.js` reads `data-post_status` and POSTs it as `filter_post_status`.
4. `get_listings()` nulls it for logged-out users (`class-wp-job-manager-ajax.php:156-157`).
5. `get_job_listings()` then uses its **default** `post_status`. With **"Hide expired listings" off**, that default is `['publish','expired']` (`wp-job-manager-functions.php:57-58`).

Result: on sites with Hide Expired off, logged-out visitors see **expired** listings even though the shortcode explicitly requested `post_status="publish"`. The guard meant to restrict anonymous users actually widens what they see on that configuration.

## Fix

Intersect the requested statuses with an allow-list (default `['publish']`) instead of nullifying:

- `post_status="publish"` → honored → expired excluded.
- Injected `draft`/`pending`/`preview`/`private` → stripped → falls back to the public default. **CVE stays closed.**

The allow-list is filterable via `job_manager_get_listings_public_post_status` for sites/addons that intentionally expose other public statuses.

## Tests

- `test_get_listings_publish_filter_preserved_for_logged_out` — with Hide Expired **off** and expired listings present, a logged-out `filter_post_status=publish` returns only published listings. Verified this test **fails** against the old nullifying guard (expired listings leak) and passes with the fix.
- `test_get_listings_disallowed_status_filter_stripped_for_logged_out` — a logged-out visitor injecting `draft`/`private` gets only published listings.

Full PHPUnit suite green; PHPCS clean.

## Affected versions

2.4.1–2.4.3, on sites with "Hide expired listings" disabled that use a `post_status` attribute on the `[jobs]` shortcode.

<!-- wpjm:plugin-zip -->
----

| Plugin build for cd65af4b9b93fe89e72005083ac23100ab761cf0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/06/wp-job-manager-zip-2994-cd65af4b.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/06/2994-cd65af4b)             |

<!-- /wpjm:plugin-zip -->
