### PR TITLE
Fix notice dismiss button colliding with core styles

### DIFF
--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -109,7 +109,8 @@ $notice-success: #43af99;
 
 		// Override WordPress core's `.notice-dismiss { width: 24px; height: 24px; }`,
 		// which would otherwise squeeze the 24px icon into the padded box (see #3034).
-		width: 36px;
+		box-sizing: border-box;
+		width: 36px; // 24px icon + 6px padding each side.
 		height: 36px;
 
 		&::before {

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -107,12 +107,18 @@ $notice-success: #43af99;
 		color: inherit;
 		position: static;
 
+		// Override WordPress core's `.notice-dismiss { width: 24px; height: 24px; }`,
+		// which would otherwise squeeze the 24px icon into the padded box (see #3034).
+		width: 36px;
+		height: 36px;
+
 		&::before {
 			color: inherit;
 			content: '';
 			background-color: currentColor;
 			mask-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'24\' height=\'24\' fill=\'none\' viewBox=\'0 0 24 24\'%3e%3cpath fill=\'%23FFFFFF\' fill-rule=\'evenodd\' d=\'m12 13.06 3.71 3.71 1.06-1.06-3.7-3.71 3.7-3.71-1.06-1.06-3.71 3.7-3.71-3.7-1.06 1.06 3.7 3.71-3.7 3.71 1.06 1.06 3.71-3.7Z\' clip-rule=\'evenodd\'/%3e%3c/svg%3e');
 
+			flex-shrink: 0;
 			width: 24px;
 			height: 24px;
 		}

--- a/assets/css/admin-notices.scss
+++ b/assets/css/admin-notices.scss
@@ -107,8 +107,7 @@ $notice-success: #43af99;
 		color: inherit;
 		position: static;
 
-		// Override WordPress core's `.notice-dismiss { width: 24px; height: 24px; }`,
-		// which would otherwise squeeze the 24px icon into the padded box (see #3034).
+		// Override core's `.notice-dismiss` fixed size so the 24px icon isn't squeezed (#3034).
 		box-sizing: border-box;
 		width: 36px; // 24px icon + 6px padding each side.
 		height: 36px;


### PR DESCRIPTION
## Summary

The dismiss (✕) button on WP Job Manager admin notices was rendering as a thin vertical sliver instead of a proper close icon.

## Root cause

CSS collision with WordPress core. Core defines:

```css
.notice-dismiss { width: 24px; height: 24px; }
```

The plugin's `.wpjm-admin-notice button.wpjm-notice-dismiss--icon` rule styled `padding`, `color`, and `position` but never set the button's own `width`/`height`, so core's `24px × 24px` leaked through. Because the button is `box-sizing: border-box` with `6px` padding, that left only a `12px` content box. The button is a flexbox, so the `24px`-wide `::before` icon (a shrinkable flex item) got squeezed down to a ~10px sliver.

## Fix

In `assets/css/admin-notices.scss`, on `button.wpjm-notice-dismiss--icon`:

- Set the button to `36px × 36px` (24px icon + 2×6px padding) to override core's dimensions.
- Pin `box-sizing: border-box` so the 36px sizing is correct regardless of inherited box-sizing.
- Add `flex-shrink: 0` to the `::before` icon so it can never be compressed again.

**Before**

<img width="3864" height="1348" alt="SCR-20260710-ksyf" src="https://github.com/user-attachments/assets/92e6bf03-19c2-4723-9f8b-1914529d8f76" />

**After**

<img width="3550" height="1838" alt="SCR-20260710-lept" src="https://github.com/user-attachments/assets/baa53826-5ba0-43df-be8e-8bd2561b5e42" />



## Testing

Verified in Chrome on a test site (WP 7.0.1): both the "Did you know?" and "Licenses required" notices now render a proper ✕ dismiss icon (button `36×36`, icon `24×24`), correctly centered.

Fixes #3034

🤖 Generated with [Claude Code](https://claude.com/claude-code)
