### PR TITLE
Fix #2851: make WPJM widgets insertable on block themes

### DIFF
--- a/includes/class-wp-job-manager-blocks.php
+++ b/includes/class-wp-job-manager-blocks.php
@@ -43,6 +43,7 @@ class WP_Job_Manager_Blocks {
 		}
 
 		add_action( 'init', [ $this, 'register_blocks' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enable_legacy_widget_block' ] );
 	}
 
 	/**
@@ -50,6 +51,36 @@ class WP_Job_Manager_Blocks {
 	 */
 	public function register_blocks() {
 		// Add script includes for gutenblocks.
+	}
+
+	/**
+	 * Enable the core Legacy Widget block in the Site Editor.
+	 *
+	 * On a block theme there is no classic Widgets screen, and the Site Editor
+	 * does not expose the Legacy Widget block by default, so there is no UI to
+	 * insert the plugin's classic widgets (Recent Jobs, Featured Jobs). Opting
+	 * the block in here restores that path. Scoped to the Site Editor screen so
+	 * the post/page editor is left untouched.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/how-to-guides/widgets/legacy-widget-block/
+	 */
+	public function enable_legacy_widget_block() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+
+		if ( ! $screen || 'site-editor' !== $screen->id ) {
+			return;
+		}
+
+		if ( ! wp_script_is( 'wp-widgets', 'registered' ) ) {
+			return;
+		}
+
+		wp_enqueue_script( 'wp-widgets' );
+		wp_add_inline_script( 'wp-widgets', 'wp.widgets.registerLegacyWidgetBlock();' );
 	}
 }
 

--- a/includes/class-wp-job-manager-blocks.php
+++ b/includes/class-wp-job-manager-blocks.php
@@ -62,7 +62,14 @@ class WP_Job_Manager_Blocks {
 	 * the block in here restores that path. Scoped to the Site Editor screen so
 	 * the post/page editor is left untouched.
 	 *
+	 * The Site Editor registers `core/legacy-widget` itself with
+	 * `supports.inserter: false`, so calling `registerLegacyWidgetBlock()` here
+	 * would be a duplicate registration and log "Block core/legacy-widget is
+	 * already registered". Instead, flip the inserter support flag on core's own
+	 * registration via the `blocks.registerBlockType` filter.
+	 *
 	 * @see https://developer.wordpress.org/block-editor/how-to-guides/widgets/legacy-widget-block/
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/
 	 */
 	public function enable_legacy_widget_block() {
 		if ( ! function_exists( 'get_current_screen' ) ) {
@@ -79,8 +86,24 @@ class WP_Job_Manager_Blocks {
 			return;
 		}
 
+		// `wp-widgets` loads before `wp-edit-site`, so the filter is in place
+		// before the Site Editor registers the block.
 		wp_enqueue_script( 'wp-widgets' );
-		wp_add_inline_script( 'wp-widgets', 'wp.widgets.registerLegacyWidgetBlock();' );
+		wp_add_inline_script(
+			'wp-widgets',
+			'wp.hooks.addFilter(
+				"blocks.registerBlockType",
+				"wp-job-manager/enable-legacy-widget-inserter",
+				function ( settings, name ) {
+					if ( "core/legacy-widget" !== name ) {
+						return settings;
+					}
+					return Object.assign( {}, settings, {
+						supports: Object.assign( {}, settings.supports, { inserter: true } ),
+					} );
+				}
+			);'
+		);
 	}
 }
 

