### PR TITLE
Add company LinkedIn link

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -363,6 +363,12 @@ div.job_listings {
 			content: "\e80a";
 		}
 
+		.company_linkedin::before {
+
+			@include display-icon();
+			content: "\e80b";
+		}
+
 		.company_header {
 			margin: 0 0 1em;
 			min-height: 60px;

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -194,6 +194,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'_company_website',
 		'_company_tagline',
 		'_company_twitter',
+		'_company_linkedin',
 		'_company_video',
 	];
 

--- a/includes/class-wp-job-manager-data-exporter.php
+++ b/includes/class-wp-job-manager-data-exporter.php
@@ -48,12 +48,13 @@ class WP_Job_Manager_Data_Exporter {
 
 		$user_data_to_export = [];
 		$user_meta_keys      = [
-			'_company_logo'    => __( 'Company Logo', 'wp-job-manager' ),
-			'_company_name'    => __( 'Company Name', 'wp-job-manager' ),
-			'_company_website' => __( 'Company Website', 'wp-job-manager' ),
-			'_company_tagline' => __( 'Company Tagline', 'wp-job-manager' ),
-			'_company_twitter' => __( 'Company X / Twitter', 'wp-job-manager' ),
-			'_company_video'   => __( 'Company Video', 'wp-job-manager' ),
+			'_company_logo'     => __( 'Company Logo', 'wp-job-manager' ),
+			'_company_name'     => __( 'Company Name', 'wp-job-manager' ),
+			'_company_website'  => __( 'Company Website', 'wp-job-manager' ),
+			'_company_tagline'  => __( 'Company Tagline', 'wp-job-manager' ),
+			'_company_twitter'  => __( 'Company X / Twitter', 'wp-job-manager' ),
+			'_company_linkedin' => __( 'Company LinkedIn', 'wp-job-manager' ),
+			'_company_video'    => __( 'Company Video', 'wp-job-manager' ),
 		];
 
 		foreach ( $user_meta_keys as $user_meta_key => $name ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1965,6 +1965,15 @@ class WP_Job_Manager_Post_Types {
 				'show_in_admin' => true,
 				'show_in_rest'  => true,
 			],
+			'_company_linkedin'    => [
+				'label'             => __( 'Company LinkedIn', 'wp-job-manager' ),
+				'placeholder'       => 'https://www.linkedin.com/company/yourcompany',
+				'priority'          => 7,
+				'data_type'         => 'string',
+				'show_in_admin'     => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => [ __CLASS__, 'sanitize_meta_field_url' ],
+			],
 			'_company_video'       => [
 				'label'             => __( 'Company Video', 'wp-job-manager' ),
 				'placeholder'       => __( 'URL to the company video', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-usage-tracking-data.php
+++ b/includes/class-wp-job-manager-usage-tracking-data.php
@@ -50,6 +50,7 @@ class WP_Job_Manager_Usage_Tracking_Data {
 			'jobs_company_site'           => self::get_jobs_count_with_meta( '_company_website' ),
 			'jobs_company_tagline'        => self::get_jobs_count_with_meta( '_company_tagline' ),
 			'jobs_company_twitter'        => self::get_jobs_count_with_meta( '_company_twitter' ),
+			'jobs_company_linkedin'       => self::get_jobs_count_with_meta( '_company_linkedin' ),
 			'jobs_company_video'          => self::get_jobs_count_with_meta( '_company_video' ),
 			'jobs_expiry'                 => self::get_jobs_count_with_meta( '_job_expires' ),
 			'jobs_featured'               => self::get_jobs_count_with_checked_meta( '_featured' ),

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -309,14 +309,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					],
 				],
 				'company' => [
-					'company_name'    => [
+					'company_name'     => [
 						'label'       => __( 'Company name', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => true,
 						'placeholder' => __( 'Enter the name of the company', 'wp-job-manager' ),
 						'priority'    => 1,
 					],
-					'company_website' => [
+					'company_website'  => [
 						'label'       => __( 'Website', 'wp-job-manager' ),
 						'type'        => 'text',
 						'sanitizer'   => 'url',
@@ -324,7 +324,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'http://', 'wp-job-manager' ),
 						'priority'    => 2,
 					],
-					'company_tagline' => [
+					'company_tagline'  => [
 						'label'       => __( 'Tagline', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
@@ -332,7 +332,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'maxlength'   => 64,
 						'priority'    => 3,
 					],
-					'company_video'   => [
+					'company_video'    => [
 						'label'       => __( 'Video', 'wp-job-manager' ),
 						'type'        => 'text',
 						'sanitizer'   => 'url',
@@ -340,19 +340,27 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'A link to a video about your company', 'wp-job-manager' ),
 						'priority'    => 4,
 					],
-					'company_twitter' => [
+					'company_twitter'  => [
 						'label'       => __( 'X / Twitter username', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
 						'placeholder' => __( '@yourcompany', 'wp-job-manager' ),
 						'priority'    => 5,
 					],
-					'company_logo'    => [
+					'company_linkedin' => [
+						'label'       => __( 'LinkedIn', 'wp-job-manager' ),
+						'type'        => 'text',
+						'sanitizer'   => 'url',
+						'required'    => false,
+						'placeholder' => __( 'https://www.linkedin.com/company/yourcompany', 'wp-job-manager' ),
+						'priority'    => 6,
+					],
+					'company_logo'     => [
 						'label'              => __( 'Logo', 'wp-job-manager' ),
 						'type'               => 'file',
 						'required'           => false,
 						'placeholder'        => '',
-						'priority'           => 6,
+						'priority'           => 7,
 						'ajax'               => true,
 						'multiple'           => false,
 						'description'        => __( 'Square format recommended (1:1 ratio).', 'wp-job-manager' ),
@@ -1161,6 +1169,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			update_user_meta( get_current_user_id(), '_company_website', isset( $values['company']['company_website'] ) ? $values['company']['company_website'] : '' );
 			update_user_meta( get_current_user_id(), '_company_tagline', isset( $values['company']['company_tagline'] ) ? $values['company']['company_tagline'] : '' );
 			update_user_meta( get_current_user_id(), '_company_twitter', isset( $values['company']['company_twitter'] ) ? $values['company']['company_twitter'] : '' );
+			update_user_meta( get_current_user_id(), '_company_linkedin', isset( $values['company']['company_linkedin'] ) ? $values['company']['company_linkedin'] : '' );
 			update_user_meta( get_current_user_id(), '_company_video', isset( $values['company']['company_video'] ) ? $values['company']['company_video'] : '' );
 		}
 

--- a/templates/content-single-job_listing-company.php
+++ b/templates/content-single-job_listing-company.php
@@ -31,6 +31,7 @@ if ( ! get_the_company_name() ) {
 				<a class="website" href="<?php echo esc_url( $website ); ?>" rel="nofollow"><?php esc_html_e( 'Website', 'wp-job-manager' ); ?></a>
 			<?php endif; ?>
 			<?php the_company_twitter(); ?>
+			<?php the_company_linkedin(); ?>
 			<?php the_company_name( '<strong>', '</strong>' ); ?>
 		</p>
 		<?php the_company_tagline( '<p class="tagline">', '</p>' ); ?>

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -14,6 +14,7 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 			'_company_tagline' => new WP_UnitTest_Generator_Sequence( 'Job Listing company tagline %s' ),
 			'_company_video'   => '',
 			'_company_twitter' => '',
+			'_company_linkedin' => '',
 			'_company_logo'    => '',
 			'_filled'          => '0',
 			'_featured'        => '0',

--- a/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
+++ b/tests/php/includes/factories/class-wp-unittest-factory-for-job-listing.php
@@ -6,18 +6,18 @@ class WP_UnitTest_Factory_For_Job_Listing extends WP_UnitTest_Factory_For_Post {
 	function __construct( $factory = null ) {
 		parent::__construct( $factory );
 		$this->default_job_listing_meta       = [
-			'_job_location'    => '',
-			'_job_type'        => 'full-time',
-			'_application'     => 'test@example.com',
-			'_company_name'    => new WP_UnitTest_Generator_Sequence( 'Job Listing company name %s' ),
-			'_company_website' => new WP_UnitTest_Generator_Sequence( 'Job Listing company website %s' ),
-			'_company_tagline' => new WP_UnitTest_Generator_Sequence( 'Job Listing company tagline %s' ),
-			'_company_video'   => '',
-			'_company_twitter' => '',
+			'_job_location'     => '',
+			'_job_type'         => 'full-time',
+			'_application'      => 'test@example.com',
+			'_company_name'     => new WP_UnitTest_Generator_Sequence( 'Job Listing company name %s' ),
+			'_company_website'  => new WP_UnitTest_Generator_Sequence( 'Job Listing company website %s' ),
+			'_company_tagline'  => new WP_UnitTest_Generator_Sequence( 'Job Listing company tagline %s' ),
+			'_company_video'    => '',
+			'_company_twitter'  => '',
 			'_company_linkedin' => '',
-			'_company_logo'    => '',
-			'_filled'          => '0',
-			'_featured'        => '0',
+			'_company_logo'     => '',
+			'_filled'           => '0',
+			'_featured'         => '0',
 		];
 		$this->default_generation_definitions = [
 			'post_status'  => 'publish',

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
@@ -212,17 +212,17 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 
 		$_POST                     = [];
 		$_POST['_job_expires']     = $job->_job_expires;
-		$_POST['_job_location']    = $job->_job_location;
-		$_POST['_job_author']      = $job->_job_author;
-		$_POST['_application']     = $job->_application;
-		$_POST['_company_name']    = $job->_company_name;
-		$_POST['_company_website'] = $job->_company_website;
-		$_POST['_company_tagline'] = $job->_company_tagline;
-		$_POST['_company_twitter'] = $job->_company_twitter;
+		$_POST['_job_location']     = $job->_job_location;
+		$_POST['_job_author']       = $job->_job_author;
+		$_POST['_application']      = $job->_application;
+		$_POST['_company_name']     = $job->_company_name;
+		$_POST['_company_website']  = $job->_company_website;
+		$_POST['_company_tagline']  = $job->_company_tagline;
+		$_POST['_company_twitter']  = $job->_company_twitter;
 		$_POST['_company_linkedin'] = $job->_company_linkedin;
-		$_POST['_company_video']   = $job->_company_video;
-		$_POST['_filled']          = $job->_filled;
-		$_POST['_featured']        = $job->_featured;
+		$_POST['_company_video']    = $job->_company_video;
+		$_POST['_filled']           = $job->_filled;
+		$_POST['_featured']         = $job->_featured;
 
 		$_POST['post_status']          = 'publish';
 		$_POST['original_post_status'] = $job->post_status;

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
@@ -219,6 +219,7 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 		$_POST['_company_website'] = $job->_company_website;
 		$_POST['_company_tagline'] = $job->_company_tagline;
 		$_POST['_company_twitter'] = $job->_company_twitter;
+		$_POST['_company_linkedin'] = $job->_company_linkedin;
 		$_POST['_company_video']   = $job->_company_video;
 		$_POST['_filled']          = $job->_filled;
 		$_POST['_featured']        = $job->_featured;

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -171,7 +171,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	 * Tests to make sure public meta fields are exposed to guest users and private meta fields are hidden.
 	 */
 	public function test_guest_can_read_only_public_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_linkedin', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
 		$private_fields = [ '_job_expires' ];
 		$this->logout();
 		$post_id = $this->get_job_listing();
@@ -192,7 +192,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_same_employer_read_access_to_private_meta_fields() {
-		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
+		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_linkedin', '_company_video', '_filled', '_featured',  '_job_expires', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();
 
@@ -207,7 +207,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_different_employer_read_access_to_private_meta_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit' ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_linkedin', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit' ];
 		$private_fields = [ '_job_expires' ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();
@@ -249,6 +249,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 			'_company_website' => 'https://www.example.com/awesome#nice',
 			'_company_tagline' => 'Best Example Money Can Buy',
 			'_company_twitter' => '@exampledotcom',
+			'_company_linkedin' => 'https://www.linkedin.com/company/example',
 			'_company_video'   => 'https://youtube.com/example',
 			'_filled'          => 0,
 			'_featured'        => 0,
@@ -331,6 +332,10 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 			'_company_twitter' => [
 				'sent'     => '    @exampledotcom ',
 				'expected' => '@exampledotcom',
+			],
+			'_company_linkedin' => [
+				'sent'     => 'http://example.com/index.php?search="><script>alert(0)</script>',
+				'expected' => 'http://example.com/index.php?search=scriptalert(0)/script',
 			],
 			'_company_video'   => [
 				'sent'     => 'http://example.com/index.php?search="><script>alert(0)</script>',

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-cleaner.php
@@ -506,6 +506,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 			'company_website',
 			'company_tagline',
 			'company_twitter',
+			'company_linkedin',
 			'company_video',
 		];
 
@@ -515,6 +516,7 @@ class WP_Job_Manager_Data_Cleaner_Test extends WP_UnitTestCase {
 			'_company_website',
 			'_company_tagline',
 			'_company_twitter',
+			'_company_linkedin',
 			'_company_video',
 		];
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-data-exporter.php
@@ -105,6 +105,7 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 					'_company_website' => 'https://example.com/',
 					'_company_tagline' => 'Just another tagline',
 					'_company_twitter' => 'https://x.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
+					'_company_linkedin' => 'https://www.linkedin.com/company/example',
 					'_company_video'   => 'https://example.com/company/video',
 				],
 				[
@@ -133,6 +134,10 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 								[
 									'name'  => 'Company X / Twitter',
 									'value' => 'https://x.com/example?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor',
+								],
+								[
+									'name'  => 'Company LinkedIn',
+									'value' => 'https://www.linkedin.com/company/example',
 								],
 								[
 									'name'  => 'Company Video',
@@ -181,6 +186,7 @@ class WP_Job_Manager_Data_Exporter_Test extends WPJM_BaseTest {
 					'_company_website',
 					'_company_tagline',
 					'_company_twitter',
+					'_company_linkedin',
 					'_company_video',
 				],
 				[

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -587,6 +587,23 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 
 	/**
 	 * Tests that get_usage_data() returns the correct number of job listings
+	 * with a company LinkedIn link.
+	 *
+	 * @since 2.4.6
+	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
+	 */
+	public function test_jobs_company_linkedin() {
+		$published = 3;
+		$expired   = 2;
+
+		$this->create_job_listings_with_meta( '_company_linkedin', 'https://www.linkedin.com/company/automattic', $published, $expired );
+
+		$data = WP_Job_Manager_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( $published + $expired, $data['jobs_company_linkedin'] );
+	}
+
+	/**
+	 * Tests that get_usage_data() returns the correct number of job listings
 	 * with a company video.
 	 *
 	 * @since 1.30.0

--- a/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-usage-tracking-data.php
@@ -589,7 +589,7 @@ class WP_Test_WP_Job_Manager_Usage_Tracking_Data extends WPJM_BaseTest {
 	 * Tests that get_usage_data() returns the correct number of job listings
 	 * with a company LinkedIn link.
 	 *
-	 * @since 2.4.6
+	 * @since $$next-version$$
 	 * @covers WP_Job_Manager_Usage_Tracking_Data::get_usage_data
 	 */
 	public function test_jobs_company_linkedin() {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -406,6 +406,7 @@ if ( ! function_exists( 'get_job_listings_keyword_search' ) ) :
 					'_company_tagline',
 					'_company_website',
 					'_company_twitter',
+					'_company_linkedin',
 					'_job_location',
 				];
 

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1201,7 +1201,7 @@ function get_the_company_twitter( $post = null ) {
 /**
  * Displays or retrieves the current company LinkedIn link with optional content.
  *
- * @since 2.4.6
+ * @since $$next-version$$
  * @param string           $before (default: '').
  * @param string           $after (default: '').
  * @param bool             $echo (default: true).
@@ -1215,7 +1215,7 @@ function the_company_linkedin( $before = '', $after = '', $echo = true, $post = 
 		return null;
 	}
 
-	$company_linkedin = $before . '<a href="' . esc_url( $company_linkedin ) . '" class="company_linkedin">' . esc_html__( 'LinkedIn', 'wp-job-manager' ) . '</a>' . $after;
+	$company_linkedin = $before . '<a href="' . esc_url( $company_linkedin ) . '" class="company_linkedin" rel="nofollow">' . esc_html__( 'LinkedIn', 'wp-job-manager' ) . '</a>' . $after;
 
 	if ( $echo ) {
 		echo wp_kses_post( $company_linkedin );
@@ -1227,7 +1227,7 @@ function the_company_linkedin( $before = '', $after = '', $echo = true, $post = 
 /**
  * Gets the company LinkedIn link.
  *
- * @since 2.4.6
+ * @since $$next-version$$
  * @param int|WP_Post|null $post (default: null).
  * @return string|null
  */

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -1199,6 +1199,54 @@ function get_the_company_twitter( $post = null ) {
 }
 
 /**
+ * Displays or retrieves the current company LinkedIn link with optional content.
+ *
+ * @since 2.4.6
+ * @param string           $before (default: '').
+ * @param string           $after (default: '').
+ * @param bool             $echo (default: true).
+ * @param int|WP_Post|null $post (default: null).
+ * @return string|null
+ */
+function the_company_linkedin( $before = '', $after = '', $echo = true, $post = null ) {
+	$company_linkedin = get_the_company_linkedin( $post );
+
+	if ( empty( $company_linkedin ) ) {
+		return null;
+	}
+
+	$company_linkedin = $before . '<a href="' . esc_url( $company_linkedin ) . '" class="company_linkedin">' . esc_html__( 'LinkedIn', 'wp-job-manager' ) . '</a>' . $after;
+
+	if ( $echo ) {
+		echo wp_kses_post( $company_linkedin );
+	} else {
+		return $company_linkedin;
+	}
+}
+
+/**
+ * Gets the company LinkedIn link.
+ *
+ * @since 2.4.6
+ * @param int|WP_Post|null $post (default: null).
+ * @return string|null
+ */
+function get_the_company_linkedin( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
+		return null;
+	}
+
+	$company_linkedin = $post->_company_linkedin;
+
+	if ( empty( $company_linkedin ) ) {
+		return null;
+	}
+
+	return apply_filters( 'the_company_linkedin', $company_linkedin, $post );
+}
+
+/**
  * Outputs the job listing class.
  *
  * @since 1.0.0

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -16,6 +16,7 @@
     <custom-field action="translate">_company_website</custom-field>
     <custom-field action="translate">_company_tagline</custom-field>
     <custom-field action="copy">_company_twitter</custom-field>
+    <custom-field action="translate">_company_linkedin</custom-field>
     <custom-field action="translate">_company_video</custom-field>
   </custom-fields>
 </wpml-config>


### PR DESCRIPTION
Fixes #2857

### Changes Proposed in this Pull Request

* Added a `_company_linkedin` field for job listings, following the same pattern as the existing Company Website and Company X/Twitter fields.
* The single job listing page now shows a LinkedIn icon in the top bar, next to the Website and X/Twitter icons, when a LinkedIn URL is set.
* The field is available in the admin edit screen, the frontend job submission form, and the REST API.
* Wired the new field into data export, data cleanup on uninstall, usage tracking, search, and the WPML config, matching how the other company fields are handled.

### Testing Instructions

* Edit or create a job listing in wp-admin and fill in the new Company LinkedIn field with a URL, along with Company Website and Company X / Twitter.
* View the listing on the frontend and confirm all three icons show in the top bar (Website, X/Twitter, LinkedIn), each linking to the value entered.
* Clear the LinkedIn field and confirm the icon disappears, same as it does for an empty Website field.
* Submit a job via the `[submit_job_form]` shortcode on the frontend, filling in the new LinkedIn field, and confirm it saves and displays correctly.
* As a logged in user, submit a second job and confirm the LinkedIn field is pre-filled from the previous submission.
* `GET /wp-json/wp/v2/job-listings/<id>` for a listing with a LinkedIn value set and confirm `meta._company_linkedin` is present.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Added a way to link to your company's LinkedIn page from job listings.

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* Added `the_company_linkedin` filter, applied to the company LinkedIn URL before it's returned by `get_the_company_linkedin()`. Mirrors the existing `the_company_twitter` and `the_company_website` filters.