### PR TITLE
fix: reset job dashboard filter when the search field is cleared

### DIFF
--- a/assets/js/job-dashboard.js
+++ b/assets/js/job-dashboard.js
@@ -105,22 +105,15 @@ function setupSearchClear() {
 	}
 
 	const submitWhenCleared = () => {
-		if ( input.value !== '' ) {
-			return;
-		}
-
-		// Only reload when a search filter is actually active, so clearing an
-		// already-empty field never triggers a needless submit.
-		if ( ! new URLSearchParams( window.location.search ).has( 'search' ) ) {
+		if ( input.value !== '' || ! new URLSearchParams( window.location.search ).has( 'search' ) ) {
 			return;
 		}
 
 		form.submit();
 	};
 
-	// WebKit/Blink fire 'search' when the native clear (×) control is used.
+	// 'search' fires on the native clear (×) in WebKit/Blink; 'input' covers select-all + delete.
 	input.addEventListener( 'search', submitWhenCleared );
-	// Covers select-all + delete (and clearing the field in any browser).
 	input.addEventListener( 'input', submitWhenCleared );
 }
 

--- a/assets/js/job-dashboard.js
+++ b/assets/js/job-dashboard.js
@@ -95,6 +95,35 @@ async function showOverlay( eventOrId ) {
 	setupEvents( contentElement );
 }
 
+function setupSearchClear() {
+	const dashboard = document.getElementById( 'job-manager-job-dashboard' );
+	const input = dashboard?.querySelector( 'input[type="search"][name="search"]' );
+	const form = input?.closest( 'form' );
+
+	if ( ! form ) {
+		return;
+	}
+
+	const submitWhenCleared = () => {
+		if ( input.value !== '' ) {
+			return;
+		}
+
+		// Only reload when a search filter is actually active, so clearing an
+		// already-empty field never triggers a needless submit.
+		if ( ! new URLSearchParams( window.location.search ).has( 'search' ) ) {
+			return;
+		}
+
+		form.submit();
+	};
+
+	// WebKit/Blink fire 'search' when the native clear (×) control is used.
+	input.addEventListener( 'search', submitWhenCleared );
+	// Covers select-all + delete (and clearing the field in any browser).
+	input.addEventListener( 'input', submitWhenCleared );
+}
+
 function setupStatsOverlay() {
 	document
 		.querySelectorAll( '.jm-dashboard-job .job-title, tr.job_listing td.column-stats' )
@@ -110,6 +139,7 @@ function setupStatsOverlay() {
 domReady( () => {
 	setupEvents( document );
 	setupActionsMenu();
+	setupSearchClear();
 
 	if ( statsEnabled ) {
 		setupStatsOverlay();

--- a/assets/js/job-dashboard.js
+++ b/assets/js/job-dashboard.js
@@ -98,23 +98,29 @@ async function showOverlay( eventOrId ) {
 function setupSearchClear() {
 	const dashboard = document.getElementById( 'job-manager-job-dashboard' );
 	const input = dashboard?.querySelector( 'input[type="search"][name="search"]' );
-	const form = input?.closest( 'form' );
 
-	if ( ! form ) {
+	if ( ! input ) {
 		return;
 	}
 
-	const submitWhenCleared = () => {
-		if ( input.value !== '' || ! new URLSearchParams( window.location.search ).has( 'search' ) ) {
+	const reloadWhenCleared = () => {
+		if ( input.value !== '' ) {
 			return;
 		}
 
-		form.submit();
+		const url = new URL( window.location.href );
+
+		if ( ! url.searchParams.has( 'search' ) ) {
+			return;
+		}
+
+		url.searchParams.delete( 'search' );
+		window.location.assign( url );
 	};
 
 	// 'search' fires on the native clear (×) in WebKit/Blink; 'input' covers select-all + delete.
-	input.addEventListener( 'search', submitWhenCleared );
-	input.addEventListener( 'input', submitWhenCleared );
+	input.addEventListener( 'search', reloadWhenCleared );
+	input.addEventListener( 'input', reloadWhenCleared );
 }
 
 function setupStatsOverlay() {


### PR DESCRIPTION
Fixes #2955

### Changes Proposed in this Pull Request

The `[job_dashboard]` search input is an `<input type="search">` inside a GET form. In Chrome and Safari, clicking the browser-native "×" clear control empties the field's value but does not submit the form, so the URL keeps `?search=<term>` and the dashboard stays filtered with no obvious way to clear it.

This adds a small handler to the existing dashboard script (`assets/js/job-dashboard.js`, already enqueued only on Job Dashboard pages) that re-submits the search form when the field transitions to empty. It listens for the `search` event (fired by the native × in WebKit/Blink) and the `input` event (covers select-all + delete in any browser), and only re-submits when a `search` filter is actually active in the URL, so it never fires a needless reload or interferes with normal typing.

No PHP change is needed — `WP_Query` already returns the unfiltered set for an empty `s` parameter.

### Testing Instructions

1. Create a page with the `[job_dashboard]` shortcode and add a few job listings owned by your user.
2. In Chrome or Safari, visit the dashboard and search for a term. The URL becomes `…/job-dashboard/?search=<term>` and the list filters.
3. Click the native "×" inside the search input. Expected: the dashboard reloads and shows the full, unfiltered list.
4. Search again, then select all text in the field and press delete (without clicking submit). Expected: same clear-and-reload.
5. Type characters into the field. Expected: no premature submission — the page only reloads on clear or on form submit.
6. Confirm no JavaScript console errors, and that the behavior is unchanged on Firefox (no native ×).

### Release Notes

Job Dashboard: clearing the search field with the browser's native clear button now resets the filtered results.

### New or Updated Hooks and Templates

None.

### Deprecated Code

None.

### Screenshot / Video

_See issue #2955 for the before behavior._ TLDR: clear did not work.

Fixed behavior:


https://github.com/user-attachments/assets/f124e239-100e-46c2-8935-d64e187d4ab3




🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- wpjm:plugin-zip -->
----

| Plugin build for 9d439df4e73535a86ee63ef714dc3d9fdd76d40d <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3024-9d439df4.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3024-9d439df4)             |

<!-- /wpjm:plugin-zip -->




