### PR TITLE
Show application deadline in visitor's local time

### DIFF
--- a/assets/js/time-localize.js
+++ b/assets/js/time-localize.js
@@ -1,0 +1,48 @@
+/**
+ * Progressively enhances `.wpjm-local-time` elements with the visitor's local time,
+ * appended alongside the site-time value already rendered server-side.
+ */
+function localizeJobManagerTimes() {
+	const elements = document.querySelectorAll( '.wpjm-local-time[datetime]' );
+
+	if ( ! elements.length || typeof Intl === 'undefined' ) {
+		return;
+	}
+
+	elements.forEach( function ( el ) {
+		const date = new Date( el.getAttribute( 'datetime' ) );
+
+		if ( isNaN( date.getTime() ) ) {
+			return;
+		}
+
+		const options = { dateStyle: 'long', timeStyle: 'short' };
+		const localText = new Intl.DateTimeFormat( undefined, options ).format( date );
+		const siteTimezone = el.getAttribute( 'data-site-timezone' );
+
+		try {
+			if ( siteTimezone ) {
+				const siteText = new Intl.DateTimeFormat(
+					undefined,
+					Object.assign( {}, options, { timeZone: siteTimezone } )
+				).format( date );
+
+				if ( siteText === localText ) {
+					return;
+				}
+			}
+		} catch ( error ) {
+			// Site timezone isn't a recognized IANA identifier (e.g. a manual UTC offset).
+			// Fall through and show the visitor's local time anyway.
+		}
+
+		const label = el.getAttribute( 'data-local-label' ) || '%s';
+		el.insertAdjacentText( 'beforeend', ' ' + label.replace( '%s', localText ) );
+	} );
+}
+
+if ( 'loading' === document.readyState ) {
+	document.addEventListener( 'DOMContentLoaded', localizeJobManagerTimes );
+} else {
+	localizeJobManagerTimes();
+}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -326,6 +326,9 @@ class WP_Job_Manager {
 
 		// Register datepicker JS. It will be enqueued if needed when a date field is used.
 		self::register_script( 'wp-job-manager-datepicker', 'js/datepicker.js', [ 'jquery', 'jquery-ui-datepicker' ], true );
+
+		// Register time localize JS. It will be enqueued if needed when a local time is displayed.
+		self::register_script( 'wp-job-manager-time-localize', 'js/time-localize.js', [], true );
 	}
 
 	/**

--- a/templates/content-single-job_listing-meta.php
+++ b/templates/content-single-job_listing-meta.php
@@ -50,6 +50,8 @@ do_action( 'single_job_listing_meta_before' ); ?>
 		<li class="position-filled"><?php _e( 'This position has been filled', 'wp-job-manager' ); ?></li>
 	<?php elseif ( ! candidates_can_apply() && 'preview' !== $post->post_status ) : ?>
 		<li class="listing-expired"><?php _e( 'Applications have closed', 'wp-job-manager' ); ?></li>
+	<?php elseif ( get_the_job_application_deadline() ) : ?>
+		<li class="application-deadline"><?php the_job_application_deadline(); ?></li>
 	<?php endif; ?>
 
 	<?php do_action( 'single_job_listing_meta_end' ); ?>

--- a/tests/php/tests/test_class.wp-job-manager-template.php
+++ b/tests/php/tests/test_class.wp-job-manager-template.php
@@ -1,0 +1,95 @@
+<?php
+
+class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
+	public function setUp(): void {
+		parent::setUp();
+		$this->reregister_post_type();
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_the_job_application_deadline
+	 */
+	public function test_get_the_job_application_deadline() {
+		$job_id = $this->factory->job_listing->create(
+			[ 'meta_input' => [ '_job_expires' => current_datetime()->add( new DateInterval( 'P1D' ) )->format( 'Y-m-d' ) ] ]
+		);
+
+		$result = get_the_job_application_deadline( $job_id );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result );
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_the_job_application_deadline
+	 */
+	public function test_get_the_job_application_deadline_no_expiry() {
+		$job_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '' ] ] );
+
+		$this->assertFalse( get_the_job_application_deadline( $job_id ) );
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_the_job_application_deadline
+	 */
+	public function test_get_the_job_application_deadline_expired() {
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_status' => 'expired',
+				'meta_input'  => [ '_job_expires' => current_datetime()->sub( new DateInterval( 'P1D' ) )->format( 'Y-m-d' ) ],
+			]
+		);
+
+		$this->assertFalse( get_the_job_application_deadline( $job_id ) );
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::get_the_job_application_deadline
+	 */
+	public function test_get_the_job_application_deadline_filled() {
+		$job_id = $this->factory->job_listing->create(
+			[
+				'meta_input' => [
+					'_job_expires' => current_datetime()->add( new DateInterval( 'P1D' ) )->format( 'Y-m-d' ),
+					'_filled'      => 1,
+				],
+			]
+		);
+
+		$this->assertFalse( get_the_job_application_deadline( $job_id ) );
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::the_job_application_deadline
+	 */
+	public function test_the_job_application_deadline_outputs_machine_readable_time() {
+		$job_id = $this->factory->job_listing->create(
+			[ 'meta_input' => [ '_job_expires' => current_datetime()->add( new DateInterval( 'P1D' ) )->format( 'Y-m-d' ) ] ]
+		);
+
+		ob_start();
+		the_job_application_deadline( $job_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'wpjm-local-time', $output );
+		$this->assertMatchesRegularExpression( '/datetime="[^"]+T[^"]+"/', $output );
+	}
+
+	/**
+	 * @since 2.5.0
+	 * @covers ::the_job_application_deadline
+	 */
+	public function test_the_job_application_deadline_no_expiry_outputs_nothing() {
+		$job_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => '' ] ] );
+
+		ob_start();
+		the_job_application_deadline( $job_id );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+}

