### PR TITLE
Fix #2911: Improve text color contrast for WCAG 2.1 AA compliance

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -349,7 +349,7 @@ div.job_listings {
 			padding: 0 0 0 1em;
 			line-height: 1.5em;
 			font-style: italic;
-			color: #767676;
+			color: $subtext-accessible;
 		}
 
 		.website::before {
@@ -405,7 +405,7 @@ div.job_listings {
 			padding: 0.5em;
 			float: left;
 			line-height: 1em;
-			color: #767676;
+			color: $subtext-accessible;
 		}
 
 		.job-type {
@@ -914,7 +914,7 @@ div.job_listings {
 		}
 
 		.job_title small {
-			color: #767676;
+			color: $subtext-accessible;
 		}
 
 		.featured-job-icon {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -12,7 +12,6 @@ $highlight: 		adjust-hue($primary, 150); 						/* Prices, In stock labels, sales
 $highlightext:		desaturate(lighten($highlight, 50%), 18%);	/* Text on highlight colour bg */
 
 $contentbg: 		#fff; 										/* Content BG - Tabs (active state) */
-$subtext: 			#777; 										/* small, breadcrumbs etc */
 
 @mixin display-icon() {
 	display: inline-block;
@@ -349,7 +348,7 @@ div.job_listings {
 			padding: 0 0 0 1em;
 			line-height: 1.5em;
 			font-style: italic;
-			color: $subtext-accessible;
+			color: $subtext;
 		}
 
 		.website::before {
@@ -405,7 +404,7 @@ div.job_listings {
 			padding: 0.5em;
 			float: left;
 			line-height: 1em;
-			color: $subtext-accessible;
+			color: $subtext;
 		}
 
 		.job-type {
@@ -809,7 +808,7 @@ div.job_listings {
 
 	.meta {
 		font-style: italic;
-		color: #777;
+		color: $subtext;
 	}
 
 	.job-type {
@@ -914,7 +913,7 @@ div.job_listings {
 		}
 
 		.job_title small {
-			color: $subtext-accessible;
+			color: $subtext;
 		}
 
 		.featured-job-icon {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -349,7 +349,7 @@ div.job_listings {
 			padding: 0 0 0 1em;
 			line-height: 1.5em;
 			font-style: italic;
-			color: #999;
+			color: #767676;
 		}
 
 		.website::before {
@@ -405,7 +405,7 @@ div.job_listings {
 			padding: 0.5em;
 			float: left;
 			line-height: 1em;
-			color: #999;
+			color: #767676;
 		}
 
 		.job-type {
@@ -914,7 +914,7 @@ div.job_listings {
 		}
 
 		.job_title small {
-			color: #999;
+			color: #767676;
 		}
 
 		.featured-job-icon {

--- a/assets/css/job-listings.scss
+++ b/assets/css/job-listings.scss
@@ -79,7 +79,7 @@ ul.job_listings {
 				}
 
 				.company {
-					color: #767676;
+					color: $subtext-accessible;
 
 					.tagline {
 						margin-left: 0.5em;
@@ -92,7 +92,7 @@ ul.job_listings {
 				text-align: left;
 				width: 25%;
 				padding: 0 0 0 1em;
-				color: #767676;
+				color: $subtext-accessible;
 				line-height: 1.5em;
 			}
 
@@ -103,7 +103,7 @@ ul.job_listings {
 				padding: 0 0 0 1em;
 				margin: 0;
 				line-height: 1.5em;
-				color: #767676;
+				color: $subtext-accessible;
 				list-style: none outside;
 
 				li {

--- a/assets/css/job-listings.scss
+++ b/assets/css/job-listings.scss
@@ -79,7 +79,7 @@ ul.job_listings {
 				}
 
 				.company {
-					color: $subtext-accessible;
+					color: $subtext;
 
 					.tagline {
 						margin-left: 0.5em;
@@ -92,7 +92,7 @@ ul.job_listings {
 				text-align: left;
 				width: 25%;
 				padding: 0 0 0 1em;
-				color: $subtext-accessible;
+				color: $subtext;
 				line-height: 1.5em;
 			}
 
@@ -103,7 +103,7 @@ ul.job_listings {
 				padding: 0 0 0 1em;
 				margin: 0;
 				line-height: 1.5em;
-				color: $subtext-accessible;
+				color: $subtext;
 				list-style: none outside;
 
 				li {

--- a/assets/css/job-listings.scss
+++ b/assets/css/job-listings.scss
@@ -79,7 +79,7 @@ ul.job_listings {
 				}
 
 				.company {
-					color: #999;
+					color: #767676;
 
 					.tagline {
 						margin-left: 0.5em;
@@ -92,7 +92,7 @@ ul.job_listings {
 				text-align: left;
 				width: 25%;
 				padding: 0 0 0 1em;
-				color: #999;
+				color: #767676;
 				line-height: 1.5em;
 			}
 
@@ -103,7 +103,7 @@ ul.job_listings {
 				padding: 0 0 0 1em;
 				margin: 0;
 				line-height: 1.5em;
-				color: #999;
+				color: #767676;
 				list-style: none outside;
 
 				li {

--- a/assets/css/mixins.scss
+++ b/assets/css/mixins.scss
@@ -4,6 +4,8 @@ $internship: #6033cc;
 $freelance: #39c;
 $temporary: #d93674;
 
+$subtext-accessible: #767676; /* WCAG AA-compliant muted secondary text */
+
 @mixin clearfix() {
 	zoom: 1; /* For IE 6/7 (trigger hasLayout) */
 

--- a/assets/css/mixins.scss
+++ b/assets/css/mixins.scss
@@ -4,7 +4,7 @@ $internship: #6033cc;
 $freelance: #39c;
 $temporary: #d93674;
 
-$subtext-accessible: #767676; /* WCAG AA-compliant muted secondary text */
+$subtext: #767676; /* small, breadcrumbs etc — WCAG AA-compliant muted text */
 
 @mixin clearfix() {
 	zoom: 1; /* For IE 6/7 (trigger hasLayout) */


### PR DESCRIPTION
## Summary

- Updates text color from `#999` to `#767676` for job listing meta fields
- Improves contrast ratio from 2.85:1 to 4.54:1 (meets WCAG 2.1 AA minimum of 4.5:1)
- Affects: company name, location, meta (date posted, job type) in both listings loop and single job view

## Files changed

- `assets/css/frontend.scss` (3 occurrences)
- `assets/css/job-listings.scss` (3 occurrences)

## Test plan

- [ ] Verify contrast ratio ≥4.5:1 using WebAIM contrast checker or browser DevTools
- [ ] Visual check: text should appear slightly darker gray, no layout changes

Note: Modern default themes (Twenty Twenty-One, Twenty Twenty-Five) override WPJM styles, so the change is only visible on themes that use WPJM's default CSS.

Closes #2911

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- wpjm:plugin-zip -->
----

| Plugin build for 505ba249903466b3188d46987e15507c3a690803 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-2998-505ba249.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/2998-505ba249)             |

<!-- /wpjm:plugin-zip -->




