### PR TITLE
feat(admin): add setting to toggle Promoted Jobs feature

### DIFF
--- a/includes/admin/class-wp-job-manager-admin.php
+++ b/includes/admin/class-wp-job-manager-admin.php
@@ -68,7 +68,7 @@ class WP_Job_Manager_Admin {
 		/**
 		 * Documented in class-wp-job-manager.php
 		 */
-		$this->are_promoted_jobs_enabled = apply_filters( 'job_manager_enable_promoted_jobs', true );
+		$this->are_promoted_jobs_enabled = WP_Job_Manager_Promoted_Jobs_Helper::is_enabled();
 		if ( $this->are_promoted_jobs_enabled ) {
 			include_once dirname( __FILE__ ) . '/class-wp-job-manager-promoted-jobs-admin.php';
 		}

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -336,6 +336,15 @@ class WP_Job_Manager_Settings {
 							'track'      => 'value',
 						],
 						[
+							'name'     => 'job_manager_enable_promoted_jobs',
+							'std'      => '1',
+							'label'    => __( 'Promoted Jobs', 'wp-job-manager' ),
+							'cb_label' => __( 'Enable Promoted Jobs', 'wp-job-manager' ),
+							'desc'     => __( 'Allow job listings to be promoted through the Promoted Jobs feature.', 'wp-job-manager' ),
+							'type'     => 'checkbox',
+							'track'    => 'bool',
+						],
+						[
 							'name'     => 'job_manager_display_location_address',
 							'std'      => '0',
 							'label'    => __( 'Location Display', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -122,6 +122,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_default_salary_unit',
 		'job_manager_enable_salary_currency',
 		'job_manager_default_salary_currency',
+		'job_manager_enable_promoted_jobs',
 		'job_manager_promoted_jobs_status_update_last_check',
 		'job_manager_promoted_jobs_webhook_interval',
 		'job_manager_promoted_jobs_cron_interval',

--- a/includes/class-wp-job-manager-promoted-jobs-helper.php
+++ b/includes/class-wp-job-manager-promoted-jobs-helper.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Helper for the Promoted Jobs feature toggle.
+ *
+ * Bridges the `job_manager_enable_promoted_jobs` admin option to the
+ * `job_manager_enable_promoted_jobs` filter. The option value is the
+ * initial value passed to `apply_filters()`, so any developer filter
+ * (regardless of priority) overrides the admin setting.
+ *
+ * @package wp-job-manager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class WP_Job_Manager_Promoted_Jobs_Helper
+ */
+class WP_Job_Manager_Promoted_Jobs_Helper {
+
+	/**
+	 * The option key for the admin toggle.
+	 */
+	const OPTION = 'job_manager_enable_promoted_jobs';
+
+	/**
+	 * Determine whether Promoted Jobs is enabled.
+	 *
+	 * Reads the admin option (default: enabled) and exposes it through the
+	 * `job_manager_enable_promoted_jobs` filter. A developer filter wins
+	 * over the option at any priority because the option value is the
+	 * initial value passed to `apply_filters()`.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		$option = get_option( self::OPTION, '1' );
+
+		/**
+		 * Filters whether Promoted Jobs is enabled.
+		 *
+		 * Initial value is the admin option (`job_manager_enable_promoted_jobs`).
+		 * A developer filter overrides the option at any priority.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param bool $enabled Whether Promoted Jobs is enabled.
+		 */
+		return (bool) apply_filters( 'job_manager_enable_promoted_jobs', ! empty( $option ) && '0' !== (string) $option );
+	}
+}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -87,6 +87,19 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-settings.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-com-api.php';
 
+		// Sync Promoted Jobs admin setting to the filter. Code override wins over option.
+		add_filter(
+			'job_manager_enable_promoted_jobs',
+			function( $enabled ) {
+				if ( ! $enabled ) {
+					return false;
+				}
+				$option = get_option( 'job_manager_enable_promoted_jobs', '1' );
+				return ! empty( $option ) && '0' !== (string) $option;
+			},
+			5
+		);
+
 		/**
 		 * Controls whether promoted jobs are enabled.
 		 *

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -86,28 +86,9 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-data-exporter.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-settings.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-com-api.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-promoted-jobs-helper.php';
 
-		// Sync Promoted Jobs admin setting to the filter. Code override wins over option.
-		add_filter(
-			'job_manager_enable_promoted_jobs',
-			function( $enabled ) {
-				if ( ! $enabled ) {
-					return false;
-				}
-				$option = get_option( 'job_manager_enable_promoted_jobs', '1' );
-				return ! empty( $option ) && '0' !== (string) $option;
-			},
-			5
-		);
-
-		/**
-		 * Controls whether promoted jobs are enabled.
-		 *
-		 * @since 2.3.0
-		 *
-		 * @param bool $enable_promoted_jobs Whether promoted jobs are enabled.
-		 */
-		if ( apply_filters( 'job_manager_enable_promoted_jobs', true ) ) {
+		if ( WP_Job_Manager_Promoted_Jobs_Helper::is_enabled() ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
 		}
 

--- a/tests/php/tests/test_class.promoted-jobs-setting.php
+++ b/tests/php/tests/test_class.promoted-jobs-setting.php
@@ -2,20 +2,18 @@
 /**
  * Tests for the Promoted Jobs enable/disable admin setting.
  *
- * Covers the 4 state combinations of option + code filter,
- * the setting registration, and the data cleaner entry.
- *
  * @package wp-job-manager
  */
 class Tests_Promoted_Jobs_Setting extends WPJM_BaseTest {
 
 	/**
-	 * Clean up option after each test.
+	 * Clean up option and filters after each test.
 	 */
 	public function tearDown(): void {
 		delete_option( 'job_manager_enable_promoted_jobs' );
 		remove_filter( 'job_manager_enable_promoted_jobs', '__return_false', 10 );
 		remove_filter( 'job_manager_enable_promoted_jobs', '__return_true', 10 );
+		remove_filter( 'job_manager_enable_promoted_jobs', '__return_true', 1 );
 		parent::tearDown();
 	}
 
@@ -25,8 +23,7 @@ class Tests_Promoted_Jobs_Setting extends WPJM_BaseTest {
 	public function test_option_on_no_filter_returns_true() {
 		update_option( 'job_manager_enable_promoted_jobs', '1' );
 
-		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
-		$this->assertTrue( $result );
+		$this->assertTrue( WP_Job_Manager_Promoted_Jobs_Helper::is_enabled() );
 	}
 
 	/**
@@ -36,8 +33,7 @@ class Tests_Promoted_Jobs_Setting extends WPJM_BaseTest {
 		update_option( 'job_manager_enable_promoted_jobs', '1' );
 		add_filter( 'job_manager_enable_promoted_jobs', '__return_false' );
 
-		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
-		$this->assertFalse( $result );
+		$this->assertFalse( WP_Job_Manager_Promoted_Jobs_Helper::is_enabled() );
 	}
 
 	/**
@@ -46,8 +42,7 @@ class Tests_Promoted_Jobs_Setting extends WPJM_BaseTest {
 	public function test_option_off_no_filter_returns_false() {
 		update_option( 'job_manager_enable_promoted_jobs', '0' );
 
-		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
-		$this->assertFalse( $result );
+		$this->assertFalse( WP_Job_Manager_Promoted_Jobs_Helper::is_enabled() );
 	}
 
 	/**
@@ -57,8 +52,17 @@ class Tests_Promoted_Jobs_Setting extends WPJM_BaseTest {
 		update_option( 'job_manager_enable_promoted_jobs', '0' );
 		add_filter( 'job_manager_enable_promoted_jobs', '__return_true', 10 );
 
-		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
-		$this->assertTrue( $result );
+		$this->assertTrue( WP_Job_Manager_Promoted_Jobs_Helper::is_enabled() );
+	}
+
+	/**
+	 * Test: Option OFF + low-priority code filter true = enabled (code wins at any priority).
+	 */
+	public function test_option_off_with_low_priority_filter_returns_true() {
+		update_option( 'job_manager_enable_promoted_jobs', '0' );
+		add_filter( 'job_manager_enable_promoted_jobs', '__return_true', 1 );
+
+		$this->assertTrue( WP_Job_Manager_Promoted_Jobs_Helper::is_enabled() );
 	}
 
 	/**
@@ -67,8 +71,7 @@ class Tests_Promoted_Jobs_Setting extends WPJM_BaseTest {
 	public function test_option_not_set_defaults_to_true() {
 		delete_option( 'job_manager_enable_promoted_jobs' );
 
-		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
-		$this->assertTrue( $result );
+		$this->assertTrue( WP_Job_Manager_Promoted_Jobs_Helper::is_enabled() );
 	}
 
 	/**

--- a/tests/php/tests/test_class.promoted-jobs-setting.php
+++ b/tests/php/tests/test_class.promoted-jobs-setting.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Tests for the Promoted Jobs enable/disable admin setting.
+ *
+ * Covers the 4 state combinations of option + code filter,
+ * the setting registration, and the data cleaner entry.
+ *
+ * @package wp-job-manager
+ */
+class Tests_Promoted_Jobs_Setting extends WPJM_BaseTest {
+
+	/**
+	 * Clean up option after each test.
+	 */
+	public function tearDown(): void {
+		delete_option( 'job_manager_enable_promoted_jobs' );
+		remove_filter( 'job_manager_enable_promoted_jobs', '__return_false', 10 );
+		remove_filter( 'job_manager_enable_promoted_jobs', '__return_true', 10 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test: Option ON + no code filter = enabled.
+	 */
+	public function test_option_on_no_filter_returns_true() {
+		update_option( 'job_manager_enable_promoted_jobs', '1' );
+
+		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test: Option ON + code filter false = disabled.
+	 */
+	public function test_option_on_with_false_filter_returns_false() {
+		update_option( 'job_manager_enable_promoted_jobs', '1' );
+		add_filter( 'job_manager_enable_promoted_jobs', '__return_false' );
+
+		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test: Option OFF + no code filter = disabled.
+	 */
+	public function test_option_off_no_filter_returns_false() {
+		update_option( 'job_manager_enable_promoted_jobs', '0' );
+
+		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test: Option OFF + code filter true = enabled (code wins).
+	 */
+	public function test_option_off_with_true_filter_returns_true() {
+		update_option( 'job_manager_enable_promoted_jobs', '0' );
+		add_filter( 'job_manager_enable_promoted_jobs', '__return_true', 10 );
+
+		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test: Option not set defaults to enabled.
+	 */
+	public function test_option_not_set_defaults_to_true() {
+		delete_option( 'job_manager_enable_promoted_jobs' );
+
+		$result = apply_filters( 'job_manager_enable_promoted_jobs', true );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test: Setting is registered in the settings array.
+	 */
+	public function test_setting_exists_in_settings() {
+		$settings = new WP_Job_Manager_Settings();
+		$all      = $settings->get_settings();
+
+		$found = false;
+		foreach ( $all as $section ) {
+			if ( ! isset( $section[1] ) || ! is_array( $section[1] ) ) {
+				continue;
+			}
+			foreach ( $section[1] as $field ) {
+				if ( isset( $field['name'] ) && 'job_manager_enable_promoted_jobs' === $field['name'] ) {
+					$found = true;
+					$this->assertSame( 'checkbox', $field['type'] );
+					$this->assertSame( '1', $field['std'] );
+					break 2;
+				}
+			}
+		}
+		$this->assertTrue( $found, 'Setting job_manager_enable_promoted_jobs not found in settings array.' );
+	}
+
+	/**
+	 * Test: Data cleaner includes the option key.
+	 */
+	public function test_data_cleaner_includes_option() {
+		$options = ( new ReflectionClass( 'WP_Job_Manager_Data_Cleaner' ) )->getConstant( 'OPTIONS' );
+
+		$this->assertContains(
+			'job_manager_enable_promoted_jobs',
+			$options,
+			'Data cleaner OPTIONS should include job_manager_enable_promoted_jobs.'
+		);
+	}
+}


### PR DESCRIPTION
## Changes Proposed in this Pull Request

Add a checkbox in **Job Listings > Settings > Job Listings** to enable/disable the Promoted Jobs feature. Fixes #2608

The developer filter `job_manager_enable_promoted_jobs` already exists. This adds a UI toggle so non-technical site owners can disable Promoted Jobs without writing code. Default: enabled (no behavior change for existing installs). Developer code filter at default priority still overrides the admin setting.

### includes/admin/class-wp-job-manager-settings.php

Registers the checkbox in the settings array so it appears in the admin UI.

### includes/class-wp-job-manager.php

Replaced the priority-based self-hook with `WP_Job_Manager_Promoted_Jobs_Helper::is_enabled()`. The option value is passed as the initial value to `apply_filters()`, so any developer filter (regardless of priority) overrides the admin setting.

### includes/class-wp-job-manager-promoted-jobs-helper.php

New helper class that bridges the admin option to the `job_manager_enable_promoted_jobs` filter. Removes the need for the self-hook at priority 5.

### includes/admin/class-wp-job-manager-admin.php

Updated to use the new helper instead of calling `apply_filters()` directly.

### includes/class-wp-job-manager-data-cleaner.php

Added `job_manager_enable_promoted_jobs` to the OPTIONS array for cleanup on uninstall.

### tests/php/tests/test_class.promoted-jobs-setting.php

Covers all state combinations (option on/off x filter true/false), default behavior, setting registration, data cleaner entry, and a low-priority filter override (priority 1).

## Testing Instructions

**Test 1: Setting visible and enabled by default**
1. Go to Job Listings > Settings > Job Listings tab
2. Confirm "Enable Promoted Jobs" checkbox is checked by default

**Test 2: Uncheck disables Promoted Jobs**
1. Uncheck the setting and save
2. Go to Job Listings screen
3. Result: "Promote" column gone, no promote button, REST endpoint returns 404

**Test 3: Code filter overrides setting**
1. Add `add_filter( 'job_manager_enable_promoted_jobs', '__return_true' );` to a mu-plugin
2. Uncheck the setting in admin
3. Result: Promoted Jobs still enabled (code wins over option)

## Release Notes

Adds a Promoted Jobs toggle in Job Listings > Settings > Job Listings.

## New or Updated Hooks and Templates

No new hooks. The existing `job_manager_enable_promoted_jobs` filter behavior is unchanged.

## Deprecated Code

No deprecations.