### PR TITLE
Unlock block editor for job listings

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -185,6 +185,7 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'wp_footer', [ $this, 'output_structured_data' ] );
 		add_filter( 'wp_sitemaps_posts_query_args', [ $this, 'sitemaps_maybe_hide_filled' ], 10, 2 );
 
+		add_filter( 'the_job_description', 'do_blocks', 9 );
 		add_filter( 'the_job_description', 'wptexturize' );
 		add_filter( 'the_job_description', 'convert_smilies' );
 		add_filter( 'the_job_description', 'convert_chars' );
@@ -450,6 +451,17 @@ class WP_Job_Manager_Post_Types {
 			'pages'      => false,
 		];
 
+		/**
+		 * Whether the job listing editor should be locked to a single Classic block.
+		 *
+		 * Defaults to false, allowing full use of the block editor for job listings,
+		 * the same as posts and pages.
+		 *
+		 * @since 2.4.6
+		 * @param bool $template_lock Whether to lock the editor to a single Classic block.
+		 */
+		$lock_to_classic_block = apply_filters( 'job_manager_job_listing_template_lock', false );
+
 		register_post_type(
 			self::PT_LISTING,
 			apply_filters(
@@ -504,8 +516,8 @@ class WP_Job_Manager_Post_Types {
 					'show_in_rest'          => true,
 					'rest_base'             => 'job-listings',
 					'rest_controller_class' => 'WP_REST_Posts_Controller',
-					'template'              => [ [ 'core/freeform' ] ],
-					'template_lock'         => 'all',
+					'template'              => $lock_to_classic_block ? [ [ 'core/freeform' ] ] : [],
+					'template_lock'         => $lock_to_classic_block ? 'all' : false,
 					'menu_position'         => 30,
 				]
 			)

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -58,6 +58,51 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @since 2.4.6
+	 * @covers WP_Job_Manager_Post_Types::register_post_types
+	 */
+	public function test_job_listing_block_editor_unlocked_by_default() {
+		$post_type_object = get_post_type_object( \WP_Job_Manager_Post_Types::PT_LISTING );
+
+		$this->assertSame( [], $post_type_object->template, 'Job listings should have no forced block template by default.' );
+		$this->assertFalse( $post_type_object->template_lock, 'Job listings should not be locked to a single block by default.' );
+	}
+
+	/**
+	 * @since 2.4.6
+	 * @covers WP_Job_Manager_Post_Types::register_post_types
+	 */
+	public function test_job_listing_block_editor_can_be_locked_to_classic_block() {
+		add_filter( 'job_manager_job_listing_template_lock', '__return_true' );
+		$this->reregister_post_type();
+
+		$post_type_object = get_post_type_object( \WP_Job_Manager_Post_Types::PT_LISTING );
+
+		$this->assertSame( [ [ 'core/freeform' ] ], $post_type_object->template, 'Job listings should be locked to the Classic block when the filter returns true.' );
+		$this->assertSame( 'all', $post_type_object->template_lock, 'Job listings should be fully locked when the filter returns true.' );
+
+		remove_filter( 'job_manager_job_listing_template_lock', '__return_true' );
+		$this->reregister_post_type();
+	}
+
+	/**
+	 * @since 2.4.6
+	 * @covers WP_Job_Manager_Post_Types::__construct
+	 */
+	public function test_job_description_renders_block_markup() {
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_content' => "<!-- wp:paragraph -->\n<p>Block content.</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+
+		$description = wpjm_get_the_job_description( $job_id );
+
+		$this->assertStringContainsString( 'Block content.', $description );
+		$this->assertStringNotContainsString( '<!-- wp:paragraph -->', $description, 'Block comment delimiters should be rendered away by do_blocks().' );
+	}
+
+	/**
 	 * Tests the WP_Job_Manager_Post_Types::instance() always returns the same `WP_Job_Manager_API` instance.
 	 *
 	 * @since 1.28.0


### PR DESCRIPTION
## Summary
Job listings were locked to a single Classic block in wp-admin, so the block inserter and Convert to blocks never worked. This removes that lock by default and makes sure block content actually renders on the frontend.

Fixes #2655

## Changes
### includes/class-wp-job-manager-post-types.php
**Before:**
```php
'template'              => [ [ 'core/freeform' ] ],
'template_lock'         => 'all',
```
**After:**
```php
$lock_to_classic_block = apply_filters( 'job_manager_job_listing_template_lock', false );
...
'template'              => $lock_to_classic_block ? [ [ 'core/freeform' ] ] : [],
'template_lock'         => $lock_to_classic_block ? 'all' : false,
```
**Why:** Job listings behave like posts and pages now, full block editor by default. Sites that relied on the classic-only lock can restore it with the new `job_manager_job_listing_template_lock` filter.

Also added `do_blocks()` to the `the_job_description` filter chain, same spot core uses for `the_content`, so block markup renders correctly on the single job listing page instead of showing raw block comments.

## Testing
**Test 1: New job listing uses block editor**
1. Create a new job listing in wp-admin
2. Open the block inserter
3. Result: full block library available, blocks can be added and saved normally

**Test 2: Frontend renders blocks**
1. Add a paragraph block to a job listing description and publish
2. View the listing on the frontend
3. Result: block renders as normal HTML, no leftover block comment markup

**Test 3: Backward compatible**
1. Open an existing plain-HTML job listing in the block editor
2. Result: WP auto-converts it into a single Classic block as usual, content unchanged

**Test 4: Filter restores old behavior**
1. Add `add_filter( 'job_manager_job_listing_template_lock', '__return_true' );`
2. Result: editor locks back to Classic block only, matching pre-fix behavior

## Screenshot
<img width="1636" height="887" alt="image" src="https://github.com/user-attachments/assets/7b54fbcb-5288-4dac-ab1c-54cabd0706d7" />
