### PR TITLE
Escape URLs in two sprintf href templates with esc_url()

### DIFF
--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -105,7 +105,7 @@ function wpml_wpjm_hide_page_selection( $settings ) {
 		$url_to_edit_page = admin_url( 'edit.php?post_type=job_listing&page=job-manager-settings&lang=' . $default_lang . '#settings-job_pages' );
 
 		// translators: Placeholder (%s) is the URL to edit the primary language in WPML.
-		$setting['desc']                  = sprintf( __( '<a href="%s">Switch to primary language</a> to edit this setting.', 'wp-job-manager' ), $url_to_edit_page );
+		$setting['desc']                  = sprintf( __( '<a href="%s">Switch to primary language</a> to edit this setting.', 'wp-job-manager' ), esc_url( $url_to_edit_page ) );
 		$settings['job_pages'][1][ $key ] = $setting;
 	}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -832,7 +832,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				$job_dashboard_page_id = get_option( 'job_manager_job_dashboard_page_id', false );
 
 				// translators: placeholder is the URL to the job dashboard page.
-				$this->add_message( sprintf( __( 'Draft was saved. Job listing drafts can be resumed from the <a href="%s">job dashboard</a>.', 'wp-job-manager' ), get_permalink( $job_dashboard_page_id ) ) );
+				$this->add_message( sprintf( __( 'Draft was saved. Job listing drafts can be resumed from the <a href="%s">job dashboard</a>.', 'wp-job-manager' ), esc_url( get_permalink( $job_dashboard_page_id ) ) ) );
 			} else {
 				// Successful, show next step.
 				$this->step++;


### PR DESCRIPTION
Wraps the URL argument in `esc_url()` before `sprintf` substitution in two `<a href="%s">` templates:

- **`class-wp-job-manager-form-submit-job.php`** — draft-saved message (job dashboard permalink).
- **`3rd-party/wpml.php`** — WPML settings description (primary-language edit link, built from a filterable `wpml_default_language` value).

Output is unchanged for legitimate URLs; this is output-escaping hygiene only.

Fixes #2977.

## Testing
- `phpcs` clean on both files.
- No behavior change for valid URLs (escaping only).

<!-- wpjm:plugin-zip -->
----

| Plugin build for e70a07b3b6746e8b9a79b3fd383fe8242ff494f7 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-2996-e70a07b3.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/2996-e70a07b3)             |

<!-- /wpjm:plugin-zip -->
