### PR TITLE
fix(pagination): sync numbered pagination page with the URL

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -49,7 +49,12 @@ jQuery( document ).ready( function( $ ) {
 	 * Instances after the first get a suffix so several [jobs] shortcodes on one page don't clash.
 	 */
 	function get_page_query_arg( $target ) {
-		var index = $( 'div.job_listings' ).index( $target );
+		var post_id = $target.data( 'post_id' );
+		var index   = $( 'div.job_listings' ).index( $target );
+
+		if ( post_id ) {
+			return index > 0 ? 'job-page-' + post_id + '-' + ( index + 1 ) : 'job-page-' + post_id;
+		}
 
 		return index > 0 ? 'job-page-' + ( index + 1 ) : 'job-page';
 	}
@@ -478,6 +483,10 @@ jQuery( document ).ready( function( $ ) {
 
 							handle_result( $target, result, append );
 
+							if ( true === $target.data( 'show_pagination' ) ) {
+								current_pages[ get_page_query_arg( $target ) ] = page;
+							}
+
 							$results.removeClass( 'loading' );
 							$target.triggerHandler( 'updated_results', result );
 
@@ -596,17 +605,22 @@ jQuery( document ).ready( function( $ ) {
 		return true;
 	} );
 
+	// Tracks the current page per [jobs] instance so popstate can skip instances whose page didn't change.
+	var current_pages = {};
+
 	// Restore the page shown for numbered pagination when navigating with the browser's back/forward buttons.
 	$( window ).on( 'popstate', function() {
 		$( 'div.job_listings' ).each( function() {
-			var $target = $( this );
+			var $target           = $( this );
+			var page_query_arg    = get_page_query_arg( $target );
+			var url_page          = get_page_from_url( $target );
 
-			if ( true !== $target.data( 'show_pagination' ) ) {
+			if ( true !== $target.data( 'show_pagination' ) || current_pages[ page_query_arg ] === url_page ) {
 				return;
 			}
 
 			suppress_url_push = true;
-			$target.triggerHandler( 'update_results', [ get_page_from_url( $target ), false ] );
+			$target.triggerHandler( 'update_results', [ url_page, false ] );
 		} );
 	} );
 
@@ -619,7 +633,7 @@ jQuery( document ).ready( function( $ ) {
 
 		if ( state ) {
 			// Restore the results from cache.
-			if ( state.results ) {
+			if ( state.results && ( ! state.data || state.data.page === get_page_from_url( $target ) ) ) {
 				results_loaded = handle_result( $target, state.results );
 
 				// We don't want this to continue to persist unless we click on another link.
@@ -639,11 +653,12 @@ jQuery( document ).ready( function( $ ) {
 			}
 		}
 
-		if ( ! results_loaded && $form.length > 0 ) {
+		if ( ! results_loaded ) {
 			// If we didn't load results from cache, load the page from the URL (defaults to 1).
 			var starting_page = true === $target.data( 'show_pagination' ) ? get_page_from_url( $target ) : 1;
 
 			suppress_url_push = true;
+			current_pages[ get_page_query_arg( $target ) ] = starting_page;
 			$target.triggerHandler( 'update_results', [ starting_page, false ] );
 		}
 	} );

--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -45,6 +45,44 @@ jQuery( document ).ready( function( $ ) {
 	}
 
 	/**
+	 * Get the query string parameter name used to track the current page for a job listings instance.
+	 * Instances after the first get a suffix so several [jobs] shortcodes on one page don't clash.
+	 */
+	function get_page_query_arg( $target ) {
+		var index = $( 'div.job_listings' ).index( $target );
+
+		return index > 0 ? 'job-page-' + ( index + 1 ) : 'job-page';
+	}
+
+	/**
+	 * Read the current page for a job listings instance from the URL.
+	 */
+	function get_page_from_url( $target ) {
+		var url  = new URL( window.location.href );
+		var page = parseInt( url.searchParams.get( get_page_query_arg( $target ) ), 10 );
+
+		return page > 0 ? page : 1;
+	}
+
+	/**
+	 * Sync the current page for a job listings instance to the URL, so reloading or navigating back keeps the place.
+	 */
+	function update_page_in_url( $target, page ) {
+		var url = new URL( window.location.href );
+		var arg = get_page_query_arg( $target );
+
+		if ( page > 1 ) {
+			url.searchParams.set( arg, page );
+		} else {
+			url.searchParams.delete( arg );
+		}
+
+		if ( url.href !== window.location.href ) {
+			window.history.pushState( {}, '', url.href );
+		}
+	}
+
+	/**
 	 * Store the filter form values and possibly the rendered results in sessionStorage.
 	 */
 	function store_state( $target, state ) {
@@ -280,6 +318,7 @@ jQuery( document ).ready( function( $ ) {
 	} );
 
 	var xhr = [];
+	var suppress_url_push = false;
 	$( 'div.job_listings' )
 		.on( 'click', 'li.job_listing a', function() {
 			var $target = $( this ).closest( 'div.job_listings' );
@@ -329,6 +368,11 @@ jQuery( document ).ready( function( $ ) {
 			if ( xhr[ index ] ) {
 				xhr[ index ].abort();
 			}
+
+			if ( true === $target.data( 'show_pagination' ) && ! suppress_url_push ) {
+				update_page_in_url( $target, page );
+			}
+			suppress_url_push = false;
 
 			if ( ! append || 1 === page ) {
 				$( 'li.job_listing, li.no_job_listings_found', $results ).css( 'visibility', 'hidden' );
@@ -552,6 +596,20 @@ jQuery( document ).ready( function( $ ) {
 		return true;
 	} );
 
+	// Restore the page shown for numbered pagination when navigating with the browser's back/forward buttons.
+	$( window ).on( 'popstate', function() {
+		$( 'div.job_listings' ).each( function() {
+			var $target = $( this );
+
+			if ( true !== $target.data( 'show_pagination' ) ) {
+				return;
+			}
+
+			suppress_url_push = true;
+			$target.triggerHandler( 'update_results', [ get_page_from_url( $target ), false ] );
+		} );
+	} );
+
 	// Initial job and $form population
 	$( 'div.job_listings' ).each( function() {
 		var $target = $( this );
@@ -582,8 +640,11 @@ jQuery( document ).ready( function( $ ) {
 		}
 
 		if ( ! results_loaded && $form.length > 0 ) {
-			// If we didn't load results from cache, load page 1.
-			$target.triggerHandler( 'update_results', [ 1, false ] );
+			// If we didn't load results from cache, load the page from the URL (defaults to 1).
+			var starting_page = true === $target.data( 'show_pagination' ) ? get_page_from_url( $target ) : 1;
+
+			suppress_url_push = true;
+			$target.triggerHandler( 'update_results', [ starting_page, false ] );
 		}
 	} );
 } );


### PR DESCRIPTION
## Summary
Numbered pagination for the `[jobs]` shortcode runs entirely over AJAX, and the pagination links are `href="#"`. Clicking a page number never changes the browser URL, so reloading the page or pressing Back always resets visitors to page 1 of the listings. This adds URL syncing via `history.pushState`/`popstate` so the current page survives reload, direct links, and back/forward navigation.

Fixes #2685

## Changes
### assets/js/ajax-filters.js
**Before:**
```js
.on( 'click', '.job-manager-pagination a', function() {
	var $target = $( this ).closest( 'div.job_listings' );
	var page = $( this ).data( 'page' );

	$target.triggerHandler( 'update_results', [ page, false ] );
	...
	return false;
} )
```
**After:**
```js
function get_page_query_arg( $target ) { /* job-page, or job-page-N for extra instances */ }
function get_page_from_url( $target ) { /* read current page from the URL */ }
function update_page_in_url( $target, page ) { /* pushState the page into the URL */ }
```
`update_results` now calls `update_page_in_url()` whenever `show_pagination` is on, a `popstate` listener restores the page on back/forward, and the initial page load reads the starting page from the URL instead of always defaulting to 1.

**Why:** keeps the existing AJAX UX (no full page reload) but makes the URL reflect the current page, which is what the browser's history and reload rely on. Scoped to numbered pagination only ("Load More Listings" mode is untouched and unaffected).

## Testing
**Test 1: Basic URL sync**
1. Set Pagination Type to "Page numbered links" in Job Listings settings.
2. On a page with the `[jobs]` shortcode, click page 2, then page 3.
Result: URL updates to `?job-page=2`, `?job-page=3` without a full reload.

**Test 2: Reload / back-forward**
1. From page 1, paginate to page 3.
2. Reload the browser.
Result: listings reload on page 3, not page 1.
3. Paginate to page 2, then press Back.
Result: returns to page 1 with matching URL and listings; Forward returns to page 2.

**Test 3: Multiple `[jobs]` shortcodes on one page**
1. Add a second `[jobs]` shortcode to the same page.
2. Paginate each block independently.
Result: each block gets its own query param (`job-page`, `job-page-2`) and restores independently.

**Test 4: Load More mode unaffected**
1. Switch Pagination Type to "Load More Listings button".
2. Click "Load more listings".
Result: works as before, URL does not change.