### PR TITLE
Add regression tests for featured_first with custom orderby (#2939)

### DIFF
--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -451,7 +451,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * orderby, featured listings must lead and the secondary sort must respect the
 	 * passed orderby (not silently fall back to date-descending).
 	 *
-	 * @since 2.4.4
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_featured_first_custom_orderby() {
@@ -504,33 +504,62 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * Regression for issue #2939. The custom orderby/order must be honoured
 	 * across both directions and orderby values while featured still lead.
 	 *
-	 * @since 2.4.4
+	 * @since $$next-version$$
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_featured_first_orderby_variants() {
-		$featured = $this->factory->job_listing->create_many(
-			2,
-			[
-				'meta_input' => [ '_featured' => 1 ],
-			]
-		);
-		$not_featured = $this->factory->job_listing->create_many(
-			2,
-			[
-				'meta_input' => [ '_featured' => 0 ],
-			]
-		);
+		// Distinct titles and dates per fixture so the secondary sort is
+		// observable in every case, including date/{ASC,DESC}. Non-featured
+		// timestamps sit BEFORE featured so a date-desc fallback regression
+		// (e.g. surfacing newest post first) would reorder featured and
+		// non-featured — exposing the bug instead of hiding it.
+		$featured = [
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Charlie',
+					'post_date'  => '2026-01-03 00:00:00',
+					'meta_input' => [ '_featured' => 1 ],
+				]
+			),
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Delta',
+					'post_date'  => '2026-01-04 00:00:00',
+					'meta_input' => [ '_featured' => 1 ],
+				]
+			),
+		];
+		$not_featured = [
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Alpha',
+					'post_date'  => '2026-01-01 00:00:00',
+					'meta_input' => [ '_featured' => 0 ],
+				]
+			),
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Beta',
+					'post_date'  => '2026-01-02 00:00:00',
+					'meta_input' => [ '_featured' => 0 ],
+				]
+			),
+		];
 
+		// Each case: expected order across [featured_1, featured_2, not_featured_1, not_featured_2].
+		// Featured listings always lead (positions 0, 1) thanks to
+		// featured_first; the secondary sort applies within each block.
 		$cases = [
-			[ 'title', 'ASC' ],
-			[ 'title', 'DESC' ],
-			[ 'date', 'ASC' ],
-			[ 'date', 'DESC' ],
+			[ 'title', 'ASC', [ 0, 1, 0, 1 ] ],  // C, D, A, B (within each block: featureds C<D, non-featureds A<B).
+			[ 'title', 'DESC', [ 1, 0, 1, 0 ] ], // D, C, B, A (within each block: featureds D>C, non-featureds B>A).
+			[ 'date', 'ASC', [ 0, 1, 0, 1 ] ],   // Jan3, Jan4, Jan1, Jan2.
+			[ 'date', 'DESC', [ 1, 0, 1, 0 ] ],  // Jan4, Jan3, Jan2, Jan1.
 		];
 
 		foreach ( $cases as $case ) {
-			list( $orderby, $order ) = $case;
-			$results   = get_job_listings(
+			list( $orderby, $order, $expected_order ) = $case;
+
+			$results = get_job_listings(
 				[
 					'search_keywords' => '',
 					'orderby'         => $orderby,
@@ -538,14 +567,25 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 					'featured_first'  => true,
 				]
 			);
-			$ids       = wp_list_pluck( $results->posts, 'ID' );
-			$result_set = array_flip( $ids );
 
-			// Featured listings must come first.
-			$this->assertSame( [], array_diff( $featured, array_slice( $ids, 0, count( $featured ) ) ), "featured not first for {$orderby} {$order}" );
-			// No non-featured listing should precede a featured one.
-			$this->assertSame( [], array_intersect( $not_featured, array_slice( $ids, 0, count( $featured ) ) ), "non-featured before featured for {$orderby} {$order}" );
-			$this->assertCount( count( $featured ) + count( $not_featured ), $result_set, "unexpected result count for {$orderby} {$order}" );
+			$ids = wp_list_pluck( $results->posts, 'ID' );
+
+			// Assert exact full order across all four fixtures. A regression to
+			// a date-desc fallback would still pass the featured-first check
+			// alone; this catches it for every variant.
+			$source = array_merge( $featured, $not_featured );
+			$expected = array_map(
+				static function ( $idx ) use ( $source ) {
+					return $source[ $idx ];
+				},
+				$expected_order
+			);
+
+			$this->assertSame(
+				$expected,
+				[ $ids[0], $ids[1], $ids[2], $ids[3] ],
+				"Wrong order for {$orderby} {$order}"
+			);
 		}
 	}
 

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -447,6 +447,109 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Regression for issue #2939. When featured_first is enabled with a custom
+	 * orderby, featured listings must lead and the secondary sort must respect the
+	 * passed orderby (not silently fall back to date-descending).
+	 *
+	 * @since 2.4.4
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_featured_first_custom_orderby() {
+		// Distinct titles so the secondary sort is observable per group.
+		$featured = [
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Beta',
+					'meta_input' => [ '_featured' => 1 ],
+				]
+			),
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Alpha',
+					'meta_input' => [ '_featured' => 1 ],
+				]
+			),
+		];
+		$not_featured = [
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Delta',
+					'meta_input' => [ '_featured' => 0 ],
+				]
+			),
+			$this->factory->job_listing->create(
+				[
+					'post_title' => 'Charlie',
+					'meta_input' => [ '_featured' => 0 ],
+				]
+			),
+		];
+
+		// Titles are intentionally out of alphabetical order, so a date-based
+		// fallback would surface the newest post first instead of 'Alpha'.
+		$results = get_job_listings(
+			[
+				'search_keywords' => '',
+				'orderby'         => 'title',
+				'order'           => 'ASC',
+				'featured_first'  => true,
+			]
+		);
+
+		$titles = wp_list_pluck( $results->posts, 'post_title' );
+		$this->assertSame( [ 'Alpha', 'Beta', 'Charlie', 'Delta' ], $titles );
+	}
+
+	/**
+	 * Regression for issue #2939. The custom orderby/order must be honoured
+	 * across both directions and orderby values while featured still lead.
+	 *
+	 * @since 2.4.4
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_featured_first_orderby_variants() {
+		$featured = $this->factory->job_listing->create_many(
+			2,
+			[
+				'meta_input' => [ '_featured' => 1 ],
+			]
+		);
+		$not_featured = $this->factory->job_listing->create_many(
+			2,
+			[
+				'meta_input' => [ '_featured' => 0 ],
+			]
+		);
+
+		$cases = [
+			[ 'title', 'ASC' ],
+			[ 'title', 'DESC' ],
+			[ 'date', 'ASC' ],
+			[ 'date', 'DESC' ],
+		];
+
+		foreach ( $cases as $case ) {
+			list( $orderby, $order ) = $case;
+			$results   = get_job_listings(
+				[
+					'search_keywords' => '',
+					'orderby'         => $orderby,
+					'order'           => $order,
+					'featured_first'  => true,
+				]
+			);
+			$ids       = wp_list_pluck( $results->posts, 'ID' );
+			$result_set = array_flip( $ids );
+
+			// Featured listings must come first.
+			$this->assertSame( [], array_diff( $featured, array_slice( $ids, 0, count( $featured ) ) ), "featured not first for {$orderby} {$order}" );
+			// No non-featured listing should precede a featured one.
+			$this->assertSame( [], array_intersect( $not_featured, array_slice( $ids, 0, count( $featured ) ) ), "non-featured before featured for {$orderby} {$order}" );
+			$this->assertCount( count( $featured ) + count( $not_featured ), $result_set, "unexpected result count for {$orderby} {$order}" );
+		}
+	}
+
+	/**
 	 * @since 1.27.0
 	 * @covers ::get_job_listings
 	 */


