### PR TITLE
Use wp_safe_remote_get for the geocoding request

### DIFF
--- a/includes/class-wp-job-manager-geocode.php
+++ b/includes/class-wp-job-manager-geocode.php
@@ -216,7 +216,7 @@ class WP_Job_Manager_Geocode {
 
 		try {
 			if ( false === $geocoded_address || empty( $geocoded_address->results[0] ) ) {
-				$result           = wp_remote_get(
+				$result           = wp_safe_remote_get(
 					$geocode_api_url,
 					[
 						'timeout'     => 5,


### PR DESCRIPTION
Fixes #

### Changes Proposed in this Pull Request

* The geocoding lookup fetched the geocode endpoint with `wp_remote_get`. Switch to `wp_safe_remote_get` so the outbound request is validated against unsafe hosts (e.g. private/loopback addresses).
* The geocode endpoint is filterable via `job_manager_geolocation_endpoint`; this adds a guard for the case where that filter points the request somewhere other than the default Google Maps host.
* No behavior change for the default Google Maps endpoint (a public host on the standard port).

### Testing Instructions

* Geocode a listing address (front-end submission or admin save) with a valid `job_manager_google_maps_api_key` set — coordinates resolve as before.
* `make test-up` then `vendor/bin/phpunit --filter WP_Test_WP_Job_Manager_Geocode` passes (the live API tests skip without `WPJM_PHPUNIT_GOOGLE_GEOCODE_API_KEY`).

### Release Notes

* 

### New or Updated Hooks and Templates

*

### Deprecated Code

*


<!-- wpjm:plugin-zip -->
----

| Plugin build for a787f272f994cb09a905318ff9af1e5c1c90158c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3007-a787f272.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3007-a787f272)             |

<!-- /wpjm:plugin-zip -->
