### PR TITLE
Only attach company logo files stored in this site's media

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -985,22 +985,36 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		$attachment_url_parts = wp_parse_url( $attachment_url );
 
+		$scheme = $attachment_url_parts['scheme'] ?? '';
+		$host   = $attachment_url_parts['host'] ?? '';
+		$path   = $attachment_url_parts['path'] ?? '';
+
 		// Relative paths aren't allowed.
-		if ( false !== strpos( $attachment_url_parts['path'], '../' ) ) {
+		if ( false !== strpos( $path, '../' ) ) {
 			return 0;
 		}
 
-		$attachment_url = sprintf( '%s://%s%s', $attachment_url_parts['scheme'], $attachment_url_parts['host'], $attachment_url_parts['path'] );
+		$attachment_url = sprintf( '%s://%s%s', $scheme, $host, $path );
 
-		$attachment_url = str_replace( [ $upload_dir['baseurl'], WP_CONTENT_URL, site_url( '/' ) ], [ $upload_dir['basedir'], WP_CONTENT_DIR, ABSPATH ], $attachment_url );
+		$local_dirs     = [ $upload_dir['basedir'], WP_CONTENT_DIR, ABSPATH ];
+		$attachment_url = str_replace( [ $upload_dir['baseurl'], WP_CONTENT_URL, site_url( '/' ) ], $local_dirs, $attachment_url );
 		if ( empty( $attachment_url ) || ! is_string( $attachment_url ) ) {
 			return 0;
 		}
 
-		// Only attach files that resolve to a local path for this site. A value
-		// that still points at a remote host after the mapping above is not one
-		// of our own uploads, so we do not turn it into an attachment.
-		if ( preg_match( '#^https?://#i', $attachment_url ) ) {
+		// Only attach files that resolve to a path under one of this site's own
+		// directories. After the mapping above a genuine upload becomes a local
+		// filesystem path; anything still pointing at a remote origin (including
+		// scheme-relative //host/... URLs) or at an arbitrary path elsewhere on
+		// disk is not one of our uploads, so we do not turn it into an attachment.
+		$is_local = false;
+		foreach ( array_filter( $local_dirs ) as $base ) {
+			if ( 0 === strpos( $attachment_url, trailingslashit( $base ) ) ) {
+				$is_local = true;
+				break;
+			}
+		}
+		if ( ! $is_local ) {
 			return 0;
 		}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -997,6 +997,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			return 0;
 		}
 
+		// Only attach files that resolve to a local path for this site. A value
+		// that still points at a remote host after the mapping above is not one
+		// of our own uploads, so we do not turn it into an attachment.
+		if ( preg_match( '#^https?://#i', $attachment_url ) ) {
+			return 0;
+		}
+
 		$attachment = [
 			'post_title'   => wpjm_get_the_job_title( $this->job_id ),
 			'post_content' => '',

--- a/tests/php/tests/includes/test_class.submit-job-attachment-local.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-local.php
@@ -114,6 +114,36 @@ class WP_Test_Submit_Job_Attachment_Local extends WPJM_BaseTest {
 	}
 
 	/**
+	 * A scheme-relative //host/... value points at a remote origin (its scheme is
+	 * empty, so a plain http(s):// prefix check does not catch it) and must not be
+	 * attached.
+	 */
+	public function test_protocol_relative_remote_url_is_not_attached() {
+		$before = count( get_posts( [ 'post_type' => 'attachment', 'fields' => 'ids', 'numberposts' => -1 ] ) );
+
+		$this->assertSame(
+			0,
+			$this->create_attachment( '//example.com/remote/logo.jpg' ),
+			'A scheme-relative remote URL must not be turned into an attachment.'
+		);
+
+		$after = count( get_posts( [ 'post_type' => 'attachment', 'fields' => 'ids', 'numberposts' => -1 ] ) );
+		$this->assertSame( $before, $after, 'No attachment post should be created for a scheme-relative remote URL.' );
+	}
+
+	/**
+	 * A bare absolute path that does not resolve under one of this site's own
+	 * directories must not be attached.
+	 */
+	public function test_arbitrary_local_path_is_not_attached() {
+		$this->assertSame(
+			0,
+			$this->create_attachment( '/etc/passwd' ),
+			'An arbitrary filesystem path outside the site directories must not be attached.'
+		);
+	}
+
+	/**
 	 * A URL under this site's uploads directory is still attached — the normal
 	 * flow where the form round-trips an already-uploaded file must keep working.
 	 */

--- a/tests/php/tests/includes/test_class.submit-job-attachment-local.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-local.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Tests that the frontend job submission form only creates attachments from
+ * files that resolve to a local path for this site. A file-field value that
+ * still points at a remote host is not one of our own uploads, so it must not
+ * be turned into an attachment (which would otherwise trigger a server-side
+ * read of the remote URL during metadata generation).
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Submit_Job_Attachment_Local extends WPJM_BaseTest {
+
+	/**
+	 * Filtered uploads base URL (deliberately port-less so URL-to-path mapping
+	 * is deterministic regardless of the test host's port).
+	 *
+	 * @var string
+	 */
+	private $base_url = 'http://example.org/wp-content/uploads';
+
+	/**
+	 * Filtered uploads base directory (a real writable temp dir).
+	 *
+	 * @var string
+	 */
+	private $base_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+
+		$this->base_dir = trailingslashit( get_temp_dir() ) . 'wpjm-uploads-' . uniqid();
+		wp_mkdir_p( $this->base_dir );
+
+		add_filter( 'upload_dir', [ $this, 'filter_upload_dir' ] );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'upload_dir', [ $this, 'filter_upload_dir' ] );
+
+		unset( $_POST, $_REQUEST );
+		$_POST    = [];
+		$_REQUEST = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Points wp_upload_dir() at our deterministic base URL / directory.
+	 *
+	 * @param array $dirs Upload directory data.
+	 * @return array
+	 */
+	public function filter_upload_dir( $dirs ) {
+		$dirs['baseurl'] = $this->base_url;
+		$dirs['basedir'] = $this->base_dir;
+		$dirs['url']     = $this->base_url;
+		$dirs['path']    = $this->base_dir;
+		return $dirs;
+	}
+
+	/**
+	 * Invokes the form's protected create_attachment() with a given value.
+	 *
+	 * @param string $attachment_url Value to pass to create_attachment().
+	 * @return int Attachment ID (0 when nothing is attached).
+	 */
+	private function create_attachment( $attachment_url ) {
+		$form   = WP_Job_Manager_Form_Submit_Job::instance();
+		$method = new ReflectionMethod( $form, 'create_attachment' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $form, $attachment_url );
+	}
+
+	/**
+	 * Writes a minimal valid PNG into the uploads base dir and returns its URL.
+	 *
+	 * @param string $filename File name to create.
+	 * @return string Public URL of the created file.
+	 */
+	private function write_local_image( $filename ) {
+		// 1x1 transparent PNG.
+		$png = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC' );
+		file_put_contents( trailingslashit( $this->base_dir ) . $filename, $png );
+		return trailingslashit( $this->base_url ) . $filename;
+	}
+
+	/**
+	 * A value pointing at a remote host is not attached.
+	 */
+	public function test_remote_url_is_not_attached() {
+		$before = count( get_posts( [ 'post_type' => 'attachment', 'fields' => 'ids', 'numberposts' => -1 ] ) );
+
+		$this->assertSame(
+			0,
+			$this->create_attachment( 'http://example.com/remote/logo.jpg' ),
+			'A remote URL must not be turned into an attachment.'
+		);
+
+		$after = count( get_posts( [ 'post_type' => 'attachment', 'fields' => 'ids', 'numberposts' => -1 ] ) );
+		$this->assertSame( $before, $after, 'No attachment post should be created for a remote URL.' );
+	}
+
+	/**
+	 * An https value pointing at a remote host is not attached either.
+	 */
+	public function test_remote_https_url_is_not_attached() {
+		$this->assertSame(
+			0,
+			$this->create_attachment( 'https://example.com/remote/logo.png' ),
+			'A remote HTTPS URL must not be turned into an attachment.'
+		);
+	}
+
+	/**
+	 * A URL under this site's uploads directory is still attached — the normal
+	 * flow where the form round-trips an already-uploaded file must keep working.
+	 */
+	public function test_local_upload_url_is_attached() {
+		$local_url = $this->write_local_image( 'local-logo.png' );
+
+		$attachment_id = $this->create_attachment( $local_url );
+
+		$this->assertGreaterThan(
+			0,
+			$attachment_id,
+			'A URL under the site uploads directory must be attached.'
+		);
+		$this->assertSame(
+			'attachment',
+			get_post_type( $attachment_id ),
+			'The created post must be an attachment.'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #

### Changes Proposed in this Pull Request

* The frontend submission form maps a submitted file-field value to a local uploads path before creating an attachment. When a value did not map to a local path, `create_attachment()` would still build an attachment from an off-site URL.
* Skip attachment creation for values that remain a remote `http(s)` URL after the local-path mapping, so only files that resolve to this site's own uploads are attached. Reusing an already-uploaded local logo continues to work unchanged.
* Applies to the company logo and any other file field routed through `create_attachment()`.

### Testing Instructions

* Run the new test: `make test-up` then `vendor/bin/phpunit --filter WP_Test_Submit_Job_Attachment_Local` — 3 tests, all passing.
* Manually: on a `[submit_job_form]` page, upload a company logo and submit a listing — the logo is attached and shown in the preview and on the published listing as before.
* Full suite (`make test`) is green (only the geocode tests skip, which require an API key).

### Release Notes

* 

### New or Updated Hooks and Templates

*

### Deprecated Code

*





<!-- wpjm:plugin-zip -->
----

| Plugin build for 0f90f259436789bbddc68c00f4bd485db88b42d0 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3005-0f90f259.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3005-0f90f259)             |

<!-- /wpjm:plugin-zip -->






