### PR TITLE
enhancement(search): filter meta keys used for location search

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -773,7 +773,8 @@ class WP_Job_Manager_Post_Types {
 		];
 
 		if ( ! empty( $input_search_location ) ) {
-			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
+			/** This filter is documented in wp-job-manager-functions.php */
+			$location_meta_keys = apply_filters( 'job_manager_get_listings_location_meta_keys', [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ] );
 			$location_search    = [ 'relation' => 'OR' ];
 			$locations          = explode( ';', $input_search_location );
 			foreach ( $locations as $location ) {

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -774,9 +774,13 @@ class WP_Job_Manager_Post_Types {
 
 		if ( ! empty( $input_search_location ) ) {
 			/** This filter is documented in wp-job-manager-functions.php */
-			$location_meta_keys = apply_filters( 'job_manager_get_listings_location_meta_keys', [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ] );
-			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = explode( ';', $input_search_location );
+			$location_meta_keys = apply_filters( 'job_manager_get_listings_location_meta_keys', job_manager_get_default_location_meta_keys() );
+
+			if ( empty( $location_meta_keys ) ) {
+				$location_meta_keys = job_manager_get_default_location_meta_keys();
+			}
+			$location_search = [ 'relation' => 'OR' ];
+			$locations       = explode( ';', $input_search_location );
 			foreach ( $locations as $location ) {
 				$location = trim( $location );
 				if ( ! empty( $location ) ) {

--- a/tests/php/tests/security/test_class.feed-author-filter.php
+++ b/tests/php/tests/security/test_class.feed-author-filter.php
@@ -13,8 +13,23 @@
  */
 class Tests_Feed_Author_Filter extends WPJM_BaseTest {
 
+	/**
+	 * Closures attached to job_manager_get_listings_location_meta_keys by this fixture,
+	 * remembered so tearDown can remove only the filters we installed without disturbing
+	 * callbacks owned by other tests in the suite.
+	 *
+	 * @var array
+	 */
+	private $location_filter_callbacks = [];
+
 	public function tearDown(): void {
 		unset( $_GET['author'] );
+		unset( $_GET['search_location'] );
+		remove_filter( 'job_manager_get_listings_location_meta_keys', '__return_empty_array' );
+		foreach ( $this->location_filter_callbacks as $callback ) {
+			remove_filter( 'job_manager_get_listings_location_meta_keys', $callback );
+		}
+		$this->location_filter_callbacks = [];
 		parent::tearDown();
 	}
 
@@ -87,6 +102,73 @@ class Tests_Feed_Author_Filter extends WPJM_BaseTest {
 			$listing_id,
 			$this->job_feed_post_ids(),
 			'A valid author filter must still return that author\'s listing.'
+		);
+	}
+
+	/**
+	 * Extending the location meta keys via the filter must let the feed return a listing
+	 * whose location only matches against the added meta key. Mirrors the shortcode test
+	 * so the filter is covered in both code paths.
+	 *
+	 * @since $$next-version$$
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_location_meta_keys_filter_includes_extra_listing() {
+		$listing_id = $this->factory->job_listing->create();
+		update_post_meta( $listing_id, '_address_region', 'Boise, Idaho' );
+
+		$_GET['search_location'] = 'Boise';
+
+		// Sanity check: the listing is on a custom meta key the feed cannot see yet.
+		$this->assertNotContains(
+			$listing_id,
+			$this->job_feed_post_ids(),
+			'Sanity: without the filter, the listing is not in the feed for \"Boise\".'
+		);
+
+		$add_address_region = function ( $location_meta_keys ) {
+			$location_meta_keys[] = '_address_region';
+			return $location_meta_keys;
+		};
+
+		add_filter( 'job_manager_get_listings_location_meta_keys', $add_address_region );
+		$this->location_filter_callbacks[] = $add_address_region;
+
+		$this->assertContains(
+			$listing_id,
+			$this->job_feed_post_ids(),
+			'With the filter extended, the listing appears in the feed for \"Boise\".'
+		);
+	}
+
+	/**
+	 * If the filter returns an empty array the feed must fall back to the defaults
+	 * rather than build a meta_query of only `relation => OR`.
+	 *
+	 * @since $$next-version$$
+	 * @covers WP_Job_Manager_Post_Types::job_feed
+	 */
+	public function test_job_feed_location_meta_keys_filter_empty_falls_back_to_defaults() {
+		$seattle_listing_id = $this->factory->job_listing->create();
+		update_post_meta( $seattle_listing_id, '_job_location', 'Seattle' );
+
+		$nonmatching_listing_id = $this->factory->job_listing->create();
+		update_post_meta( $nonmatching_listing_id, '_job_location', 'Portland' );
+
+		$_GET['search_location'] = 'Seattle';
+
+		add_filter( 'job_manager_get_listings_location_meta_keys', '__return_empty_array' );
+
+		$post_ids = $this->job_feed_post_ids();
+		$this->assertContains(
+			$seattle_listing_id,
+			$post_ids,
+			'Empty filter result must fall back to defaults so _job_location still matches.'
+		);
+		$this->assertNotContains(
+			$nonmatching_listing_id,
+			$post_ids,
+			'Empty filter result must still apply location filtering rather than returning an unfiltered feed.'
 		);
 	}
 }

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -160,6 +160,45 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @since $$next-version$$
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_location_meta_keys_filter() {
+		$boise_job = $this->factory->job_listing->create(
+			[
+				'post_title' => 'Dinosaur Test Boise',
+				'meta_input' => [
+					'_address_region' => 'Boise, Idaho',
+				],
+			]
+		);
+
+		$no_filter_results = get_job_listings(
+			[
+				'search_keywords' => 'Dinosaur',
+				'search_location' => 'Boise',
+			]
+		);
+		$this->assertEqualSets( [], wp_list_pluck( $no_filter_results->posts, 'ID' ) );
+
+		add_filter(
+			'job_manager_get_listings_location_meta_keys',
+			function ( $location_meta_keys ) {
+				$location_meta_keys[] = '_address_region';
+				return $location_meta_keys;
+			}
+		);
+
+		$filtered_results = get_job_listings(
+			[
+				'search_keywords' => 'Dinosaur',
+				'search_location' => 'Boise',
+			]
+		);
+		$this->assertEqualSets( [ $boise_job ], wp_list_pluck( $filtered_results->posts, 'ID' ) );
+	}
+
+	/**
 	 * @since 1.27.0
 	 * @covers ::get_job_listings
 	 */

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -199,6 +199,34 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
+	 * If the filter returns an empty array the shortcode query must fall back to
+	 * the defaults rather than build a meta_query of only `relation => OR`.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_location_meta_keys_filter_empty_falls_back_to_defaults() {
+		$job = $this->factory->job_listing->create(
+			[
+				'post_title' => 'Dinosaur Test Seattle',
+				'meta_input' => [
+					'_job_location' => 'Seattle',
+				],
+			]
+		);
+
+		add_filter( 'job_manager_get_listings_location_meta_keys', '__return_empty_array' );
+
+		$results = get_job_listings(
+			[
+				'search_keywords' => 'Dinosaur',
+				'search_location' => 'Seattle',
+			]
+		);
+		$this->assertEqualSets( [ $job ], wp_list_pluck( $results->posts, 'ID' ) );
+	}
+
+	/**
 	 * @since 1.27.0
 	 * @covers ::get_job_listings
 	 */

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -103,7 +103,13 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 		}
 
 		if ( ! empty( $args['search_location'] ) ) {
-			$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
+			/**
+			 * Filters the meta keys that are checked against the location search term.
+			 *
+			 * @since $$next-version$$
+			 * @param array $location_meta_keys The meta keys.
+			 */
+			$location_meta_keys = apply_filters( 'job_manager_get_listings_location_meta_keys', [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ] );
 			$location_search    = [ 'relation' => 'OR' ];
 			$locations          = explode( ';', $args['search_location'] );
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -7,6 +7,23 @@
  * @package wp-job-manager
  */
 
+if ( ! function_exists( 'job_manager_get_default_location_meta_keys' ) ) :
+	/**
+	 * Returns the default list of meta keys checked against the location search term.
+	 *
+	 * Both `get_job_listings()` and the RSS feed use this list. Extracted to a shared
+	 * helper so that the two code paths cannot silently diverge. Defined outside the
+	 * `get_job_listings` override guard so it stays available even if a theme/plugin
+	 * supplies its own `get_job_listings`.
+	 *
+	 * @since $$next-version$$
+	 * @return array Default location meta keys.
+	 */
+	function job_manager_get_default_location_meta_keys() {
+		return [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
+	}
+endif;
+
 if ( ! function_exists( 'get_job_listings' ) ) :
 	/**
 	 * Queries job listings with certain criteria and returns them.
@@ -109,9 +126,13 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			 * @since $$next-version$$
 			 * @param array $location_meta_keys The meta keys.
 			 */
-			$location_meta_keys = apply_filters( 'job_manager_get_listings_location_meta_keys', [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ] );
-			$location_search    = [ 'relation' => 'OR' ];
-			$locations          = explode( ';', $args['search_location'] );
+			$location_meta_keys = apply_filters( 'job_manager_get_listings_location_meta_keys', job_manager_get_default_location_meta_keys() );
+
+			if ( empty( $location_meta_keys ) ) {
+				$location_meta_keys = job_manager_get_default_location_meta_keys();
+			}
+			$location_search = [ 'relation' => 'OR' ];
+			$locations       = explode( ';', $args['search_location'] );
 
 			foreach ( $locations as $location ) {
 				$location = trim( $location );


### PR DESCRIPTION
## Summary
Location search checks a hardcoded list of meta keys (`geolocation_formatted_address`, `_job_location`, `geolocation_state_long`). Sites that store location in a custom meta field have no way to include it without editing plugin core files, which get overwritten on every update. This adds a filter around that list.
Fixes #2704

## Changes
### wp-job-manager-functions.php
**Before:**
```php
$location_meta_keys = [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ];
```
**After:**
```php
$location_meta_keys = apply_filters( 'job_manager_get_listings_location_meta_keys', [ 'geolocation_formatted_address', '_job_location', 'geolocation_state_long' ] );
```
**Why:** lets a theme or add-on append a custom meta key (e.g. `_address_region`) via `add_filter()`, matching the existing `job_listing_searchable_meta_keys` filter used for keyword search.

### includes/class-wp-job-manager-post-types.php
Same change in `job_feed()` so the RSS feed's location search stays consistent with `get_job_listings()`.

## Testing
**Test 1: filter adds a custom meta key to location search**
1. Add `add_filter( 'job_manager_get_listings_location_meta_keys', fn( $keys ) => [ ...$keys, '_address_region' ] );`
2. Create a job listing with `_address_region` set to a city not present in `_job_location`
3. Search job listings by that city
Result: listing is returned, without touching plugin core files

**Test 2: default behavior unchanged**
1. Search job listings by location on an unmodified install
Result: same results as before this change

Covered by new PHPUnit test `test_get_job_listings_location_meta_keys_filter` in `tests/php/tests/test_class.wp-job-manager-functions.php`. Full suite (559 tests) passes, phpcs clean.

### Release Notes
- Added `job_manager_get_listings_location_meta_keys` filter that allows customizing the meta keys used for job listing location search

### New or Updated Hooks and Templates
New filter `job_manager_get_listings_location_meta_keys`:
- **File:** `wp-job-manager-functions.php` (in `get_job_listings()`) and `includes/class-wp-job-manager-post-types.php` (in `job_feed()`)
- **Arguments:** `$location_meta_keys` (array) — the default list of meta keys checked against the location search term
- **Purpose:** allows themes and plugins to add custom meta keys to the location search, matching the existing pattern of `job_listing_searchable_meta_keys`

### Deprecated Code
None.

### Screenshot / Video
No UI changes — backend/CLI only.