### PR TITLE
Fix [jobs] shortcode adding extra elements in block themes

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -38,7 +38,41 @@ class WP_Job_Manager_Shortcodes {
 		add_shortcode( 'job_summary', [ $this, 'output_job_summary' ] );
 		add_shortcode( 'job_apply', [ $this, 'output_job_apply' ] );
 
+		// Block themes expand shortcodes before do_blocks(), so the core/shortcode block's
+		// wpautop() would run on our already-rendered HTML and inject stray p/br tags.
+		add_filter( 'pre_render_block', [ $this, 'protect_jobs_shortcode_from_wpautop' ], 10, 2 );
+
 		Job_Dashboard_Shortcode::instance();
+	}
+
+	/**
+	 * Skip core/shortcode wpautop when the block already holds expanded [jobs] markup.
+	 *
+	 * In block templates, get_the_block_template_html() runs do_shortcode() before
+	 * do_blocks(). By the time the shortcode block renders, [jobs] is already HTML.
+	 * Returning that HTML here bypasses render_block_core_shortcode()'s wpautop() call.
+	 *
+	 * @param string|null $pre_render   Existing pre-render value.
+	 * @param array       $parsed_block Parsed block.
+	 * @return string|null
+	 */
+	public function protect_jobs_shortcode_from_wpautop( $pre_render, $parsed_block ) {
+		if ( null !== $pre_render ) {
+			return $pre_render;
+		}
+
+		if ( empty( $parsed_block['blockName'] ) || 'core/shortcode' !== $parsed_block['blockName'] ) {
+			return $pre_render;
+		}
+
+		$html = isset( $parsed_block['innerHTML'] ) ? $parsed_block['innerHTML'] : '';
+
+		// Marker is hard-coded on the [jobs] wrapper, outside the filterable data attributes.
+		if ( false !== strpos( $html, 'data-wp-job-manager-jobs-shortcode="1"' ) ) {
+			return $html;
+		}
+
+		return $pre_render;
 	}
 
 	/**
@@ -421,7 +455,8 @@ class WP_Job_Manager_Shortcodes {
 
 		$job_listings_output = apply_filters( 'job_manager_job_listings_output', ob_get_clean() );
 
-		return '<div class="job_listings" ' . $data_attributes_string . '>' . $job_listings_output . '</div>';
+		// Marker lets pre_render_block recognize expanded [jobs] markup without relying on filterable attributes.
+		return '<div class="job_listings" data-wp-job-manager-jobs-shortcode="1" ' . $data_attributes_string . '>' . $job_listings_output . '</div>';
 	}
 
 	/**

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -68,7 +68,13 @@ class WP_Job_Manager_Shortcodes {
 		$html = isset( $parsed_block['innerHTML'] ) ? $parsed_block['innerHTML'] : '';
 
 		// Marker is hard-coded on the [jobs] wrapper, outside the filterable data attributes.
-		if ( false !== strpos( $html, 'data-wp-job-manager-jobs-shortcode="1"' ) ) {
+		// Anchor to the first '>' so listing titles or employer-supplied text that happens to
+		// contain the literal marker string cannot trigger the short-circuit on unrelated blocks.
+		$marker   = 'data-wp-job-manager-jobs-shortcode="1"';
+		$tag_end  = strpos( $html, '>' );
+		$has_open = false !== strpos( $html, '<div' );
+
+		if ( $has_open && false !== $tag_end && false !== strpos( $html, $marker ) && strpos( $html, $marker ) < $tag_end ) {
 			return $html;
 		}
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-shortcodes.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-shortcodes.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Regression tests for the `[jobs]` shortcode in block templates.
+ *
+ * Block themes run do_shortcode() before do_blocks() when rendering a template
+ * (see WordPress core get_the_block_template_html()), so the core/shortcode
+ * block's wpautop() call runs on our already-rendered listing markup instead
+ * of the raw shortcode tag. That injected stray p/br tags into the output.
+ *
+ * @see https://github.com/Automattic/WP-Job-Manager/issues/2521
+ */
+class WP_Test_WP_Job_Manager_Shortcodes extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->factory->job_listing->create(
+			[
+				'post_title'  => 'Shortcode Test Listing',
+				'post_status' => 'publish',
+			]
+		);
+	}
+
+	/**
+	 * Expanded [jobs] markup inside a core/shortcode block must skip wpautop.
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::protect_jobs_shortcode_from_wpautop
+	 * @covers WP_Job_Manager_Shortcodes::output_jobs
+	 */
+	public function test_jobs_shortcode_block_does_not_inject_paragraphs() {
+		// Simulate the block-template pipeline: shortcode expands first.
+		$expanded = do_shortcode( '[jobs show_filters=false]' );
+
+		$this->assertStringContainsString( 'data-wp-job-manager-jobs-shortcode="1"', $expanded );
+
+		// Then the core/shortcode block renders the already-expanded HTML.
+		$block = [
+			'blockName'    => 'core/shortcode',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => $expanded,
+			'innerContent' => [ $expanded ],
+		];
+
+		$output = render_block( $block );
+
+		// Without the fix, wpautop() leaves stray </p>/<p> inside the listing card.
+		$this->assertStringNotContainsString( '</p></div>', $output );
+		$this->assertStringNotContainsString( '<p> </a>', $output );
+		$this->assertStringNotContainsString( '<p></a>', $output );
+		$this->assertStringContainsString( 'Shortcode Test Listing', $output );
+		$this->assertStringContainsString( 'class="job_listings"', $output );
+		$this->assertStringContainsString( 'data-wp-job-manager-jobs-shortcode="1"', $output );
+	}
+
+	/**
+	 * Colliding job_listings class without our marker must not short-circuit.
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::protect_jobs_shortcode_from_wpautop
+	 */
+	public function test_unrelated_job_listings_markup_is_not_short_circuited() {
+		$shortcodes = WP_Job_Manager_Shortcodes::instance();
+
+		$result = $shortcodes->protect_jobs_shortcode_from_wpautop(
+			null,
+			[
+				'blockName' => 'core/shortcode',
+				'innerHTML' => '<div class="job_listings" data-show_filters="false"></div>',
+			]
+		);
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Unrelated shortcode blocks still go through core's normal render path.
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::protect_jobs_shortcode_from_wpautop
+	 */
+	public function test_unrelated_shortcode_block_is_not_short_circuited() {
+		$shortcodes = WP_Job_Manager_Shortcodes::instance();
+		$html       = '[gallery]';
+
+		$result = $shortcodes->protect_jobs_shortcode_from_wpautop(
+			null,
+			[
+				'blockName' => 'core/shortcode',
+				'innerHTML' => $html,
+			]
+		);
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Filter leaves non-shortcode blocks alone.
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::protect_jobs_shortcode_from_wpautop
+	 */
+	public function test_non_shortcode_block_is_not_short_circuited() {
+		$shortcodes = WP_Job_Manager_Shortcodes::instance();
+
+		$result = $shortcodes->protect_jobs_shortcode_from_wpautop(
+			null,
+			[
+				'blockName' => 'core/paragraph',
+				'innerHTML' => '<div class="job_listings" data-show_filters="false"></div>',
+			]
+		);
+
+		$this->assertNull( $result );
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-shortcodes.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-shortcodes.php
@@ -110,4 +110,29 @@ class WP_Test_WP_Job_Manager_Shortcodes extends WPJM_BaseTest {
 
 		$this->assertNull( $result );
 	}
+
+	/**
+	 * Marker appearing in body text (after the first '>') must not short-circuit.
+	 *
+	 * Employer-supplied listing titles or company names land in the block HTML,
+	 * so the marker must be anchored to the opening tag of our own wrapper.
+	 *
+	 * @covers WP_Job_Manager_Shortcodes::protect_jobs_shortcode_from_wpautop
+	 */
+	public function test_marker_in_body_text_does_not_short_circuit() {
+		$shortcodes = WP_Job_Manager_Shortcodes::instance();
+
+		// Marker sits in the visible body text, not in any opening attribute.
+		$html = '<div class="job_listings"><p>data-wp-job-manager-jobs-shortcode="1"</p></div>';
+
+		$result = $shortcodes->protect_jobs_shortcode_from_wpautop(
+			null,
+			[
+				'blockName' => 'core/shortcode',
+				'innerHTML' => $html,
+			]
+		);
+
+		$this->assertNull( $result );
+	}
 }


### PR DESCRIPTION
Fixes #2521

### Changes Proposed in this Pull Request

* In block themes, `get_the_block_template_html()` runs `do_shortcode()` before `do_blocks()`. The `core/shortcode` block then runs `wpautop()` on listing HTML that already contains block elements nested inside anchors, which injected stray `<p>` and `<br>` tags under each listing card.
* Add a hard-coded `data-wp-job-manager-jobs-shortcode="1"` marker on the `[jobs]` wrapper and short-circuit `pre_render_block` for `core/shortcode` blocks that hold expanded `[jobs]` markup. This bypasses `render_block_core_shortcode()`'s `wpautop()` call so the already-rendered listings stay intact.
* The marker lives on the wrapper itself, outside the filterable `data-*` attributes, so detection does not depend on shortcode attributes or class names.

### Testing Instructions

1. Use a block theme (e.g. Twenty Twenty-Four) with at least one published job listing.
2. In the Site Editor, add a Shortcode block with `[jobs show_filters=false]` to a template and save.
3. View the front end.
4. Confirm listings render cleanly with no extra empty `<p>` tags or broken/orphaned `<a>` elements under each card.
5. Add `[jobs]` (with filters) as a second block and confirm the filter form and AJAX loading still work.

Run `vendor/bin/phpunit --filter WP_Test_WP_Job_Manager_Shortcodes` (4 tests, 10 assertions pass).

### Release Notes

* Fixed the `[jobs]` shortcode adding extra paragraph and anchor elements when added through a Shortcode block in block themes.

### New or Updated Hooks and Templates

* None.

### Deprecated Code

* None.

### Screenshot / Video

Not needed; this is a markup-only fix with no visible UI change beyond the removed extra elements.