### PR TITLE
fix: allow past dates in date-type form fields

### DIFF
--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -3,8 +3,13 @@ jQuery(document).ready( function() {
 	if ( jQuery.datepicker._defaults.dateFormat == '' ) {
 		jQuery.datepicker._defaults.dateFormat = 'MM d, yy';
 	}
+	var $date_today = new Date();
+	$date_today.setHours( 0, 0, 0, 0 );
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
+		beforeShowDay : function( date ) {
+			return [ date >= $date_today, '' ];
+		},
 	};
 
 	if ( typeof job_manager_datepicker !== 'undefined' ) {
@@ -14,11 +19,6 @@ jQuery(document).ready( function() {
 	var initializeDatepicker = function ( targetInput ) {
 		var $target = jQuery( targetInput );
 		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: $target.attr( 'name' ) } ).insertAfter( $target );
-		var options = jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } );
-
-		if ( $target.is( '#_job_expires' ) || $target.data( 'restrictPastDates' ) ) {
-			options.minDate = new Date();
-		}
 
 		$target.attr( 'name', $target.attr( 'name' ) + '-datepicker' );
 		$target.on( 'keyup', function() {
@@ -26,7 +26,7 @@ jQuery(document).ready( function() {
 				$hidden_input.val( '' );
 			}
 		} );
-		$target.datepicker( options );
+		$target.datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
 		if ( $target.val() ) {
 			var dateParts = $target.val().split('-');
 			if ( 3 === dateParts.length ) {

--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -3,10 +3,8 @@ jQuery(document).ready( function() {
 	if ( jQuery.datepicker._defaults.dateFormat == '' ) {
 		jQuery.datepicker._defaults.dateFormat = 'MM d, yy';
 	}
-	var $date_today = new Date();
 	var datePickerOptions = {
 		altFormat  : 'yy-mm-dd',
-		minDate    : $date_today,
 	};
 
 	if ( typeof job_manager_datepicker !== 'undefined' ) {
@@ -16,6 +14,11 @@ jQuery(document).ready( function() {
 	var initializeDatepicker = function ( targetInput ) {
 		var $target = jQuery( targetInput );
 		var $hidden_input = jQuery( '<input />', { type: 'hidden', name: $target.attr( 'name' ) } ).insertAfter( $target );
+		var options = jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } );
+
+		if ( $target.is( '#_job_expires' ) || $target.data( 'restrictPastDates' ) ) {
+			options.minDate = new Date();
+		}
 
 		$target.attr( 'name', $target.attr( 'name' ) + '-datepicker' );
 		$target.on( 'keyup', function() {
@@ -23,7 +26,7 @@ jQuery(document).ready( function() {
 				$hidden_input.val( '' );
 			}
 		} );
-		$target.datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
+		$target.datepicker( options );
 		if ( $target.val() ) {
 			var dateParts = $target.val().split('-');
 			if ( 3 === dateParts.length ) {

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -323,7 +323,7 @@ class WP_Job_Manager_Writepanels {
 				<span class="tips" data-tip="<?php echo esc_attr( $field['description'] ); ?>">[?]</span>
 			<?php endif; ?>
 			</label>
-			<input type="text" autocomplete="off" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $classes ); ?>" id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo esc_attr( $field['placeholder'] ); ?>" value="<?php echo esc_attr( $field['value'] ); ?>" />
+			<input type="text" autocomplete="off" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $classes ); ?>" id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo esc_attr( $field['placeholder'] ); ?>" value="<?php echo esc_attr( $field['value'] ); ?>" <?php echo ! empty( $field['restrict_past_dates'] ) ? 'data-restrict-past-dates="1"' : ''; ?> />
 		</p>
 		<?php
 	}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -394,12 +394,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		if ( get_option( 'job_manager_enable_scheduled_listings' ) ) {
 			$this->fields['job']['job_schedule_listing'] = [
-				'label'       => __( 'Scheduled Date', 'wp-job-manager' ),
-				'description' => __( 'Optionally set the date when this listing will be published.', 'wp-job-manager' ),
-				'type'        => 'date',
-				'required'    => false,
-				'placeholder' => '',
-				'priority'    => '6.5',
+				'label'               => __( 'Scheduled Date', 'wp-job-manager' ),
+				'description'         => __( 'Optionally set the date when this listing will be published.', 'wp-job-manager' ),
+				'type'                => 'date',
+				'required'            => false,
+				'placeholder'         => '',
+				'priority'            => '6.5',
+				'restrict_past_dates' => true,
 			];
 		}
 

--- a/templates/form-fields/date-field.php
+++ b/templates/form-fields/date-field.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     2.4.6
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/form-fields/date-field.php
+++ b/templates/form-fields/date-field.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.31.1
+ * @version     2.4.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,5 +19,5 @@ wp_enqueue_script( 'wp-job-manager-datepicker' );
 wp_enqueue_style( 'jquery-ui' );
 
 ?>
-<input type="text" class="input-date job-manager-datepicker" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>"<?php if ( isset( $field['autocomplete'] ) && false === $field['autocomplete'] ) { echo ' autocomplete="off"'; } ?> id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" value="<?php echo isset( $field['value'] ) ? esc_attr( $field['value'] ) : ''; ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
+<input type="text" class="input-date job-manager-datepicker" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>"<?php if ( isset( $field['autocomplete'] ) && false === $field['autocomplete'] ) { echo ' autocomplete="off"'; } ?> id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" value="<?php echo isset( $field['value'] ) ? esc_attr( $field['value'] ) : ''; ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> <?php if ( ! empty( $field['restrict_past_dates'] ) ) echo 'data-restrict-past-dates="1"'; ?> />
 <?php if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>


### PR DESCRIPTION
## Summary
Any custom date field on a job listing form (built via a `type => 'date'` field definition) was blocked from selecting a past date. The shared datepicker script applied a `minDate: today` restriction to every date input site-wide, even though only two fields actually need it: Listing Expiry Date and Scheduled Date.

Fixes #2858

## Changes
### assets/js/datepicker.js
**Before:**
```js
var $date_today = new Date();
var datePickerOptions = {
    altFormat  : 'yy-mm-dd',
    minDate    : $date_today,
};
...
$target.datepicker( jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } ) );
```
**After:**
```js
var datePickerOptions = {
    altFormat  : 'yy-mm-dd',
};
...
var options = jQuery.extend( {}, datePickerOptions, { altField: $hidden_input } );

if ( $target.is( '#_job_expires' ) || $target.data( 'restrictPastDates' ) ) {
    options.minDate = new Date();
}
...
$target.datepicker( options );
```
**Why:** moves the `minDate` restriction from a global default to an opt-in, applied only to `_job_expires` (existing id-based selector) or a field that explicitly asks for it via a data attribute.

### templates/form-fields/date-field.php
Added `data-restrict-past-dates="1"` output when `$field['restrict_past_dates']` is set, so a field definition can opt back into the future-only restriction.

### includes/forms/class-wp-job-manager-form-submit-job.php
Added `'restrict_past_dates' => true` to the `job_schedule_listing` (Scheduled Date) field definition, to keep its existing future-only behavior unchanged.

## Testing
**Test 1: custom date field allows past dates**
1. Register a custom `type => 'date'` field via `submit_job_form_fields`.
2. Open the frontend job submission form and click the field's datepicker.
Result: past dates are selectable.

**Test 2: Listing Expiry Date still blocks past dates**
1. Edit a job listing in wp-admin, open the Listing Expiry Date datepicker.
Result: past dates still greyed out, unchanged.

**Test 3: Scheduled Date still blocks past dates**
1. Enable scheduled listings, open the Scheduled Date field on the frontend submission form.
Result: past dates still greyed out, unchanged.