### PR TITLE
fix(post-types): fire action when job filled status changes

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -204,6 +204,7 @@ class WP_Job_Manager_Post_Types {
 
 		add_filter( 'wp_insert_post_data', [ $this, 'fix_post_name' ], 10, 2 );
 		add_action( 'add_post_meta', [ $this, 'maybe_add_geolocation_data' ], 10, 3 );
+		add_action( 'add_post_meta', [ $this, 'add_post_meta' ], 10, 3 );
 		add_action( 'update_post_meta', [ $this, 'update_post_meta' ], 10, 4 );
 		add_action( 'wp_insert_post', [ $this, 'maybe_add_default_meta_data' ], 10, 2 );
 		add_filter( 'post_types_to_delete_with_user', [ $this, 'delete_user_add_job_listings_post_type' ] );
@@ -1622,6 +1623,32 @@ class WP_Job_Manager_Post_Types {
 	}
 
 	/**
+	 * Triggered when adding meta to a job listing.
+	 *
+	 * @param int    $object_id
+	 * @param string $meta_key
+	 * @param mixed  $meta_value
+	 */
+	public function add_post_meta( $object_id, $meta_key, $meta_value ) {
+		if ( self::PT_LISTING !== get_post_type( $object_id ) ) {
+			return;
+		}
+
+		if ( '_filled' === $meta_key && (bool) $meta_value ) {
+			/**
+			 * Fires when a job listing's filled status changes.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param int  $object_id  Job listing ID.
+			 * @param bool $is_filled  New filled state.
+			 * @param bool $was_filled Previous filled state.
+			 */
+			do_action( 'job_manager_job_listing_filled_status_changed', $object_id, true, false );
+		}
+	}
+
+	/**
 	 * Triggered when updating meta on a job listing.
 	 *
 	 * @param int    $meta_id
@@ -1648,6 +1675,8 @@ class WP_Job_Manager_Post_Types {
 				if ( $was_filled !== $is_filled ) {
 					/**
 					 * Fires when a job listing's filled status changes.
+					 *
+					 * @since $$next-version$$
 					 *
 					 * @param int  $object_id  Job listing ID.
 					 * @param bool $is_filled  New filled state.

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1641,6 +1641,21 @@ class WP_Job_Manager_Post_Types {
 			case '_featured':
 				$this->maybe_update_menu_order( $meta_id, $object_id, $meta_key, $meta_value );
 				break;
+			case '_filled':
+				$was_filled = (bool) get_post_meta( $object_id, '_filled', true );
+				$is_filled  = (bool) $meta_value;
+
+				if ( $was_filled !== $is_filled ) {
+					/**
+					 * Fires when a job listing's filled status changes.
+					 *
+					 * @param int  $object_id  Job listing ID.
+					 * @param bool $is_filled  New filled state.
+					 * @param bool $was_filled Previous filled state.
+					 */
+					do_action( 'job_manager_job_listing_filled_status_changed', $object_id, $is_filled, $was_filled );
+				}
+				break;
 		}
 	}
 

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -796,6 +796,39 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @since 2.5.0
+	 * @covers WP_Job_Manager_Post_Types::update_post_meta
+	 */
+	public function test_update_post_meta_fired_on_filled_transition() {
+		global $wp_actions;
+		$instance = WP_Job_Manager_Post_Types::instance();
+		$post = get_post(
+			$this->factory->job_listing->create(
+				[
+					'meta_input' => [ '_filled' => 0 ],
+				]
+			)
+		);
+
+		// 0 -> 1 transition fires action.
+		unset( $wp_actions['job_manager_job_listing_filled_status_changed'] );
+		$this->assertEquals( 0, did_action( 'job_manager_job_listing_filled_status_changed' ) );
+		update_post_meta( $post->ID, '_filled', '1' );
+		$this->assertEquals( 1, did_action( 'job_manager_job_listing_filled_status_changed' ) );
+
+		// 1 -> 0 transition fires action.
+		unset( $wp_actions['job_manager_job_listing_filled_status_changed'] );
+		update_post_meta( $post->ID, '_filled', '0' );
+		$this->assertEquals( 1, did_action( 'job_manager_job_listing_filled_status_changed' ) );
+
+		// Same value -> no action.
+		unset( $wp_actions['job_manager_job_listing_filled_status_changed'] );
+		update_post_meta( $post->ID, '_filled', '0' );
+		$this->assertEquals( 0, did_action( 'job_manager_job_listing_filled_status_changed' ) );
+	}
+
+
+	/**
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::maybe_update_geolocation_data
 	 */

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -796,7 +796,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.5.0
+	 * @since $$next-version$$
 	 * @covers WP_Job_Manager_Post_Types::update_post_meta
 	 */
 	public function test_update_post_meta_fired_on_filled_transition() {
@@ -824,6 +824,33 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 		// Same value -> no action.
 		unset( $wp_actions['job_manager_job_listing_filled_status_changed'] );
 		update_post_meta( $post->ID, '_filled', '0' );
+		$this->assertEquals( 0, did_action( 'job_manager_job_listing_filled_status_changed' ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers WP_Job_Manager_Post_Types::add_post_meta
+	 */
+	public function test_update_post_meta_fired_on_filled_add_transition() {
+		global $wp_actions;
+		WP_Job_Manager_Post_Types::instance();
+		$post = get_post(
+			$this->factory->job_listing->create()
+		);
+
+		// Default seed populates _filled = 0; remove it so add_post_meta path triggers.
+		delete_post_meta( $post->ID, '_filled' );
+
+		// add_post_meta with truthy _filled fires action with was_filled = false.
+		unset( $wp_actions['job_manager_job_listing_filled_status_changed'] );
+		$this->assertEquals( 0, did_action( 'job_manager_job_listing_filled_status_changed' ) );
+		add_post_meta( $post->ID, '_filled', '1', true );
+		$this->assertEquals( 1, did_action( 'job_manager_job_listing_filled_status_changed' ) );
+
+		// add_post_meta with falsy _filled does NOT fire (seed paths should be silent).
+		delete_post_meta( $post->ID, '_filled' );
+		unset( $wp_actions['job_manager_job_listing_filled_status_changed'] );
+		add_post_meta( $post->ID, '_filled', '0', true );
 		$this->assertEquals( 0, did_action( 'job_manager_job_listing_filled_status_changed' ) );
 	}
 


### PR DESCRIPTION
## Summary

Added `job_manager_job_listing_filled_status_changed` action. Fires when `_filled` meta changes (0→1 or 1→0). Core has no applications system; this hook enables the Applications add-on to update application statuses when a job is marked filled.

Refs #2791

## Changes

### includes/class-wp-job-manager-post-types.php
Added `case '_filled':` branch to `update_post_meta()` handler. Compares old/new values and fires action only on real transition. Also added an `add_post_meta` handler that fires the same action on the first transition when `_filled` is inserted with a truthy value (covers paths where the meta row does not exist before being set). Both gated to `job_listing` posts.

### tests/php/tests/includes/test_class.wp-job-manager-post-types.php
Added `test_update_post_meta_fired_on_filled_transition()` verifying:
- 0→1 transition fires once
- 1→0 transition fires once  
- Same-value re-save does not fire

Added `test_update_post_meta_fired_on_filled_add_transition()` verifying the new `add_post_meta` handler:
- Inserting `_filled = 1` on a listing without prior meta fires the action once
- Inserting `_filled = 0` does not fire (matches seed-path semantics)

## Testing

**Test 1: Hook fires on filled toggle**
1. Add `add_action('job_manager_job_listing_filled_status_changed', ...)` listener
2. Mark job filled via dashboard or admin bulk edit
3. Check debug.log: should see "filled: was=0 now=1"

**Test 2: No fire on same value**
1. Edit job without touching filled checkbox
2. Save
3. Hook does not fire

**Test 3: PHPCS**
Run `npm run lint:php -- --standard=phpcs.xml.dist` – passes.

**Test 4: PHPUnit**
Run the full `tests/php` suite – `test_update_post_meta_fired_on_filled_transition` and `test_update_post_meta_fired_on_filled_add_transition` both pass.

## Screenshots

No UI changes.
