### PR TITLE
Enforce attachment ownership on the draft-save submission path

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -441,6 +441,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @throws Exception Uploaded file is not a valid mime-type or other validation error.
 	 */
 	protected function validate_fields( $values ) {
+		$attachment_validation = $this->validate_attachment_ownership( $values );
+		if ( is_wp_error( $attachment_validation ) ) {
+			throw new Exception( $attachment_validation->get_error_message() );
+		}
+
 		foreach ( $this->fields as $group_key => $group_fields ) {
 			foreach ( $group_fields as $key => $field ) {
 				if (
@@ -504,12 +509,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 								}
 							}
 
-							// Check if attachment is valid.
+							// Attachment IDs are validated for ownership in validate_attachment_ownership().
 							if ( is_numeric( $file_url ) ) {
-								$attachment_id = absint( $file_url );
-								if ( $attachment_id && ! $this->is_attachment_authorized_for_current_user( $attachment_id ) ) {
-									throw new Exception( __( 'Invalid attachment provided.', 'wp-job-manager' ) );
-								}
 								continue;
 							}
 							$file_url = esc_url( $file_url, [ 'http', 'https' ] );
@@ -731,16 +732,22 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 			// Validate fields.
 			if ( $is_saving_draft ) {
-				/**
-				 * Perform additional validation on the job submission fields when saving drafts.
-				 *
-				 * @since 1.33.1
-				 *
-				 * @param bool  $is_valid Whether the fields are valid.
-				 * @param array $fields   Array of all fields being validated.
-				 * @param array $values   Submitted input values.
-				 */
-				$validation_status = apply_filters( 'submit_draft_job_form_validate_fields', true, $this->fields, $values );
+				// Drafts skip validate_fields() (incomplete forms are allowed), but attachment
+				// ownership must still be enforced so a draft can't bind another user's attachment.
+				$validation_status = $this->validate_attachment_ownership( $values );
+
+				if ( ! is_wp_error( $validation_status ) ) {
+					/**
+					 * Perform additional validation on the job submission fields when saving drafts.
+					 *
+					 * @since 1.33.1
+					 *
+					 * @param bool  $is_valid Whether the fields are valid.
+					 * @param array $fields   Array of all fields being validated.
+					 * @param array $values   Submitted input values.
+					 */
+					$validation_status = apply_filters( 'submit_draft_job_form_validate_fields', true, $this->fields, $values );
+				}
 			} else {
 				$validation_status = $this->validate_fields( $values );
 			}
@@ -936,6 +943,42 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				update_post_meta( $this->job_id, '_submitting_key', $submitting_key );
 			}
 		}
