### PR TITLE
fix(search): match locations regardless of accents

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -713,6 +713,7 @@ class WP_Job_Manager_Post_Types {
 	 *
 	 * @param string $search_location Location search term(s), separated by `;` for OR matching.
 	 * @return array Meta query clause.
+	 * @since $$next-version$$
 	 */
 	public static function get_location_meta_query( $search_location ) {
 		$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
@@ -742,8 +743,19 @@ class WP_Job_Manager_Post_Types {
 	 * Turns a search term into a REGEXP pattern that also matches common Latin accented
 	 * variants of its letters, so plain and accented spellings match each other.
 	 *
+	 * Note: `meta_query` REGEXP runs per row without index support for these patterns
+	 * and is materially more CPU-costly than `LIKE`; operators on `utf8mb4_unicode_*_ci`
+	 * collations already fold accents via the collation and may not need this path. This
+	 * code is kept for `utf8mb4_bin` installs and other cases where the collation alone
+	 * does not produce the desired match.
+	 *
+	 * The accent table covers French/Iberian/Italian Latin variants only, against NFC
+	 * input — NFD-decomposed input (e.g. `é` as `e` + combining U+0301) will not fold.
+	 * This is not a general Unicode case-fold.
+	 *
 	 * @param string $term Raw search term.
 	 * @return string REGEXP pattern.
+	 * @since $$next-version$$
 	 */
 	private static function get_accent_insensitive_regex( $term ) {
 		static $char_to_variants = null;
@@ -767,8 +779,16 @@ class WP_Job_Manager_Post_Types {
 			}
 		}
 
+		// `preg_split( '//u', … )` returns false on malformed UTF-8 input.
+		// An empty pattern (`REGEXP ''`) matches every row and silently disables
+		// location filtering, so fall back to an escaped literal match.
+		$chars = preg_split( '//u', $term, -1, PREG_SPLIT_NO_EMPTY );
+		if ( false === $chars ) {
+			return preg_quote( $term, '/' );
+		}
+
 		$pattern = '';
-		foreach ( preg_split( '//u', $term, -1, PREG_SPLIT_NO_EMPTY ) as $character ) {
+		foreach ( $chars as $character ) {
 			$pattern .= isset( $char_to_variants[ $character ] )
 				? '[' . $char_to_variants[ $character ] . ']'
 				: preg_quote( $character, '/' );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -707,6 +707,77 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
+	 * Builds a meta query matching job listings by location, tolerating common Latin
+	 * accent differences between the search term and the stored value (e.g. a search
+	 * for "Asnieres" also matches a listing stored as "Asnières").
+	 *
+	 * @param string $search_location Location search term(s), separated by `;` for OR matching.
+	 * @return array Meta query clause.
+	 */
+	public static function get_location_meta_query( $search_location ) {
+		$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
+		$location_search    = [ 'relation' => 'OR' ];
+
+		foreach ( explode( ';', $search_location ) as $location ) {
+			$location = trim( $location );
+			if ( '' === $location ) {
+				continue;
+			}
+
+			$location_subquery = [ 'relation' => 'OR' ];
+			foreach ( $location_meta_keys as $meta_key ) {
+				$location_subquery[] = [
+					'key'     => $meta_key,
+					'value'   => self::get_accent_insensitive_regex( $location ),
+					'compare' => 'REGEXP',
+				];
+			}
+			$location_search[] = $location_subquery;
+		}
+
+		return $location_search;
+	}
+
+	/**
+	 * Turns a search term into a REGEXP pattern that also matches common Latin accented
+	 * variants of its letters, so plain and accented spellings match each other.
+	 *
+	 * @param string $term Raw search term.
+	 * @return string REGEXP pattern.
+	 */
+	private static function get_accent_insensitive_regex( $term ) {
+		static $char_to_variants = null;
+
+		if ( null === $char_to_variants ) {
+			$accent_groups    = [
+				'aàáâãäåAÀÁÂÃÄÅ',
+				'eèéêëEÈÉÊË',
+				'iìíîïIÌÍÎÏ',
+				'oòóôõöOÒÓÔÕÖ',
+				'uùúûüUÙÚÛÜ',
+				'cçCÇ',
+				'nñNÑ',
+				'yýÿYÝŸ',
+			];
+			$char_to_variants = [];
+			foreach ( $accent_groups as $variants ) {
+				foreach ( preg_split( '//u', $variants, -1, PREG_SPLIT_NO_EMPTY ) as $character ) {
+					$char_to_variants[ $character ] = $variants;
+				}
+			}
+		}
+
+		$pattern = '';
+		foreach ( preg_split( '//u', $term, -1, PREG_SPLIT_NO_EMPTY ) as $character ) {
+			$pattern .= isset( $char_to_variants[ $character ] )
+				? '[' . $char_to_variants[ $character ] . ']'
+				: preg_quote( $character, '/' );
+		}
+
+		return $pattern;
+	}
+
+	/**
 	 * Generates the RSS feed for Job Listings.
 	 */
 	public function job_feed() {
@@ -773,24 +844,7 @@ class WP_Job_Manager_Post_Types {
 		];
 
 		if ( ! empty( $input_search_location ) ) {
-			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
-			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = explode( ';', $input_search_location );
-			foreach ( $locations as $location ) {
-				$location = trim( $location );
-				if ( ! empty( $location ) ) {
-					$location_subquery = [ 'relation' => 'OR' ];
-					foreach ( $location_meta_keys as $meta_key ) {
-						$location_subquery[] = [
-							'key'     => $meta_key,
-							'value'   => $location,
-							'compare' => 'like',
-						];
-					}
-					$location_search[] = $location_subquery;
-				}
-			}
-			$query_args['meta_query'][] = $location_search;
+			$query_args['meta_query'][] = self::get_location_meta_query( $input_search_location );
 		}
 
 		if ( null !== $input_featured ) {

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -191,6 +191,40 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 * @covers WP_Job_Manager_Post_Types::get_location_meta_query
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_job_feed_location_search_with_accents() {
+		$accented_job_id = $this->factory->job_listing->create(
+			[
+				'meta_input' => [
+					'_job_location' => 'Asnières-sur-Seine, France',
+				],
+			]
+		);
+		$chicago_job_id  = $this->factory->job_listing->create(
+			[
+				'meta_input' => [
+					'_job_location' => 'Chicago, IL, USA',
+				],
+			]
+		);
+
+		$_GET['search_location'] = 'Asnieres';
+		$feed                    = $this->do_job_feed();
+		unset( $_GET['search_location'] );
+		$xml = xml_to_array( $feed );
+		$this->assertNotEmpty( $xml );
+		// Get all the <item> child elements of the <channel> element.
+		$items = xml_find( $xml, 'rss', 'channel', 'item' );
+		$this->assertEquals( 1, count( $items ) );
+		$this->assertHasRssItem( $items, $accented_job_id );
+		$this->assertNotHasRssItem( $items, $chicago_job_id );
+	}
+
+	/**
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::job_feed
 	 * @runInSeparateProcess

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -160,6 +160,45 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @covers ::get_job_listings
+	 * @covers WP_Job_Manager_Post_Types::get_location_meta_query
+	 */
+	public function test_get_job_listings_location_with_accents() {
+		$accented_job = $this->factory->job_listing->create(
+			[
+				'post_title' => 'Dinosaur Test Asnieres',
+				'meta_input' => [
+					'_job_location' => 'Asnières-sur-Seine, Rue de la Station, Asnières-sur-Seine, France',
+				],
+			]
+		);
+		$plain_job    = $this->factory->job_listing->create(
+			[
+				'post_title' => 'Dinosaur Test Villeneuve',
+				'meta_input' => [
+					'_job_location' => 'Villeneuve-Loubet, France',
+				],
+			]
+		);
+
+		$unaccented_search = get_job_listings(
+			[
+				'search_keywords' => 'Dinosaur',
+				'search_location' => 'Asnieres',
+			]
+		);
+		$accented_search    = get_job_listings(
+			[
+				'search_keywords' => 'Dinosaur',
+				'search_location' => 'Villeneuve-Loubét',
+			]
+		);
+
+		$this->assertEqualSets( [ $accented_job ], wp_list_pluck( $unaccented_search->posts, 'ID' ) );
+		$this->assertEqualSets( [ $plain_job ], wp_list_pluck( $accented_search->posts, 'ID' ) );
+	}
+
+	/**
 	 * @since 1.27.0
 	 * @covers ::get_job_listings
 	 */

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -103,24 +103,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		}
 
 		if ( ! empty( $args['search_location'] ) ) {
-			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
-			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = explode( ';', $args['search_location'] );
-
-			foreach ( $locations as $location ) {
-				$location = trim( $location );
-				if ( ! empty( $location ) ) {
-					$location_subquery = [ 'relation' => 'OR' ];
-					foreach ( $location_meta_keys as $meta_key ) {
-						$location_subquery[] = [
-							'key'     => $meta_key,
-							'value'   => $location,
-							'compare' => 'like',
-						];
-					}
-					$location_search[] = $location_subquery;
-				}
-			}
+			$location_search = \WP_Job_Manager_Post_Types::get_location_meta_query( $args['search_location'] );
 
 			if ( $remote_position_search ) {
 				$location_search = [


### PR DESCRIPTION
Fixes #2877

### Changes Proposed in this Pull Request

- Extracted the inline location meta-query construction in `get_job_listings()` (`wp-job-manager-functions.php`) and `job_feed()` (`includes/class-wp-job-manager-post-types.php`) into a new public static helper, `WP_Job_Manager_Post_Types::get_location_meta_query( $search_location )`. Removes the duplicated meta_query building logic between the two callers.
- Switched the location `meta_query` from `compare => 'like'` against the raw term to `compare => 'REGEXP'` against a pattern generated by the new private helper `WP_Job_Manager_Post_Types::get_accent_insensitive_regex( $term )`. The helper folds each input character into a class containing the common Latin accented variants (e.g. `e` becomes `[eèéêëEÈÉÊË]`) so searches match plain and accented spellings of a location.
- Hardened `get_accent_insensitive_regex()` against invalid UTF-8 input. `preg_split( '//u', … )` returns `false` on malformed UTF-8, and the previous code emitted an empty `REGEXP ''` pattern that matched every row and silently disabled location filtering. The method now falls back to a single `preg_quote( $term, '/' )` literal in that case.
- Added `@since $$next-version$$` to both new helpers and expanded the `get_accent_insensitive_regex()` docblock with notes on REGEXP cost vs LIKE, and on the accent table's French/Iberian/Italian, NFC-only scope.

### Testing Instructions

1. Search-without-accents-matches-accented-listing:
   - Create a job listing with `_job_location` set to `Asnières-sur-Seine, France`.
   - Call `get_job_listings( [ 'search_location' => 'Asnieres' ] )`.
   - Expect the listing in the result set.
2. Search-with-accents-matches-plain-listing:
   - Create a job listing with `_job_location` set to `Villeneuve-Loubet, France`.
   - Call `get_job_listings( [ 'search_location' => 'Villeneuve-Loubét' ] )`.
   - Expect the listing in the result set.
3. RSS-feed-parity:
   - Create listings with `_job_location` set to `Asnières-sur-Seine, France` and `Chicago, IL, USA`.
   - Request `/feed/?post_type=job_listing&search_location=Asnieres`.
   - Expect only the Asnières item.
4. Invalid-UTF-8-fallback:
   - Call `WP_Job_Manager_Post_Types::get_location_meta_query( "\xc3\x28" )` (a malformed 2-byte sequence).
   - Expect: no PHP warning or notice (PHPUnit's `convertWarningsToExceptions="true"` would otherwise throw an exception), and the returned clause resolves to an escaped literal rather than an empty `REGEXP ''`.

Unit tests covering the accent match directions are in `tests/php/tests/includes/test_class.wp-job-manager-post-types.php` and `tests/php/tests/test_class.wp-job-manager-functions.php`. Full PHPUnit suite and PHPCS pass.

### Release Notes

<!-- left empty — release tooling handles the changelog (CONTRIBUTING.md: "avoid modifying the changelog directly or updating the .pot files") -->

### New or Updated Hooks and Templates

- `WP_Job_Manager_Post_Types::get_location_meta_query( string $search_location ): array` — new public static. Builds the `meta_query` clause used by location search inside `get_job_listings()` and by the RSS `job_feed()`. Input is `;`-separated; empty terms are skipped. Each term becomes an OR-grouped sub-query across `_job_location`, `geolocation_formatted_address`, `geolocation_state_long`. No filters added in this PR. An opt-out filter (e.g. `job_manager_accent_insensitive_location_search`) can be added as a follow-up if maintainers want one.

### Deprecated Code

<!-- none -->

### Screenshot / Video

<!-- CLI/no UI change. -->
