### PR TITLE
Add setting to allow editing listings during renewal

### DIFF
--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -475,6 +475,16 @@ class WP_Job_Manager_Settings {
 							'track'             => 'value',
 						],
 						[
+							'name'       => 'job_manager_renewal_allow_edits',
+							'std'        => '0',
+							'label'      => __( 'Renewal Edits', 'wp-job-manager' ),
+							'cb_label'   => __( 'Allow editing the listing when renewing it', 'wp-job-manager' ),
+							'desc'       => __( 'Shows the listing edit form as the first step of renewal, before the preview. Has no effect when "Allow Published Edits" requires admin approval, since a renewal must not take a listing offline while edits are pending.', 'wp-job-manager' ),
+							'type'       => 'checkbox',
+							'attributes' => [],
+							'track'      => 'bool',
+						],
+						[
 							'name'              => 'job_manager_submission_limit',
 							'std'               => '',
 							'label'             => __( 'Listing Limit', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-data-cleaner.php
+++ b/includes/class-wp-job-manager-data-cleaner.php
@@ -92,6 +92,7 @@ class WP_Job_Manager_Data_Cleaner {
 		'job_manager_registration_role',
 		'job_manager_submission_requires_approval',
 		'job_manager_renewal_days',
+		'job_manager_renewal_allow_edits',
 		'job_manager_show_agreement_job_submission',
 		'job_manager_terms_and_conditions_page_id',
 		'job_manager_user_can_edit_pending_submissions',

--- a/includes/helper/class-wp-job-manager-helper-renewals.php
+++ b/includes/helper/class-wp-job-manager-helper-renewals.php
@@ -39,8 +39,14 @@ class WP_Job_Manager_Helper_Renewals {
 		$this->form = $form;
 
 		if ( self::is_renew_action() ) {
-			add_filter( 'submit_job_steps', [ $this, 'remove_edit_steps_for_renewal' ] );
 			add_filter( 'submit_job_step_preview_submit_text', [ $this, 'submit_button_text_renewal' ], 15 );
+
+			if ( wpjm_renewal_allows_edits() ) {
+				add_filter( 'submit_job_steps', [ $this, 'use_renewal_preview_handler' ] );
+				add_filter( 'submit_job_form_can_continue_later', '__return_false' );
+			} else {
+				add_filter( 'submit_job_steps', [ $this, 'remove_edit_steps_for_renewal' ] );
+			}
 		}
 	}
 
@@ -100,6 +106,22 @@ class WP_Job_Manager_Helper_Renewals {
 	}
 
 	/**
+	 * Handle steps for renewing a listing before expiry when edits are allowed, keeps the
+	 * edit step and only overrides the preview step's handler to renew on continue.
+	 *
+	 * @access private
+	 * @param array $steps Form submit steps.
+	 * @return array
+	 */
+	public function use_renewal_preview_handler( $steps ) {
+		$steps['preview']['name']    = 'Renew Preview';
+		$steps['preview']['handler'] = [ $this, 'renew_preview_handler' ];
+
+		/** This filter is documented in includes/helper/class-wp-job-manager-helper-renewals.php */
+		return apply_filters( 'renew_job_steps', $steps, $this->form );
+	}
+
+	/**
 	 * Handles the renew-listing form submission.
 	 *
 	 * @throws Exception On validation error.
@@ -111,6 +133,12 @@ class WP_Job_Manager_Helper_Renewals {
 		}
 
 		$this->form->check_preview_form_nonce_field();
+
+		// Edit = show submit form again. Only reachable when the edit step is still part of the renewal flow.
+		if ( ! empty( $_POST['edit_job'] ) && isset( $this->form->get_steps()['submit'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
+			$this->form->previous_step();
+			return;
+		}
 
 		if ( ! empty( $_POST['continue'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Input is used safely.
 			if ( $this->should_renew_job_listing() ) {

--- a/templates/job-preview.php
+++ b/templates/job-preview.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.41.0
+ * @version     2.4.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	?>
 	<div class="job_listing_preview_title">
 		<input type="submit" name="continue" id="job_preview_submit_button" class="button job-manager-button-submit-listing" value="<?php echo esc_attr( apply_filters( 'submit_job_step_preview_submit_text', __( 'Submit Listing', 'wp-job-manager' ) ) ); ?>" />
-		<?php if ( ! WP_Job_Manager_Helper_Renewals::is_renew_action() ) : ?>
+		<?php if ( ! WP_Job_Manager_Helper_Renewals::is_renew_action() || wpjm_renewal_allows_edits() ) : ?>
 			<input type="submit" name="edit_job" class="button job-manager-button-edit-listing" value="<?php esc_attr_e( 'Edit listing', 'wp-job-manager' ); ?>" />
 		<?php endif; ?>
 		<h2><?php esc_html_e( 'Preview', 'wp-job-manager' ); ?></h2>

--- a/tests/php/tests/includes/test_class.renewal-edits.php
+++ b/tests/php/tests/includes/test_class.renewal-edits.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests that the listing edit step is included in the renewal flow only when
+ * the "Renewal Edits" setting is on and published edits don't require moderation.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Renewal_Edits extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+
+		update_option( 'job_manager_renewal_days', 5 );
+		update_option( 'job_manager_user_edit_published_submissions', 'yes' );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_renewal_days' );
+		delete_option( 'job_manager_renewal_allow_edits' );
+		delete_option( 'job_manager_user_edit_published_submissions' );
+		unset( $_GET, $_POST, $_REQUEST );
+		$_GET     = [];
+		$_POST    = [];
+		$_REQUEST = [];
+		$this->reset_form_instance();
+		parent::tearDown();
+	}
+
+	/**
+	 * The form's static instance persists renewal step wiring across tests, so
+	 * each test needs a fresh instance built under its own option state.
+	 */
+	private function reset_form_instance() {
+		$class    = new ReflectionClass( 'WP_Job_Manager_Form_Submit_Job' );
+		$instance = $class->getProperty( 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+
+		$helper_class    = new ReflectionClass( 'WP_Job_Manager_Helper_Renewals' );
+		$helper_instance = $helper_class->getProperty( 'instance' );
+		$helper_instance->setAccessible( true );
+		$helper_instance->setValue( null, null );
+	}
+
+	/**
+	 * Sets up `$_GET` with a valid renew action and nonce for the given job.
+	 *
+	 * @param int $job_id Job listing to renew.
+	 */
+	private function set_renew_action_query( $job_id ) {
+		$_GET['job_id'] = $job_id;
+		$_GET['action'] = 'renew';
+		$_GET['nonce']  = wp_create_nonce( 'job_manager_renew_job_' . $job_id );
+	}
+
+	private function create_renewable_job( $user_id ) {
+		return $this->factory->job_listing->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'publish',
+			]
+		);
+	}
+
+	/**
+	 * By default (setting off), the renewal flow keeps its current behavior:
+	 * the edit ("submit") step is removed.
+	 */
+	public function test_edit_step_removed_by_default() {
+		$this->login_as_employer();
+		$job_id = $this->create_renewable_job( get_current_user_id() );
+		update_post_meta( $job_id, '_job_expires', wp_date( 'Y-m-d', strtotime( '+1 day' ) ) );
+
+		$this->set_renew_action_query( $job_id );
+		$this->reset_form_instance();
+
+		$form = WP_Job_Manager_Form_Submit_Job::instance();
+
+		$this->assertArrayNotHasKey( 'submit', $form->get_steps() );
+	}
+
+	/**
+	 * With the setting on and moderation not required, the edit step stays in
+	 * the renewal flow.
+	 */
+	public function test_edit_step_kept_when_allowed() {
+		update_option( 'job_manager_renewal_allow_edits', 1 );
+
+		$this->login_as_employer();
+		$job_id = $this->create_renewable_job( get_current_user_id() );
+		update_post_meta( $job_id, '_job_expires', wp_date( 'Y-m-d', strtotime( '+1 day' ) ) );
+
+		$this->set_renew_action_query( $job_id );
+		$this->reset_form_instance();
+
+		$form = WP_Job_Manager_Form_Submit_Job::instance();
+
+		$this->assertArrayHasKey( 'submit', $form->get_steps() );
+		$this->assertSame( 'Renew Preview', $form->get_steps()['preview']['name'] );
+	}
+
+	/**
+	 * The setting has no effect when published edits require moderation: the
+	 * renewal must not be able to take the listing offline mid-flow.
+	 */
+	public function test_edit_step_removed_when_moderation_required() {
+		update_option( 'job_manager_renewal_allow_edits', 1 );
+		update_option( 'job_manager_user_edit_published_submissions', 'yes_moderated' );
+
+		$this->login_as_employer();
+		$job_id = $this->create_renewable_job( get_current_user_id() );
+		update_post_meta( $job_id, '_job_expires', wp_date( 'Y-m-d', strtotime( '+1 day' ) ) );
+
+		$this->set_renew_action_query( $job_id );
+		$this->reset_form_instance();
+
+		$form = WP_Job_Manager_Form_Submit_Job::instance();
+
+		$this->assertArrayNotHasKey( 'submit', $form->get_steps() );
+	}
+
+	/**
+	 * Completing the renewal preview step still extends the expiry and
+	 * republishes the listing when the edit step was part of the flow.
+	 */
+	public function test_renewal_completes_after_allowed_edit_step() {
+		update_option( 'job_manager_renewal_allow_edits', 1 );
+
+		$this->login_as_employer();
+		$job_id = $this->create_renewable_job( get_current_user_id() );
+		update_post_meta( $job_id, '_job_expires', wp_date( 'Y-m-d', strtotime( '+1 day' ) ) );
+
+		$this->set_renew_action_query( $job_id );
+		$this->reset_form_instance();
+
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$job_id_prop = $class->getProperty( 'job_id' );
+		$job_id_prop->setAccessible( true );
+		$job_id_prop->setValue( $form, $job_id );
+
+		$steps     = array_keys( $form->get_steps() );
+		$step_prop = $class->getProperty( 'step' );
+		$step_prop->setAccessible( true );
+		$step_prop->setValue( $form, array_search( 'preview', $steps, true ) );
+
+		$nonce                   = wp_create_nonce( 'preview-job-' . $job_id );
+		$_POST                   = [
+			'continue'    => '1',
+			'job_id'      => $job_id,
+			'_wpjm_nonce' => $nonce,
+		];
+		$_REQUEST['_wpjm_nonce'] = $nonce;
+
+		$form->process();
+
+		$this->assertEquals( 'publish', get_post_status( $job_id ) );
+		$this->assertFalse( WP_Job_Manager_Helper_Renewals::job_can_be_renewed( get_post( $job_id ) ) );
+	}
+}

--- a/tests/php/tests/includes/test_class.renewal-edits.php
+++ b/tests/php/tests/includes/test_class.renewal-edits.php
@@ -160,4 +160,123 @@ class WP_Test_Renewal_Edits extends WPJM_BaseTest {
 		$this->assertEquals( 'publish', get_post_status( $job_id ) );
 		$this->assertFalse( WP_Job_Manager_Helper_Renewals::job_can_be_renewed( get_post( $job_id ) ) );
 	}
+
+	/**
+	 * Field values edited on the renewal submit step persist on the listing
+	 * and the job still completes the renewal (status publish, expiry extended).
+	 */
+	public function test_edited_fields_persist_through_renewal() {
+		update_option( 'job_manager_renewal_allow_edits', 1 );
+
+		$this->login_as_employer();
+		$user_id = get_current_user_id();
+		$job_id  = $this->create_renewable_job( $user_id );
+		update_post_meta( $job_id, '_job_expires', wp_date( 'Y-m-d', strtotime( '+1 day' ) ) );
+
+		$this->set_renew_action_query( $job_id );
+		$this->reset_form_instance();
+
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$job_id_prop = $class->getProperty( 'job_id' );
+		$job_id_prop->setAccessible( true );
+		$job_id_prop->setValue( $form, $job_id );
+
+		$step_prop = $class->getProperty( 'step' );
+		$step_prop->setAccessible( true );
+
+		$steps     = array_keys( $form->get_steps() );
+		$submit_ix = array_search( 'submit', $steps, true );
+		$step_prop->setValue( $form, $submit_ix );
+
+		// Submit the edit step with changed field values.
+		$nonce                                      = wp_create_nonce( 'submit-job-' . $job_id );
+		$_POST['job']                               = [
+			'job_title'       => 'Renewed Engineer',
+			'job_location'    => 'Remote (HQ)',
+			'job_type'        => 'full-time',
+			'job_description' => 'Updated description.',
+			'application'     => 'apply@example.com',
+		];
+		$_POST['company']                           = [
+			'company_name' => 'Acme Co',
+		];
+		$_POST                                       = array_merge(
+			$_POST,
+			[
+				'submit_job'  => '1',
+				'job_id'      => $job_id,
+				'_wpjm_nonce' => $nonce,
+			]
+		);
+		$_REQUEST['_wpjm_nonce']                    = $nonce;
+		$_REQUEST['job']                            = $_POST['job'];
+		$_REQUEST['company']                        = $_POST['company'];
+
+		$form->submit_handler();
+
+		$this->assertSame( $submit_ix + 1, $form->get_step() );
+
+		// Continue the renewal preview step.
+		$preview_ix       = array_search( 'preview', $steps, true );
+		$step_prop->setValue( $form, $preview_ix );
+
+		$nonce                   = wp_create_nonce( 'preview-job-' . $job_id );
+		$_POST                   = [
+			'continue'    => '1',
+			'job_id'      => $job_id,
+			'_wpjm_nonce' => $nonce,
+		];
+		$_REQUEST['_wpjm_nonce'] = $nonce;
+
+		$form->process();
+
+		$this->assertSame( 'Renewed Engineer', get_post( $job_id )->post_title );
+		$this->assertSame( 'Remote (HQ)', get_post_meta( $job_id, '_job_location', true ) );
+		$this->assertSame( 'apply@example.com', get_post_meta( $job_id, '_application', true ) );
+		$this->assertSame( 'publish', get_post_status( $job_id ) );
+		$this->assertFalse( WP_Job_Manager_Helper_Renewals::job_can_be_renewed( get_post( $job_id ) ) );
+	}
+
+	/**
+	 * The "Edit listing" button on the renewal preview step navigates back to
+	 * the submit (edit) step.
+	 */
+	public function test_edit_job_navigates_back_from_preview() {
+		update_option( 'job_manager_renewal_allow_edits', 1 );
+
+		$this->login_as_employer();
+		$job_id = $this->create_renewable_job( get_current_user_id() );
+		update_post_meta( $job_id, '_job_expires', wp_date( 'Y-m-d', strtotime( '+1 day' ) ) );
+
+		$this->set_renew_action_query( $job_id );
+		$this->reset_form_instance();
+
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$job_id_prop = $class->getProperty( 'job_id' );
+		$job_id_prop->setAccessible( true );
+		$job_id_prop->setValue( $form, $job_id );
+
+		$steps       = array_keys( $form->get_steps() );
+		$submit_ix   = array_search( 'submit', $steps, true );
+		$preview_ix  = array_search( 'preview', $steps, true );
+		$step_prop   = $class->getProperty( 'step' );
+		$step_prop->setAccessible( true );
+		$step_prop->setValue( $form, $preview_ix );
+
+		$nonce                   = wp_create_nonce( 'preview-job-' . $job_id );
+		$_POST                   = [
+			'edit_job'    => '1',
+			'job_id'      => $job_id,
+			'_wpjm_nonce' => $nonce,
+		];
+		$_REQUEST['_wpjm_nonce'] = $nonce;
+
+		$form->process();
+
+		$this->assertSame( $submit_ix, $form->get_step() );
+	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1282,6 +1282,31 @@ function wpjm_published_submission_edits_require_moderation() {
 }
 
 /**
+ * Checks if the listing edit form should be shown as part of the renewal flow.
+ *
+ * Always false when published listings can't be edited, or edits require
+ * moderation, since a renewal must not take a listing offline while its
+ * edits await admin approval.
+ *
+ * @since 2.4.6
+ * @return bool
+ */
+function wpjm_renewal_allows_edits() {
+	$allow_edits = 1 === intval( get_option( 'job_manager_renewal_allow_edits' ) )
+		&& wpjm_user_can_edit_published_submissions()
+		&& ! wpjm_published_submission_edits_require_moderation();
+
+	/**
+	 * Override whether the listing edit form is shown as part of the renewal flow.
+	 *
+	 * @since 2.4.6
+	 *
+	 * @param bool $allow_edits
+	 */
+	return apply_filters( 'job_manager_renewal_allows_edits', $allow_edits );
+}
+
+/**
  * Get the category slugs from the search query string.
  * The query string is made with the category slugs separate by commas.
  *

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1288,7 +1288,7 @@ function wpjm_published_submission_edits_require_moderation() {
  * moderation, since a renewal must not take a listing offline while its
  * edits await admin approval.
  *
- * @since 2.4.6
+ * @since $$next-version$$
  * @return bool
  */
 function wpjm_renewal_allows_edits() {
@@ -1299,7 +1299,7 @@ function wpjm_renewal_allows_edits() {
 	/**
 	 * Override whether the listing edit form is shown as part of the renewal flow.
 	 *
-	 * @since 2.4.6
+	 * @since $$next-version$$
 	 *
 	 * @param bool $allow_edits
 	 */


### PR DESCRIPTION
## Summary
Adds a "Renewal Edits" setting so users can edit their job listing as part of the renewal flow, the same way relisting an expired listing already works. Off by default, so existing sites see no behavior change.
Fixes #2560

## Changes
### includes/helper/class-wp-job-manager-helper-renewals.php
**Before:**
```php
if ( self::is_renew_action() ) {
    add_filter( 'submit_job_steps', [ $this, 'remove_edit_steps_for_renewal' ] );
    add_filter( 'submit_job_step_preview_submit_text', [ $this, 'submit_button_text_renewal' ], 15 );
}
```
**After:**
```php
if ( self::is_renew_action() ) {
    add_filter( 'submit_job_step_preview_submit_text', [ $this, 'submit_button_text_renewal' ], 15 );

    if ( wpjm_renewal_allows_edits() ) {
        add_filter( 'submit_job_steps', [ $this, 'use_renewal_preview_handler' ] );
        add_filter( 'submit_job_form_can_continue_later', '__return_false' );
    } else {
        add_filter( 'submit_job_steps', [ $this, 'remove_edit_steps_for_renewal' ] );
    }
}
```
**Why:** keeps the current behavior (strip the edit step) unless edits are explicitly allowed. `renew_preview_handler()` also learned to handle the "Edit listing" button so users can go back to the edit step from the renewal preview, same as the normal submit flow.

### wp-job-manager-functions.php
Added `wpjm_renewal_allows_edits()`, which returns true only when the new option is on, published listings are editable, and edits don't require moderation:
```php
function wpjm_renewal_allows_edits() {
    $allow_edits = 1 === intval( get_option( 'job_manager_renewal_allow_edits' ) )
        && wpjm_user_can_edit_published_submissions()
        && ! wpjm_published_submission_edits_require_moderation();

    return apply_filters( 'job_manager_renewal_allows_edits', $allow_edits );
}
```
**Why:** the setting is a no-op when published edits require admin approval. Submitting a moderated edit sets the listing to `pending` immediately, which would take it offline mid-renewal and defeat the point of renewing. Renewals must never be able to unpublish a listing.

### includes/admin/class-wp-job-manager-settings.php
New checkbox setting `job_manager_renewal_allow_edits`, default off, next to the existing "Renewal Window" setting.

### templates/job-preview.php
Shows the "Edit listing" button on the renewal preview step when `wpjm_renewal_allows_edits()` is true, instead of always hiding it during renewal.

## Testing
**Test 1: Setting off (default) - no behavior change**
1. Renewable published listing, "Renewal Edits" unchecked.
2. Click Renew from the job dashboard.
Result: goes straight to preview, no edit step, same as before this change.

**Test 2: Setting on, edits not moderated**
1. Check "Renewal Edits", set "Allow Published Edits" to "without admin approval".
2. Click Renew on a renewable published listing.
Result: edit form shows first, then preview with an "Edit listing" button, then renewing extends expiry and keeps the listing published throughout.

**Test 3: Setting on, edits require moderation**
1. Check "Renewal Edits", set "Allow Published Edits" to "require admin approval".
2. Click Renew.
Result: goes straight to preview, no edit step. The setting has no effect here by design.

**Test 4: Regressions**
- Normal edit (not renewal) and Relist (expired listing) flows checked, unaffected.

Automated: `npm run test` (562 tests, 0 failures, added `tests/php/tests/includes/test_class.renewal-edits.php`), `npm run lint:php` (0 errors), `coderabbit review --agent` (0 findings).