### PR TITLE
Enable Mark Filled for Expired Listings

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -222,6 +222,16 @@ class WP_Job_Manager_Settings {
 							'track'      => 'bool',
 						],
 						[
+							'name'       => 'job_manager_enable_filled_expired',
+							'std'        => '0',
+							'label'      => __( 'Filled Expired Listings', 'wp-job-manager' ),
+							'cb_label'   => __( 'Allow marking expired listings as filled', 'wp-job-manager' ),
+							'desc'       => __( 'If enabled, employers can mark an expired job listing as filled from their job dashboard.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+							'track'      => 'bool',
+						],
+						[
 							'name'       => 'job_manager_enable_categories',
 							'std'        => '0',
 							'label'      => __( 'Categories', 'wp-job-manager' ),

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -209,17 +209,7 @@ class Job_Dashboard_Shortcode {
 						'nonce' => false,
 					];
 				}
-				if ( is_position_filled( $job ) ) {
-					$actions['mark_not_filled'] = [
-						'label' => __( 'Mark not filled', 'wp-job-manager' ),
-						'nonce' => $base_nonce_action_name,
-					];
-				} else {
-					$actions['mark_filled'] = [
-						'label' => __( 'Mark filled', 'wp-job-manager' ),
-						'nonce' => $base_nonce_action_name,
-					];
-				}
+				$this->add_filled_actions( $actions, $job, $base_nonce_action_name );
 				if (
 					get_option( 'job_manager_renewal_days' ) > 0
 					&& \WP_Job_Manager_Helper_Renewals::job_can_be_renewed( $job )
@@ -233,6 +223,9 @@ class Job_Dashboard_Shortcode {
 				}
 				break;
 			case 'expired':
+				if ( get_option( 'job_manager_enable_filled_expired' ) ) {
+					$this->add_filled_actions( $actions, $job, $base_nonce_action_name );
+				}
 				if ( job_manager_get_permalink( 'submit_job_form' ) ) {
 					$actions['relist'] = [
 						'label' => __( 'Relist', 'wp-job-manager' ),
@@ -301,6 +294,27 @@ class Job_Dashboard_Shortcode {
 		}
 
 		return $actions;
+	}
+
+	/**
+	 * Add the `mark_filled` or `mark_not_filled` action, depending on the job's current filled state.
+	 *
+	 * @param array    $actions                Actions to add to, by reference.
+	 * @param \WP_Post $job                    The job post object.
+	 * @param string   $base_nonce_action_name The nonce action name to use for the action.
+	 */
+	private function add_filled_actions( array &$actions, $job, $base_nonce_action_name ) {
+		if ( is_position_filled( $job ) ) {
+			$actions['mark_not_filled'] = [
+				'label' => __( 'Mark not filled', 'wp-job-manager' ),
+				'nonce' => $base_nonce_action_name,
+			];
+		} else {
+			$actions['mark_filled'] = [
+				'label' => __( 'Mark filled', 'wp-job-manager' ),
+				'nonce' => $base_nonce_action_name,
+			];
+		}
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
+++ b/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
@@ -83,4 +83,95 @@ class WP_Test_Job_Dashboard_Shortcode extends WPJM_BaseTest {
 
 		$this->assertArrayHasKey( 'mark_filled', $actions );
 	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::handle_actions
+	 * @runInSeparateProcess
+	 */
+	public function test_handle_actions_marks_expired_listing_filled_when_setting_enabled() {
+		update_option( 'job_manager_enable_filled_expired', '1' );
+
+		$job = get_post( $this->factory->job_listing->create( [
+			'post_status' => 'expired',
+			'post_author' => $this->user_id,
+			'meta_input'  => [ '_filled' => '0' ],
+		] ) );
+
+		$actions = \WP_Job_Manager\Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+		$nonce    = wp_create_nonce( $actions['mark_filled']['nonce'] );
+
+		add_filter( 'job_manager_should_run_shortcode_action_handler', '__return_true' );
+
+		$_REQUEST = [
+			'action'   => 'mark_filled',
+			'job_id'   => $job->ID,
+			'_wpnonce' => $nonce,
+		];
+
+		// Intercept the exit inside Redirect_Message::redirect so assertions run.
+		register_shutdown_function( function () use ( $job ) {
+			$this->assertSame( 1, (int) get_post_meta( $job->ID, '_filled', true ) );
+		} );
+
+		\WP_Job_Manager\Job_Dashboard_Shortcode::instance()->handle_actions();
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::handle_actions
+	 * @runInSeparateProcess
+	 */
+	public function test_handle_actions_refuses_mark_filled_on_non_owner_expired_listing() {
+		$other_user_id = $this->factory->user->create();
+		$job           = get_post( $this->factory->job_listing->create( [
+			'post_status' => 'expired',
+			'post_author' => $other_user_id,
+			'meta_input'  => [ '_filled' => '0' ],
+		] ) );
+
+		$actions = \WP_Job_Manager\Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+		// Non-owner cannot manage job, so get_job_actions() returns [] — use nonce action name directly.
+		$nonce = wp_create_nonce( 'job_manager_my_job_actions' );
+
+		add_filter( 'job_manager_should_run_shortcode_action_handler', '__return_true' );
+
+		$_REQUEST = [
+			'action'   => 'mark_filled',
+			'job_id'   => $job->ID,
+			'_wpnonce' => $nonce,
+		];
+
+		register_shutdown_function( function () use ( $job ) {
+			$this->assertSame( '0', get_post_meta( $job->ID, '_filled', true ) );
+		} );
+
+		\WP_Job_Manager\Job_Dashboard_Shortcode::instance()->handle_actions();
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::handle_actions
+	 * @runInSeparateProcess
+	 */
+	public function test_handle_actions_refuses_invalid_nonce_on_expired_listing() {
+		update_option( 'job_manager_enable_filled_expired', '1' );
+
+		$job = get_post( $this->factory->job_listing->create( [
+			'post_status' => 'expired',
+			'post_author' => $this->user_id,
+			'meta_input'  => [ '_filled' => '0' ],
+		] ) );
+
+		$_REQUEST = [
+			'action'   => 'mark_filled',
+			'job_id'   => $job->ID,
+			'_wpnonce' => 'bad-nonce',
+		];
+
+		add_filter( 'job_manager_should_run_shortcode_action_handler', '__return_true' );
+
+		register_shutdown_function( function () use ( $job ) {
+			$this->assertSame( '0', get_post_meta( $job->ID, '_filled', true ) );
+		} );
+
+		\WP_Job_Manager\Job_Dashboard_Shortcode::instance()->handle_actions();
+	}
 }

--- a/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
+++ b/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
@@ -1,0 +1,86 @@
+<?php
+
+class WP_Test_Job_Dashboard_Shortcode extends WPJM_BaseTest {
+
+	private $user_id;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->user_id = $this->factory->user->create();
+		wp_set_current_user( $this->user_id );
+	}
+
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		delete_option( 'job_manager_enable_filled_expired' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
+	 */
+	public function test_expired_listing_has_no_filled_action_by_default() {
+		$job = get_post( $this->factory->job_listing->create( [
+			'post_status' => 'expired',
+			'post_author' => $this->user_id,
+		] ) );
+
+		$actions = \WP_Job_Manager\Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$this->assertArrayNotHasKey( 'mark_filled', $actions );
+		$this->assertArrayNotHasKey( 'mark_not_filled', $actions );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
+	 */
+	public function test_expired_listing_offers_mark_filled_when_setting_enabled() {
+		update_option( 'job_manager_enable_filled_expired', '1' );
+
+		$job = get_post( $this->factory->job_listing->create( [
+			'post_status' => 'expired',
+			'post_author' => $this->user_id,
+			'meta_input'  => [ '_filled' => '0' ],
+		] ) );
+
+		$actions = \WP_Job_Manager\Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$this->assertArrayHasKey( 'mark_filled', $actions );
+		$this->assertArrayNotHasKey( 'mark_not_filled', $actions );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
+	 */
+	public function test_expired_filled_listing_offers_mark_not_filled_when_setting_enabled() {
+		update_option( 'job_manager_enable_filled_expired', '1' );
+
+		$job = get_post( $this->factory->job_listing->create( [
+			'post_status' => 'expired',
+			'post_author' => $this->user_id,
+			'meta_input'  => [ '_filled' => '1' ],
+		] ) );
+
+		$actions = \WP_Job_Manager\Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$this->assertArrayHasKey( 'mark_not_filled', $actions );
+		$this->assertArrayNotHasKey( 'mark_filled', $actions );
+	}
+
+	/**
+	 * @covers \WP_Job_Manager\Job_Dashboard_Shortcode::get_job_actions
+	 */
+	public function test_published_listing_offers_mark_filled_regardless_of_setting() {
+		update_option( 'job_manager_enable_filled_expired', '0' );
+
+		$job = get_post( $this->factory->job_listing->create( [
+			'post_status' => 'publish',
+			'post_author' => $this->user_id,
+			'meta_input'  => [ '_filled' => '0' ],
+		] ) );
+
+		$actions = \WP_Job_Manager\Job_Dashboard_Shortcode::instance()->get_job_actions( $job );
+
+		$this->assertArrayHasKey( 'mark_filled', $actions );
+	}
+}


### PR DESCRIPTION
Fixes #2859

### Changes Proposed in this Pull Request

* Add a new "Filled Expired Listings" checkbox setting under **Job Listings > Settings > Job Listings** (`job_manager_enable_filled_expired`), off by default.
* When enabled, the front-end job dashboard now offers "Mark filled" / "Mark not filled" on expired listings, the same as it already does for active listings. Previously the dashboard only offered "Relist" for expired listings, with no way to record that a position was filled before it expired.
* Extracted the mark filled/not filled action logic (previously only inline in the `publish` case of `get_job_actions()`) into a small private helper, `add_filled_actions()`, reused by both the `publish` case and the newly gated `expired` case, instead of duplicating the block.
* No changes needed to the action handler, `is_position_filled()`, admin bulk actions, or front-end templates — they already work regardless of post status; the restriction was only in which actions the dashboard offered.

### Testing Instructions

* In **Job Listings > Settings > Job Listings**, confirm "Filled Expired Listings" is present and unchecked by default. With it off, an expired listing's dashboard actions still only show Relist/Duplicate/Delete.
* Enable the setting, save. On the front-end **Job Dashboard**, an expired listing now shows "Mark filled". Click it, confirm success message and the action flips to "Mark not filled"; click again to confirm it flips back.
* With the listing marked filled, view the single job listing page as a visitor and confirm it shows "This position has been filled".
* Toggle the setting on/off and confirm a published (active) listing's actions are unaffected either way.
* Confirm the existing wp-admin bulk "Mark filled" action on expired listings still works as before (unrelated to this change, already worked).
* `npm run test-php` — full suite passes, including new tests in `tests/php/tests/includes/test_class.job-dashboard-shortcode.php` covering the setting on/off for both expired and published listings.
* `npm run lint:php` — clean.

### Release Notes

* Added a setting to allow marking expired job listings as filled from the employer's job dashboard.