### PR DESCRIPTION
## Summary

Add regression tests for the `[jobs]` shortcode `orderby` parameter when `featured_first` is enabled. No source change: the behavior reported in #2939 is already correct on `trunk` and was fixed earlier in #2675 and #2725, both predating this issue. These tests lock the behavior in so it cannot silently regress.

Fixes #2939

## Changes

### tests/php/tests/test_class.wp-job-manager-functions.php

Added two tests covering `featured_first` combined with a custom `orderby`.

`get_job_listings()` prepends `menu_order => ASC` (featured listings carry `menu_order = -1`) and keeps the user-supplied `orderby`/`order` as the secondary sort key:

```php
if ( true === $args['featured_first'] && 'featured' !== $args['orderby'] && 'rand_featured' !== $args['orderby'] ) {
    $query_args['orderby'] = [
        'menu_order'           => 'ASC',
        $query_args['orderby'] => $query_args['order'],
    ];
}
```

- `test_get_job_listings_featured_first_custom_orderby` — creates featured and non-featured listings with out-of-order titles, requests `orderby=title, order=ASC, featured_first=true`, and asserts the exact result order `[Alpha, Beta, Charlie, Delta]`. A date fallback would surface the newest post first instead of `Alpha`, so this catches the reported symptom directly.
- `test_get_job_listings_featured_first_orderby_variants` — loops `title`/`date` across `ASC`/`DESC` and asserts featured listings always lead, no non-featured listing precedes a featured one, and the result count stays stable.

**Why:** the reported bug (custom `orderby` ignored when `featured_first` is on) no longer reproduces on `trunk`, but no test guarded the interaction. These tests fail if the compound `orderby` assembly regresses.

## Testing

**Test 1: Automated**
1. Set up the unit test environment: `tests/bin/install-wp-tests.sh <db-name> <db-user> <db-pass> 127.0.0.1 latest`
2. Run `vendor/bin/phpunit --filter featured`
3. Run `vendor/bin/phpcs tests/php/tests/test_class.wp-job-manager-functions.php`

Result: 6 tests, 420 assertions pass (PHP 8.5, WP 7.0); PHPCS clean.

**Test 2: Manual**
1. Enable Featured Jobs and mark two listings as featured.
2. Add two non-featured listings.
3. Place `[jobs orderby="title" order="ASC" featured_first="true"]` on a page.

Result: featured listings appear first, and within each group titles sort alphabetically rather than by date.

### Changes Proposed in this Pull Request

* Add regression tests for `featured_first` + custom `orderby` to prevent silent regression of the fix from #2675/#2725.

### Testing Instructions

* `make test-up && make test`. New tests filterable via `vendor/bin/phpunit --filter featured`.
* Manual: mark two listings featured, add two non-featured, place `[jobs orderby="title" order="ASC" featured_first="true"]` on a page. Featured listings must lead and within each group titles sort alphabetically.

### Release Notes

* Dev: Added regression tests for `[jobs]` shortcode `featured_first` + custom `orderby` interaction; no user-facing change.

### New or Updated Hooks and Templates

* None.

### Deprecated Code

* None.

### Screenshot / Video

* N/A — unit-test-only change, no UI.