### PR TITLE
Only accept a manual listing expiry from the gated admin edit

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1304,8 +1304,8 @@ class WP_Job_Manager_Post_Types {
 		// manually. Front-end submissions must have the expiry derived server-side from the
 		// configured submission duration, so an attacker-supplied value is ignored here.
 		$input_job_expires = null;
-		if ( $this->current_user_can_set_expiry( $post ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in current_user_can_set_expiry().
+		if ( $this->is_authorized_expiry_edit_request( $post ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in is_authorized_expiry_edit_request().
 			$input_job_expires = isset( $_POST['_job_expires'] ) ? sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) : null;
 		}
 		$input_job_expires_datetime = ! empty( $input_job_expires ) ? DateTimeImmutable::createFromFormat( 'Y-m-d', $input_job_expires, wp_timezone() ) : null;
@@ -1335,11 +1335,13 @@ class WP_Job_Manager_Post_Types {
 	 * front-end submission's preview -> publish transition — must fall back to the
 	 * server-side calculated expiry.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param WP_Post $post The job listing being saved.
 	 *
 	 * @return bool
 	 */
-	private function current_user_can_set_expiry( $post ) {
+	private function is_authorized_expiry_edit_request( $post ) {
 		if (
 			empty( $_POST['job_manager_nonce'] )
 			|| ! wp_verify_nonce( wp_unslash( $_POST['job_manager_nonce'] ), 'save_meta_data' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1300,8 +1300,14 @@ class WP_Job_Manager_Post_Types {
 			$this->set_job_expiration( $post, null );
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check handled by WP core.
-		$input_job_expires          = isset( $_POST['_job_expires'] ) ? sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) : null;
+		// Only a gated admin edit (metabox nonce + edit capability) may set the expiry date
+		// manually. Front-end submissions must have the expiry derived server-side from the
+		// configured submission duration, so an attacker-supplied value is ignored here.
+		$input_job_expires = null;
+		if ( $this->current_user_can_set_expiry( $post ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in current_user_can_set_expiry().
+			$input_job_expires = isset( $_POST['_job_expires'] ) ? sanitize_text_field( wp_unslash( $_POST['_job_expires'] ) ) : null;
+		}
 		$input_job_expires_datetime = ! empty( $input_job_expires ) ? DateTimeImmutable::createFromFormat( 'Y-m-d', $input_job_expires, wp_timezone() ) : null;
 
 		// See if the user has set the expiry manually.
@@ -1318,6 +1324,30 @@ class WP_Job_Manager_Post_Types {
 				$_POST['_job_expires'] = $expires ? $expires->format( 'Y-m-d' ) : '';
 			}
 		}
+	}
+
+	/**
+	 * Whether the current request is authorized to set a job listing's expiry date manually.
+	 *
+	 * The expiry date may only be supplied directly from the gated admin edit screen, which
+	 * carries the `save_meta_data` nonce and requires the edit capability for the listing
+	 * (see WP_Job_Manager_Writepanels::save_post()). All other paths — in particular a
+	 * front-end submission's preview -> publish transition — must fall back to the
+	 * server-side calculated expiry.
+	 *
+	 * @param WP_Post $post The job listing being saved.
+	 *
+	 * @return bool
+	 */
+	private function current_user_can_set_expiry( $post ) {
+		if (
+			empty( $_POST['job_manager_nonce'] )
+			|| ! wp_verify_nonce( wp_unslash( $_POST['job_manager_nonce'] ), 'save_meta_data' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+		) {
+			return false;
+		}
+
+		return current_user_can( 'edit_post', $post->ID );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -525,9 +525,9 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 */
 	public function test_set_expiry_post() {
 		// A manual expiry is only honored from the gated admin edit (save_meta_data nonce +
-		// edit capability); set both up so this path exercises the authorized case.
-		$admin = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		wp_set_current_user( $admin );
+		// edit capability); log in as a capable admin (login_as_admin installs the
+		// job-listing caps) and provide the nonce so this path exercises the authorized case.
+		$this->login_as_admin();
 
 		$post                       = get_post( $this->factory->job_listing->create() );
 		$instance                   = WP_Job_Manager_Post_Types::instance();

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -524,11 +524,18 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	 * @covers WP_Job_Manager_Post_Types::set_expiry
 	 */
 	public function test_set_expiry_post() {
-		$post                  = get_post( $this->factory->job_listing->create() );
-		$instance              = WP_Job_Manager_Post_Types::instance();
-		$_POST['_job_expires'] = $expire_date = wp_date( 'Y-m-d', strtotime( '+10 days', current_datetime()->getTimestamp() ) );
+		// A manual expiry is only honored from the gated admin edit (save_meta_data nonce +
+		// edit capability); set both up so this path exercises the authorized case.
+		$admin = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin );
+
+		$post                       = get_post( $this->factory->job_listing->create() );
+		$instance                   = WP_Job_Manager_Post_Types::instance();
+		$_POST['job_manager_nonce'] = wp_create_nonce( 'save_meta_data' );
+		$_POST['_job_expires']      = $expire_date = wp_date( 'Y-m-d', strtotime( '+10 days', current_datetime()->getTimestamp() ) );
 		$instance->set_expiry( $post );
-		unset( $_POST['_job_expires'] );
+		unset( $_POST['_job_expires'], $_POST['job_manager_nonce'] );
+		wp_set_current_user( 0 );
 		$this->assertEquals( $expire_date, get_post_meta( $post->ID, '_job_expires', true ) );
 	}
 

--- a/tests/php/tests/security/test_class.frontend-expiry-authorization.php
+++ b/tests/php/tests/security/test_class.frontend-expiry-authorization.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Regression tests: a front-end publish transition must not honor an attacker-supplied
+ * `_job_expires` value.
+ *
+ * WP_Job_Manager_Post_Types::set_expiry() fires on every transition into `publish`,
+ * including the front-end preview -> publish performed synchronously during a submitter's
+ * own POST. Only a gated admin edit (save_meta_data nonce + edit capability) may set the
+ * expiry date manually; a front-end submitter must have expiry derived server-side from
+ * the configured submission duration, otherwise they could grant their own listing an
+ * unlimited lifetime and bypass the paid duration model (CWE-639).
+ *
+ * @package wp-job-manager
+ */
+class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
+
+	public function tearDown(): void {
+		$_POST    = [];
+		$_REQUEST = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Creates a listing in a non-published status, ready to transition to publish.
+	 *
+	 * @param int    $author Author user ID.
+	 * @param string $status Initial post status.
+	 *
+	 * @return int Job listing ID.
+	 */
+	private function create_listing( $author, $status ) {
+		return wp_insert_post(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_status' => $status,
+				'post_author' => $author,
+				'post_title'  => 'Expiry authorization',
+			]
+		);
+	}
+
+	/**
+	 * Runs the expiry logic the transition_post_status handler invokes on a publish
+	 * transition. Called directly to isolate the authorization gate from the admin
+	 * writepanels save path (which the loaded WP_Job_Manager_Writepanels hooks into).
+	 *
+	 * @param int $job_id Job listing ID.
+	 */
+	private function publish( $job_id ) {
+		\WP_Job_Manager_Post_Types::instance()->set_expiry( get_post( $job_id ) );
+	}
+
+	/**
+	 * A front-end submitter (no admin nonce) must not be able to set an arbitrary expiry.
+	 */
+	public function test_frontend_publish_ignores_posted_job_expires() {
+		$submitter = $this->factory->user->create( [ 'role' => 'author' ] );
+		wp_set_current_user( $submitter );
+
+		$job_id = $this->create_listing( $submitter, 'preview' );
+
+		// Attacker appends the field to their own preview -> publish POST; no admin nonce.
+		$_POST['_job_expires'] = '2999-12-31';
+
+		$this->publish( $job_id );
+
+		$this->assertNotEquals(
+			'2999-12-31',
+			get_post_meta( $job_id, '_job_expires', true ),
+			'A front-end publish must not honor an attacker-supplied _job_expires value.'
+		);
+	}
+
+	/**
+	 * The gated admin edit path (valid save_meta_data nonce + edit capability) may still
+	 * set the expiry date manually.
+	 */
+	public function test_admin_edit_honors_posted_job_expires() {
+		$admin = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin );
+
+		$job_id = $this->create_listing( $admin, 'pending' );
+
+		$_POST['job_manager_nonce'] = wp_create_nonce( 'save_meta_data' );
+		$_POST['_job_expires']      = '2999-12-31';
+
+		$this->publish( $job_id );
+
+		$this->assertEquals(
+			'2999-12-31',
+			get_post_meta( $job_id, '_job_expires', true ),
+			'A gated admin edit must still be able to set the expiry date manually.'
+		);
+	}
+
+	/**
+	 * A valid edit capability without the admin nonce is not sufficient: the manual expiry
+	 * value must be ignored, so a logged-in author cannot self-serve an unlimited expiry.
+	 */
+	public function test_edit_capability_without_nonce_ignores_posted_job_expires() {
+		$admin = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin );
+
+		$job_id = $this->create_listing( $admin, 'preview' );
+
+		// Capability is present, but the save_meta_data nonce is not.
+		$_POST['_job_expires'] = '2999-12-31';
+
+		$this->publish( $job_id );
+
+		$this->assertNotEquals(
+			'2999-12-31',
+			get_post_meta( $job_id, '_job_expires', true ),
+			'Without the admin nonce, a posted _job_expires must be ignored even for a capable user.'
+		);
+	}
+}

--- a/tests/php/tests/security/test_class.frontend-expiry-authorization.php
+++ b/tests/php/tests/security/test_class.frontend-expiry-authorization.php
@@ -81,7 +81,7 @@ class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 	 * set the expiry date manually.
 	 */
 	public function test_admin_edit_honors_posted_job_expires() {
-		// login_as_admin() installs the job-listing capabilities on the administrator role
+		// get_user_by_role() installs the job-listing capabilities on the administrator role
 		// (WP_Job_Manager_Install::install()), which a bare factory admin would not have.
 		$admin = $this->get_user_by_role( 'administrator' );
 		$this->login_as( $admin );

--- a/tests/php/tests/security/test_class.frontend-expiry-authorization.php
+++ b/tests/php/tests/security/test_class.frontend-expiry-authorization.php
@@ -76,8 +76,10 @@ class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 	 * set the expiry date manually.
 	 */
 	public function test_admin_edit_honors_posted_job_expires() {
-		$admin = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		wp_set_current_user( $admin );
+		// login_as_admin() installs the job-listing capabilities on the administrator role
+		// (WP_Job_Manager_Install::install()), which a bare factory admin would not have.
+		$admin = $this->get_user_by_role( 'administrator' );
+		$this->login_as( $admin );
 
 		$job_id = $this->create_listing( $admin, 'pending' );
 
@@ -98,8 +100,9 @@ class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 	 * value must be ignored, so a logged-in author cannot self-serve an unlimited expiry.
 	 */
 	public function test_edit_capability_without_nonce_ignores_posted_job_expires() {
-		$admin = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		wp_set_current_user( $admin );
+		// A genuinely capable admin (job-listing caps installed), but no admin nonce.
+		$admin = $this->get_user_by_role( 'administrator' );
+		$this->login_as( $admin );
 
 		$job_id = $this->create_listing( $admin, 'preview' );
 

--- a/tests/php/tests/security/test_class.frontend-expiry-authorization.php
+++ b/tests/php/tests/security/test_class.frontend-expiry-authorization.php
@@ -14,6 +14,11 @@
  */
 class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 
+	/**
+	 * An implausibly distant expiry an attacker would try to smuggle in.
+	 */
+	private const ATTACKER_EXPIRY = '2999-12-31';
+
 	public function tearDown(): void {
 		$_POST    = [];
 		$_REQUEST = [];
@@ -46,7 +51,7 @@ class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 	 *
 	 * @param int $job_id Job listing ID.
 	 */
-	private function publish( $job_id ) {
+	private function run_publish_expiry_handler( $job_id ) {
 		\WP_Job_Manager_Post_Types::instance()->set_expiry( get_post( $job_id ) );
 	}
 
@@ -60,12 +65,12 @@ class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 		$job_id = $this->create_listing( $submitter, 'preview' );
 
 		// Attacker appends the field to their own preview -> publish POST; no admin nonce.
-		$_POST['_job_expires'] = '2999-12-31';
+		$_POST['_job_expires'] = self::ATTACKER_EXPIRY;
 
-		$this->publish( $job_id );
+		$this->run_publish_expiry_handler( $job_id );
 
-		$this->assertNotEquals(
-			'2999-12-31',
+		$this->assertNotSame(
+			self::ATTACKER_EXPIRY,
 			get_post_meta( $job_id, '_job_expires', true ),
 			'A front-end publish must not honor an attacker-supplied _job_expires value.'
 		);
@@ -84,12 +89,12 @@ class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 		$job_id = $this->create_listing( $admin, 'pending' );
 
 		$_POST['job_manager_nonce'] = wp_create_nonce( 'save_meta_data' );
-		$_POST['_job_expires']      = '2999-12-31';
+		$_POST['_job_expires']      = self::ATTACKER_EXPIRY;
 
-		$this->publish( $job_id );
+		$this->run_publish_expiry_handler( $job_id );
 
-		$this->assertEquals(
-			'2999-12-31',
+		$this->assertSame(
+			self::ATTACKER_EXPIRY,
 			get_post_meta( $job_id, '_job_expires', true ),
 			'A gated admin edit must still be able to set the expiry date manually.'
 		);
@@ -107,14 +112,42 @@ class Tests_Frontend_Expiry_Authorization extends WPJM_BaseTest {
 		$job_id = $this->create_listing( $admin, 'preview' );
 
 		// Capability is present, but the save_meta_data nonce is not.
-		$_POST['_job_expires'] = '2999-12-31';
+		$_POST['_job_expires'] = self::ATTACKER_EXPIRY;
 
-		$this->publish( $job_id );
+		$this->run_publish_expiry_handler( $job_id );
 
-		$this->assertNotEquals(
-			'2999-12-31',
+		$this->assertNotSame(
+			self::ATTACKER_EXPIRY,
 			get_post_meta( $job_id, '_job_expires', true ),
 			'Without the admin nonce, a posted _job_expires must be ignored even for a capable user.'
+		);
+	}
+
+	/**
+	 * A valid save_meta_data nonce without the edit capability is not sufficient: the manual
+	 * expiry value must be ignored. Nonces are not capability- or post-bound, so any logged-in
+	 * user can mint a valid save_meta_data nonce for themselves; the edit_post capability check
+	 * exists precisely to stop that self-minted nonce from unlocking a manual expiry. This is
+	 * the exact attack shape the capability check defends against.
+	 */
+	public function test_minted_nonce_without_capability_ignores_posted_job_expires() {
+		// A low-privilege author has no job_listing capabilities, so current_user_can(
+		// 'edit_post', $job_id ) is false for a job_listing even one they authored.
+		$submitter = $this->factory->user->create( [ 'role' => 'author' ] );
+		wp_set_current_user( $submitter );
+
+		$job_id = $this->create_listing( $submitter, 'preview' );
+
+		// Any logged-in user can mint this nonce; the capability check is the real gate.
+		$_POST['job_manager_nonce'] = wp_create_nonce( 'save_meta_data' );
+		$_POST['_job_expires']      = self::ATTACKER_EXPIRY;
+
+		$this->run_publish_expiry_handler( $job_id );
+
+		$this->assertNotSame(
+			self::ATTACKER_EXPIRY,
+			get_post_meta( $job_id, '_job_expires', true ),
+			'A self-minted nonce without the edit capability must not honor a posted _job_expires value.'
 		);
 	}
 }


### PR DESCRIPTION
`set_expiry()` runs on every transition into `publish`, including the front-end preview → publish that happens during a submitter's own request, and it read `$_POST['_job_expires']` unconditionally. Honor a manually supplied expiry only when the request carries the admin metabox nonce (`save_meta_data`) and the edit capability for the listing, matching the writepanels save path; all other transitions derive the expiry server-side from the submission duration, as before.

Includes a regression test covering the front-end, admin, and capability-without-nonce cases.




<!-- wpjm:plugin-zip -->
----

| Plugin build for 53e032f60ed01a6653ad9e18f24257337a52f84c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3011-53e032f6.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3011-53e032f6)             |

<!-- /wpjm:plugin-zip -->