--- a/tests/php/tests/test_class.wp-job-manager-template.php
+++ b/tests/php/tests/test_class.wp-job-manager-template.php
@@ -4,10 +4,16 @@ class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->reregister_post_type();
+		$this->original_timezone = get_option( 'timezone_string' );
+	}
+
+	public function tearDown(): void {
+		update_option( 'timezone_string', $this->original_timezone ?? '' );
+		parent::tearDown();
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_the_job_application_deadline
 	 */
 	public function test_get_the_job_application_deadline() {
@@ -21,7 +27,7 @@ class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_the_job_application_deadline
 	 */
 	public function test_get_the_job_application_deadline_no_expiry() {
@@ -31,7 +37,7 @@ class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_the_job_application_deadline
 	 */
 	public function test_get_the_job_application_deadline_expired() {
@@ -46,7 +52,7 @@ class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::get_the_job_application_deadline
 	 */
 	public function test_get_the_job_application_deadline_filled() {
@@ -63,7 +69,7 @@ class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::the_job_application_deadline
 	 */
 	public function test_the_job_application_deadline_outputs_machine_readable_time() {
@@ -80,7 +86,7 @@ class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers ::the_job_application_deadline
 	 */
 	public function test_the_job_application_deadline_no_expiry_outputs_nothing() {
@@ -91,5 +97,76 @@ class WP_Test_WP_Job_Manager_Template extends WPJM_BaseTest {
 		$output = ob_get_clean();
 
 		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * The deadline must be a real, offset-aware DateTimeImmutable in the site's timezone —
+	 * not a naive datetime as `date()` would emit — so a regression to naive date handling
+	 * can't pass silently in a UTC test environment.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::get_the_job_application_deadline
+	 */
+	public function test_get_the_job_application_deadline_non_utc_timezone_has_correct_offset() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$job_id = $this->factory->job_listing->create(
+			[ 'meta_input' => [ '_job_expires' => '2026-12-15' ] ]
+		);
+
+		$result = get_the_job_application_deadline( $job_id );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result );
+		$this->assertSame( 'America/New_York', $result->getTimezone()->getName() );
+
+		// Exact moment: 2026-12-15 23:59:59 in America/New_York (EST, -05:00).
+		$this->assertSame( '2026-12-15T23:59:59-05:00', $result->format( 'c' ) );
+	}
+
+	/**
+	 * DST boundary regression guard: the deadline must keep the post-transition offset
+	 * (EST, -05:00) for an expiry just after US fall-back on 2026-11-02.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::get_the_job_application_deadline
+	 */
+	public function test_get_the_job_application_deadline_dst_boundary_keeps_post_transition_offset() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$job_id = $this->factory->job_listing->create(
+			[ 'meta_input' => [ '_job_expires' => '2026-11-03' ] ]
+		);
+
+		$result = get_the_job_application_deadline( $job_id );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result );
+		$this->assertSame( 'America/New_York', $result->getTimezone()->getName() );
+
+		// 2026-11-03 is post US fall-back, so still EST (-05:00).
+		$this->assertSame( '2026-11-03T23:59:59-05:00', $result->format( 'c' ) );
+	}
+
+	/**
+	 * When the site is configured with a raw UTC offset rather than a named IANA timezone,
+	 * `Intl` rejects the offset as a `timeZone`, so the local-time JS would always append a
+	 * redundant suffix. The fallback should leave the data attributes off entirely.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::the_job_application_deadline
+	 */
+	public function test_the_job_application_deadline_omits_optional_data_attrs_on_raw_offset() {
+		update_option( 'timezone_string', '+05:30' );
+
+		$job_id = $this->factory->job_listing->create(
+			[ 'meta_input' => [ '_job_expires' => current_datetime()->add( new DateInterval( 'P1D' ) )->format( 'Y-m-d' ) ] ]
+		);
+
+		ob_start();
+		the_job_application_deadline( $job_id );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'data-site-timezone', $output );
+		$this->assertStringNotContainsString( 'data-local-label', $output );
+		$this->assertStringContainsString( 'datetime="', $output );
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const files = {
 	'js/job-application': 'js/job-application.js',
 	'js/job-dashboard': 'js/job-dashboard.js',
 	'js/job-submission': 'js/job-submission.js',
+	'js/time-localize': 'js/time-localize.js',
 	'js/ui-theme-support': 'js/ui-theme-support.js',
 	'js/multiselect': 'js/multiselect.js',
 	'js/term-multiselect': 'js/term-multiselect.js',

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -191,7 +191,7 @@ function is_position_featured( $post = null ) {
  */
 function candidates_can_apply( $post = null ) {
 	$post = get_post( $post );
-	return apply_filters( 'job_manager_candidates_can_apply', ( ! is_position_filled() && ! in_array( $post->post_status, [ 'preview', 'expired' ], true ) ), $post );
+	return apply_filters( 'job_manager_candidates_can_apply', ( ! is_position_filled( $post ) && ! in_array( $post->post_status, [ 'preview', 'expired' ], true ) ), $post );
 }
 
 /**
@@ -805,6 +805,57 @@ function get_the_job_publish_date( $post = null ) {
 		// translators: Placeholder %s is the relative, human readable time since the job listing was posted.
 		return sprintf( __( 'Posted %s ago', 'wp-job-manager' ), human_time_diff( get_post_timestamp(), time() ) );
 	}
+}
+
+/**
+ * Gets the application deadline for the job listing, if one is set and the listing is
+ * still accepting applications.
+ *
+ * @since 2.5.0
+ * @param int|WP_Post $post (default: null).
+ * @return DateTimeImmutable|false
+ */
+function get_the_job_application_deadline( $post = null ) {
+	$post = get_post( $post );
+
+	if ( ! $post || ! candidates_can_apply( $post ) ) {
+		return false;
+	}
+
+	return WP_Job_Manager_Post_Types::instance()->get_job_expiration( $post );
+}
+
+/**
+ * Displays the application deadline for the job listing, in the site's timezone. Also
+ * outputs a machine-readable `<time>` element so the deadline can be progressively
+ * enhanced with the visitor's local time in the browser.
+ *
+ * @since 2.5.0
+ * @param int|WP_Post $post (default: null).
+ */
+function the_job_application_deadline( $post = null ) {
+	$deadline = get_the_job_application_deadline( $post );
+
+	if ( ! $deadline ) {
+		return;
+	}
+
+	$wp_date_format = get_option( 'date_format' ) ?: JOB_MANAGER_DATE_FORMAT_FALLBACK;
+	$wp_time_format = get_option( 'time_format' );
+
+	// translators: Placeholder %s is the application deadline date and time, in the site's timezone.
+	$display_date = sprintf( esc_html__( 'Apply by %s', 'wp-job-manager' ), wp_date( trim( $wp_date_format . ' ' . $wp_time_format ), $deadline->getTimestamp() ) );
+
+	wp_enqueue_script( 'wp-job-manager-time-localize' );
+
+	printf(
+		'<time class="wpjm-local-time" datetime="%1$s" data-site-timezone="%2$s" data-local-label="%3$s">%4$s</time>',
+		esc_attr( $deadline->format( DateTimeInterface::ATOM ) ),
+		esc_attr( wp_timezone_string() ),
+		// translators: Placeholder %s is the application deadline, converted to the visitor's local time by their browser.
+		esc_attr__( '(%s your local time)', 'wp-job-manager' ),
+		wp_kses_post( $display_date )
+	);
 }
 
 /**

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -811,7 +811,7 @@ function get_the_job_publish_date( $post = null ) {
  * Gets the application deadline for the job listing, if one is set and the listing is
  * still accepting applications.
  *
- * @since 2.5.0
+ * @since $$next-version$$
  * @param int|WP_Post $post (default: null).
  * @return DateTimeImmutable|false
  */
@@ -830,7 +830,7 @@ function get_the_job_application_deadline( $post = null ) {
  * outputs a machine-readable `<time>` element so the deadline can be progressively
  * enhanced with the visitor's local time in the browser.
  *
- * @since 2.5.0
+ * @since $$next-version$$
  * @param int|WP_Post $post (default: null).
  */
 function the_job_application_deadline( $post = null ) {
@@ -846,14 +846,24 @@ function the_job_application_deadline( $post = null ) {
 	// translators: Placeholder %s is the application deadline date and time, in the site's timezone.
 	$display_date = sprintf( esc_html__( 'Apply by %s', 'wp-job-manager' ), wp_date( trim( $wp_date_format . ' ' . $wp_time_format ), $deadline->getTimestamp() ) );
 
-	wp_enqueue_script( 'wp-job-manager-time-localize' );
+	$site_timezone      = wp_timezone_string();
+	$has_named_timezone = ! in_array( $site_timezone[0] ?? '', [ '+', '-' ], true );
+
+	if ( $has_named_timezone ) {
+		wp_enqueue_script( 'wp-job-manager-time-localize' );
+	}
 
 	printf(
-		'<time class="wpjm-local-time" datetime="%1$s" data-site-timezone="%2$s" data-local-label="%3$s">%4$s</time>',
+		'<time class="wpjm-local-time" datetime="%1$s"%2$s>%3$s</time>',
 		esc_attr( $deadline->format( DateTimeInterface::ATOM ) ),
-		esc_attr( wp_timezone_string() ),
-		// translators: Placeholder %s is the application deadline, converted to the visitor's local time by their browser.
-		esc_attr__( '(%s your local time)', 'wp-job-manager' ),
+		$has_named_timezone
+			? sprintf(
+				' data-site-timezone="%1$s" data-local-label="%2$s"',
+				esc_attr( $site_timezone ),
+				// translators: Placeholder %s is the application deadline, converted to the visitor's local time by their browser.
+				esc_attr__( '(%s your local time)', 'wp-job-manager' )
+			)
+			: '',
 		wp_kses_post( $display_date )
 	);
 }


### PR DESCRIPTION
## Summary
Job deadlines were never shown on the single job listing page until a listing had already expired, and even then the only place a date appeared (employer's Job Dashboard) was in the site's timezone with no local-time context. A visitor in a different timezone than the site had no reliable way to know when a listing actually closed. This adds an "Apply by" date to the listing page and progressively enhances it with the visitor's own local-time equivalent.

Fixes #2873

## Changes
### wp-job-manager-template.php
**Before:** no template tag existed for the application deadline.

**After:**
```php
function get_the_job_application_deadline( $post = null ) {
	$post = get_post( $post );
	if ( ! $post || ! candidates_can_apply( $post ) ) {
		return false;
	}
	return WP_Job_Manager_Post_Types::instance()->get_job_expiration( $post );
}

function the_job_application_deadline( $post = null ) {
	// outputs "Apply by <date>" wrapped in a <time> element with a
	// machine-readable ISO8601 datetime + the site's timezone name
}
```
**Why:** follows the existing `get_the_job_publish_date()` / `the_job_publish_date()` pattern already used for the posted date.

Also fixed `candidates_can_apply()`, which called `is_position_filled()` without passing `$post` through, silently relying on the global `$post` set by The Loop. That's fine for its existing in-template callers, but broke when I called it with an explicit post ID from outside the loop. The fix is a no-op for every existing call site (confirmed: `$post` is resolved once and reused for both checks, so nothing can diverge).

### templates/content-single-job_listing-meta.php
**Before:**
```php
<?php elseif ( ! candidates_can_apply() && 'preview' !== $post->post_status ) : ?>
	<li class="listing-expired"><?php _e( 'Applications have closed', 'wp-job-manager' ); ?></li>
<?php endif; ?>
```
**After:**
```php
<?php elseif ( ! candidates_can_apply() && 'preview' !== $post->post_status ) : ?>
	<li class="listing-expired"><?php _e( 'Applications have closed', 'wp-job-manager' ); ?></li>
<?php elseif ( get_the_job_application_deadline() ) : ?>
	<li class="application-deadline"><?php the_job_application_deadline(); ?></li>
<?php endif; ?>
```
**Why:** shows the deadline while the listing is still open, falls back to the existing "closed" message once expired.

### assets/js/time-localize.js (new)
Small vanilla JS, no dependencies. Finds `.wpjm-local-time[datetime]` elements, formats the parsed datetime with `Intl.DateTimeFormat` in the visitor's browser timezone, and appends it next to the site-time text only if it's actually different from the site's timezone. Wrapped in try/catch since a manually-configured UTC offset (rather than a named timezone) isn't a valid `Intl` timeZone value — falls back to always showing local time in that case.

**Why:** the site-configured deadline stays the source of truth (unchanged, still site-timezone based, per the deliberate design from #919/#2114) — this only fixes how it's communicated to a visitor. Pure progressive enhancement: without JS, the page still shows a correct, unambiguous site-time deadline.

### webpack.config.js / includes/class-wp-job-manager.php
Register the new script as a build entry and register it with WordPress; it's only enqueued when `the_job_application_deadline()` actually outputs something, so it's never loaded on pages that don't need it.

## Testing
**Test 1: Deadline shows before expiry, in site time**
1. Set site timezone to something other than your own (Settings > General).
2. Publish a job listing with an expiry date set.
3. View the single listing page as a logged-out visitor.
Result: "Apply by <date>" appears in site time, before the listing expires.

**Test 2: Local-time enhancement**
1. Same listing, override the browser's timezone via DevTools > Sensors to something different from the site.
2. Reload.
Result: a "(... your local time)" note is appended with the correctly converted time. No console errors.

**Test 3: No-JS fallback**
1. Disable JavaScript, reload the listing page.
Result: "Apply by <date>" still renders correctly in site time.

**Test 4: Existing behavior unchanged**
1. Let a listing expire, or mark it filled.
Result: falls back to "Applications have closed" / "This position has been filled" as before. Employer Job Dashboard's relative "Expires in X days" text is unchanged.

Also added PHPUnit coverage for `get_the_job_application_deadline()` (open listing, no expiry set, expired, filled) and `the_job_application_deadline()` output. Full suite passes (564 tests; the only failures are 4 pre-existing RSS feed test errors caused by an unrelated environment/PHP8.5 deprecation notice, confirmed present on trunk before this change). phpcs and eslint are clean.

### Release Notes

* Fix - Show application deadline on the single job listing page in the site's timezone, with optional progressive enhancement to the visitor's local time.

### New or Updated Hooks and Templates

* New template tag `get_the_job_application_deadline( int|WP_Post $post = null )` in `wp-job-manager-template.php`. Returns a `DateTimeImmutable` for the expiry of the listing if one is set and applications are still accepted, or `false`.
* New template tag `the_job_application_deadline( int|WP_Post $post = null )` in `wp-job-manager-template.php`. Outputs a `<time>` element with the "Apply by <date>" label, a machine-readable ISO 8601 `datetime`, the site's IANA timezone name in `data-site-timezone`, and a `data-local-label` template for the visitor-local-time suffix. Enqueues the new `wp-job-manager-time-localize` script. When the site timezone is a raw UTC offset rather than a named IANA zone, the data attributes (and the script enqueue) are omitted, since `Intl` cannot resolve the offset.
* Updated template `templates/content-single-job_listing-meta.php` to render the deadline while the listing is still open.
* Fix: `candidates_can_apply()` now forwards `$post` to `is_position_filled()` instead of relying on the Loop's global `$post`.