### PR TITLE
feat(listings): show job salary on the listings page

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -336,6 +336,16 @@ class WP_Job_Manager_Settings {
 							'track'      => 'value',
 						],
 						[
+							'name'       => 'job_manager_show_salary_in_listings',
+							'std'        => '0',
+							'label'      => __( 'Salary on Listings', 'wp-job-manager' ),
+							'cb_label'   => __( 'Show Job Salary on Listings Page', 'wp-job-manager' ),
+							'desc'       => __( 'This displays the job salary on the job listings page, in addition to the single job page.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+							'track'      => 'bool',
+						],
+						[
 							'name'     => 'job_manager_display_location_address',
 							'std'      => '0',
 							'label'    => __( 'Location Display', 'wp-job-manager' ),
@@ -809,6 +819,7 @@ class WP_Job_Manager_Settings {
 			var $job_manager_enable_salary_unit = jQuery('#setting-job_manager_enable_salary_unit');
 			var $job_manager_default_salary_currency = jQuery('#setting-job_manager_default_salary_currency');
 			var $job_manager_default_salary_unit = jQuery('#setting-job_manager_default_salary_unit');
+			var $job_manager_show_salary_in_listings = jQuery('#setting-job_manager_show_salary_in_listings');
 
 			jQuery('#setting-job_manager_enable_registration').change(function(){
 				var $job_manager_enable_registration_is_checked = jQuery( this ).is(':checked');
@@ -823,6 +834,7 @@ class WP_Job_Manager_Settings {
 				$job_manager_enable_salary_unit.closest('tr').toggle($job_manager_enable_salary_is_checked);
 				$job_manager_default_salary_currency.closest('tr').toggle($job_manager_enable_salary_is_checked);
 				$job_manager_default_salary_unit.closest('tr').toggle($job_manager_enable_salary_is_checked);
+				$job_manager_show_salary_in_listings.closest('tr').toggle($job_manager_enable_salary_is_checked);
 			}).change();
 
 			jQuery( '.sub-settings-expander' ).on( 'change', function() {

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -122,6 +122,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_default_salary_unit',
 		'job_manager_enable_salary_currency',
 		'job_manager_default_salary_currency',
+		'job_manager_show_salary_in_listings',
 		'job_manager_promoted_jobs_status_update_last_check',
 		'job_manager_promoted_jobs_webhook_interval',
 		'job_manager_promoted_jobs_cron_interval',

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -9,7 +9,7 @@
  * @package     wp-job-manager
  * @category    Template
  * @since       1.0.0
- * @version     1.34.0
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -49,14 +49,14 @@ if ( post_password_required( $post ) || ! job_manager_user_can_view_job_listing(
 				<?php endforeach; endif; ?>
 			<?php } ?>
 
+			<li class="date"><?php the_job_publish_date(); ?></li>
+
 			<?php if ( get_option( 'job_manager_show_salary_in_listings' ) ) : ?>
 				<?php $job_salary = the_job_salary( '', '', false ); ?>
 				<?php if ( ! empty( $job_salary ) ) : ?>
 					<li class="salary"><?php echo esc_html( $job_salary ); ?></li>
 				<?php endif; ?>
 			<?php endif; ?>
-
-			<li class="date"><?php the_job_publish_date(); ?></li>
 
 			<?php do_action( 'job_listing_meta_end' ); ?>
 		</ul>

--- a/templates/content-job_listing.php
+++ b/templates/content-job_listing.php
@@ -49,6 +49,13 @@ if ( post_password_required( $post ) || ! job_manager_user_can_view_job_listing(
 				<?php endforeach; endif; ?>
 			<?php } ?>
 
+			<?php if ( get_option( 'job_manager_show_salary_in_listings' ) ) : ?>
+				<?php $job_salary = the_job_salary( '', '', false ); ?>
+				<?php if ( ! empty( $job_salary ) ) : ?>
+					<li class="salary"><?php echo esc_html( $job_salary ); ?></li>
+				<?php endif; ?>
+			<?php endif; ?>
+
 			<li class="date"><?php the_job_publish_date(); ?></li>
 
 			<?php do_action( 'job_listing_meta_end' ); ?>

--- a/tests/php/tests/includes/test_class.job-listing-salary-display.php
+++ b/tests/php/tests/includes/test_class.job-listing-salary-display.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Regression tests for showing the job salary on the job listings loop, gated by the
+ * `job_manager_show_salary_in_listings` option.
+ *
+ * @package wp-job-manager/tests
+ */
+
+class Tests_Job_Listing_Salary_Display extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		update_option( 'job_manager_enable_salary', 1 );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_enable_salary' );
+		delete_option( 'job_manager_show_salary_in_listings' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers ::the_job_salary
+	 */
+	public function test_salary_hidden_from_listings_by_default() {
+		$post_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_salary' => '55000' ] ] );
+		delete_option( 'job_manager_show_salary_in_listings' );
+
+		$html = $this->render_job_listing_loop( $post_id );
+
+		$this->assertStringNotContainsString( 'class="salary"', $html );
+	}
+
+	/**
+	 * @covers ::the_job_salary
+	 */
+	public function test_salary_shown_in_listings_when_enabled() {
+		$post_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_salary' => '55000' ] ] );
+		update_option( 'job_manager_show_salary_in_listings', 1 );
+
+		$html = $this->render_job_listing_loop( $post_id );
+
+		$this->assertStringContainsString( 'class="salary"', $html );
+		$this->assertStringContainsString( '55000', $html );
+	}
+
+	/**
+	 * @covers ::the_job_salary
+	 *
+	 * Sanity: enabling the listings setting must not print an empty <li> for a listing
+	 * that has no salary value set.
+	 */
+	public function test_no_salary_markup_when_listing_has_no_salary_value() {
+		$post_id = $this->factory->job_listing->create();
+		update_option( 'job_manager_show_salary_in_listings', 1 );
+
+		$html = $this->render_job_listing_loop( $post_id );
+
+		$this->assertStringNotContainsString( 'class="salary"', $html );
+	}
+
+	/**
+	 * Renders the job listing loop template for a single post, mirroring how the `[jobs]`
+	 * shortcode outputs each card via `get_job_manager_template_part( 'content', 'job_listing' )`.
+	 */
+	private function render_job_listing_loop( $post_id ) {
+		global $post;
+		$post = get_post( $post_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		ob_start();
+		setup_postdata( $post );
+		get_job_manager_template_part( 'content', 'job_listing' );
+		wp_reset_postdata();
+
+		return (string) ob_get_clean();
+	}
+}


### PR DESCRIPTION
## Summary
Salary was only shown on the single job page, so site owners had to use a template override just to show it on the listings/archive page. This adds a new opt-in setting that shows the salary on the listings page too, reusing the existing salary formatting and styling.
Fixes #2579

## Changes
### includes/admin/class-wp-job-manager-settings.php
Added a new checkbox setting, `job_manager_show_salary_in_listings` (default off), placed with the other salary settings. It only shows in the admin UI when the main Salary setting is enabled, same pattern already used for the currency/unit rows.

### templates/content-job_listing.php
**Before:**
```php
<li class="date"><?php the_job_publish_date(); ?></li>
```
**After:**
```php
<li class="date"><?php the_job_publish_date(); ?></li>

<?php if ( get_option( 'job_manager_show_salary_in_listings' ) ) : ?>
    <?php $job_salary = the_job_salary( '', '', false ); ?>
    <?php if ( ! empty( $job_salary ) ) : ?>
        <li class="salary"><?php echo esc_html( $job_salary ); ?></li>
    <?php endif; ?>
<?php endif; ?>
```
**Why:** Renders the salary in the listings loop when the new setting is on, using the same `the_job_salary()` helper and `.salary` CSS class already used on the single job page, so no new styling is needed. Placed after the date `<li>` so cards match the ordering of the single-page meta template (types → date → salary).

### includes/class-wp-job-manager-data-cleaner.php
Added the new option to the uninstall cleanup list so it gets removed along with the other salary-related options.

## Testing
**Test 1: Setting off (default)**
1. Enable Salary and set a salary value on a job listing, leave "Salary on Listings" off.
2. View the `[jobs]` listings page.
Result: no salary shown on listing cards, single job page salary display unaffected.

**Test 2: Setting on**
1. Turn on "Salary on Listings" in Job Listings > Settings.
2. View the `[jobs]` listings page.
Result: salary shows on each listing card that has a salary value, positioned after the date `<li>` to match single-page order. Listings without a salary value show no empty item.

Added PHPUnit coverage in `tests/php/tests/includes/test_class.job-listing-salary-display.php` for both states plus the no-salary-value case. Full suite (561 tests) passes locally via `make test`. PHPCS clean.