### PR TITLE
feat(admin): add Job Data fields to Bulk Edit

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -773,12 +773,12 @@ class WP_Job_Manager_Writepanels {
 	 * @return string[]
 	 */
 	private function get_bulk_edit_excluded_field_types() {
-		$excluded = [ 'file', 'info', 'hidden', 'author' ];
+		$excluded = [ 'file', 'info', 'hidden', 'author', 'textarea', 'wp_editor' ];
 
 		/**
 		 * Filters the field types excluded from the Job Data bulk edit form.
 		 *
-		 * @since 2.4.6
+		 * @since $$next-version$$
 		 *
 		 * @param string[] $excluded Field type strings that should not appear in bulk edit.
 		 */
@@ -1009,12 +1009,15 @@ class WP_Job_Manager_Writepanels {
 		// A past (or cleared-without-duration) expiry moves the listing to expired, mirroring single edit.
 		if ( $expiry_changed && 'trash' !== $post->post_status && $post_types->has_job_expired( $post_id ) ) {
 			if ( 'expired' !== get_post_status( $post_id ) ) {
+				// Unhook before wp_update_post to avoid re-entering save_post (and every other save_post listener) with this same id.
+				remove_action( 'save_post', [ $this, 'bulk_edit_save' ], 10 );
 				wp_update_post(
 					[
 						'ID'          => $post_id,
 						'post_status' => 'expired',
 					]
 				);
+				add_action( 'save_post', [ $this, 'bulk_edit_save' ], 10, 2 );
 			}
 		}
 	}

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -45,6 +45,8 @@ class WP_Job_Manager_Writepanels {
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
 		add_action( 'save_post', [ $this, 'save_post' ], 1, 2 );
 		add_action( 'job_manager_save_job_listing', [ $this, 'save_job_listing_data' ], 20, 2 );
+		add_action( 'bulk_edit_custom_box', [ $this, 'bulk_edit_fields' ], 10, 2 );
+		add_action( 'save_post', [ $this, 'bulk_edit_save' ], 10, 2 );
 	}
 
 	/**
@@ -763,6 +765,258 @@ class WP_Job_Manager_Writepanels {
 				)
 				&& $to_status === $_POST['post_status'];
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * Job data field types that are excluded from bulk edit.
+	 *
+	 * @return string[]
+	 */
+	private function get_bulk_edit_excluded_field_types() {
+		$excluded = [ 'file', 'info', 'hidden', 'author' ];
+
+		/**
+		 * Filters the field types excluded from the Job Data bulk edit form.
+		 *
+		 * @since 2.4.6
+		 *
+		 * @param string[] $excluded Field type strings that should not appear in bulk edit.
+		 */
+		return apply_filters( 'job_manager_bulk_edit_excluded_field_types', $excluded );
+	}
+
+	/**
+	 * Returns the job data fields available for bulk edit, filtered for the current user.
+	 *
+	 * @return array
+	 */
+	private function get_bulk_edit_fields() {
+		$user_id     = get_current_user_id();
+		$fields      = WP_Job_Manager_Post_Types::get_job_listing_fields();
+		$excluded    = $this->get_bulk_edit_excluded_field_types();
+		$bulk_fields = [];
+
+		foreach ( $fields as $meta_key => $field ) {
+			$type = isset( $field['type'] ) ? $field['type'] : 'text';
+			if ( in_array( $type, $excluded, true ) ) {
+				continue;
+			}
+
+			$show_in_admin = isset( $field['show_in_admin'] ) ? $field['show_in_admin'] : true;
+			if ( is_callable( $show_in_admin ) ) {
+				$show_in_admin = (bool) call_user_func( $show_in_admin, true, $meta_key, 0, $user_id );
+			}
+			if ( ! $show_in_admin ) {
+				continue;
+			}
+
+			$auth_edit_callback = isset( $field['auth_edit_callback'] ) ? $field['auth_edit_callback'] : null;
+			if ( ! is_callable( $auth_edit_callback ) || ! call_user_func( $auth_edit_callback, false, $meta_key, 0, $user_id ) ) {
+				continue;
+			}
+
+			$bulk_fields[ $meta_key ] = $field;
+		}
+
+		uasort( $bulk_fields, [ __CLASS__, 'sort_by_priority' ] );
+
+		return $bulk_fields;
+	}
+
+	/**
+	 * Renders the Job Data fields inside the bulk edit row.
+	 *
+	 * Fires once per column during bulk edit rendering; we render only on the primary
+	 * `job_position` column so the fieldset appears a single time.
+	 *
+	 * @param string $column_name Name of the current column being rendered.
+	 * @param string $post_type   Post type of the list table.
+	 */
+	public function bulk_edit_fields( $column_name, $post_type ) {
+		if ( \WP_Job_Manager_Post_Types::PT_LISTING !== $post_type || 'job_position' !== $column_name ) {
+			return;
+		}
+
+		$fields = $this->get_bulk_edit_fields();
+		if ( empty( $fields ) ) {
+			return;
+		}
+
+		$no_change = __( '— No Change —', 'wp-job-manager' );
+		?>
+		<fieldset class="inline-edit-col-right inline-edit-job-manager">
+			<div class="inline-edit-col">
+				<h4><?php esc_html_e( 'Job Data', 'wp-job-manager' ); ?></h4>
+				<?php wp_nonce_field( 'job_manager_bulk_edit', 'job_manager_bulk_edit_nonce' ); ?>
+				<input type="hidden" name="job_manager_bulk_edit" value="1" />
+				<?php
+				foreach ( $fields as $key => $field ) {
+					$label = isset( $field['label'] ) ? $field['label'] : $key;
+					$type  = isset( $field['type'] ) ? $field['type'] : 'text';
+					$name  = 'job_manager_bulk[' . $key . ']';
+					?>
+					<div class="inline-edit-group">
+						<label class="inline-edit-group-label">
+							<span class="title"><?php echo esc_html( wp_strip_all_tags( $label ) ); ?></span>
+							<span class="input-text-wrap">
+								<?php
+								if ( 'checkbox' === $type ) {
+									?>
+									<select name="<?php echo esc_attr( $name ); ?>">
+										<option value=""><?php echo esc_html( $no_change ); ?></option>
+										<option value="1"><?php esc_html_e( 'Yes', 'wp-job-manager' ); ?></option>
+										<option value="0"><?php esc_html_e( 'No', 'wp-job-manager' ); ?></option>
+									</select>
+									<?php
+								} elseif ( 'select' === $type ) {
+									$options = isset( $field['options'] ) ? (array) $field['options'] : [];
+									?>
+									<select name="<?php echo esc_attr( $name ); ?>">
+										<option value=""><?php echo esc_html( $no_change ); ?></option>
+										<?php
+										foreach ( $options as $option_value => $option_label ) {
+											printf(
+												'<option value="%s">%s</option>',
+												esc_attr( $option_value ),
+												esc_html( $option_label )
+											);
+										}
+										?>
+									</select>
+									<?php
+								} elseif ( '_job_expires' === $key ) {
+									$classes = isset( $field['classes'] ) && is_array( $field['classes'] ) ? implode( ' ', $field['classes'] ) : '';
+									?>
+									<input type="text" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $classes ); ?>" value="" autocomplete="off" />
+									<label class="inline-edit-job-manager-clear">
+										<span class="checkbox-title"><?php esc_html_e( 'Clear expiry', 'wp-job-manager' ); ?></span>
+										<input type="checkbox" name="job_manager_bulk[_job_expires_clear]" value="1" />
+									</label>
+									<?php
+								} else {
+									?>
+									<input type="text" name="<?php echo esc_attr( $name ); ?>" value="" autocomplete="off" />
+									<?php
+								}
+								?>
+							</span>
+						</label>
+					</div>
+					<?php
+				}
+				?>
+			</div>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Saves Job Data fields submitted from the bulk edit form.
+	 *
+	 * WordPress fires `save_post` once per post during a bulk edit update. This handler
+	 * only acts when our bulk edit flag and nonce are present, and only writes fields the
+	 * user actually filled in (empty values mean no change).
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function bulk_edit_save( $post_id, $post ) {
+		if ( empty( $_REQUEST['job_manager_bulk_edit'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+		if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
+			return;
+		}
+		if (
+			empty( $_REQUEST['job_manager_bulk_edit_nonce'] )
+			|| ! wp_verify_nonce( wp_unslash( $_REQUEST['job_manager_bulk_edit_nonce'] ), 'job_manager_bulk_edit' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+		) {
+			return;
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$bulk = isset( $_REQUEST['job_manager_bulk'] ) ? wp_unslash( $_REQUEST['job_manager_bulk'] ) : []; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+		if ( ! is_array( $bulk ) ) {
+			return;
+		}
+
+		$user_id        = get_current_user_id();
+		$fields         = $this->get_bulk_edit_fields();
+		$post_types     = WP_Job_Manager_Post_Types::instance();
+		$clear_expiry   = ! empty( $bulk['_job_expires_clear'] );
+		$expiry_changed = false;
+
+		// Explicit clear takes priority over a date value. Re-check auth for the real post.
+		if ( $clear_expiry && isset( $fields['_job_expires']['auth_edit_callback'] ) && call_user_func( $fields['_job_expires']['auth_edit_callback'], false, '_job_expires', $post_id, $user_id ) ) {
+			$post_types->set_job_expiration( $post_id, null );
+			$expiry_changed = true;
+		}
+
+		foreach ( $fields as $key => $field ) {
+			if ( ! array_key_exists( $key, $bulk ) ) {
+				continue;
+			}
+
+			$value = $bulk[ $key ];
+			// Bulk edit fields are scalar form inputs; skip crafted array values before sanitizing.
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+			$value = trim( $value );
+
+			// Empty means no change for every field type.
+			if ( '' === $value ) {
+				continue;
+			}
+
+			// Re-check auth for the real post, in case the listing list filter was broader.
+			$auth_edit_callback = isset( $field['auth_edit_callback'] ) ? $field['auth_edit_callback'] : null;
+			if ( ! is_callable( $auth_edit_callback ) || ! call_user_func( $auth_edit_callback, false, $key, $post_id, $user_id ) ) {
+				continue;
+			}
+
+			if ( '_job_expires' === $key ) {
+				if ( $clear_expiry ) {
+					// Already cleared above; skip setting a date.
+					continue;
+				}
+				$date = DateTimeImmutable::createFromFormat( 'Y-m-d', sanitize_text_field( $value ), wp_timezone() );
+				if ( $date ) {
+					$post_types->set_job_expiration( $post_id, $date );
+					$expiry_changed = true;
+				}
+				continue;
+			}
+
+			$sanitize_callback = isset( $field['sanitize_callback'] ) ? $field['sanitize_callback'] : null;
+			if ( is_callable( $sanitize_callback ) ) {
+				$value = call_user_func( $sanitize_callback, $value, $key );
+			} else {
+				$value = sanitize_text_field( $value );
+			}
+
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// A past (or cleared-without-duration) expiry moves the listing to expired, mirroring single edit.
+		if ( $expiry_changed && 'trash' !== $post->post_status && $post_types->has_job_expired( $post_id ) ) {
+			if ( 'expired' !== get_post_status( $post_id ) ) {
+				wp_update_post(
+					[
+						'ID'          => $post_id,
+						'post_status' => 'expired',
+					]
+				);
+			}
+		}
 	}
 }
 

--- a/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
+++ b/tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php
@@ -230,4 +230,252 @@ class WP_Test_WP_Job_Manager_Writepanels extends WPJM_BaseTest {
 
 		return $job;
 	}
+
+	/**
+	 * Sets up a bulk edit request payload on $_REQUEST.
+	 *
+	 * @param array $bulk Bulk edit field values keyed by meta key.
+	 */
+	private function mock_bulk_edit_request( $bulk = [] ) {
+		$_REQUEST = [];
+		if ( null !== $bulk ) {
+			$_REQUEST['job_manager_bulk_edit'] = '1';
+			$_REQUEST['job_manager_bulk_edit_nonce'] = wp_create_nonce( 'job_manager_bulk_edit' );
+			$_REQUEST['job_manager_bulk'] = $bulk;
+		}
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_updates_text_fields() {
+		$this->login_as_admin();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$job_id = $this->factory->job_listing->create();
+		$job    = get_post( $job_id );
+
+		$this->mock_bulk_edit_request(
+			[
+				'_job_location' => 'London',
+				'_company_name' => 'Acme Corp',
+			]
+		);
+
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertEquals( 'London', get_post_meta( $job_id, '_job_location', true ) );
+		$this->assertEquals( 'Acme Corp', get_post_meta( $job_id, '_company_name', true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_empty_means_no_change() {
+		$this->login_as_admin();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$job_id = $this->factory->job_listing->create(
+			[
+				'meta_input' => [
+					'_job_location' => 'Berlin',
+					'_company_name' => 'Existing Co',
+				],
+			]
+		);
+		$job = get_post( $job_id );
+
+		// Empty string sent for fields we leave untouched.
+		$this->mock_bulk_edit_request(
+			[
+				'_job_location' => '',
+				'_company_name' => '',
+			]
+		);
+
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertEquals( 'Berlin', get_post_meta( $job_id, '_job_location', true ) );
+		$this->assertEquals( 'Existing Co', get_post_meta( $job_id, '_company_name', true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_checkbox_tristate() {
+		$this->login_as_admin();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		// Set filled to 1.
+		$job_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_filled' => 0 ] ] );
+		$job    = get_post( $job_id );
+		$this->mock_bulk_edit_request( [ '_filled' => '1' ] );
+		$writepanels->bulk_edit_save( $job_id, $job );
+		$this->assertEquals( 1, absint( get_post_meta( $job_id, '_filled', true ) ) );
+
+		// Set filled back to 0.
+		$this->mock_bulk_edit_request( [ '_filled' => '0' ] );
+		$writepanels->bulk_edit_save( $job_id, $job );
+		$this->assertEquals( 0, absint( get_post_meta( $job_id, '_filled', true ) ) );
+
+		// Empty (No Change) leaves it at 0.
+		$this->mock_bulk_edit_request( [ '_filled' => '' ] );
+		$writepanels->bulk_edit_save( $job_id, $job );
+		$this->assertEquals( 0, absint( get_post_meta( $job_id, '_filled', true ) ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_clear_expiry() {
+		$this->login_as_admin();
+		$this->enable_manage_job_listings_cap();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$future_date = wp_date( 'Y-m-d', strtotime( '+2 months', current_datetime()->getTimestamp() ) );
+		$job_id      = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_expires' => $future_date ] ] );
+		$job         = get_post( $job_id );
+
+		$this->mock_bulk_edit_request( [ '_job_expires_clear' => '1' ] );
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertSame( '', get_post_meta( $job_id, '_job_expires', true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_set_expiry_date() {
+		$this->login_as_admin();
+		$this->enable_manage_job_listings_cap();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$future_date = wp_date( 'Y-m-d', strtotime( '+3 months', current_datetime()->getTimestamp() ) );
+		$job_id      = $this->factory->job_listing->create();
+		$job         = get_post( $job_id );
+
+		$this->mock_bulk_edit_request( [ '_job_expires' => $future_date ] );
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertEquals( $future_date, get_post_meta( $job_id, '_job_expires', true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_past_expiry_sets_expired_status() {
+		$this->login_as_admin();
+		$this->enable_manage_job_listings_cap();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$past_date = wp_date( 'Y-m-d', strtotime( '-2 months', current_datetime()->getTimestamp() ) );
+		$job_id    = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+		$job       = get_post( $job_id );
+
+		$this->mock_bulk_edit_request( [ '_job_expires' => $past_date ] );
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertEquals( 'expired', get_post_status( $job_id ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_featured_requires_manage_cap() {
+		// The base test setUp grants manage_job_listings to everyone; turn it off so we can
+		// verify a plain editor can update normal fields but not _featured (needs manage).
+		$this->disable_manage_job_listings_cap();
+
+		$editor_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$editor    = get_user_by( 'ID', $editor_id );
+		$editor->add_cap( \WP_Job_Manager_Post_Types::CAP_EDIT_LISTINGS );
+		$editor->add_cap( \WP_Job_Manager_Post_Types::CAP_EDIT_PUBLISHED_LISTINGS );
+		$editor->add_cap( \WP_Job_Manager_Post_Types::CAP_EDIT_OTHERS_LISTINGS );
+
+		$this->login_as( $editor_id );
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_status' => 'publish',
+				'meta_input'  => [ '_featured' => 0, '_company_name' => 'Original' ],
+			]
+		);
+		$job = get_post( $job_id );
+
+		$this->mock_bulk_edit_request(
+			[
+				'_featured'     => '1',
+				'_company_name' => 'Updated',
+			]
+		);
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertEquals( 0, absint( get_post_meta( $job_id, '_featured', true ) ) );
+		$this->assertEquals( 'Updated', get_post_meta( $job_id, '_company_name', true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_rejects_bad_nonce() {
+		$this->login_as_admin();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$job_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_company_name' => 'Original' ] ] );
+		$job    = get_post( $job_id );
+
+		$_REQUEST = [
+			'job_manager_bulk_edit'        => '1',
+			'job_manager_bulk_edit_nonce'  => 'garbage',
+			'job_manager_bulk'             => [ '_company_name' => 'Changed' ],
+		];
+
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertEquals( 'Original', get_post_meta( $job_id, '_company_name', true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_save
+	 */
+	public function test_bulk_edit_without_flag_is_noop() {
+		$this->login_as_admin();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		$job_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_company_name' => 'Original' ] ] );
+		$job    = get_post( $job_id );
+
+		$_REQUEST = [];
+
+		$writepanels->bulk_edit_save( $job_id, $job );
+
+		$this->assertEquals( 'Original', get_post_meta( $job_id, '_company_name', true ) );
+	}
+
+	/**
+	 * @covers WP_Job_Manager_Writepanels::bulk_edit_fields
+	 */
+	public function test_bulk_edit_fields_render_only_for_job_position() {
+		$this->login_as_admin();
+		$writepanels = WP_Job_Manager_Writepanels::instance();
+
+		ob_start();
+		$writepanels->bulk_edit_fields( 'job_position', 'job_listing' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Job Data', $output );
+		$this->assertStringContainsString( 'job_manager_bulk_edit_nonce', $output );
+
+		// Other columns and post types render nothing.
+		ob_start();
+		$writepanels->bulk_edit_fields( 'job_location', 'job_listing' );
+		$other_column = ob_get_clean();
+		$this->assertSame( '', $other_column );
+
+		ob_start();
+		$writepanels->bulk_edit_fields( 'job_position', 'post' );
+		$other_type = ob_get_clean();
+		$this->assertSame( '', $other_type );
+	}
 }


### PR DESCRIPTION
## Summary
This pull request adds support for bulk editing Job Data fields on the job listings list table. Administrators can now update common fields (such as Location, Company Name, Expiry date, and Filled status) for multiple listings at once, where empty fields are treated as "no change."
Closes #2448

## Changes
### WP_Job_Manager_Writepanels
**Before:**
```php
	public function __construct() {
		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
		add_action( 'save_post', [ $this, 'save_post' ], 1, 2 );
		add_action( 'job_manager_save_job_listing', [ $this, 'save_job_listing_data' ], 20, 2 );
	}
```
**After:**
```php
	public function __construct() {
		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
		add_action( 'save_post', [ $this, 'save_post' ], 1, 2 );
		add_action( 'job_manager_save_job_listing', [ $this, 'save_job_listing_data' ], 20, 2 );
		add_action( 'bulk_edit_custom_box', [ $this, 'bulk_edit_fields' ], 10, 2 );
		add_action( 'save_post', [ $this, 'bulk_edit_save' ], 10, 2 );
	}
```
**Why:**
We need to register hooks for native WordPress bulk edit rendering (`bulk_edit_custom_box`) and saving (`save_post`). We implemented `get_bulk_edit_fields()`, `bulk_edit_fields()`, and `bulk_edit_save()` to handle rendering and processing the bulk metadata fields securely with nonce validation and proper capability checks.

## Testing

**Test 1: Bulk Edit text fields and selects**
1. Select multiple listings in the Jobs list table.
2. Select **Edit** under Bulk actions and click **Apply**.
3. Set **Location** to "London" and **Position Filled** to "Yes**.
4. Click **Update** and verify the changes on the selected listings. Verify empty fields were not modified.
Result: works as expected

**Test 2: Clearing Expiry Date**
1. Select multiple listings that have an expiry date set.
2. Select **Edit** under Bulk actions and click **Apply**.
3. Check the **Clear expiry** checkbox.
4. Click **Update** and verify that the expiry date meta field is cleared.
Result: works as expected

**Test 3: Expiry Date Past status flip**
1. Select a listing.
2. Bulk Edit and set **Listing Expiry Date** to a past date (e.g. yesterday).
3. Click **Update** and verify the listing status is automatically flipped to **expired**.
Result: works as expected

**Test 4: Capability and security checks**
1. Log in as a user who lacks `manage_job_listings` capability.
2. Try to bulk edit. Verify that fields requiring manage capability (like Featured or Expiry Date) are not visible/editable, and any unauthorized save requests are ignored.
Result: works as expected

Automated PHPUnit tests were also added in `tests/php/tests/includes/admin/test_class.wp-job-manager-writepanels.php` and they all pass cleanly.

## Screenshots
| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/e7f2c14e-8e49-431d-b95a-d9fd87306b89) | ![After](https://github.com/user-attachments/assets/274f5dd9-7a65-4aea-bff8-5bd01f50089f) |

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. Delete section to use PR title. -->
### Release Notes

* Added bulk editing support for Job Data fields on the job listings list table (location, company name, expiry date, filled status). Empty fields act as "no change"; nonces and capability checks gate the request; reviews already in the past flip automatically to expired.

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* New filter `job_manager_bulk_edit_excluded_field_types` (array of field type strings excluded from bulk edit; defaults to `file`, `info`, `hidden`, `author`, `textarea`, `wp_editor`). Receives `$excluded` array.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*