### PR TITLE
Release WP Job Manager 2.4.5

### DIFF
--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -159,7 +159,7 @@ class WP_Job_Manager_Ajax {
 			/**
 			 * Post statuses a visitor without listing-editing capabilities is allowed to filter by.
 			 *
-			 * @since $$next-version$$
+			 * @since 2.4.5
 			 *
 			 * @param string[] $allowed_post_status Allowed post statuses. Defaults to `[ 'publish' ]`.
 			 */

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -946,7 +946,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * own listing — and expose it through the public listing output — by supplying
 	 * a foreign attachment ID in the hidden `current_<field>` value.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.5
 	 *
 	 * @param int $attachment_id Attachment post ID.
 	 * @return bool True if the current user may use the attachment.

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 2.4.4\n"
+"Project-Id-Version: WP Job Manager 2.4.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-24T19:38:44+00:00\n"
+"POT-Creation-Date: 2026-07-01T15:59:46+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: wp-job-manager\n"
@@ -1360,7 +1360,7 @@ msgstr ""
 
 #. translators: Used in user select. %1$s is the user's display name; #%2$s is the user ID; %3$s is the user email.
 #: includes/admin/class-wp-job-manager-writepanels.php:532
-#: includes/class-wp-job-manager-ajax.php:456
+#: includes/class-wp-job-manager-ajax.php:470
 #, php-format
 msgid "%1$s (#%2$s – %3$s)"
 msgstr ""
@@ -1769,14 +1769,14 @@ msgid "Unable to log stats."
 msgstr ""
 
 #. translators: Placeholder %d is the number of found search results.
-#: includes/class-wp-job-manager-ajax.php:222
+#: includes/class-wp-job-manager-ajax.php:236
 #, php-format
 msgid "Search completed. Found %d matching record."
 msgid_plural "Search completed. Found %d matching records."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-wp-job-manager-ajax.php:321
+#: includes/class-wp-job-manager-ajax.php:335
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 
 #. translators: Placeholder %d is the number of files to that users are limited to.
 #: includes/class-wp-job-manager.php:590
-#: includes/forms/class-wp-job-manager-form-submit-job.php:530
+#: includes/forms/class-wp-job-manager-form-submit-job.php:534
 #, php-format
 msgid "You are only allowed to upload a maximum of %d files."
 msgstr ""
@@ -2346,7 +2346,7 @@ msgid "Submit Details"
 msgstr ""
 
 #: includes/forms/class-wp-job-manager-form-submit-job.php:104
-#: includes/forms/class-wp-job-manager-form-submit-job.php:696
+#: includes/forms/class-wp-job-manager-form-submit-job.php:700
 #: templates/job-preview.php:32
 msgid "Preview"
 msgstr ""
@@ -2454,59 +2454,60 @@ msgstr ""
 msgid "\"%1$s\" (filetype %2$s) needs to be one of the following file types: %3$s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:513
+#: includes/forms/class-wp-job-manager-form-submit-job.php:511
+#: includes/forms/class-wp-job-manager-form-submit-job.php:517
 msgid "Invalid attachment provided."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:559
+#: includes/forms/class-wp-job-manager-form-submit-job.php:563
 msgid "Please enter a valid application email address"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:564
+#: includes/forms/class-wp-job-manager-form-submit-job.php:568
 msgid "Please enter a valid application URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:570
+#: includes/forms/class-wp-job-manager-form-submit-job.php:574
 msgid "Please enter a valid application email address or URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:755
+#: includes/forms/class-wp-job-manager-form-submit-job.php:759
 msgid "Please enter a username."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:759
+#: includes/forms/class-wp-job-manager-form-submit-job.php:763
 msgid "Please enter a password."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:763
+#: includes/forms/class-wp-job-manager-form-submit-job.php:767
 msgid "Please enter your email address."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:769
+#: includes/forms/class-wp-job-manager-form-submit-job.php:773
 msgid "Passwords must match."
 msgstr ""
 
 #. translators: Placeholder %s is the password hint.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:775
+#: includes/forms/class-wp-job-manager-form-submit-job.php:779
 #, php-format
 msgid "Invalid Password: %s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:777
+#: includes/forms/class-wp-job-manager-form-submit-job.php:781
 msgid "Password is not valid."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:809
+#: includes/forms/class-wp-job-manager-form-submit-job.php:813
 msgid "You must be signed in to post a new listing."
 msgstr ""
 
 #. translators: placeholder is the URL to the job dashboard page.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:835
+#: includes/forms/class-wp-job-manager-form-submit-job.php:839
 #, php-format
 msgid "Draft was saved. Job listing drafts can be resumed from the <a href=\"%s\">job dashboard</a>."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:1174
+#: includes/forms/class-wp-job-manager-form-submit-job.php:1207
 msgid "You have reached the listing limit for your account and cannot publish this listing."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jobs, careers, company, hiring, job board
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.4.4
+Stable tag: 2.4.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
@@ -287,7 +287,7 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 	 * `[jobs post_status="publish"]` shortcode) must be honored, not discarded back to the more
 	 * permissive default which can include expired listings when "Hide expired listings" is off.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.5
 	 * @covers WP_Job_Manager_Ajax::get_listings
 	 */
 	public function test_get_listings_publish_filter_preserved_for_logged_out() {
@@ -336,7 +336,7 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 	 * disallowed `filter_post_status` values (the original disclosure vector). Disallowed values are
 	 * stripped and the query falls back to the public default.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.5
 	 * @covers WP_Job_Manager_Ajax::get_listings
 	 */
 	public function test_get_listings_disallowed_status_filter_stripped_for_logged_out() {

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 2.4.4
+ * Version: 2.4.5
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '2.4.4' );
+define( 'JOB_MANAGER_VERSION', '2.4.5' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## WP Job Manager 2.4.5

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Escape URLs in two sprintf href templates with esc_url() (#2996)
* Validate attachment ownership when reusing a company logo by ID (#2995)
* Honor restrictive filter_post_status=publish for logged-out visitors (#2994)
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org


<!-- wpjm:plugin-zip -->
----

| Plugin build for 5d53c8f97814ead04b82dfefefe6c7eba5e62497 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-2997-5d53c8f9.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/2997-5d53c8f9)             |

<!-- /wpjm:plugin-zip -->
