### PR TITLE
Handle CRLF and missing lockfiles in release tooling

### DIFF
--- a/scripts/create-release.mjs
+++ b/scripts/create-release.mjs
@@ -42,7 +42,9 @@ await success();
 
 function getReleaseNotes() {
 
-	const prDescription = JSON.parse( execSync( `gh pr view ${ prNumber } -R ${ plugin.repo } --json body` ).toString() ).body;
+	// Normalize CRLF to LF: GitHub stores PR bodies edited in the web UI with
+	// CRLF line endings, which would break the `\n`-based fence regex below.
+	const prDescription = JSON.parse( execSync( `gh pr view ${ prNumber } -R ${ plugin.repo } --json body` ).toString() ).body.replace( /\r\n/g, '\n' );
 	const releaseNotes  = prDescription
 		.match( /### Release Notes\s*\n---([\S\s]*?)---/ )[ 1 ]
 		.replace( /^- /gm, '* ' )

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -249,10 +249,17 @@ function replaceNextVersionPlaceholder() {
 function updatePackageJsonFiles() {
 	console.log( 'Updating package.json version...' );
 	try {
-		execSync( `npm version ${ version } --no-git-tag-version` );
-		execSync(
-			`git add package.json package-lock.json`,
-		);
+		execSync( `npm version ${ version } --no-git-tag-version --allow-same-version` );
+		execSync( `git add package.json` );
+		// Stage whichever lockfile the repo actually uses. `git add` on a missing
+		// pathspec aborts and stages nothing, so only add lockfiles that exist —
+		// this keeps the script working for npm (package-lock.json) and pnpm
+		// (pnpm-lock.yaml) repos alike.
+		for ( const lockfile of [ 'package-lock.json', 'pnpm-lock.yaml', 'npm-shrinkwrap.json' ] ) {
+			if ( fs.existsSync( lockfile ) ) {
+				execSync( `git add ${ lockfile }` );
+			}
+		}
 	} catch {
 		console.log( 'Version could not be updated in package.json file.' );
 	}


### PR DESCRIPTION
- create-release.mjs: normalize CRLF→LF before matching the release-notes fences. GitHub stores PR bodies edited in the web UI with CRLF, which broke the `\n`-based fence regex (the intended 'edit changelog in the PR body' workflow).
- prepare-release.mjs: stage only lockfiles that exist, so `git add` no longer fails on repos without `package-lock.json`.

Both surfaced during the crowdsignal-forms 1.8.2 release, which uses this same shared tooling.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 7ff6deea2ad920b6e408579d99d06f593a8c2bce <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3003-7ff6deea.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3003-7ff6deea)             |

<!-- /wpjm:plugin-zip -->
