### PR TITLE
Honor post password in [job] and [job_apply] shortcodes

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -498,7 +498,12 @@ class WP_Job_Manager_Shortcodes {
 		if ( $jobs->have_posts() ) {
 			while ( $jobs->have_posts() ) {
 				$jobs->the_post();
-				echo '<h1>' . wp_kses_post( wpjm_get_the_job_title() ) . '</h1>';
+				// Only emit the title when the listing is actually viewable. This mirrors the gate in
+				// content-single-job_listing.php so a password-protected (or capability-restricted)
+				// listing doesn't leak its title via the H1 before the template's access-denied notice.
+				if ( ( ! post_password_required() || is_super_admin() ) && job_manager_user_can_view_job_listing( get_the_ID() ) ) {
+					echo '<h1>' . wp_kses_post( wpjm_get_the_job_title() ) . '</h1>';
+				}
 				get_job_manager_template_part( 'content-single', \WP_Job_Manager_Post_Types::PT_LISTING );
 			}
 		}

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -600,6 +600,11 @@ class WP_Job_Manager_Shortcodes {
 		if ( $jobs->have_posts() ) {
 			while ( $jobs->have_posts() ) {
 				$jobs->the_post();
+				// Don't expose application details for a password-protected listing (same guard as
+				// WP_Job_Manager_Post_Types::job_content()); the [job_apply] shortcode bypasses that filter.
+				if ( post_password_required() && ! is_super_admin() ) {
+					continue;
+				}
 				$apply = get_the_job_application_method();
 				do_action( 'job_manager_before_job_apply_' . absint( $id ) );
 				if ( apply_filters( 'job_manager_show_job_apply_' . absint( $id ), true ) ) {

--- a/templates/content-single-job_listing.php
+++ b/templates/content-single-job_listing.php
@@ -18,7 +18,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $post;
 
-if ( job_manager_user_can_view_job_listing( $post->ID ) ) : ?>
+// Defense in depth: the normal single-listing render is gated in WP_Job_Manager_Post_Types::job_content(),
+// but this template is also loaded directly by the [job] shortcode, which bypasses that guard. Re-assert the
+// post-password check here (with the same super-admin exception) so a shortcode-embedded protected listing
+// cannot leak its content. See templates/content-job_listing.php for the sibling pattern.
+if ( ( ! post_password_required( $post ) || is_super_admin() ) && job_manager_user_can_view_job_listing( $post->ID ) ) : ?>
 	<div class="single_job_listing">
 		<?php if ( get_option( 'job_manager_hide_expired_content', 1 ) && 'expired' === $post->post_status ) : ?>
 			<div class="job-manager-info"><?php _e( 'This listing has expired.', 'wp-job-manager' ); ?></div>

--- a/tests/php/tests/security/test_class.password-protected-listing-shortcode.php
+++ b/tests/php/tests/security/test_class.password-protected-listing-shortcode.php
@@ -75,6 +75,31 @@ class Tests_Password_Protected_Listing_Shortcode extends WPJM_BaseTest {
 	}
 
 	/**
+	 * The listing title is emitted by output_job() as an <h1> before the gated template, so it
+	 * must also be withheld for a password-protected listing (WordPress otherwise renders it as
+	 * "Protected: <title>", leaking title content that may carry confidential role/company info).
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::output_job
+	 */
+	public function test_job_shortcode_hides_protected_title_from_anonymous() {
+		$protected = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'post_title'    => 'sentinel-TITANIUM protected title',
+			]
+		);
+		$this->logout();
+
+		$output = do_shortcode( '[job id="' . $protected . '"]' );
+
+		$this->assertStringNotContainsString(
+			'sentinel-TITANIUM',
+			$output,
+			'[job] must not render a password-protected listing title to anonymous visitors.'
+		);
+	}
+
+	/**
 	 * Parity with job_content(): a super admin keeps access to protected content via [job].
 	 *
 	 * @covers WP_Job_Manager_Shortcodes::output_job
@@ -83,6 +108,7 @@ class Tests_Password_Protected_Listing_Shortcode extends WPJM_BaseTest {
 		$protected = $this->factory->job_listing->create(
 			[
 				'post_password' => 'secret',
+				'post_title'    => 'sentinel-TUNGSTEN protected title',
 				'post_content'  => 'sentinel-MERIDIAN protected description',
 			]
 		);
@@ -94,6 +120,11 @@ class Tests_Password_Protected_Listing_Shortcode extends WPJM_BaseTest {
 			'sentinel-MERIDIAN',
 			$output,
 			'A super admin must retain access to protected listings via [job], matching job_content().'
+		);
+		$this->assertStringContainsString(
+			'sentinel-TUNGSTEN',
+			$output,
+			'A super admin must still see the listing title via [job].'
 		);
 	}
 }

--- a/tests/php/tests/security/test_class.password-protected-listing-shortcode.php
+++ b/tests/php/tests/security/test_class.password-protected-listing-shortcode.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Regression tests covering the [job] and [job_apply] shortcodes: a password-protected
+ * listing embedded via these shortcodes must not leak its content or application details to
+ * an anonymous visitor, while super admins retain access (parity with
+ * WP_Job_Manager_Post_Types::job_content()).
+ *
+ * @package wp-job-manager/tests
+ */
+
+class Tests_Password_Protected_Listing_Shortcode extends WPJM_BaseTest {
+
+	/**
+	 * @covers WP_Job_Manager_Shortcodes::output_job
+	 */
+	public function test_job_shortcode_hides_protected_description_from_anonymous() {
+		$protected = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'post_content'  => 'sentinel-COBALT protected description',
+			]
+		);
+		$this->logout();
+
+		$output = do_shortcode( '[job id="' . $protected . '"]' );
+
+		$this->assertStringNotContainsString(
+			'sentinel-COBALT',
+			$output,
+			'[job] must not render a password-protected listing description to anonymous visitors.'
+		);
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Shortcodes::output_job_apply
+	 */
+	public function test_job_apply_shortcode_hides_application_email_from_anonymous() {
+		$protected = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'meta_input'    => [ '_application' => 'apply-sentinel@example.test' ],
+			]
+		);
+		$this->logout();
+
+		$output = do_shortcode( '[job_apply id="' . $protected . '"]' );
+
+		$this->assertStringNotContainsString(
+			'apply-sentinel@example.test',
+			html_entity_decode( $output ),
+			'[job_apply] must not render a password-protected listing application method to anonymous visitors.'
+		);
+	}
+
+	/**
+	 * No-regression: a public (non-protected) listing still renders through [job].
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::output_job
+	 */
+	public function test_job_shortcode_still_renders_public_listing() {
+		$public = $this->factory->job_listing->create(
+			[
+				'post_content' => 'sentinel-VANILLA public description',
+			]
+		);
+		$this->logout();
+
+		$output = do_shortcode( '[job id="' . $public . '"]' );
+
+		$this->assertStringContainsString(
+			'sentinel-VANILLA',
+			$output,
+			'[job] must still render non-protected listings.'
+		);
+	}
+
+	/**
+	 * Parity with job_content(): a super admin keeps access to protected content via [job].
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::output_job
+	 */
+	public function test_job_shortcode_allows_super_admin() {
+		$protected = $this->factory->job_listing->create(
+			[
+				'post_password' => 'secret',
+				'post_content'  => 'sentinel-MERIDIAN protected description',
+			]
+		);
+		$this->login_as_admin();
+
+		$output = do_shortcode( '[job id="' . $protected . '"]' );
+
+		$this->assertStringContainsString(
+			'sentinel-MERIDIAN',
+			$output,
+			'A super admin must retain access to protected listings via [job], matching job_content().'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #

### Changes Proposed in this Pull Request

The `[job]` and `[job_apply]` shortcodes render a listing from their own `WP_Query`, which skips the `post_password_required()` check that the normal single-listing (`the_content`) path, the list/summary/widget templates, and the REST API all apply. This makes password handling consistent across every listing render path:

* `content-single-job_listing.php`: gate the render on `post_password_required()`, keeping the `is_super_admin()` exception for parity with `WP_Job_Manager_Post_Types::job_content()`.
* `output_job_apply()`: skip application details when a password is required (same guard).

### Testing Instructions

1. Create a job listing and set a WordPress post password on it.
2. Add `[job id="<listing_id>"]` and `[job_apply id="<listing_id>"]` to a public page.
3. View that page while logged out (or in a private window): the listing content and application details are no longer shown — consistent with viewing the listing directly.
4. Confirm a listing **without** a password still renders normally via the shortcodes.
5. Confirm an administrator still sees the content (parity with the single-listing view).

Automated coverage: `vendor/bin/phpunit --filter Tests_Password_Protected_Listing_Shortcode`

### Release Notes

* Apply the post-password check to the `[job]` and `[job_apply]` shortcodes.

### New or Updated Hooks and Templates

* `templates/content-single-job_listing.php` — the render is now additionally gated on `post_password_required()` (super admins are unaffected). Themes overriding this template should re-assert the same check.

### Deprecated Code

* None.



<!-- wpjm:plugin-zip -->
----

| Plugin build for 4bf347691c6d434a5443c40d4e63e51eb4c9411f <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3004-4bf34769.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3004-4bf34769)             |

<!-- /wpjm:plugin-zip -->


