### PR TITLE
fix(datepicker): keep past expiry date visible when editing job

### DIFF
--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -4,9 +4,12 @@ jQuery(document).ready( function() {
 		jQuery.datepicker._defaults.dateFormat = 'MM d, yy';
 	}
 	var $date_today = new Date();
+	$date_today.setHours( 0, 0, 0, 0 );
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
-		minDate    : $date_today,
+		beforeShowDay : function( date ) {
+			return [ date >= $date_today, '' ];
+		},
 	};
 
 	if ( typeof job_manager_datepicker !== 'undefined' ) {


### PR DESCRIPTION
## Summary
When editing a job listing with a past "Listing Expiry Date", the datepicker was silently rewriting the field to today's date instead of showing the real past date. This happened because `setDate()` clamps any date earlier than `minDate` up to `minDate` before writing it into the input, and `minDate` was set to today.

Fixes #2855

## Changes
### assets/js/datepicker.js
**Before:**
```js
var $date_today = new Date();
var datePickerOptions = {
	altFormat  : 'yy-mm-dd',
	minDate    : $date_today,
};
```
**After:**
```js
var $date_today = new Date();
$date_today.setHours( 0, 0, 0, 0 );
var datePickerOptions = {
	altFormat  : 'yy-mm-dd',
	beforeShowDay : function( date ) {
		return [ date >= $date_today, '' ];
	},
};
```
**Why:** `beforeShowDay` only controls which calendar days render as selectable, it is not consulted by `setDate()`'s min/max clamping. Swapping to it keeps the "no past dates selectable" restriction while letting an already-stored past date display correctly. Normalizing `$date_today` to midnight keeps today itself selectable at any time of day, since calendar day cells are always midnight-normalized internally.

## Testing
**Test 1: Editing a job with a past expiry date**
1. Set a job's `_job_expires` meta to a past date (e.g. `wp post meta update <id> _job_expires 2024-01-01`).
2. Open the job for editing in wp-admin.
Result: "Listing Expiry Date" shows the real past date instead of today.

**Test 2: Calendar still blocks past date selection**
1. On the same field, click to open the calendar popup.
Result: past days (including the currently set one) render disabled, today and future days are selectable.

**Test 3: New job listing, no regression**
1. Create a new job listing with an empty expiry field.
Result: calendar opens on today, past days disabled, picking a date works normally.

Tested manually on WordPress 6.4+, PHP 7.4+.