### PR TITLE
Indicate WordPress 7.0 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,7 @@ There are three ways to customize the fields in WP Job Manager;
 2. For field changes, or adding new fields, using functions/filters inside your theme's functions.php file: [https://wpjobmanager.com/document/editing-job-submission-fields/](https://wpjobmanager.com/document/editing-job-submission-fields/)
 3. Use a 3rd party plugin such as [https://plugins.smyl.es/wp-job-manager-field-editor/](https://plugins.smyl.es/wp-job-manager-field-editor/?in=1) which has a UI for field editing.
 
-If you'd like to learn about WordPress filters, here is a great place to start: [https://pippinsplugins.com/a-quick-introduction-to-using-filters/](https://pippinsplugins.com/a-quick-introduction-to-using-filters/)
+If you'd like to learn about WordPress filters, here is a great place to start: [https://developer.wordpress.org/plugins/hooks/filters/](https://developer.wordpress.org/plugins/hooks/filters/)
 
 = How can I be notified of new jobs via email? =
 If you wish to be notified of new postings on your site you can use a plugin such as [Post Status Notifier](http://wordpress.org/plugins/post-status-notifier-lite/).

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mikejolley, automattic, adamkheckler, alexsanford1, annezazu, cena, chaselivingston, csonnek, davor.altman, donnapep, donncha, drawmyface, erania-pinnera, fjorgemota, jacobshere, jakeom, jeherve, jenhooks, jgs, jonryan, kraftbj, lamdayap, lschuyler, macmanx, nancythanki, orangesareorange, rachelsquirrel, renathoc, ryanc413, richardmtl, scarstocea
 Tags: jobs, careers, company, hiring, job board
 Requires at least: 6.4
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 2.4.5
 License: GPLv3

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.4
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * Requires PHP: 7.4
  * Text Domain: wp-job-manager
  * Domain Path: /languages/


### PR DESCRIPTION
## Summary

- Bump the `Tested up to:` header from 6.9 → 7.0 in both `wp-job-manager.php` and `readme.txt` to indicate compatibility with WordPress 7.0.
- Update an outdated WordPress filters link in `readme.txt` (Pippin's Plugins → official WordPress developer docs).

## Test plan

- Documentation-only change; no functional impact.
- Verified diffs touch only the intended lines (CRLF line endings in the `readme.txt` changelog preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wpjm:plugin-zip -->
----

| Plugin build for d1525e07a481576cef06f44b9075d06688a2162b <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3015-d1525e07.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3015-d1525e07)             |

<!-- /wpjm:plugin-zip -->
