### PR TITLE
Reflect WordPress.org release confirmation in the release PR comment

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,4 +51,4 @@ jobs:
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: gh pr comment ${{ github.event.number }} --body "✅ Release **${{ steps.create_release.outputs.version }}** [deployed to WordPress.org](https://wordpress.org/plugins/wp-job-manager/)."
+        run: gh pr comment ${{ github.event.number }} --body "🚀 Release **${{ steps.create_release.outputs.version }}** pushed to WordPress.org — [confirm the release email](https://wordpress.org/plugins/wp-job-manager/advanced/) to publish it to users."


### PR DESCRIPTION
## Summary

Release Confirmations are now enabled for the plugin on WordPress.org: a merged release is pushed to SVN but **held pending email confirmation** rather than published immediately.

The release workflow's final PR comment currently says the release was "deployed to WordPress.org", which now overstates what happened — at that point it's pushed and awaiting your confirmation. This rewords it:

> 🚀 Release **X** pushed to WordPress.org — [confirm the release email](https://wordpress.org/plugins/wp-job-manager/advanced/) to publish it to users.

One-line change to `.github/workflows/create-release.yml`. The "release workflow started" comment is unchanged. Independent of #2999 (that PR touches `create-release.mjs`; this touches the workflow YAML).

https://claude.ai/code/session_01CZWPVHhcZmaVPRC1ARiVyf

<!-- wpjm:plugin-zip -->
----

| Plugin build for c7837d4781b6d6bbc2b9ec85fc4804661e1d2c92 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3000-c7837d47.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3000-c7837d47)             |

<!-- /wpjm:plugin-zip -->
