### PR TITLE
Fix unreadable notice-banner button text on Settings

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -31,10 +31,14 @@ $notice-success: #43af99;
 
 	.wpjm-button {
 		font-size: 13px;
+	}
 
+	// Reassert the brand colors on link buttons. Scoped to `a` so it only
+	// counters WP core's `div.notice a` styling and leaves the dismiss
+	// <button>'s `color: inherit` intact.
+	a.wpjm-button {
 		text-decoration: underline;
 
-		// Keep the brand button colors over WP core's `div.notice a` styling.
 		&,
 		&:hover,
 		&:focus,

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -31,6 +31,30 @@ $notice-success: #43af99;
 
 	.wpjm-button {
 		font-size: 13px;
+
+		text-decoration: underline;
+
+		// Keep the brand button colors over WP core's `div.notice a` styling.
+		&,
+		&:hover,
+		&:focus,
+		&:active {
+			color: #ffffff;
+		}
+
+		&.is-outline,
+		&.is-link {
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				color: var(--wpjm-brand-color-primary);
+			}
+		}
+
+		&.is-outline:active {
+			color: #1e1e1e;
+		}
 	}
 
 	.wp-core-ui &.is-dismissible {

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -50,10 +50,13 @@ $notice-success: #43af99;
 		&.is-link {
 			&,
 			&:hover,
-			&:focus,
-			&:active {
+			&:focus {
 				color: var(--wpjm-brand-color-primary);
 			}
+		}
+
+		&.is-link:active {
+			color: var(--wpjm-brand-color-primary);
 		}
 
 		&.is-outline:active {

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -37,7 +37,7 @@ $notice-success: #43af99;
 	// counters WP core's `div.notice a` styling and leaves the dismiss
 	// <button>'s `color: inherit` intact.
 	a.wpjm-button {
-		text-decoration: underline;
+		text-decoration: none;
 
 		&,
 		&:hover,


### PR DESCRIPTION
### Summary

Buttons in the Settings-page admin notices (e.g. **View Extensions**, **Manage Licenses**, **My Account**) rendered with dark blue text instead of the brand button colors, making the white-on-purple primary buttons hard to read.

These buttons are `<a class="wpjm-button">` elements inside WordPress admin notices (`div.notice.wpjm-admin-notice`). WP core styles notice links with:

```css
div.notice a       { color: var(--wp-admin-theme-color-darker-10); text-decoration: underline; }  /* 0,1,2 */
div.notice a:hover { color: var(--wp-admin-theme-color-darker-20); }                              /* 0,1,3 */
```

The brand component's `.wpjm-button { color:#fff }` (specificity 0,1,0) loses to those, so button label text inherited the unreadable link color.

Note: Dismiss button error handled on https://github.com/Automattic/WP-Job-Manager/pull/3036

### Fix

Reassert the brand button colors under `.wpjm-admin-notice .wpjm-button` (specificity 0,2,0 / 0,2,1 for `:hover`) so they beat `div.notice a`, keeping the reusable `wpjm-button` component context-free. This mirrors the existing `a:where(:not(.wpjm-button))` protection already in `admin-notices.scss`. Each variant keeps its correct color: primary → white, `is-outline`/`is-link` → brand purple, `is-outline:active` → near-black. 

The stray underline was also removed.

**Before**

<img width="3942" height="1888" alt="SCR-20260710-hqze" src="https://github.com/user-attachments/assets/6a95e062-0e5d-49d9-9128-e07780435d61" />



**After**

<img width="3118" height="1432" alt="SCR-20260710-lqeh" src="https://github.com/user-attachments/assets/de4b9edc-a54f-4fd9-942b-fe1b978ffecf" />


### Testing

Verified via Chrome DevTools against the live Settings page: computed button text color changed from `rgb(0,107,161)` to `#fff` for primary buttons and brand purple for the outline button; the underline is removed, matching the `wpjm-button` component.

Fixes #3028

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- wpjm:plugin-zip -->
----

| Plugin build for f2e2b212ab83c0cddadff99462165cd7dce912e9 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3029-f2e2b212.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3029-f2e2b212)             |

<!-- /wpjm:plugin-zip -->







