### PR TITLE
Log search keywords and filters used on jobs page

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -132,7 +132,7 @@ class WP_Job_Manager_Settings {
 							'std'        => '0',
 							'label'      => __( 'Job Statistics', 'wp-job-manager' ),
 							'cb_label'   => __( 'Enable job statistics', 'wp-job-manager' ),
-							'desc'       => __( 'Collect anonymous visitor data about job listings (page views, search impressions), and show them in the job dashboard.', 'wp-job-manager' ),
+							'desc'       => __( 'Collect anonymous visitor data about job listings (page views, search impressions, and search terms/filters used on the [jobs] shortcode), and show them in the job dashboard. Search terms are normalized (lowercased, trimmed) before storage and pruned after 90 days.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
 							'track'      => 'bool',

--- a/includes/class-search-stats.php
+++ b/includes/class-search-stats.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Log the search filters used on the `[jobs]` shortcode.
  *
- * @since 2.4.0
+ * @since $$next-version$$
  */
 class Search_Stats {
 	use Singleton;
@@ -39,13 +39,38 @@ class Search_Stats {
 	 */
 	const FILTER_JOB_TYPE = 'job_type';
 
+	/**
+	 * Cron hook for daily pruning of old search stats rows.
+	 */
+	const CRON_HOOK = 'job_manager_prune_search_stats';
+
 	private const TABLE = 'wpjm_search_stats';
+
+	/**
+	 * Number of days to retain search stats rows.
+	 */
+	const RETENTION_DAYS = 90;
+
+	/**
+	 * Per-IP rate-limit window (seconds) for log_search().
+	 */
+	private const RATE_LIMIT_SECONDS = 2;
 
 	/**
 	 * Constructor.
 	 */
 	private function __construct() {
 		$this->init_wpdb_alias();
+		$this->init_cron();
+	}
+
+	/**
+	 * Register the pruning cron hook.
+	 *
+	 * @return void
+	 */
+	private function init_cron() {
+		add_action( self::CRON_HOOK, [ $this, 'prune' ] );
 	}
 
 	/**
@@ -94,7 +119,7 @@ class Search_Stats {
 	 * row per selected value rather than a joined string, since a comma-joined list
 	 * of every combination would be far less useful for aggregation.
 	 *
-	 * @since 2.4.0
+	 * @since $$next-version$$
 	 *
 	 * @param array $filters {
 	 * Filter name to value (or array of values) used in the search.
@@ -110,6 +135,10 @@ class Search_Stats {
 	public function log_search( array $filters ) {
 
 		if ( ! Stats::is_enabled() ) {
+			return false;
+		}
+
+		if ( $this->is_rate_limited() ) {
 			return false;
 		}
 
@@ -203,6 +232,10 @@ class Search_Stats {
 	/**
 	 * Get logged search stats.
 	 *
+	 * The returned rows include the raw `value` field, which is visitor-supplied
+	 * search text. Callers displaying these rows in the dashboard MUST escape with
+	 * `esc_html()` (and `esc_attr()` when used in attributes).
+	 *
 	 * @param string $filter Optional filter name to limit results to.
 	 * @param string $date   Optional date (YYYY-MM-DD) to limit results to.
 	 * @param int    $limit  Maximum number of rows to return.
@@ -233,5 +266,53 @@ class Search_Stats {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared above; admin-only aggregate read, matches Stats::get_stats().
 		return $wpdb->get_results( $query );
+	}
+
+	/**
+	 * Per-IP cooldown for log_search().
+	 *
+	 * Returns true once a given IP has logged in the last RATE_LIMIT_SECONDS.
+	 * Skipped in admin context so dashboard runs aren't blocked.
+	 *
+	 * @return bool
+	 */
+	private function is_rate_limited() {
+		if ( is_admin() && ! wp_doing_ajax() ) {
+			return false;
+		}
+
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		if ( '' === $ip ) {
+			return false;
+		}
+
+		$key   = 'wpjm_search_stats_rl_' . md5( $ip );
+		$stamp = get_transient( $key );
+		if ( false !== $stamp ) {
+			return true;
+		}
+
+		set_transient( $key, time(), self::RATE_LIMIT_SECONDS );
+		return false;
+	}
+
+	/**
+	 * Delete rows older than the retention window. Runs on the CRON_HOOK schedule.
+	 *
+	 * @return int Number of rows deleted.
+	 */
+	public function prune() {
+		global $wpdb;
+
+		$cutoff = gmdate( 'Y-m-d', time() - ( self::RETENTION_DAYS * DAY_IN_SECONDS ) );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $wpdb->wpjm_search_stats is the table alias.
+		$deleted = $wpdb->query(
+			$wpdb->prepare( "DELETE FROM {$wpdb->wpjm_search_stats} WHERE date < %s", $cutoff )
+		);
+		// phpcs:enable
+
+		return is_numeric( $deleted ) ? (int) $deleted : 0;
 	}
 }

--- a/includes/class-search-stats.php
+++ b/includes/class-search-stats.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * File containing the class WP_Job_Manager\Search_Stats
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Log the search filters used on the `[jobs]` shortcode.
+ *
+ * @since 2.4.0
+ */
+class Search_Stats {
+	use Singleton;
+
+	/**
+	 * Filter name for the search keyword.
+	 */
+	const FILTER_KEYWORD = 'keyword';
+
+	/**
+	 * Filter name for the search location.
+	 */
+	const FILTER_LOCATION = 'location';
+
+	/**
+	 * Filter name for the search category.
+	 */
+	const FILTER_CATEGORY = 'category';
+
+	/**
+	 * Filter name for the search job type.
+	 */
+	const FILTER_JOB_TYPE = 'job_type';
+
+	private const TABLE = 'wpjm_search_stats';
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->init_wpdb_alias();
+	}
+
+	/**
+	 * Initialize the alias for the search stats table on the wpdb object.
+	 *
+	 * @return void
+	 */
+	private function init_wpdb_alias() {
+		global $wpdb;
+		if ( isset( $wpdb->wpjm_search_stats ) ) {
+			return;
+		}
+		$wpdb->wpjm_search_stats = $wpdb->prefix . self::TABLE;
+		$wpdb->tables[]          = self::TABLE;
+	}
+
+	/**
+	 * Migrate the search stats table to the latest version.
+	 *
+	 * @return void
+	 */
+	public function migrate_db() {
+		global $wpdb;
+		$collate = $wpdb->get_charset_collate();
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		\dbDelta(
+			[
+				"CREATE TABLE {$wpdb->wpjm_search_stats} (
+				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				`date` date NOT NULL,
+				`filter` varchar(20) NOT NULL,
+				`value` varchar(191) NOT NULL,
+				`value_hash` char(32) NOT NULL,
+				`count` bigint(20) unsigned not null default 1,
+				PRIMARY KEY (`id`),
+				UNIQUE INDEX `idx_wpjm_search_stats_hash_date` (`value_hash`, `date`)
+			) {$collate}",
+			]
+		);
+	}
+
+	/**
+	 * Log the filter values used for a `[jobs]` search.
+	 *
+	 * A filter value that is an array (eg. `category`, `job_type`) is logged as one
+	 * row per selected value rather than a joined string, since a comma-joined list
+	 * of every combination would be far less useful for aggregation.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @param array $filters {
+	 * Filter name to value (or array of values) used in the search.
+	 *
+	 * @type string       $keyword  Search keyword.
+	 * @type string       $location Search location.
+	 * @type array|string $category Selected categories.
+	 * @type array|string $job_type Selected job types.
+	 * }
+	 *
+	 * @return bool
+	 */
+	public function log_search( array $filters ) {
+
+		if ( ! Stats::is_enabled() ) {
+			return false;
+		}
+
+		if ( isset( $filters[ self::FILTER_KEYWORD ] ) ) {
+			$filters[ self::FILTER_KEYWORD ] = $this->normalize_keyword( (string) $filters[ self::FILTER_KEYWORD ] );
+		}
+
+		$rows = [];
+		$seen = [];
+		foreach ( $filters as $filter => $values ) {
+			foreach ( (array) $values as $value ) {
+				$value = trim( (string) $value );
+				if ( '' === $value ) {
+					continue;
+				}
+				$dedup_key = $filter . '|' . $value;
+				if ( isset( $seen[ $dedup_key ] ) ) {
+					continue;
+				}
+				$seen[ $dedup_key ] = true;
+				$rows[]             = [
+					'filter' => $filter,
+					'value'  => $value,
+				];
+			}
+		}
+
+		if ( empty( $rows ) ) {
+			return false;
+		}
+
+		return $this->batch_log( $rows );
+	}
+
+	/**
+	 * Write a batch of search stat rows, incrementing the count on duplicates.
+	 *
+	 * @param array[] $rows {
+	 * Array of rows to log.
+	 *
+	 * @type string $filter The filter name.
+	 * @type string $value  The filter value.
+	 * }
+	 *
+	 * @return bool
+	 */
+	private function batch_log( array $rows ) {
+		global $wpdb;
+
+		$today  = gmdate( 'Y-m-d' );
+		$values = [];
+
+		foreach ( $rows as $row ) {
+			if ( strlen( $row['filter'] ) > 20 || strlen( $row['value'] ) > 191 ) {
+				continue;
+			}
+			$value_hash = md5( $row['filter'] . '|' . $row['value'] );
+			$values[]   = $wpdb->prepare( '(%s, %s, %s, %s, %d)', $today, $row['filter'], $row['value'], $value_hash, 1 );
+		}
+
+		if ( empty( $values ) ) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching,
+		$result = $wpdb->query(
+			"INSERT INTO {$wpdb->wpjm_search_stats} " .
+			'(`date`, `filter`, `value`, `value_hash`, `count` )' .
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			'VALUES ' . implode( ', ', $values ) .
+			'ON DUPLICATE KEY UPDATE `count` = `count` + VALUES(`count`)',
+		);
+		// phpcs:enable
+
+		return false !== $result;
+	}
+
+	/**
+	 * Normalize a search keyword before logging: lowercase, trim, and collapse
+	 * repeated whitespace so equivalent searches aggregate together.
+	 *
+	 * @param string $keyword The raw search keyword.
+	 *
+	 * @return string
+	 */
+	private function normalize_keyword( string $keyword ) {
+		$lower = function_exists( 'mb_strtolower' ) ? mb_strtolower( $keyword, 'UTF-8' ) : strtolower( $keyword );
+		return trim( preg_replace( '/\s+/', ' ', $lower ) );
+	}
+
+	/**
+	 * Get logged search stats.
+	 *
+	 * @param string $filter Optional filter name to limit results to.
+	 * @param string $date   Optional date (YYYY-MM-DD) to limit results to.
+	 * @param int    $limit  Maximum number of rows to return.
+	 *
+	 * @return array
+	 */
+	public function get_stats( $filter = '', $date = null, $limit = 1000 ) {
+		global $wpdb;
+
+		$query  = "SELECT * FROM {$wpdb->wpjm_search_stats} WHERE 1=1 ";
+		$params = [];
+
+		if ( ! empty( $filter ) ) {
+			$query   .= ' AND filter = %s';
+			$params[] = $filter;
+		}
+
+		if ( ! empty( $date ) ) {
+			$query   .= ' AND date = %s';
+			$params[] = $date;
+		}
+
+		$query   .= ' ORDER BY id DESC LIMIT %d';
+		$params[] = absint( $limit );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Dynamic query.
+		$query = $wpdb->prepare( $query, $params );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared above; admin-only aggregate read, matches Stats::get_stats().
+		return $wpdb->get_results( $query );
+	}
+}

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -189,6 +189,29 @@ class WP_Job_Manager_Ajax {
 		$types              = get_job_listing_types();
 		$job_types_filtered = ! is_null( $filter_job_types ) && count( $types ) !== count( $filter_job_types );
 
+		$search_filters = [
+			'keyword'  => $search_keywords,
+			'location' => $search_location,
+			'category' => $search_categories,
+			'job_type' => $job_types_filtered ? $filter_job_types : [],
+		];
+
+		// Only log on the first page of results so paging through the same
+		// search doesn't inflate its counts on every page request.
+		if ( 1 === $page ) {
+			/**
+			 * Fires when search filters are about to be logged, allowing add-ons
+			 * (e.g. the Tags add-on) to log their own filter value.
+			 *
+			 * @since 2.4.0
+			 *
+			 * @param array $search_filters Filter name to value (or array of values) used in the search.
+			 */
+			do_action( 'wpjm_search_stats_log', $search_filters );
+
+			\WP_Job_Manager\Search_Stats::instance()->log_search( $search_filters );
+		}
+
 		$args = [
 			'search_location'   => $search_location,
 			'search_keywords'   => $search_keywords,

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -203,7 +203,7 @@ class WP_Job_Manager_Ajax {
 			 * Fires when search filters are about to be logged, allowing add-ons
 			 * (e.g. the Tags add-on) to log their own filter value.
 			 *
-			 * @since 2.4.0
+			 * @since $$next-version$$
 			 *
 			 * @param array $search_filters Filter name to value (or array of values) used in the search.
 			 */

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -35,6 +35,7 @@ class WP_Job_Manager_Data_Cleaner {
 	 */
 	private const CUSTOM_TABLES = [
 		'wpjm_stats',
+		'wpjm_search_stats',
 	];
 
 	/**
@@ -56,6 +57,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_delete_old_previews',
 		'job_manager_email_daily_notices',
 		'job_manager_usage_tracking_send_usage_data',
+		\WP_Job_Manager\Search_Stats::CRON_HOOK,
 
 		// Old cron jobs.
 		'job_manager_clear_expired_transients',

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -82,6 +82,7 @@ class WP_Job_Manager_Install {
 		}
 
 		\WP_Job_Manager\Stats::instance()->migrate_db();
+		\WP_Job_Manager\Search_Stats::instance()->migrate_db();
 
 		delete_transient( 'wp_job_manager_addons_html' );
 		update_option( 'wp_job_manager_version', JOB_MANAGER_VERSION );

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -335,6 +335,18 @@ class WP_Job_Manager_Shortcodes {
 				echo '<a class="load_more_jobs" href="#" style="display:none;"><strong>' . esc_html__( 'Load more listings', 'wp-job-manager' ) . '</strong></a>';
 			}
 		} else {
+			$search_filters = [
+				'keyword'  => $atts['keywords'],
+				'location' => $atts['location'],
+				'category' => $atts['categories'],
+				'job_type' => $atts['job_types'],
+			];
+
+			/** This action is documented in includes/class-wp-job-manager-ajax.php */
+			do_action( 'wpjm_search_stats_log', $search_filters );
+
+			\WP_Job_Manager\Search_Stats::instance()->log_search( $search_filters );
+
 			$jobs = get_job_listings(
 				apply_filters(
 					'job_manager_output_jobs_args',

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -280,6 +280,9 @@ class WP_Job_Manager {
 		if ( class_exists( 'WP_Job_Manager_Promoted_Jobs_Status_Handler' ) && ! wp_next_scheduled( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK ) ) {
 			wp_schedule_event( time(), 'hourly', WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK );
 		}
+		if ( ! wp_next_scheduled( \WP_Job_Manager\Search_Stats::CRON_HOOK ) ) {
+			wp_schedule_event( time() + DAY_IN_SECONDS, 'daily', \WP_Job_Manager\Search_Stats::CRON_HOOK );
+		}
 	}
 
 	/**
@@ -291,6 +294,7 @@ class WP_Job_Manager {
 		wp_clear_scheduled_hook( 'job_manager_email_daily_notices' );
 		wp_clear_scheduled_hook( 'job_manager_promoted_jobs_notification' );
 		wp_clear_scheduled_hook( WP_Job_Manager_Promoted_Jobs_Status_Handler::CRON_HOOK );
+		wp_clear_scheduled_hook( \WP_Job_Manager\Search_Stats::CRON_HOOK );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.search-stats.php
+++ b/tests/php/tests/includes/test_class.search-stats.php
@@ -187,4 +187,56 @@ class WP_Test_Search_Stats extends \WPJM_BaseTest {
 		$this->assertEmpty( Search_Stats::instance()->get_stats() );
 	}
 
+	public function test_log_search_skips_when_rate_limited_by_ip() {
+		$_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+
+		// Prime the transient by calling once.
+		Search_Stats::instance()->log_search( [ 'keyword' => 'first' ] );
+
+		// Second call within RATE_LIMIT_SECONDS should be dropped.
+		Search_Stats::instance()->log_search( [ 'keyword' => 'second' ] );
+
+		$stats = Search_Stats::instance()->get_stats( 'keyword' );
+		$this->assertCount( 1, $stats );
+		$this->assertEquals( 'first', $stats[0]->value );
+
+		unset( $_SERVER['REMOTE_ADDR'] );
+	}
+
+	public function test_prune_deletes_rows_older_than_retention_window() {
+		$old_date = gmdate( 'Y-m-d', time() - ( Search_Stats::RETENTION_DAYS + 1 ) * DAY_IN_SECONDS );
+		$recent   = gmdate( 'Y-m-d', time() - 5 * DAY_IN_SECONDS );
+
+		global $wpdb;
+		$wpdb->insert(
+			$wpdb->wpjm_search_stats,
+			[
+				'date'      => $old_date,
+				'filter'    => 'keyword',
+				'value'     => 'old-term',
+				'value_hash' => md5( 'keyword|old-term' ),
+				'count'     => 1,
+			],
+			[ '%s', '%s', '%s', '%s', '%d' ]
+		);
+		$wpdb->insert(
+			$wpdb->wpjm_search_stats,
+			[
+				'date'      => $recent,
+				'filter'    => 'keyword',
+				'value'     => 'recent-term',
+				'value_hash' => md5( 'keyword|recent-term' ),
+				'count'     => 1,
+			],
+			[ '%s', '%s', '%s', '%s', '%d' ]
+		);
+
+		$deleted = Search_Stats::instance()->prune();
+
+		$this->assertEquals( 1, $deleted );
+		$remaining = Search_Stats::instance()->get_stats();
+		$this->assertCount( 1, $remaining );
+		$this->assertEquals( 'recent-term', $remaining[0]->value );
+	}
+
 }

--- a/tests/php/tests/includes/test_class.search-stats.php
+++ b/tests/php/tests/includes/test_class.search-stats.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace WP_Job_Manager;
+
+class WP_Test_Search_Stats extends \WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		update_option( Stats::OPTION_ENABLE_STATS, true );
+		Search_Stats::instance()->migrate_db();
+	}
+
+	public function test_log_search_creates_record_for_keyword() {
+		Search_Stats::instance()->log_search( [ 'keyword' => 'Plumber' ] );
+
+		$stats = Search_Stats::instance()->get_stats( 'keyword' );
+
+		$this->assertCount( 1, $stats );
+		$this->assertEquals( 'plumber', $stats[0]->value );
+		$this->assertEquals( 1, $stats[0]->count );
+	}
+
+	public function test_log_search_normalizes_keyword() {
+		Search_Stats::instance()->log_search( [ 'keyword' => '  Senior   PHP  Developer  ' ] );
+
+		$stats = Search_Stats::instance()->get_stats( 'keyword' );
+
+		$this->assertCount( 1, $stats );
+		$this->assertEquals( 'senior php developer', $stats[0]->value );
+	}
+
+	public function test_log_search_logs_one_row_per_category_value() {
+		Search_Stats::instance()->log_search( [ 'category' => [ '12', '5' ] ] );
+
+		$stats = Search_Stats::instance()->get_stats( 'category' );
+
+		$this->assertCount( 2, $stats );
+		$this->assertEqualsCanonicalizing( [ '12', '5' ], wp_list_pluck( $stats, 'value' ) );
+	}
+
+	public function test_log_search_increments_count_for_repeated_search() {
+		Search_Stats::instance()->log_search( [ 'location' => 'New York' ] );
+		Search_Stats::instance()->log_search( [ 'location' => 'New York' ] );
+
+		$stats = Search_Stats::instance()->get_stats( 'location' );
+
+		$this->assertCount( 1, $stats );
+		$this->assertEquals( 2, $stats[0]->count );
+	}
+
+	public function test_log_search_skips_empty_values() {
+		$result = Search_Stats::instance()->log_search(
+			[
+				'keyword'  => '',
+				'location' => '   ',
+				'category' => [],
+			]
+		);
+
+		$this->assertFalse( $result );
+		$this->assertEmpty( Search_Stats::instance()->get_stats() );
+	}
+
+	public function test_log_search_noop_when_stats_disabled() {
+		update_option( Stats::OPTION_ENABLE_STATS, false );
+
+		$result = Search_Stats::instance()->log_search( [ 'keyword' => 'plumber' ] );
+
+		update_option( Stats::OPTION_ENABLE_STATS, true );
+
+		$this->assertFalse( $result );
+		$this->assertEmpty( Search_Stats::instance()->get_stats() );
+	}
+
+	public function test_log_search_logs_multiple_filters_in_one_call() {
+		Search_Stats::instance()->log_search(
+			[
+				'keyword'  => 'plumber',
+				'location' => 'Chicago',
+				'job_type' => [ 'full-time', 'part-time' ],
+			]
+		);
+
+		$stats = Search_Stats::instance()->get_stats();
+
+		$this->assertCount( 4, $stats );
+
+		$by_filter = [];
+		foreach ( $stats as $stat ) {
+			$by_filter[ $stat->filter ][] = $stat->value;
+		}
+
+		$this->assertEquals( [ 'plumber' ], $by_filter['keyword'] );
+		$this->assertEquals( [ 'Chicago' ], $by_filter['location'] );
+		$this->assertEqualsCanonicalizing( [ 'full-time', 'part-time' ], $by_filter['job_type'] );
+		foreach ( $stats as $stat ) {
+			$this->assertEquals( 1, $stat->count );
+		}
+	}
+
+	public function test_log_search_dedupes_repeated_value_in_same_call() {
+		Search_Stats::instance()->log_search( [ 'category' => [ '12', '12' ] ] );
+
+		$stats = Search_Stats::instance()->get_stats( 'category' );
+
+		$this->assertCount( 1, $stats );
+		$this->assertEquals( 1, $stats[0]->count );
+	}
+
+	public function test_ajax_get_listings_logs_search_and_fires_action_once() {
+		$captured   = null;
+		$call_count = 0;
+		$listener   = function ( $filters ) use ( &$captured, &$call_count ) {
+			$captured = $filters;
+			$call_count++;
+		};
+		add_action( 'wpjm_search_stats_log', $listener );
+
+		$_REQUEST['search_location']   = 'Chicago';
+		$_REQUEST['search_keywords']   = 'welder';
+		$_REQUEST['search_categories'] = null;
+		$_REQUEST['filter_job_type']   = null;
+		$_REQUEST['orderby']           = null;
+		$_REQUEST['order']             = null;
+		$_REQUEST['page']              = 1;
+		$_REQUEST['per_page']          = 100;
+
+		try {
+			$instance = \WP_Job_Manager_Ajax::instance();
+
+			add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+			ob_start();
+			$instance->get_listings();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+			remove_action( 'wpjm_search_stats_log', $listener );
+			unset( $_REQUEST['search_location'], $_REQUEST['search_keywords'], $_REQUEST['search_categories'], $_REQUEST['filter_job_type'], $_REQUEST['orderby'], $_REQUEST['order'], $_REQUEST['page'], $_REQUEST['per_page'] );
+		}
+
+		$this->assertEquals( 1, $call_count );
+		$this->assertIsArray( $captured );
+		$this->assertEquals(
+			[
+				'keyword'  => 'welder',
+				'location' => 'Chicago',
+				'category' => [],
+				'job_type' => [],
+			],
+			$captured
+		);
+
+		$stats = Search_Stats::instance()->get_stats();
+		$this->assertCount( 2, $stats );
+	}
+
+	public function test_ajax_get_listings_does_not_log_on_second_page() {
+		$call_count = 0;
+		$listener   = function () use ( &$call_count ) {
+			$call_count++;
+		};
+		add_action( 'wpjm_search_stats_log', $listener );
+
+		$_REQUEST['search_location']   = null;
+		$_REQUEST['search_keywords']   = 'welder';
+		$_REQUEST['search_categories'] = null;
+		$_REQUEST['filter_job_type']   = null;
+		$_REQUEST['orderby']           = null;
+		$_REQUEST['order']             = null;
+		$_REQUEST['page']              = 2;
+		$_REQUEST['per_page']          = 100;
+
+		try {
+			$instance = \WP_Job_Manager_Ajax::instance();
+
+			add_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+			ob_start();
+			$instance->get_listings();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_do_not_die' ] );
+			remove_action( 'wpjm_search_stats_log', $listener );
+			unset( $_REQUEST['search_location'], $_REQUEST['search_keywords'], $_REQUEST['search_categories'], $_REQUEST['filter_job_type'], $_REQUEST['orderby'], $_REQUEST['order'], $_REQUEST['page'], $_REQUEST['per_page'] );
+		}
+
+		$this->assertEquals( 0, $call_count );
+		$this->assertEmpty( Search_Stats::instance()->get_stats() );
+	}
+
+}


### PR DESCRIPTION
## Summary
When Job Statistics is enabled, log the search filters used on the `[jobs]` shortcode (keyword, location, category, job type) so site owners can see what job seekers actually search for. Today the plugin only logs engagement with existing listings (views, applies), not what visitors were looking for.

Fixes #2783

## Changes
### `includes/class-search-stats.php` (new)
New `Search_Stats` class, modeled on the existing `Stats` class. Owns a new `wpjm_search_stats` table (`date`, `filter`, `value`, `count`, plus a hashed dedup key to stay under the InnoDB index byte limit). `log_search()` normalizes the keyword (lowercase, trim, collapse whitespace) and writes one row per filter value, incrementing `count` on repeat searches within the same day.

### `includes/class-wp-job-manager-ajax.php`
**Before:**
```php
$args = [
    'search_location'   => $search_location,
    ...
```
**After:**
```php
$search_filters = [
    'keyword'  => $search_keywords,
    'location' => $search_location,
    'category' => $search_categories,
    'job_type' => $job_types_filtered ? $filter_job_types : [],
];

if ( 1 === $page ) {
    do_action( 'wpjm_search_stats_log', $search_filters );
    \WP_Job_Manager\Search_Stats::instance()->log_search( $search_filters );
}

$args = [
    'search_location'   => $search_location,
    ...
```
**Why:** this is the actual search execution endpoint used by the default `[jobs]` filter UI. Gated to the first page only, so paging through results doesn't inflate counts.

### `includes/class-wp-job-manager-shortcodes.php`
Same logging call added to the non-AJAX render branch (`[jobs show_filters="false"]`), since that path never touches the AJAX handler.

### `includes/class-wp-job-manager-install.php`
Added `Search_Stats::instance()->migrate_db()` next to the existing `Stats::instance()->migrate_db()` call, so the new table is created on activation/upgrade the same way the existing stats table is.

**Note on scope:** the issue also mentions Tags, which live in a separate add-on not in this repo. Instead of touching that, this adds a `wpjm_search_stats_log` action the Tags add-on can hook to log its own filter value later.

## Testing
**Test 1: keyword search is logged and normalized**
1. Enable Job Statistics.
2. Search `[jobs]` for `"  Senior   PHP  Developer  "`.
3. Query `wp_wpjm_search_stats`.
Result: one row, `filter = keyword`, `value = senior php developer`, `count = 1`.

**Test 2: repeat search increments, doesn't duplicate**
1. Search the same keyword again.
Result: same row, `count = 2`, no second row.

**Test 3: pagination doesn't inflate counts**
1. Run a search with multiple result pages, click to page 2.
Result: no new row, count unchanged.

**Test 4: disabled stats = no logging**
1. Disable Job Statistics, run a new search.
Result: no row created.

Also covered by 10 new PHPUnit tests in `tests/php/tests/includes/test_class.search-stats.php`. Full suite (568 tests) passes, PHPCS clean.