### PR TITLE
enhancement(apply): add direct apply option for URL applications

### DIFF
--- a/assets/js/job-application.js
+++ b/assets/js/job-application.js
@@ -5,6 +5,9 @@ jQuery(document).ready(function($) {
 	}
 
 	$( document.body ).on( 'click', '.job_application .application_button', function() {
+		if ( 'a' === this.tagName.toLowerCase() ) {
+			return;
+		}
 		var $details = $(this).parents('.job_application').find('.application_details').first();
 		var $button = $(this);
 		$details.slideToggle( 400, function() {

--- a/assets/js/job-application.js
+++ b/assets/js/job-application.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function($) {
 	}
 
 	$( document.body ).on( 'click', '.job_application .application_button', function() {
+		// If the button is an anchor link, let the browser navigate to the URL; no toggle needed.
 		if ( 'a' === this.tagName.toLowerCase() ) {
 			return;
 		}

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -499,6 +499,16 @@ class WP_Job_Manager_Settings {
 							'track'   => 'value',
 						],
 						[
+							'name'       => 'job_manager_direct_apply_url',
+							'std'        => '0',
+							'label'      => __( 'Direct Apply for URLs', 'wp-job-manager' ),
+							'cb_label'   => __( 'Link directly to the application URL', 'wp-job-manager' ),
+							'desc'       => __( 'When enabled, the Apply button for URL applications will link directly to the application page instead of showing an intermediate panel. Only applies when the application method is a URL.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+							'track'      => 'bool',
+						],
+						[
 							'name'              => 'job_manager_company_logo_max_size',
 							'std'               => '',
 							'placeholder'       => __( 'No limit', 'wp-job-manager' ),

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -165,6 +165,16 @@ class WP_Job_Manager_Settings {
 							'attributes' => [],
 							'track'      => 'bool',
 						],
+						[
+							'name'       => 'job_manager_direct_apply_url',
+							'std'        => '0',
+							'label'      => __( 'Direct Apply for URLs', 'wp-job-manager' ),
+							'cb_label'   => __( 'Link directly to the application URL', 'wp-job-manager' ),
+							'desc'       => __( 'When enabled, the Apply button for URL applications will link directly to the application page instead of showing an intermediate panel. Only applies when the application method is a URL.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+							'track'      => 'bool',
+						],
 					],
 				],
 				'job_listings'   => [
@@ -497,16 +507,6 @@ class WP_Job_Manager_Settings {
 								'url'   => __( 'Website URLs only', 'wp-job-manager' ),
 							],
 							'track'   => 'value',
-						],
-						[
-							'name'       => 'job_manager_direct_apply_url',
-							'std'        => '0',
-							'label'      => __( 'Direct Apply for URLs', 'wp-job-manager' ),
-							'cb_label'   => __( 'Link directly to the application URL', 'wp-job-manager' ),
-							'desc'       => __( 'When enabled, the Apply button for URL applications will link directly to the application page instead of showing an intermediate panel. Only applies when the application method is a URL.', 'wp-job-manager' ),
-							'type'       => 'checkbox',
-							'attributes' => [],
-							'track'      => 'bool',
 						],
 						[
 							'name'              => 'job_manager_company_logo_max_size',

--- a/includes/class-stats-script.php
+++ b/includes/class-stats-script.php
@@ -422,7 +422,7 @@ class Stats_Script {
 				Job_Listing_Stats::APPLY_CLICK       => [
 					'type'   => 'domEvent',
 					'args'   => [
-						'element' => 'input.application_button',
+						'element' => '.application_button',
 						'event'   => 'click',
 					],
 					'unique' => true,

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1466,9 +1466,17 @@ class WP_Job_Manager_Post_Types {
 	/**
 	 * Displays the application content when the application method is a url.
 	 *
+	 * Skipped when `job_manager_direct_apply_url` is enabled, because the template renders
+	 * an anchor link to the application URL directly and adding the "please visit host"
+	 * paragraph below it is redundant. Addon listeners on `job_manager_application_details_url`
+	 * continue to fire via the direct-apply branch in `templates/job-application.php`.
+	 *
 	 * @param stdClass $apply
 	 */
 	public function application_details_url( $apply ) {
+		if ( 'url' === $apply->type && get_option( 'job_manager_direct_apply_url' ) ) {
+			return;
+		}
 		get_job_manager_template( 'job-application-url.php', [ 'apply' => $apply ] );
 	}
 

--- a/templates/job-application.php
+++ b/templates/job-application.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.31.1
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -26,6 +26,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<?php if ( $is_direct_url ) : ?>
 			<a class="application_button button" href="<?php echo esc_url( $apply->url ); ?>" rel="nofollow"><?php esc_html_e( 'Apply for job', 'wp-job-manager' ); ?></a>
+			<?php
+			/**
+			 * Fires for the application method type, regardless of whether the intermediate
+			 * details panel is rendered. Addons listing on `job_manager_application_details_url`
+			 * (click tracking, redirect wrappers, etc.) still receive the event in direct-apply mode.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param object $apply Application method object.
+			 */
+			do_action( 'job_manager_application_details_' . $apply->type, $apply );
+			?>
 		<?php else : ?>
 			<input type="button" class="application_button button" value="<?php esc_attr_e( 'Apply for job', 'wp-job-manager' ); ?>" />
 

--- a/templates/job-application.php
+++ b/templates/job-application.php
@@ -16,21 +16,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <?php if ( $apply = get_the_job_application_method() ) :
-	wp_enqueue_script( 'wp-job-manager-job-application' );
+	$is_direct_url = 'url' === $apply->type && get_option( 'job_manager_direct_apply_url' );
+	if ( ! $is_direct_url ) {
+		wp_enqueue_script( 'wp-job-manager-job-application' );
+	}
 	?>
 	<div class="job_application application">
 		<?php do_action( 'job_application_start', $apply ); ?>
 
-		<input type="button" class="application_button button" value="<?php esc_attr_e( 'Apply for job', 'wp-job-manager' ); ?>" />
+		<?php if ( $is_direct_url ) : ?>
+			<a class="application_button button" href="<?php echo esc_url( $apply->url ); ?>" rel="nofollow"><?php esc_html_e( 'Apply for job', 'wp-job-manager' ); ?></a>
+		<?php else : ?>
+			<input type="button" class="application_button button" value="<?php esc_attr_e( 'Apply for job', 'wp-job-manager' ); ?>" />
 
-		<div class="application_details">
-			<?php
-				/**
-				 * job_manager_application_details_email or job_manager_application_details_url hook
-				 */
-				do_action( 'job_manager_application_details_' . $apply->type, $apply );
-			?>
-		</div>
+			<div class="application_details">
+				<?php
+					/**
+					 * job_manager_application_details_email or job_manager_application_details_url hook
+					 */
+					do_action( 'job_manager_application_details_' . $apply->type, $apply );
+				?>
+			</div>
+		<?php endif; ?>
+
 		<?php do_action( 'job_application_end', $apply ); ?>
 	</div>
 <?php endif; ?>

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-settings.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-settings.php
@@ -26,3 +26,165 @@ class WP_Test_WP_Job_Manager_Settings extends WPJM_BaseTest {
 	}
 
 }
+
+/**
+ * Regression coverage for the `job_manager_direct_apply_url` setting and the
+ * `templates/job-application.php` rendering branch it enables.
+ */
+class WP_Test_Job_Application_Direct_Apply_Template extends WPJM_BaseTest {
+
+	/**
+	 * Reset the option and the script queue after each test so a failed assertion
+	 * (or an early-throwing render) does not leak state into the next case.
+	 */
+	public function tear_down() {
+		delete_option( 'job_manager_direct_apply_url' );
+		wp_dequeue_script( 'wp-job-manager-job-application' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the job-application template after priming the global $post so
+	 * `get_the_job_application_method()` resolves correctly in test scope.
+	 *
+	 * @param int $job_id Job listing ID.
+	 * @return string Rendered HTML.
+	 */
+	private function render_job_application_template( $job_id ) {
+		global $post;
+		$post = get_post( $job_id );
+		setup_postdata( $post );
+
+		ob_start();
+		get_job_manager_template( 'job-application.php' );
+		$html = ob_get_clean();
+
+		wp_reset_postdata();
+		return $html;
+	}
+
+	/**
+	 * Default (setting off): URL applications render the intermediate `<input>` panel.
+	 */
+	public function test_default_off_renders_input_button_for_url_application() {
+		delete_option( 'job_manager_direct_apply_url' );
+		wp_dequeue_script( 'wp-job-manager-job-application' );
+
+		$job_id = $this->factory->job_listing->create(
+			[
+				'meta_input' => [ '_application' => 'https://example.com/apply' ],
+			]
+		);
+
+		$html = $this->render_job_application_template( $job_id );
+
+		$this->assertStringContainsString( '<input', $html );
+		$this->assertStringContainsString( 'application_button', $html );
+		$this->assertStringNotContainsString( '<a class="application_button', $html );
+		$this->assertTrue(
+			wp_script_is( 'wp-job-manager-job-application', 'enqueued' ),
+			'Default (off) mode must enqueue the slide-toggle JS.'
+		);
+	}
+
+	/**
+	 * Setting on + URL application: renders an `<a>` direct link and skips the JS enqueue.
+	 */
+	public function test_direct_apply_on_renders_anchor_for_url_application() {
+		update_option( 'job_manager_direct_apply_url', '1' );
+		wp_dequeue_script( 'wp-job-manager-job-application' );
+
+		$job_id = $this->factory->job_listing->create(
+			[
+				'meta_input' => [ '_application' => 'https://example.com/apply' ],
+			]
+		);
+
+		$html = $this->render_job_application_template( $job_id );
+
+		$this->assertStringContainsString( '<a class="application_button button"', $html );
+		$this->assertStringContainsString( 'href="https://example.com/apply"', $html );
+		$this->assertStringContainsString( 'rel="nofollow"', $html );
+		$this->assertStringNotContainsString( '<input type="button" class="application_button', $html );
+
+		$this->assertFalse(
+			wp_script_is( 'wp-job-manager-job-application', 'enqueued' ),
+			'Direct-apply mode must skip enqueuing the application-details JS.'
+		);
+	}
+
+	/**
+	 * Setting on + email application: still renders the `<input>` panel; setting is
+	 * scoped to URL applications only.
+	 */
+	public function test_direct_apply_on_renders_input_button_for_email_application() {
+		update_option( 'job_manager_direct_apply_url', '1' );
+		wp_dequeue_script( 'wp-job-manager-job-application' );
+
+		$job_id = $this->factory->job_listing->create(
+			[
+				'meta_input' => [ '_application' => 'apply@example.com' ],
+			]
+		);
+
+		$html = $this->render_job_application_template( $job_id );
+
+		$this->assertStringContainsString( '<input type="button" class="application_button', $html );
+		$this->assertStringNotContainsString( '<a class="application_button', $html );
+		$this->assertTrue(
+			wp_script_is( 'wp-job-manager-job-application', 'enqueued' ),
+			'Email applications must still enqueue the slide-toggle JS in direct-apply mode.'
+		);
+	}
+
+	/**
+	 * Direct-apply URL must not echo the "please visit host" paragraph from
+	 * `templates/job-application-url.php` — that copy is redundant once a direct link
+	 * is rendered. The core handler short-circuits under
+	 * `WP_Job_Manager_Post_Types::application_details_url()` in direct-apply mode.
+	 */
+	public function test_direct_apply_on_does_not_render_url_details_paragraph() {
+		update_option( 'job_manager_direct_apply_url', '1' );
+
+		$job_id = $this->factory->job_listing->create(
+			[
+				'meta_input' => [ '_application' => 'https://example.com/apply' ],
+			]
+		);
+
+		$html = $this->render_job_application_template( $job_id );
+
+		$this->assertStringNotContainsString(
+			'To apply for this job please visit',
+			$html,
+			'Direct-apply mode must suppress the URL details paragraph.'
+		);
+	}
+
+	/**
+	 * Regression: in direct-apply mode the addon extension surface must still fire so
+	 * third-party listeners on `job_manager_application_details_url` see the event.
+	 */
+	public function test_direct_apply_on_fires_application_details_hook_for_url() {
+		update_option( 'job_manager_direct_apply_url', '1' );
+		$fired = 0;
+		$callback = function () use ( &$fired ) {
+			$fired++;
+		};
+		add_action( 'job_manager_application_details_url', $callback );
+
+		try {
+			$job_id = $this->factory->job_listing->create(
+				[
+					'meta_input' => [ '_application' => 'https://example.com/apply' ],
+				]
+			);
+
+			$this->render_job_application_template( $job_id );
+			$this->assertGreaterThan( 0, $fired, '`job_manager_application_details_url` must fire in direct-apply mode.' );
+		} finally {
+			remove_action( 'job_manager_application_details_url', $callback );
+		}
+	}
+}
+


### PR DESCRIPTION
## Summary
Adds a `job_manager_direct_apply_url` setting that lets the Apply button link directly to the application URL instead of showing an intermediate panel that requires a second click. Reduces friction and lost applicants.

Fixes #1701

## Changes

### `includes/admin/class-wp-job-manager-settings.php`
**After:**
```php
[
    'name'       => 'job_manager_direct_apply_url',
    'std'        => '0',
    'label'      => __( 'Direct Apply for URLs', 'wp-job-manager' ),
    'cb_label'   => __( 'Link directly to the application URL', 'wp-job-manager' ),
    'desc'       => __( 'When enabled, the Apply button for URL applications will link directly to the application page instead of showing an intermediate panel. Only applies when the application method is a URL.', 'wp-job-manager' ),
    'type'       => 'checkbox',
    'attributes' => [],
    'track'      => 'bool',
],
```
**Why:** Opt-in setting so existing behavior stays intact for sites that rely on the current flow.

### `templates/job-application.php`
**After:**
```php
<?php if ( $apply = get_the_job_application_method() ) :
    $is_direct_url = 'url' === $apply->type && get_option( 'job_manager_direct_apply_url' );
    if ( ! $is_direct_url ) {
        wp_enqueue_script( 'wp-job-manager-job-application' );
    }
    ?>
    <div class="job_application application">
        <?php do_action( 'job_application_start', $apply ); ?>

        <?php if ( $is_direct_url ) : ?>
            <a class="application_button button" href="<?php echo esc_url( $apply->url ); ?>" rel="nofollow"><?php esc_html_e( 'Apply for job', 'wp-job-manager' ); ?></a>
        <?php else : ?>
            <input type="button" class="application_button button" value="<?php esc_attr_e( 'Apply for job', 'wp-job-manager' ); ?>" />
            <div class="application_details">
                <?php do_action( 'job_manager_application_details_' . $apply->type, $apply ); ?>
            </div>
        <?php endif; ?>
    ...
```
**Why:** Renders `<a>` when setting ON and application type is URL. Skips JS enqueue and details div since they are not needed. Email applications unaffected.

### `assets/js/job-application.js`
**After:**
```javascript
$( document.body ).on( 'click', '.job_application .application_button', function() {
    if ( 'a' === this.tagName.toLowerCase() ) {
        return;
    }
    // ... existing slideToggle
});
```
**Why:** Prevents JS from running slideToggle on direct links. Backward compatible with existing behavior.

### `includes/class-stats-script.php`
Changed stats tracking CSS selector from `input.application_button` to `.application_button` so it matches both `<input>` and `<a>` elements.

## Testing

**Test 1: Default behavior (setting OFF)**
1. Create/find job listing with URL application method
2. Click "Apply for job"
3. Result: application details panel slides open with link (unchanged)

**Test 2: Direct apply enabled (setting ON)**
1. Job Listings > Settings > Submission, enable "Direct Apply for URLs"
2. Visit same job listing
3. Result: "Apply for job" button is a direct link, navigates in one click

**Test 3: Email applications unaffected**
1. Find job listing with email application method
2. With "Direct Apply for URLs" ON, click Apply
3. Result: email panel slides open (unchanged)

**Test 4: Stats tracking**
1. With stats enabled and direct apply ON
2. Click Apply button on URL application
3. Result: apply click is tracked in statistics