### PR TITLE
Validate attachment ownership when reusing a company logo by ID

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -506,6 +506,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 							// Check if attachment is valid.
 							if ( is_numeric( $file_url ) ) {
+								$attachment_id = absint( $file_url );
+								if ( $attachment_id && ! $this->is_attachment_authorized_for_current_user( $attachment_id ) ) {
+									throw new Exception( __( 'Invalid attachment provided.', 'wp-job-manager' ) );
+								}
 								continue;
 							}
 							$file_url = esc_url( $file_url, [ 'http', 'https' ] );
@@ -932,6 +936,35 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				update_post_meta( $this->job_id, '_submitting_key', $submitting_key );
 			}
 		}
+	}
+
+	/**
+	 * Checks whether the current user is allowed to reuse an existing attachment
+	 * by referencing its numeric ID in a file field (e.g. the company logo).
+	 *
+	 * Without this check a submitter could bind another user's attachment to their
+	 * own listing — and expose it through the public listing output — by supplying
+	 * a foreign attachment ID in the hidden `current_<field>` value.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return bool True if the current user may use the attachment.
+	 */
+	protected function is_attachment_authorized_for_current_user( $attachment_id ) {
+		$attachment = get_post( $attachment_id );
+
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return false;
+		}
+
+		// The user owns the attachment (the normal case: they uploaded it).
+		if ( get_current_user_id() === (int) $attachment->post_author ) {
+			return true;
+		}
+
+		// Or has the capability to edit it (e.g. an admin editing another user's listing).
+		return current_user_can( 'edit_post', $attachment_id );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests that the frontend job submission form rejects file-field attachment IDs
+ * the current user is not authorized to reuse, preventing a submitter from
+ * binding another user's attachment to their own listing (object-level IDOR).
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+	}
+
+	public function tearDown(): void {
+		unset( $_POST, $_REQUEST );
+		$_POST    = [];
+		$_REQUEST = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Creates an attachment owned by the given user.
+	 *
+	 * @param int $author_id Owner user ID.
+	 * @return int Attachment ID.
+	 */
+	private function create_attachment_owned_by( $author_id ) {
+		return wp_insert_attachment(
+			[
+				'post_title'     => 'Logo ' . $author_id,
+				'post_mime_type' => 'image/png',
+				'post_status'    => 'inherit',
+				'post_author'    => $author_id,
+			],
+			'logo-' . $author_id . '.png'
+		);
+	}
+
+	/**
+	 * Runs the form's field validation against a single company_logo value.
+	 *
+	 * @param mixed $logo_value Value to validate for the company_logo field.
+	 * @throws Exception When validation rejects the value.
+	 * @return bool|WP_Error validate_fields() result.
+	 */
+	private function validate_company_logo( $logo_value ) {
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$fields_prop = $class->getProperty( 'fields' );
+		$fields_prop->setAccessible( true );
+		$fields_prop->setValue(
+			$form,
+			[
+				'company' => [
+					'company_logo' => [
+						'label'              => 'Logo',
+						'type'               => 'file',
+						'required'           => false,
+						'file_limit'         => 1,
+						'allowed_mime_types' => [ 'png' => 'image/png' ],
+					],
+				],
+			]
+		);
+
+		$validate = $class->getMethod( 'validate_fields' );
+		$validate->setAccessible( true );
+
+		return $validate->invoke( $form, [ 'company' => [ 'company_logo' => $logo_value ] ] );
+	}
+
+	/**
+	 * A submitter cannot validate a company_logo pointing at an attachment owned
+	 * by another user.
+	 */
+	public function test_foreign_attachment_id_is_rejected() {
+		$this->login_as_admin();
+		$admin_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo( (string) $admin_attachment );
+	}
+
+	/**
+	 * A submitter can validate a company_logo pointing at an attachment they own —
+	 * the normal reuse-your-own-logo flow must keep working.
+	 */
+	public function test_own_attachment_id_is_accepted() {
+		$this->login_as_employer();
+		$own_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->assertTrue(
+			$this->validate_company_logo( (string) $own_attachment ),
+			'A user must be able to reuse an attachment they own.'
+		);
+	}
+
+	/**
+	 * An empty / "no logo" value (0) is not treated as an attachment and passes
+	 * validation unchanged.
+	 */
+	public function test_empty_logo_value_is_accepted() {
+		$this->login_as_employer();
+
+		$this->assertTrue(
+			$this->validate_company_logo( '0' ),
+			'A zero/empty logo value must not be rejected.'
+		);
+	}
+
+	/**
+	 * A user with capability to edit the attachment (e.g. an admin handling
+	 * another user's listing) is authorized even when they do not own it.
+	 */
+	public function test_editor_capability_authorizes_foreign_attachment() {
+		$this->login_as_employer();
+		$employer_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_admin();
+
+		$this->assertTrue(
+			$this->validate_company_logo( (string) $employer_attachment ),
+			'A user who can edit the attachment must be authorized to reuse it.'
+		);
+	}
+}


### PR DESCRIPTION
## What

The frontend job submission form lets a user carry a previously uploaded company logo forward by its numeric attachment ID. This adds a validation check so a referenced attachment ID is only accepted when the current user is allowed to use that attachment (they own it, or have permission to edit it).

Reusing your own logo and admin edits of other users' listings are unaffected.

## Why

Tightens input validation on the company logo file field so an arbitrary attachment ID can't be bound to a listing.

## Testing

- Adds `WP_Test_Submit_Job_Attachment_Ownership` covering the accept/reject paths (own attachment, empty value, edit-capability, and a disallowed ID).
- Full PHPUnit suite passes; `phpcs` clean.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 3acb0e7c62f56a7dff14aeb6bab2a81dc4c530bb <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-2995-3acb0e7c.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/2995-3acb0e7c)             |

<!-- /wpjm:plugin-zip -->
