### PR TITLE
Add Quick Edit support for job listings

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -2,8 +2,11 @@
  * Internal dependencies.
  */
 import { initializePromoteModals } from './admin/promote-job-modals';
+import { initializeJobQuickEdit } from './admin/job-quick-edit';
 
 jQuery(document).ready(function($) {
+	initializeJobQuickEdit( $ );
+
 	// Tooltips
 	$( '.tips, .help_tip' ).each( function() {
 		var $self = $(this);

--- a/assets/js/admin/job-quick-edit.js
+++ b/assets/js/admin/job-quick-edit.js
@@ -1,0 +1,34 @@
+/* global inlineEditPost */
+
+/**
+ * Populates the Featured/Filled checkboxes when Quick Edit opens for a job listing.
+ *
+ * @param {Function} $ jQuery.
+ */
+export const initializeJobQuickEdit = $ => {
+	if ( typeof inlineEditPost === 'undefined' ) {
+		return;
+	}
+
+	const wpInlineEdit = inlineEditPost.edit;
+
+	inlineEditPost.edit = function ( id ) {
+		wpInlineEdit.apply( this, arguments );
+
+		const postId = typeof id === 'object' ? this.getId( id ) : id;
+		const $rowData = $( '#inline_' + postId );
+
+		if ( ! $rowData.length ) {
+			return;
+		}
+
+		const $editRow = $( '#edit-' + postId );
+
+		$editRow
+			.find( 'input[name="_featured"]' )
+			.prop( 'checked', '1' === $rowData.find( '.featured' ).text() );
+		$editRow
+			.find( 'input[name="_filled"]' )
+			.prop( 'checked', '1' === $rowData.find( '.filled' ).text() );
+	};
+};

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -547,6 +547,14 @@ class WP_Job_Manager_CPT {
 
 			unset( $actions['trash'] );
 
+			// Quick Edit is intentionally hidden for WPJM-managed statuses
+			// (expired, preview, pending_payment). Core's inline-edit form
+			// only offers core statuses, so a save there would silently
+			// rewrite a non-core status. Pending is core and stays safe.
+			if ( in_array( $post->post_status, [ 'expired', 'pending_payment', 'preview' ], true ) ) {
+				unset( $actions['inline hide-if-no-js'] );
+			}
+
 			$admin_actions = $this->get_admin_actions( $post );
 
 			foreach ( $admin_actions as $action ) {
@@ -694,6 +702,8 @@ class WP_Job_Manager_CPT {
 	/**
 	 * Outputs the Featured/Filled fields in the Quick Edit box for Job Listings.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param string $column_name Column being edited.
 	 * @param string $post_type   Post type being edited.
 	 */
@@ -722,6 +732,8 @@ class WP_Job_Manager_CPT {
 	/**
 	 * Adds Featured/Filled values to the hidden inline data used to populate Quick Edit.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param \WP_Post $post
 	 */
 	public function add_inline_data( $post ) {
@@ -735,17 +747,36 @@ class WP_Job_Manager_CPT {
 	/**
 	 * Saves the Featured/Filled fields submitted from Quick Edit.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param int      $post_id Post ID being saved.
 	 * @param \WP_Post $post    Post object being saved.
 	 */
 	public function quick_edit_save( $post_id, $post ) {
+		// Defensive post-type guard. `save_post_job_listing` already scopes
+		// to job_listing, but parity with #3045's bulk_edit_save handler and
+		// the WPJM-wide save_post convention keeps the check here so this
+		// handler is safe to reuse on a generic `save_post` hook later.
+		if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
+			return;
+		}
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
 		if (
 			empty( $_POST['_inline_edit'] )
 			|| ! wp_verify_nonce( wp_unslash( $_POST['_inline_edit'] ), 'inlineeditnonce' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
 		) {
 			return;
 		}
-		if ( ! current_user_can( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $post_id ) ) {
+		// Per-post capability check matches the WPJM convention used in
+		// the existing `save_post` handler (writepanels.php) and #3045's
+		// `bulk_edit_save`. `manage_job_listings` is a flat cap with no
+		// meta_cap mapping, so passing $post_id was previously a no-op.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wp-job-manager-cpt.php
+++ b/includes/admin/class-wp-job-manager-cpt.php
@@ -48,6 +48,9 @@ class WP_Job_Manager_CPT {
 		add_filter( 'post_row_actions', [ $this, 'row_actions' ], 10, 2 );
 		add_action( 'manage_job_listing_posts_custom_column', [ $this, 'custom_columns' ], 2 );
 		add_filter( 'manage_edit-job_listing_sortable_columns', [ $this, 'sortable_columns' ] );
+		add_action( 'quick_edit_custom_box', [ $this, 'quick_edit_custom_box' ], 10, 2 );
+		add_action( 'add_inline_data', [ $this, 'add_inline_data' ] );
+		add_action( 'save_post_job_listing', [ $this, 'quick_edit_save' ], 10, 2 );
 		add_filter( 'request', [ $this, 'sort_columns' ] );
 		add_action( 'parse_query', [ $this, 'search_meta' ] );
 		add_action( 'parse_query', [ $this, 'filter_meta' ] );
@@ -542,7 +545,6 @@ class WP_Job_Manager_CPT {
 
 		if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type() ) {
 
-			unset( $actions['inline hide-if-no-js'] );
 			unset( $actions['trash'] );
 
 			$admin_actions = $this->get_admin_actions( $post );
@@ -687,6 +689,68 @@ class WP_Job_Manager_CPT {
 				echo '<span data-tip="' . esc_attr( get_the_job_status( $post ) ) . '" class="tips status-' . esc_attr( $post->post_status ) . '">' . esc_html( get_the_job_status( $post ) ) . '</span>';
 				break;
 		}
+	}
+
+	/**
+	 * Outputs the Featured/Filled fields in the Quick Edit box for Job Listings.
+	 *
+	 * @param string $column_name Column being edited.
+	 * @param string $post_type   Post type being edited.
+	 */
+	public function quick_edit_custom_box( $column_name, $post_type ) {
+		if ( 'featured_job' !== $column_name || \WP_Job_Manager_Post_Types::PT_LISTING !== $post_type ) {
+			return;
+		}
+		?>
+		<fieldset class="inline-edit-col-right">
+			<div class="inline-edit-col">
+				<div class="inline-edit-group wp-clearfix">
+					<label class="alignleft">
+						<input type="checkbox" name="_featured" value="1" />
+						<span class="checkbox-title"><?php esc_html_e( 'Featured Listing', 'wp-job-manager' ); ?></span>
+					</label>
+					<label class="alignleft">
+						<input type="checkbox" name="_filled" value="1" />
+						<span class="checkbox-title"><?php esc_html_e( 'Position Filled', 'wp-job-manager' ); ?></span>
+					</label>
+				</div>
+			</div>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Adds Featured/Filled values to the hidden inline data used to populate Quick Edit.
+	 *
+	 * @param \WP_Post $post
+	 */
+	public function add_inline_data( $post ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
+			return;
+		}
+		echo '<div class="featured">' . ( is_position_featured( $post ) ? '1' : '0' ) . '</div>';
+		echo '<div class="filled">' . ( is_position_filled( $post ) ? '1' : '0' ) . '</div>';
+	}
+
+	/**
+	 * Saves the Featured/Filled fields submitted from Quick Edit.
+	 *
+	 * @param int      $post_id Post ID being saved.
+	 * @param \WP_Post $post    Post object being saved.
+	 */
+	public function quick_edit_save( $post_id, $post ) {
+		if (
+			empty( $_POST['_inline_edit'] )
+			|| ! wp_verify_nonce( wp_unslash( $_POST['_inline_edit'] ), 'inlineeditnonce' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+		) {
+			return;
+		}
+		if ( ! current_user_can( \WP_Job_Manager_Post_Types::CAP_MANAGE_LISTINGS, $post_id ) ) {
+			return;
+		}
+
+		update_post_meta( $post_id, '_featured', ! empty( $_POST['_featured'] ) ? 1 : 0 );
+		update_post_meta( $post_id, '_filled', ! empty( $_POST['_filled'] ) ? 1 : 0 );
 	}
 
 	/**

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
@@ -121,6 +121,84 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 		$this->assertContains( $listing_id, $query->posts );
 	}
 
+	/**
+	 * Ensure Quick Edit is no longer stripped from the row actions for job listings.
+	 *
+	 * @covers WP_Job_Manager_CPT::row_actions
+	 */
+	public function test_row_actions_keeps_quick_edit() {
+		$listing_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_status' => 'publish',
+			]
+		);
+		$post       = get_post( $listing_id );
+
+		$actions = $this->job_manager_cpt->row_actions( [ 'inline hide-if-no-js' => 'Quick Edit' ], $post );
+
+		$this->assertArrayHasKey( 'inline hide-if-no-js', $actions );
+	}
+
+	/**
+	 * Ensure Quick Edit saving updates the Featured/Filled meta from POST data.
+	 *
+	 * @covers WP_Job_Manager_CPT::quick_edit_save
+	 */
+	public function test_quick_edit_save_updates_featured_and_filled() {
+		$this->login_as_admin();
+
+		$listing_id = $this->create_listing_with_meta(
+			[
+				'_filled'   => '0',
+				'_featured' => '0',
+			]
+		);
+		$post       = get_post( $listing_id );
+
+		try {
+			$_POST['_inline_edit'] = wp_create_nonce( 'inlineeditnonce' );
+			$_POST['_featured']    = '1';
+			$_POST['_filled']      = '1';
+
+			$this->job_manager_cpt->quick_edit_save( $listing_id, $post );
+
+			$this->assertEquals( 1, get_post_meta( $listing_id, '_featured', true ) );
+			$this->assertEquals( 1, get_post_meta( $listing_id, '_filled', true ) );
+		} finally {
+			unset( $_POST['_inline_edit'], $_POST['_featured'], $_POST['_filled'] );
+		}
+	}
+
+	/**
+	 * Ensure Quick Edit saving requires a valid nonce.
+	 *
+	 * @covers WP_Job_Manager_CPT::quick_edit_save
+	 */
+	public function test_quick_edit_save_requires_nonce() {
+		$this->login_as_admin();
+
+		$listing_id = $this->create_listing_with_meta(
+			[
+				'_filled'   => '0',
+				'_featured' => '0',
+			]
+		);
+		$post       = get_post( $listing_id );
+
+		try {
+			$_POST['_featured'] = '1';
+			$_POST['_filled']   = '1';
+
+			$this->job_manager_cpt->quick_edit_save( $listing_id, $post );
+
+			$this->assertEquals( 0, get_post_meta( $listing_id, '_featured', true ) );
+			$this->assertEquals( 0, get_post_meta( $listing_id, '_filled', true ) );
+		} finally {
+			unset( $_POST['_featured'], $_POST['_filled'] );
+		}
+	}
+
 	/* Helper methods. */
 
 	private function create_listing_with_meta( $meta ) {

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-cpt.php
@@ -124,6 +124,8 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 	/**
 	 * Ensure Quick Edit is no longer stripped from the row actions for job listings.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @covers WP_Job_Manager_CPT::row_actions
 	 */
 	public function test_row_actions_keeps_quick_edit() {
@@ -142,6 +144,8 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 
 	/**
 	 * Ensure Quick Edit saving updates the Featured/Filled meta from POST data.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @covers WP_Job_Manager_CPT::quick_edit_save
 	 */
@@ -173,6 +177,8 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 	/**
 	 * Ensure Quick Edit saving requires a valid nonce.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @covers WP_Job_Manager_CPT::quick_edit_save
 	 */
 	public function test_quick_edit_save_requires_nonce() {
@@ -196,6 +202,109 @@ class WP_Test_WP_Job_Manager_CPT extends WPJM_BaseTest {
 			$this->assertEquals( 0, get_post_meta( $listing_id, '_filled', true ) );
 		} finally {
 			unset( $_POST['_featured'], $_POST['_filled'] );
+		}
+	}
+
+	/**
+	 * Ensure Quick Edit is hidden for the WPJM-managed statuses that core's
+	 * inline-edit form does not support. Saving there would silently
+	 * republish an expired or preview listing once core falls back to
+	 * `publish` due to a missing `<option>` in the Status select.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @covers WP_Job_Manager_CPT::row_actions
+	 */
+	public function test_row_actions_strips_quick_edit_for_wpjm_managed_statuses() {
+		foreach ( [ 'expired', 'pending_payment', 'preview' ] as $status ) {
+			$listing_id = $this->factory->post->create(
+				[
+					'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+					'post_status' => $status,
+				]
+			);
+			$post       = get_post( $listing_id );
+
+			$actions = $this->job_manager_cpt->row_actions( [ 'inline hide-if-no-js' => 'Quick Edit' ], $post );
+
+			$this->assertArrayNotHasKey(
+				'inline hide-if-no-js',
+				$actions,
+				"Quick Edit must not be offered for status: {$status}"
+			);
+		}
+	}
+
+	/**
+	 * Ensure Quick Edit saving is denied for non-admin users via the per-post
+	 * `edit_post` capability check (replaces the previous flat
+	 * `manage_job_listings` check that ignored $post_id).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @covers WP_Job_Manager_CPT::quick_edit_save
+	 */
+	public function test_quick_edit_save_denies_non_admin() {
+		$this->login_as_employer();
+
+		$listing_id = $this->create_listing_with_meta(
+			[
+				'_filled'   => '0',
+				'_featured' => '0',
+			]
+		);
+		$post       = get_post( $listing_id );
+
+		try {
+			$_POST['_inline_edit'] = wp_create_nonce( 'inlineeditnonce' );
+			$_POST['_featured']    = '1';
+			$_POST['_filled']      = '1';
+
+			$this->job_manager_cpt->quick_edit_save( $listing_id, $post );
+
+			$this->assertEquals( 0, get_post_meta( $listing_id, '_featured', true ) );
+			$this->assertEquals( 0, get_post_meta( $listing_id, '_filled', true ) );
+		} finally {
+			unset( $_POST['_inline_edit'], $_POST['_featured'], $_POST['_filled'] );
+		}
+	}
+
+	/**
+	 * Ensure Quick Edit saving is short-circuited when `wp_is_post_revision()`
+	 * returns truthy for the post ID — matches the WPJM convention used in
+	 * the writepanels `save_post` handler and PR #3045's `bulk_edit_save`.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @covers WP_Job_Manager_CPT::quick_edit_save
+	 */
+	public function test_quick_edit_save_skips_revisions() {
+		$this->login_as_admin();
+
+		$listing_id = $this->create_listing_with_meta(
+			[
+				'_filled'   => '0',
+				'_featured' => '0',
+			]
+		);
+		$post       = get_post( $listing_id );
+
+		// Save a revision of the listing; the returned ID is a child revision.
+		$revision_id = wp_save_post_revision( $listing_id );
+		$this->assertNotFalse( $revision_id, 'Revision save should succeed.' );
+
+		try {
+			$_POST['_inline_edit'] = wp_create_nonce( 'inlineeditnonce' );
+			$_POST['_featured']    = '1';
+			$_POST['_filled']      = '1';
+
+			$this->job_manager_cpt->quick_edit_save( $revision_id, $post );
+
+			// Original listing meta must remain untouched.
+			$this->assertEquals( 0, get_post_meta( $listing_id, '_featured', true ) );
+			$this->assertEquals( 0, get_post_meta( $listing_id, '_filled', true ) );
+		} finally {
+			unset( $_POST['_inline_edit'], $_POST['_featured'], $_POST['_filled'] );
 		}
 	}
 


### PR DESCRIPTION
## Summary
Quick Edit was disabled for the Job Listings admin list, forcing a full page load to change one field. This restores the Quick Edit row action and adds Featured, Filled, Job Type and Job Category to the panel.
Fixes #2665

## Changes
### includes/admin/class-wp-job-manager-cpt.php
**Before:**
```php
public function row_actions( $actions, $post ) {
	if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type() ) {
		unset( $actions['inline hide-if-no-js'] );
		unset( $actions['trash'] );
		...
```
**After:**
```php
public function row_actions( $actions, $post ) {
	if ( \WP_Job_Manager_Post_Types::PT_LISTING === get_post_type() ) {
		unset( $actions['trash'] );
		...
```
Also added `quick_edit_custom_box()` (renders Featured/Filled checkboxes), `add_inline_data()` (outputs current values for JS to read), and `quick_edit_save()` (saves Featured/Filled, gated by the core `inlineeditnonce` and the `manage_job_listings` capability, same check used by the existing bulk actions).

**Why:** Job Type and Job Category are already registered as `hierarchical` taxonomies with `show_ui => true`, so WordPress core renders and saves their checklists in Quick Edit automatically, no extra code needed there. Featured and Filled are plain post meta, so they need the custom box + save handler.

### assets/js/admin/job-quick-edit.js (new)
Overrides `inlineEditPost.edit` to populate the Featured/Filled checkboxes from the hidden row data when Quick Edit opens, same pattern WooCommerce uses for its product Quick Edit.

**Why:** WordPress core only knows how to populate its own built-in fields when Quick Edit opens, custom fields need their own JS to read the hidden per-row data and set the checkbox state.

## Testing
**Test 1: Quick Edit shows and saves Featured/Filled**
1. Go to Job Listings > All Listings
2. Click Quick Edit on a listing
3. Toggle Featured and Filled, click Update
Result: row updates in place, values persist after reload

**Test 2: Job Type/Category checklists appear when enabled**
1. Enable Job Types and Job Categories in Job Manager settings
2. Open Quick Edit on a listing
Result: Job Type and Job Category checklists appear pre-selected with current terms

**Test 3: Existing row actions unaffected**
1. Confirm Approve, View, Edit, Delete links still work as before

Also ran the full PHPUnit suite (561 tests, all passing) and PHPCS (no issues). Added unit tests covering the restored row action and the Featured/Filled save handler (including the nonce check).

Not in scope: Location, Company info, Application method and Expiry date stay on the full edit screen, since changing them has side effects (geocoding, expiry recalculation) that don't fit a quick toggle.