### PR TITLE
Add deactivate/reactivate action to job dashboard

### DIFF
--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -501,6 +501,15 @@ class Job_Dashboard_Shortcode {
 
 					break;
 				case 'reactivate':
+					// Reset the expiry date before transitioning back to published.
+					// set_expiry() snapshots the existing _job_expires before clearing
+					// it, so the regeneration branch never fires for a stale past date.
+					$expires = calculate_job_expiry( $job_id, true );
+
+					if ( $expires ) {
+						WP_Job_Manager_Post_Types::instance()->set_job_expiration( $job_id, $expires );
+					}
+
 					$updated = wp_update_post(
 						[
 							'ID'          => $job_id,

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -231,6 +231,16 @@ class Job_Dashboard_Shortcode {
 						'nonce' => $base_nonce_action_name,
 					];
 				}
+				$actions['deactivate'] = [
+					'label' => __( 'Deactivate', 'wp-job-manager' ),
+					'nonce' => $base_nonce_action_name,
+				];
+				break;
+			case 'wpjm_deactivated':
+				$actions['reactivate'] = [
+					'label' => __( 'Reactivate', 'wp-job-manager' ),
+					'nonce' => $base_nonce_action_name,
+				];
 				break;
 			case 'expired':
 				if ( job_manager_get_permalink( 'submit_job_form' ) ) {
@@ -318,6 +328,7 @@ class Job_Dashboard_Shortcode {
 			'renew',
 			'relist',
 			'continue',
+			'reactivate',
 			'edit',
 			'delete',
 			'duplicate',
@@ -470,6 +481,40 @@ class Job_Dashboard_Shortcode {
 					// Message.
 					// translators: Placeholder %s is the job listing title.
 					$this->job_dashboard_message = Notice::success( sprintf( __( '%s has been deleted', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) );
+
+					break;
+				case 'deactivate':
+					$updated = wp_update_post(
+						[
+							'ID'          => $job_id,
+							'post_status' => 'wpjm_deactivated',
+						]
+					);
+
+					if ( ! $updated ) {
+						throw new \Exception( __( 'Unable to deactivate this job listing', 'wp-job-manager' ) );
+					}
+
+					// Message.
+					// translators: Placeholder %s is the job listing title.
+					$this->job_dashboard_message = Notice::success( sprintf( __( '%s has been deactivated', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) );
+
+					break;
+				case 'reactivate':
+					$updated = wp_update_post(
+						[
+							'ID'          => $job_id,
+							'post_status' => 'publish',
+						]
+					);
+
+					if ( ! $updated ) {
+						throw new \Exception( __( 'Unable to reactivate this job listing', 'wp-job-manager' ) );
+					}
+
+					// Message.
+					// translators: Placeholder %s is the job listing title.
+					$this->job_dashboard_message = Notice::success( sprintf( __( '%s has been reactivated', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) );
 
 					break;
 				case 'duplicate':
@@ -656,10 +701,11 @@ class Job_Dashboard_Shortcode {
 		}
 
 		$status_icon = [
-			'pending'         => 'alert',
-			'pending_payment' => 'alert',
-			'draft'           => 'edit',
-			'expired'         => 'alert',
+			'pending'          => 'alert',
+			'pending_payment'  => 'alert',
+			'draft'            => 'edit',
+			'expired'          => 'alert',
+			'wpjm_deactivated' => 'info',
 		][ $job->post_status ] ?? null;
 
 		$status[] = '<span class="job-status-' . esc_attr( $job->post_status ) . ' jm-ui-row">'
@@ -741,7 +787,7 @@ class Job_Dashboard_Shortcode {
 			$args,
 			[
 				'post_type'           => \WP_Job_Manager_Post_Types::PT_LISTING,
-				'post_status'         => [ 'publish', 'expired', 'pending', 'draft', 'preview' ],
+				'post_status'         => [ 'publish', 'expired', 'pending', 'draft', 'preview', 'wpjm_deactivated' ],
 				'ignore_sticky_posts' => 1,
 				'orderby'             => 'date',
 				'order'               => 'desc',

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -544,6 +544,19 @@ class WP_Job_Manager_Post_Types {
 				'label_count'               => _n_noop( 'Preview <span class="count">(%s)</span>', 'Preview <span class="count">(%s)</span>', 'wp-job-manager' ),
 			]
 		);
+		register_post_status(
+			'wpjm_deactivated',
+			[
+				'label'                     => _x( 'Deactivated', 'post status', 'wp-job-manager' ),
+				'public'                    => false,
+				'protected'                 => true,
+				'exclude_from_search'       => true,
+				'show_in_admin_all_list'    => true,
+				'show_in_admin_status_list' => true,
+				// translators: Placeholder %s is the number of deactivated posts of this type.
+				'label_count'               => _n_noop( 'Deactivated <span class="count">(%s)</span>', 'Deactivated <span class="count">(%s)</span>', 'wp-job-manager' ),
+			]
+		);
 
 		/**
 		 * Custom post type used to store guest user data.

--- a/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
+++ b/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
@@ -1,0 +1,77 @@
+<?php
+
+use WP_Job_Manager\Job_Dashboard_Shortcode;
+
+class WP_Test_Job_Dashboard_Shortcode extends WPJM_BaseTest {
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
+	 */
+	public function test_published_job_has_deactivate_action() {
+		$user_id = $this->get_user_by_role( 'employer' );
+		$this->login_as( $user_id );
+		$job = get_post( $this->factory->job_listing->create( [ 'post_author' => $user_id ] ) );
+
+		$actions = Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$this->assertArrayHasKey( 'deactivate', $actions );
+		$this->assertArrayNotHasKey( 'reactivate', $actions );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
+	 */
+	public function test_deactivated_job_has_reactivate_action() {
+		$user_id = $this->get_user_by_role( 'employer' );
+		$this->login_as( $user_id );
+		$job = get_post(
+			$this->factory->job_listing->create(
+				[
+					'post_author' => $user_id,
+					'post_status' => 'wpjm_deactivated',
+				]
+			)
+		);
+
+		$actions = Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$this->assertArrayHasKey( 'reactivate', $actions );
+		$this->assertArrayNotHasKey( 'deactivate', $actions );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_primary_action
+	 */
+	public function test_reactivate_is_primary_action_for_deactivated_job() {
+		$user_id = $this->get_user_by_role( 'employer' );
+		$this->login_as( $user_id );
+		$job = get_post(
+			$this->factory->job_listing->create(
+				[
+					'post_author' => $user_id,
+					'post_status' => 'wpjm_deactivated',
+				]
+			)
+		);
+
+		$actions        = Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+		$primary_action = Job_Dashboard_Shortcode::get_primary_action( $job, $actions );
+
+		$this->assertSame( 'reactivate', $primary_action['name'] );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
+	 */
+	public function test_other_users_job_has_no_actions() {
+		$owner_id = $this->get_user_by_role( 'employer' );
+		$job      = get_post( $this->factory->job_listing->create( [ 'post_author' => $owner_id ] ) );
+
+		$viewer_id = $this->get_user_by_role( 'employer', '_b' );
+		$this->login_as( $viewer_id );
+
+		$actions = Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$this->assertEmpty( $actions );
+	}
+}

--- a/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
+++ b/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
@@ -4,6 +4,11 @@ use WP_Job_Manager\Job_Dashboard_Shortcode;
 
 class WP_Test_Job_Dashboard_Shortcode extends WPJM_BaseTest {
 
+	public function setUp(): void {
+		parent::setUp();
+		update_option( 'job_manager_submission_duration', 30 );
+	}
+
 	/**
 	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
 	 */
@@ -73,5 +78,140 @@ class WP_Test_Job_Dashboard_Shortcode extends WPJM_BaseTest {
 		$actions = Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
 
 		$this->assertEmpty( $actions );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::handle_actions
+	 */
+	public function test_handle_deactivate_action_transitions_status() {
+		$user_id = $this->get_user_by_role( 'employer' );
+		$this->login_as( $user_id );
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$this->handle_dashboard_action( 'deactivate', $job_id );
+
+		$this->assertSame( 'wpjm_deactivated', get_post_status( $job_id ) );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::handle_actions
+	 */
+	public function test_handle_reactivate_action_transitions_status() {
+		$user_id = $this->get_user_by_role( 'employer' );
+		$this->login_as( $user_id );
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_author'   => $user_id,
+				'post_status'   => 'wpjm_deactivated',
+				'meta_input'    => [
+					'_job_expires' => '',
+				],
+			]
+		);
+
+		$this->handle_dashboard_action( 'reactivate', $job_id );
+
+		$this->assertSame( 'publish', get_post_status( $job_id ) );
+	}
+
+	/**
+	 * Reactivating a listing whose expiry date passed while deactivated must
+	 * reset _job_expires, otherwise the hourly expiry cron would flip it back
+	 * to expired on the next run.
+	 *
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::handle_actions
+	 */
+	public function test_handle_reactivate_action_resets_stale_expiry() {
+		$user_id = $this->get_user_by_role( 'employer' );
+		$this->login_as( $user_id );
+
+		$past_date = ( new DateTimeImmutable( '-10 days', wp_timezone() ) )->format( 'Y-m-d' );
+		$job_id    = $this->factory->job_listing->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'wpjm_deactivated',
+				'meta_input'  => [
+					'_job_expires' => $past_date,
+				],
+			]
+		);
+
+		$this->handle_dashboard_action( 'reactivate', $job_id );
+
+		$this->assertSame( 'publish', get_post_status( $job_id ) );
+
+		$expires = WP_Job_Manager_Post_Types::instance()->get_job_expiration( $job_id );
+		$this->assertNotEmpty( $expires, 'Reactivate must set a new expiry date.' );
+		$this->assertGreaterThan(
+			current_datetime(),
+			$expires,
+			'Reactivated expiry must be in the future, not the stale past date.'
+		);
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::handle_actions
+	 */
+	public function test_handle_action_rejected_for_non_owner() {
+		$owner_id = $this->get_user_by_role( 'employer' );
+		$job_id   = $this->factory->job_listing->create(
+			[
+				'post_author' => $owner_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$viewer_id = $this->get_user_by_role( 'employer', '_b' );
+		$this->login_as( $viewer_id );
+
+		$this->handle_dashboard_action( 'deactivate', $job_id );
+
+		$this->assertSame( 'publish', get_post_status( $job_id ), 'Non-owner must not change the listing status.' );
+	}
+
+	/**
+	 * Drive handle_actions() with a valid nonce for the given action and job,
+	 * neutralising the redirect/exit so the test can assert the result.
+	 *
+	 * @param string $action Action name.
+	 * @param int    $job_id Job post ID.
+	 */
+	private function handle_dashboard_action( $action, $job_id ) {
+		$nonce = wp_create_nonce( 'job_manager_my_job_actions' );
+
+		$_REQUEST['action']  = $action;
+		$_REQUEST['job_id']  = $job_id;
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		// Prevent wp_safe_redirect()/exit from terminating the test run.
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RuntimeException( 'redirect intercepted' );
+			}
+		);
+
+		// Bypass the is_job_dashboard_page() gate since we're not on a real dashboard page in unit tests.
+		add_filter(
+			'job_manager_should_run_shortcode_action_handler',
+			static function () {
+				return true;
+			}
+		);
+
+		try {
+			Job_Dashboard_Shortcode::instance()->handle_actions();
+		} catch ( RuntimeException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected: redirect was intercepted.
+		} finally {
+			remove_all_filters( 'wp_redirect' );
+			remove_all_filters( 'job_manager_should_run_shortcode_action_handler' );
+			unset( $_REQUEST['action'], $_REQUEST['job_id'], $_REQUEST['_wpnonce'] );
+		}
 	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -554,13 +554,14 @@ if ( ! function_exists( 'get_job_listing_post_statuses' ) ) :
 		return apply_filters(
 			'job_listing_post_statuses',
 			[
-				'draft'           => _x( 'Draft', 'post status', 'wp-job-manager' ),
-				'expired'         => _x( 'Expired', 'post status', 'wp-job-manager' ),
-				'preview'         => _x( 'Preview', 'post status', 'wp-job-manager' ),
-				'pending'         => _x( 'Pending approval', 'post status', 'wp-job-manager' ),
-				'pending_payment' => _x( 'Pending payment', 'post status', 'wp-job-manager' ),
-				'publish'         => _x( 'Active', 'post status', 'wp-job-manager' ),
-				'future'          => _x( 'Scheduled', 'post status', 'wp-job-manager' ),
+				'draft'            => _x( 'Draft', 'post status', 'wp-job-manager' ),
+				'expired'          => _x( 'Expired', 'post status', 'wp-job-manager' ),
+				'preview'          => _x( 'Preview', 'post status', 'wp-job-manager' ),
+				'pending'          => _x( 'Pending approval', 'post status', 'wp-job-manager' ),
+				'pending_payment'  => _x( 'Pending payment', 'post status', 'wp-job-manager' ),
+				'publish'          => _x( 'Active', 'post status', 'wp-job-manager' ),
+				'future'           => _x( 'Scheduled', 'post status', 'wp-job-manager' ),
+				'wpjm_deactivated' => _x( 'Deactivated', 'post status', 'wp-job-manager' ),
 			]
 		);
 	}


### PR DESCRIPTION
## Summary
Employers could only Delete a job listing from `[job_dashboard]`, with no way to temporarily hide it and bring it back later. This adds a Deactivate action for published listings and a Reactivate action to restore them.

Fixes #2860

## Changes
### includes/class-wp-job-manager-post-types.php
**Before:**
```php
register_post_status( 'preview', [ ... ] );
```
**After:**
```php
register_post_status( 'preview', [ ... ] );
register_post_status(
	'wpjm_deactivated',
	[
		'label'                     => _x( 'Deactivated', 'post status', 'wp-job-manager' ),
		'public'                    => false,
		'protected'                 => true,
		'exclude_from_search'       => true,
		'show_in_admin_all_list'    => true,
		'show_in_admin_status_list' => true,
		'label_count'               => _n_noop( 'Deactivated <span class="count">(%s)</span>', 'Deactivated <span class="count">(%s)</span>', 'wp-job-manager' ),
	]
);
```
**Why:** the issue asked to move listings to Draft status, but `draft` already means "submission in progress" in this codebase — the dashboard shows a "Continue Submission" action for draft/preview jobs, which would be wrong for a completed listing that's just paused. A dedicated status avoids that collision.

### includes/class-job-dashboard-shortcode.php
**Before:**
```php
case 'publish':
	...
	break;
```
**After:**
```php
case 'publish':
	...
	$actions['deactivate'] = [ 'label' => __( 'Deactivate', 'wp-job-manager' ), 'nonce' => $base_nonce_action_name ];
	break;
case 'wpjm_deactivated':
	$actions['reactivate'] = [ 'label' => __( 'Reactivate', 'wp-job-manager' ), 'nonce' => $base_nonce_action_name ];
	break;
```
Also added handling in `handle_actions()` for the `deactivate`/`reactivate` actions (with `wp_update_post()` return value checked before showing a success message), added `wpjm_deactivated` to the dashboard's query args so deactivated jobs stay visible on the owner's dashboard, added it to the status icon map, and made `reactivate` a primary action candidate.

### wp-job-manager-functions.php
Added a `wpjm_deactivated` entry to `get_job_listing_post_statuses()` so the dashboard shows a "Deactivated" label instead of falling back to "Inactive".

## Testing
**Test 1: Deactivate a published listing**
1. Log in as an employer with a published listing, go to `[job_dashboard]`.
2. Click Deactivate on a published listing.
3. Result: listing shows "Deactivated" status, disappears from the public `[jobs]` archive/search, stays visible on the owner's dashboard.

**Test 2: Reactivate**
1. Click Reactivate on a deactivated listing.
2. Result: listing status is back to Active and reappears publicly.

**Test 3: Permission check**
1. Confirm another employer can't deactivate/reactivate a listing that isn't theirs.

**Automated:**
- Added `tests/php/tests/includes/test_class.job-dashboard-shortcode.php` covering action visibility per status and primary action selection.
- `npm run test-php` passes (562 tests, same 4 pre-existing unrelated failures on trunk from an amphp/PHP 8.5 deprecation, confirmed via `git stash` before this change).
- `./vendor/bin/phpcs` clean on all changed files.