--- a/includes/class-wp-job-manager-widget.php
+++ b/includes/class-wp-job-manager-widget.php
@@ -63,8 +63,9 @@ class WP_Job_Manager_Widget extends WP_Widget {
 	 */
 	public function register() {
 		$widget_ops = [
-			'classname'   => $this->widget_cssclass,
-			'description' => $this->widget_description,
+			'classname'             => $this->widget_cssclass,
+			'description'           => $this->widget_description,
+			'show_instance_in_rest' => true,
 		];
 
 		parent::__construct( $this->widget_id, $this->widget_name, $widget_ops );

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -107,7 +107,7 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		$title           = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 		$number          = absint( $instance['number'] );
-		$remote_position = isset( $instance['remote_position'] ) ? $instance['remote_position'] : '';
+		$remote_position = $instance['remote_position'] ?? '';
 		$jobs            = get_job_listings(
 			[
 				'search_location' => $instance['location'],

--- a/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
+++ b/includes/widgets/class-wp-job-manager-widget-recent-jobs.php
@@ -105,19 +105,20 @@ class WP_Job_Manager_Widget_Recent_Jobs extends WP_Job_Manager_Widget {
 
 		ob_start();
 
-		$title     = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
-		$number    = absint( $instance['number'] );
-		$jobs      = get_job_listings(
+		$title           = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
+		$number          = absint( $instance['number'] );
+		$remote_position = isset( $instance['remote_position'] ) ? $instance['remote_position'] : '';
+		$jobs            = get_job_listings(
 			[
 				'search_location' => $instance['location'],
-				'remote_position' => in_array( $instance['remote_position'], [ 'true', 'false' ], true ) ? 'true' === $instance['remote_position'] : null,
+				'remote_position' => in_array( $remote_position, [ 'true', 'false' ], true ) ? 'true' === $remote_position : null,
 				'search_keywords' => $instance['keyword'],
 				'posts_per_page'  => $number,
 				'orderby'         => 'date',
 				'order'           => 'DESC',
 			]
 		);
-		$show_logo = absint( $instance['show_logo'] );
+		$show_logo       = absint( $instance['show_logo'] );
 
 		/**
 		 * Runs before Recent Jobs widget content.

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,9 @@ If you wish to be notified of new postings on your site you can use a plugin suc
 = What language files are available? =
 You can view (and contribute) translations via the [translate.wordpress.org](https://translate.wordpress.org/projects/wp-plugins/wp-job-manager).
 
+= How do I add the Recent Jobs or Featured Jobs widgets on a block theme? =
+Block themes have no classic Widgets screen, but you can still add the Recent Jobs and Featured Jobs widgets through the Site Editor. Go to **Appearance → Editor**, open a template or template part, add the **Legacy Widget** block from the inserter, and choose **Recent Jobs** or **Featured Jobs**. The widget's settings and preview appear right in the editor, just as they do on a classic theme.
+
 == Screenshots ==
 
 1. The submit job form.

--- a/tests/php/tests/test_class.wp-job-manager-widgets.php
+++ b/tests/php/tests/test_class.wp-job-manager-widgets.php
@@ -37,13 +37,14 @@ class WP_Test_WP_Job_Manager_Widgets extends WPJM_BaseTest {
 	}
 
 	/**
-	 * Rendering the Recent Jobs widget with a minimal instance should not fatal,
-	 * whether or not matching listings exist.
+	 * Rendering the Recent Jobs widget with a minimal instance should render the
+	 * matching listing (and not fatal on the missing remote_position key, which
+	 * is the #2851 regression the block-editor REST render path exposed).
 	 *
-	 * Smoke test for #2851 (the block editor invokes widget() via REST render).
+	 * Regression test for #2851 (the block editor invokes widget() via REST render).
 	 */
-	public function test_recent_jobs_widget_renders_without_error() {
-		$this->factory->job_listing->create();
+	public function test_recent_jobs_widget_renders_matching_listing() {
+		$this->factory->job_listing->create( [ 'post_title' => 'Senior Widget Engineer' ] );
 
 		$widget   = new WP_Job_Manager_Widget_Recent_Jobs();
 		$instance = [ 'title' => 'Recent Jobs', 'number' => 5 ];
@@ -52,15 +53,49 @@ class WP_Test_WP_Job_Manager_Widgets extends WPJM_BaseTest {
 		$widget->widget( $this->get_widget_args(), $instance );
 		$output = ob_get_clean();
 
-		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'job_listings', $output );
+		$this->assertStringContainsString( 'Senior Widget Engineer', $output );
 	}
 
 	/**
-	 * Rendering the Featured Jobs widget with a minimal instance should not fatal.
+	 * Recent Jobs should also render when remote positions are enabled, so the
+	 * instance carries a remote_position value and takes the in_array() branch.
 	 *
-	 * Smoke test for #2851.
+	 * Regression test for #2851.
 	 */
-	public function test_featured_jobs_widget_renders_without_error() {
+	public function test_recent_jobs_widget_renders_with_remote_position() {
+		update_option( 'job_manager_enable_remote_position', 1 );
+		$this->factory->job_listing->create(
+			[
+				'post_title' => 'Remote Widget Engineer',
+				'meta_input' => [ '_remote_position' => 1 ],
+			]
+		);
+
+		$widget   = new WP_Job_Manager_Widget_Recent_Jobs();
+		$instance = [ 'title' => 'Recent Jobs', 'number' => 5, 'remote_position' => 'true' ];
+
+		ob_start();
+		$widget->widget( $this->get_widget_args(), $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'job_listings', $output );
+	}
+
+	/**
+	 * Rendering the Featured Jobs widget should render a matching featured
+	 * listing (exercising the render loop, not just the no-jobs-found branch).
+	 *
+	 * Regression test for #2851.
+	 */
+	public function test_featured_jobs_widget_renders_matching_listing() {
+		$this->factory->job_listing->create(
+			[
+				'post_title' => 'Featured Widget Engineer',
+				'meta_input' => [ '_featured' => 1 ],
+			]
+		);
+
 		$widget   = new WP_Job_Manager_Widget_Featured_Jobs();
 		$instance = [ 'title' => 'Featured Jobs', 'number' => 5 ];
 
@@ -68,7 +103,8 @@ class WP_Test_WP_Job_Manager_Widgets extends WPJM_BaseTest {
 		$widget->widget( $this->get_widget_args(), $instance );
 		$output = ob_get_clean();
 
-		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'job_listings', $output );
+		$this->assertStringContainsString( 'Featured Widget Engineer', $output );
 	}
 
 	/**

--- a/tests/php/tests/test_class.wp-job-manager-widgets.php
+++ b/tests/php/tests/test_class.wp-job-manager-widgets.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tests for the plugin's widgets.
+ *
+ * @package wp-job-manager
+ */
+
+/**
+ * @group widgets
+ */
+class WP_Test_WP_Job_Manager_Widgets extends WPJM_BaseTest {
+
+	/**
+	 * The plugin's widgets should opt into the block editor's REST pipeline so
+	 * they can be edited and previewed through the Legacy Widget block (e.g. in
+	 * the Site Editor on block themes).
+	 *
+	 * Regression test for #2851.
+	 */
+	public function test_widgets_are_shown_in_rest() {
+		$widgets = [
+			new WP_Job_Manager_Widget_Recent_Jobs(),
+			new WP_Job_Manager_Widget_Featured_Jobs(),
+		];
+
+		foreach ( $widgets as $widget ) {
+			$this->assertArrayHasKey(
+				'show_instance_in_rest',
+				$widget->widget_options,
+				get_class( $widget ) . ' must declare the show_instance_in_rest widget option.'
+			);
+			$this->assertTrue(
+				$widget->widget_options['show_instance_in_rest'],
+				get_class( $widget ) . ' must set show_instance_in_rest to true.'
+			);
+		}
+	}
+
+	/**
+	 * Rendering the Recent Jobs widget with a minimal instance should not fatal,
+	 * whether or not matching listings exist.
+	 *
+	 * Smoke test for #2851 (the block editor invokes widget() via REST render).
+	 */
+	public function test_recent_jobs_widget_renders_without_error() {
+		$this->factory->job_listing->create();
+
+		$widget   = new WP_Job_Manager_Widget_Recent_Jobs();
+		$instance = [ 'title' => 'Recent Jobs', 'number' => 5 ];
+
+		ob_start();
+		$widget->widget( $this->get_widget_args(), $instance );
+		$output = ob_get_clean();
+
+		$this->assertIsString( $output );
+	}
+
+	/**
+	 * Rendering the Featured Jobs widget with a minimal instance should not fatal.
+	 *
+	 * Smoke test for #2851.
+	 */
+	public function test_featured_jobs_widget_renders_without_error() {
+		$widget   = new WP_Job_Manager_Widget_Featured_Jobs();
+		$instance = [ 'title' => 'Featured Jobs', 'number' => 5 ];
+
+		ob_start();
+		$widget->widget( $this->get_widget_args(), $instance );
+		$output = ob_get_clean();
+
+		$this->assertIsString( $output );
+	}
+
+	/**
+	 * Minimal sidebar args as passed to WP_Widget::widget().
+	 *
+	 * @return array
+	 */
+	private function get_widget_args() {
+		return [
+			'before_widget' => '',
+			'after_widget'  => '',
+			'before_title'  => '',
+			'after_title'   => '',
+			'widget_id'     => 'test-widget-1',
+		];
+	}
+}


### PR DESCRIPTION
Fixes #2851

### Changes Proposed in this Pull Request

On a block theme (no classic Widgets screen), the Recent Jobs and Featured
Jobs widgets could not be added through Appearance → Editor. In WP's Site
Editor the core Legacy Widget block is not exposed by default, and the
widgets were not opted into the block-editor REST pipeline, so there was no
working path to insert or configure them.

- Expose the core Legacy Widget block in the inserter on the **Site Editor
  screen only** (scoped so the post/page editor is unchanged). The Site
  Editor already registers `core/legacy-widget` itself on every WP version
  we support (6.4–7.0), deliberately with `supports.inserter: false`, so
  calling `wp.widgets.registerLegacyWidgetBlock()` — the approach in earlier
  revisions of this PR — was a duplicate registration that logged
  `Block "core/legacy-widget" is already registered` in the console.
  Instead, the documented [`blocks.registerBlockType` JS filter](https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/)
  flips the inserter support flag on core's own registration: one
  registration, no warning, and no race against core's `domReady`-deferred
  registration.
- Set `show_instance_in_rest => true` on the shared widget abstract so both
  widgets round-trip their settings via REST and render an inline form +
  live preview in the block editor.
- Guard a pre-existing "Undefined array key remote_position" notice in the
  Recent Jobs widget that fires on the block-editor REST render path when
  remote positions are disabled.

### Testing Instructions

1. Activate a block theme (e.g. Twenty Twenty-Five) and create a few
   published job listings.
2. Go to Appearance → Editor and open a template, with the browser console
   open.
3. Confirm the console shows no
   `Block "core/legacy-widget" is already registered` warning.
4. In the inserter, add the **Legacy Widget** block and choose **Recent Jobs**
   (or Featured Jobs).
5. Confirm the settings form is editable and the preview renders listings.
6. Save the template and view the corresponding front-end page; the widget
   renders identically to a classic theme.
7. Confirm the post/page editor is unchanged (no Legacy Widget block in the
   inserter there).

### Release Notes

Recent Jobs and Featured Jobs widgets can now be added via the Legacy Widget
block in the Site Editor on block themes.

### New or Updated Hooks and Templates

None.

### Deprecated Code

None.

### Screenshot / Video

Editor: Legacy Widget → Recent Jobs renders listings with an editable form
and a clean console (verified locally on WP 7.0 / Twenty Twenty-Five).
Frontend parity verified via the saved template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- wpjm:plugin-zip -->
----

| Plugin build for d67150c6ea16d8db25bd499095757d5484e4314f <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3009-d67150c6.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3009-d67150c6)             |

<!-- /wpjm:plugin-zip -->