+	}
+
+	/**
+	 * Validates that every attachment referenced by ID in the posted file fields is owned by
+	 * (or editable by) the current user.
+	 *
+	 * Shared by the normal ({@see validate_fields()}) and the draft-save submission paths so a
+	 * draft save cannot bind another user's attachment (e.g. as a company logo / featured image)
+	 * — the draft path skips validate_fields() and would otherwise reach the sink unchecked.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $values Submitted input values.
+	 * @return bool|WP_Error True when all referenced attachments are authorized, WP_Error otherwise.
+	 */
+	protected function validate_attachment_ownership( $values ) {
+		foreach ( $this->fields as $group_key => $group_fields ) {
+			foreach ( $group_fields as $key => $field ) {
+				if ( 'file' !== $field['type'] || ! isset( $values[ $group_key ][ $key ] ) ) {
+					continue;
+				}
+
+				$file_urls = is_array( $values[ $group_key ][ $key ] ) ? $values[ $group_key ][ $key ] : [ $values[ $group_key ][ $key ] ];
+
+				foreach ( array_filter( $file_urls ) as $file_url ) {
+					if ( is_numeric( $file_url ) ) {
+						$attachment_id = absint( $file_url );
+						if ( $attachment_id && ! $this->is_attachment_authorized_for_current_user( $attachment_id ) ) {
+							return new WP_Error( 'validation-error', __( 'Invalid attachment provided.', 'wp-job-manager' ) );
+						}
+					}
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
@@ -18,6 +18,8 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 		unset( $_POST, $_REQUEST );
 		$_POST    = [];
 		$_REQUEST = [];
+		delete_option( 'job_manager_job_dashboard_page_id' );
+		delete_option( 'job_manager_submission_requires_approval' );
 		parent::tearDown();
 	}
 
@@ -127,6 +129,109 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 		$this->assertTrue(
 			$this->validate_company_logo( (string) $employer_attachment ),
 			'A user who can edit the attachment must be authorized to reuse it.'
+		);
+	}
+
+	/**
+	 * Drives WP_Job_Manager_Form_Submit_Job::submit_handler() for a "Save draft"
+	 * POST binding the given company_logo value, the way the draft-save POST does.
+	 *
+	 * The draft path deliberately skips validate_fields() (incomplete forms are
+	 * allowed), so this exercises the shared attachment-ownership check directly.
+	 *
+	 * @param mixed $logo_value Value for the current_company_logo field.
+	 * @return int The resulting job listing ID (0 when submission was rejected).
+	 */
+	private function save_draft_with_logo( $logo_value ) {
+		// can_continue_later() requires a configured job dashboard page.
+		update_option( 'job_manager_job_dashboard_page_id', $this->factory->post->create( [ 'post_type' => 'page' ] ) );
+
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		// Reset singleton state so init_fields() rebuilds and the job starts fresh.
+		foreach ( [
+			'fields' => [],
+			'job_id' => 0,
+			'step'   => 0,
+		] as $prop => $value ) {
+			$property = $class->getProperty( $prop );
+			$property->setAccessible( true );
+			$property->setValue( $form, $value );
+		}
+
+		$nonce                   = wp_create_nonce( 'submit-job-0' );
+		$_POST                   = [
+			'job_manager_form'     => 'submit-job',
+			'_wpjm_nonce'          => $nonce,
+			'job_id'               => 0,
+			'step'                 => 0,
+			'save_draft'           => 'Save draft',
+			'job_title'            => 'Attacker Draft With Foreign Logo',
+			'job_location'         => 'Anywhere',
+			'job_description'      => 'save-draft ownership poc',
+			'application'          => 'someone@example.com',
+			'company_name'         => 'DraftCo',
+			'current_company_logo' => (string) $logo_value,
+		];
+		$_REQUEST['_wpjm_nonce'] = $nonce;
+
+		$form->submit_handler();
+
+		return $form->get_job_id();
+	}
+
+	/**
+	 * Regression: the "Save draft" path (which skips validate_fields()) must still
+	 * reject a company_logo pointing at another user's attachment. Before the shared
+	 * ownership check, this bound the foreign attachment as the draft's featured image
+	 * and the submitter's default company logo.
+	 */
+	public function test_save_draft_rejects_foreign_attachment() {
+		$this->login_as_admin();
+		$foreign_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		$employer_id = get_current_user_id();
+
+		$draft_id = $this->save_draft_with_logo( (string) $foreign_attachment );
+
+		$this->assertSame( 0, $draft_id, 'A draft save with a foreign attachment must be rejected before the listing is created.' );
+
+		$bound = get_posts(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_status' => 'any',
+				'meta_key'    => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'  => $foreign_attachment, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'fields'      => 'ids',
+			]
+		);
+		$this->assertEmpty( $bound, 'The foreign attachment must not be bound to any listing as a featured image.' );
+
+		$this->assertNotEquals(
+			(string) $foreign_attachment,
+			get_user_meta( $employer_id, '_company_logo', true ),
+			'The foreign attachment must not persist as the submitter default company logo.'
+		);
+	}
+
+	/**
+	 * No-regression: the draft path still accepts a company_logo the submitter owns,
+	 * creating the draft and binding their own attachment.
+	 */
+	public function test_save_draft_accepts_own_attachment() {
+		$this->login_as_employer();
+		$own_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$draft_id = $this->save_draft_with_logo( (string) $own_attachment );
+
+		$this->assertGreaterThan( 0, $draft_id, 'A draft save with an owned attachment must succeed.' );
+		$this->assertSame( 'draft', get_post_status( $draft_id ) );
+		$this->assertEquals(
+			$own_attachment,
+			(int) get_post_meta( $draft_id, '_thumbnail_id', true ),
+			'The submitter own attachment must bind as the draft featured image.'
 		);
 	}
 }


### PR DESCRIPTION
Fixes #

### Changes Proposed in this Pull Request

The attachment-ownership check added in #2995 lives inside `validate_fields()`. The "Save draft" branch of `submit_handler()` deliberately skips `validate_fields()` (drafts are allowed to be incomplete), so that branch reached the attachment sink in `update_job_data()` without the ownership check — a `current_company_logo=<foreign_id>` on a draft save would bind another user's attachment as the draft's featured image and the submitter's default company logo.

This makes both submission paths enforce the check consistently:

* Extract the ownership check into a shared `validate_attachment_ownership()` helper.
* Call it from `validate_fields()` (normal path) and from the `$is_saving_draft` branch (draft path), before the sink runs.

The draft path still skips the rest of `validate_fields()` (required-field/mime/limit checks) as before — only the attachment-ownership check is now shared.

### Testing Instructions

1. As user A, upload a media item (note its attachment ID).
2. As user B (author/employer role) on the Submit Job form, save a **draft** while posting `current_company_logo=<user A's attachment ID>`.
3. The draft is rejected ("Invalid attachment provided") and no listing is created bound to A's attachment; `_company_logo` user meta for B is not set to A's attachment.
4. Confirm B can still save a draft using an attachment **they** own (normal reuse-your-own-logo flow).

Automated coverage: `vendor/bin/phpunit --filter Attachment_Ownership`

### Release Notes

* Enforce company-logo attachment ownership when saving a job listing as a draft.

### New or Updated Hooks and Templates

* None.

### Deprecated Code

* None.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 4c5fd4092428e5052d1a050366e32dcdc09d6421 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3006-4c5fd409.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3006-4c5fd409)             |

<!-- /wpjm:plugin-zip -->
