### PR TITLE
feat: group jobs by status in employer job dashboard

### DIFF
--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -211,3 +211,56 @@
 		flex: 1 1 calc(33% - 2 * var(--jm-ui-space-sm));
 	}
 }
+
+.jm-dashboard-group {
+	.jm-dashboard-header {
+		margin-top: 0;
+	}
+
+	&__summary {
+		cursor: pointer;
+		padding: var(--jm-ui-space-sm);
+		font-size: var(--jm-ui-font-size);
+		font-weight: 600;
+		display: flex;
+		align-items: center;
+		gap: var(--jm-ui-space-xs);
+
+		list-style: none;
+
+		&::-webkit-details-marker {
+			display: none;
+		}
+
+		&::after {
+			content: '';
+			margin-left: auto;
+			width: var(--jm-ui-icon-size-xs);
+			height: var(--jm-ui-icon-size-xs);
+			mask-image: var(--jm-ui-svg-arrow-down);
+			-webkit-mask-image: var(--jm-ui-svg-arrow-down);
+			mask-repeat: no-repeat;
+			-webkit-mask-repeat: no-repeat;
+			background-color: fadeCurrentColor(70%);
+			transition: transform 0.15s ease;
+			flex-shrink: 0;
+		}
+	}
+
+	&[open] &__summary::after {
+		transform: rotate(180deg);
+	}
+
+	&__count {
+		font-weight: 400;
+		color: fadeCurrentColor(70%);
+	}
+
+	&__rows {
+		margin: var(--jm-ui-space-sm) 0;
+	}
+
+	+ .jm-dashboard-group {
+		margin-top: var(--jm-ui-space-md);
+	}
+}

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -93,13 +93,15 @@ class Job_Dashboard_Shortcode {
 			return ob_get_clean();
 		}
 
-		$attrs          = shortcode_atts(
+		$attrs           = shortcode_atts(
 			[
-				'posts_per_page' => '25',
+				'posts_per_page'  => '25',
+				'group_by_status' => 'no',
 			],
 			$attrs
 		);
-		$posts_per_page = $attrs['posts_per_page'];
+		$posts_per_page  = $attrs['posts_per_page'];
+		$group_by_status = in_array( strtolower( (string) $attrs['group_by_status'] ), [ 'yes', 'true', '1' ], true );
 
 		Job_Overlay::instance()->init_dashboard_overlay();
 
@@ -121,14 +123,20 @@ class Job_Dashboard_Shortcode {
 		$search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
 
 		// ....If not show the job dashboard.
+		$query_args = [
+			'posts_per_page' => $group_by_status ? -1 : $posts_per_page,
+			's'              => $search,
+		];
+
 		$jobs = new \WP_Query(
-			$this->get_job_dashboard_query_args(
-				[
-					'posts_per_page' => $posts_per_page,
-					's'              => $search,
-				]
-			),
+			$this->get_job_dashboard_query_args( $query_args ),
 		);
+
+		// When grouping, ensure pagination offset is removed after the filter runs.
+		if ( $group_by_status ) {
+			$jobs->query_vars['posts_per_page'] = -1;
+			$jobs->query_vars['offset']         = 0;
+		}
 
 		// Cache IDs for access check later on.
 		$this->job_dashboard_job_ids = wp_list_pluck( $jobs->posts, 'ID' );
@@ -160,15 +168,29 @@ class Job_Dashboard_Shortcode {
 		 */
 		do_action( 'job_manager_job_dashboard_before', $jobs );
 
+		$group_data = $group_by_status
+			? [
+				'group_by_status' => true,
+				'job_groups'      => $this->group_jobs_by_status( $jobs->posts ),
+				'max_num_pages'   => 1,
+			]
+			: [
+				'group_by_status' => false,
+				'job_groups'      => [],
+				'max_num_pages'   => $jobs->max_num_pages,
+			];
+
 		get_job_manager_template(
 			'job-dashboard.php',
-			[
-				'jobs'                  => $jobs->posts,
-				'job_actions'           => $job_actions,
-				'max_num_pages'         => $jobs->max_num_pages,
-				'job_dashboard_columns' => $job_dashboard_columns,
-				'search_input'          => $search,
-			]
+			array_merge(
+				$group_data,
+				[
+					'jobs'                  => $jobs->posts,
+					'job_actions'           => $job_actions,
+					'job_dashboard_columns' => $job_dashboard_columns,
+					'search_input'          => $search,
+				]
+			)
 		);
 
 		Job_Overlay::instance()->output_modal_element();
@@ -684,6 +706,34 @@ class Job_Dashboard_Shortcode {
 		} else {
 			return home_url( '/' );
 		}
+	}
+
+	/**
+	 * Group jobs by status bucket for the dashboard.
+	 *
+	 * @since 2.5.0
+	 * @param array $jobs Array of WP_Post objects.
+	 * @return array{active: array, pending: array, inactive: array}
+	 */
+	private function group_jobs_by_status( array $jobs ): array {
+		$groups = [
+			'active'   => [],
+			'pending'  => [],
+			'inactive' => [],
+		];
+
+		foreach ( $jobs as $job ) {
+			$group = 'inactive';
+
+			if ( in_array( $job->post_status, [ 'publish', 'future' ], true ) ) {
+				$group = 'active';
+			} elseif ( in_array( $job->post_status, [ 'pending', 'pending_payment', 'draft', 'preview' ], true ) ) {
+				$group = 'pending';
+			}
+			$groups[ $group ][] = $job;
+		}
+
+		return $groups;
 	}
 
 	/**

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -132,12 +132,6 @@ class Job_Dashboard_Shortcode {
 			$this->get_job_dashboard_query_args( $query_args ),
 		);
 
-		// When grouping, ensure pagination offset is removed after the filter runs.
-		if ( $group_by_status ) {
-			$jobs->query_vars['posts_per_page'] = -1;
-			$jobs->query_vars['offset']         = 0;
-		}
-
 		// Cache IDs for access check later on.
 		$this->job_dashboard_job_ids = wp_list_pluck( $jobs->posts, 'ID' );
 
@@ -179,6 +173,22 @@ class Job_Dashboard_Shortcode {
 				'job_groups'      => [],
 				'max_num_pages'   => $jobs->max_num_pages,
 			];
+
+		/**
+		 * Limit the number of jobs shown in each group on the grouped dashboard.
+		 *
+		 * When set to a positive integer, each group (active/pending/inactive) is
+		 * truncated to that many entries. Default 0 means no limit.
+		 *
+		 * @since $$next-version$$
+		 * @param int $limit Maximum entries per group. 0 for unlimited.
+		 */
+		$group_limit = apply_filters( 'job_manager_job_dashboard_group_limit', 0 );
+		if ( $group_limit > 0 && ! empty( $group_data['job_groups'] ) ) {
+			foreach ( $group_data['job_groups'] as $key => $jobs_in_group ) {
+				$group_data['job_groups'][ $key ] = array_slice( $jobs_in_group, 0, $group_limit );
+			}
+		}
 
 		get_job_manager_template(
 			'job-dashboard.php',
@@ -711,7 +721,18 @@ class Job_Dashboard_Shortcode {
 	/**
 	 * Group jobs by status bucket for the dashboard.
 	 *
-	 * @since 2.5.0
+	 * Buckets:
+	 * - active: publish, future
+	 * - pending: pending, pending_payment, draft, preview
+	 * - inactive: expired
+	 *
+	 * Filled listings (post_status = publish, meta _filled = 1) intentionally
+	 * stay in the active bucket. They are still publicly visible until expired;
+	 * the "Filled" chip on the row signals the closed-for-applications state.
+	 * This matches the flat (non-grouped) view, which has always shown filled
+	 * publish listings inline.
+	 *
+	 * @since $$next-version$$
 	 * @param array $jobs Array of WP_Post objects.
 	 * @return array{active: array, pending: array, inactive: array}
 	 */

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -8,12 +8,12 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     2.5.0
+ * @version     $$next-version$$
  *
  * @since 2.3.0 Switched to a responsive layout. job_manager_job_dashboard_column_{$key} action is called for all columns.
  * @since 1.34.4 Available job actions are passed in an array (`$job_actions`, keyed by job ID) and not generated in the template.
  * @since 1.35.0 Switched to new date functions.
- * @since 2.5.0 Jobs can be grouped by status using group_by_status shortcode attribute.
+ * @since $$next-version$$ Jobs can be grouped by status using group_by_status shortcode attribute.
  *
  * @var array     $job_dashboard_columns Array of the columns to show on the job dashboard page.
  * @var int       $max_num_pages Maximum number of pages.
@@ -94,7 +94,7 @@ $render_row = function ( $job ) use ( $job_dashboard_columns, $job_actions ) {
 	</div>
 	<?php $table_class = count( $job_dashboard_columns ) > 4 ? 'jm-dashboard-table--large' : ''; ?>
 	<div class="job-manager-jobs jm-dashboard-table <?php echo esc_attr( $table_class ); ?>">
-		<?php if ( $group_by_status && ! empty( $job_groups ) ) : ?>
+		<?php if ( $group_by_status && $jobs && ! empty( $job_groups ) ) : ?>
 			<?php $group_order = [ 'active', 'pending', 'inactive' ]; ?>
 			<?php foreach ( $group_order as $group_key ) : ?>
 				<?php

--- a/templates/job-dashboard.php
+++ b/templates/job-dashboard.php
@@ -8,17 +8,20 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     2.3.0
+ * @version     2.5.0
  *
  * @since 2.3.0 Switched to a responsive layout. job_manager_job_dashboard_column_{$key} action is called for all columns.
  * @since 1.34.4 Available job actions are passed in an array (`$job_actions`, keyed by job ID) and not generated in the template.
  * @since 1.35.0 Switched to new date functions.
+ * @since 2.5.0 Jobs can be grouped by status using group_by_status shortcode attribute.
  *
  * @var array     $job_dashboard_columns Array of the columns to show on the job dashboard page.
- * @var int       $max_num_pages Maximum number of pages
+ * @var int       $max_num_pages Maximum number of pages.
  * @var WP_Post[] $jobs Array of job post results.
  * @var array     $job_actions Array of actions available for each job.
  * @var string    $search_input Search input.
+ * @var bool      $group_by_status True if jobs should be grouped by status.
+ * @var array     $job_groups Array of jobs grouped by status key.
  */
 
 use WP_Job_Manager\Job_Overlay;
@@ -31,8 +34,45 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 
-?>
+$group_labels = [
+	'active'   => __( 'Active', 'wp-job-manager' ),
+	'pending'  => __( 'Pending', 'wp-job-manager' ),
+	'inactive' => __( 'Inactive', 'wp-job-manager' ),
+];
 
+/**
+ * Render a single dashboard job row.
+ *
+ * @param WP_Post $job The job post object.
+ */
+$render_row = function ( $job ) use ( $job_dashboard_columns, $job_actions ) {
+	?>
+	<div class="jm-dashboard-job">
+		<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
+			<div class="jm-dashboard-job-column <?php echo esc_attr( $key ); ?>"
+				aria-label="<?php echo esc_attr( $column ); ?>">
+				<div class="jm-dashboard-job-column-label"><?php echo esc_html( $column ); ?></div>
+				<?php do_action( 'job_manager_job_dashboard_column_' . $key, $job ); ?>
+			</div>
+		<?php endforeach; ?>
+		<div class="jm-dashboard-job-column actions job-dashboard-job-actions">
+			<?php do_action( 'job_manager_job_dashboard_column_actions', $job, $job_actions[ $job->ID ] ?? [] ); ?>
+			<?php
+			$actions_html = '';
+			if ( ! empty( $job_actions[ $job->ID ] ) ) {
+				foreach ( $job_actions[ $job->ID ] as $action ) {
+					$actions_html .= '<a href="' . esc_url( $action['url'] ) . '" class=" jm-dashboard-action jm-ui-button--link job-dashboard-action-' . esc_attr( $action['name'] ) . '">' . esc_html( $action['label'] ) . '</a>' . "\n";
+				}
+			}
+
+			echo UI_Elements::actions_menu( $actions_html );
+			?>
+		</div>
+	</div>
+	<?php
+};
+
+?>
 <div id="job-manager-job-dashboard" class="alignwide jm-dashboard jm-ui">
 	<div class="jm-dashboard__intro">
 		<div class="jm-dashboard__filters">
@@ -54,7 +94,41 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 	</div>
 	<?php $table_class = count( $job_dashboard_columns ) > 4 ? 'jm-dashboard-table--large' : ''; ?>
 	<div class="job-manager-jobs jm-dashboard-table <?php echo esc_attr( $table_class ); ?>">
-		<?php if ( ! $jobs ) : ?>
+		<?php if ( $group_by_status && ! empty( $job_groups ) ) : ?>
+			<?php $group_order = [ 'active', 'pending', 'inactive' ]; ?>
+			<?php foreach ( $group_order as $group_key ) : ?>
+				<?php
+				if ( empty( $job_groups[ $group_key ] ) ) {
+					continue;
+				}
+
+				$label = $group_labels[ $group_key ] ?? $group_key;
+				$count = count( $job_groups[ $group_key ] );
+				$open  = 'inactive' !== $group_key;
+				?>
+				<details class="jm-dashboard-group jm-dashboard-group--<?php echo esc_attr( $group_key ); ?>" <?php echo $open ? 'open' : ''; ?>>
+					<summary class="jm-dashboard-group__summary">
+						<span class="jm-dashboard-group__label"><?php echo esc_html( $label ); ?></span>
+						<span class="jm-dashboard-group__count">(<?php echo esc_html( (string) $count ); ?>)</span>
+					</summary>
+					<div class="jm-dashboard-header">
+						<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
+							<div class="jm-dashboard-job-column jm-dashboard-job-column-label <?php echo esc_attr( $key ); ?>">
+								<?php echo esc_html( $column ); ?>
+							</div>
+						<?php endforeach; ?>
+						<div class="jm-dashboard-job-column jm-dashboard-job-column-label actions">
+							<?php esc_html_e( 'Actions', 'wp-job-manager' ); ?>
+						</div>
+					</div>
+					<div class="jm-dashboard-group__rows">
+						<?php foreach ( $job_groups[ $group_key ] as $job ) : ?>
+							<?php $render_row( $job ); ?>
+						<?php endforeach; ?>
+					</div>
+				</details>
+			<?php endforeach; ?>
+		<?php elseif ( ! $jobs ) : ?>
 			<div
 				class="jm-dashboard-empty">
 				<?php echo Notice::dialog(
@@ -79,28 +153,7 @@ $submit_job_form_page_id = get_option( 'job_manager_submit_job_form_page_id' );
 			</div>
 			<div class="jm-dashboard-rows">
 				<?php foreach ( $jobs as $job ) : ?>
-					<div class="jm-dashboard-job">
-						<?php foreach ( $job_dashboard_columns as $key => $column ) : ?>
-							<div class="jm-dashboard-job-column <?php echo esc_attr( $key ); ?>"
-								aria-label="<?php echo esc_attr( $column ); ?>">
-								<div class="jm-dashboard-job-column-label"><?php echo esc_html( $column ); ?></div>
-								<?php do_action( 'job_manager_job_dashboard_column_' . $key, $job ); ?>
-							</div>
-						<?php endforeach; ?>
-						<div class="jm-dashboard-job-column actions job-dashboard-job-actions">
-							<?php do_action( 'job_manager_job_dashboard_column_actions', $job, $job_actions[ $job->ID ] ?? [] ); ?>
-							<?php
-							$actions_html = '';
-							if ( ! empty( $job_actions[ $job->ID ] ) ) {
-								foreach ( $job_actions[ $job->ID ] as $action ) {
-									$actions_html .= '<a href="' . esc_url( $action['url'] ) . '" class=" jm-dashboard-action jm-ui-button--link job-dashboard-action-' . esc_attr( $action['name'] ) . '">' . esc_html( $action['label'] ) . '</a>' . "\n";
-								}
-							}
-
-							echo UI_Elements::actions_menu( $actions_html );
-							?>
-						</div>
-					</div>
+					<?php $render_row( $job ); ?>
 				<?php endforeach; ?>
 			</div>
 		<?php endif; ?>

--- a/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
+++ b/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace WP_Job_Manager;
+
+/**
+ * Tests for Job_Dashboard_Shortcode grouping by status.
+ *
+ * @group job-dashboard
+ */
+class WP_Test_Job_Dashboard_Shortcode extends \WPJM_BaseTest {
+
+	/**
+	 * @var Job_Dashboard_Shortcode
+	 */
+	private $shortcode;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->shortcode = Job_Dashboard_Shortcode::instance();
+
+		// Set up the current user as the post author.
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Test that default shortcode atts do not enable grouping.
+	 */
+	public function test_default_atts_no_grouping() {
+		$this->factory->job_listing->create( [ 'post_author' => get_current_user_id() ] );
+		$output = $this->shortcode->output_job_dashboard( [] );
+
+		$this->assertStringNotContainsString( 'jm-dashboard-group', $output );
+		$this->assertStringContainsString( 'jm-dashboard-rows', $output );
+	}
+
+	/**
+	 * Test that group_by_status="yes" enables grouping.
+	 */
+	public function test_group_by_status_att_enables_grouping() {
+		$this->factory->job_listing->create_many( 3, [ 'post_author' => get_current_user_id() ] );
+
+		$output = $this->shortcode->output_job_dashboard( [ 'group_by_status' => 'yes' ] );
+
+		$this->assertStringContainsString( 'jm-dashboard-group', $output );
+	}
+
+	/**
+	 * Test status-to-group mapping via reflection on the private method.
+	 */
+	public function test_group_jobs_by_status_mapping() {
+		$publish_job   = $this->factory->job_listing->create_and_get( [ 'post_status' => 'publish', 'post_author' => get_current_user_id() ] );
+		$future_job    = $this->factory->job_listing->create_and_get( [ 'post_status' => 'future', 'post_author' => get_current_user_id() ] );
+		$pending_job   = $this->factory->job_listing->create_and_get( [ 'post_status' => 'pending', 'post_author' => get_current_user_id() ] );
+		$pending_pay   = $this->factory->job_listing->create_and_get( [ 'post_status' => 'pending_payment', 'post_author' => get_current_user_id() ] );
+		$draft_job     = $this->factory->job_listing->create_and_get( [ 'post_status' => 'draft', 'post_author' => get_current_user_id() ] );
+		$expired_job   = $this->factory->job_listing->create_and_get( [ 'post_status' => 'expired', 'post_author' => get_current_user_id() ] );
+
+		$method = new \ReflectionMethod( $this->shortcode, 'group_jobs_by_status' );
+		$method->setAccessible( true );
+
+		$groups = $method->invoke( $this->shortcode, [ $publish_job, $future_job, $pending_job, $pending_pay, $draft_job, $expired_job ] );
+
+		$active_ids   = wp_list_pluck( $groups['active'], 'ID' );
+		$pending_ids  = wp_list_pluck( $groups['pending'], 'ID' );
+		$inactive_ids = wp_list_pluck( $groups['inactive'], 'ID' );
+
+		$this->assertCount( 2, $groups['active'], 'Active should contain publish and future' );
+		$this->assertCount( 3, $groups['pending'], 'Pending should contain pending, pending_payment, and draft' );
+		$this->assertCount( 1, $groups['inactive'], 'Inactive should contain expired' );
+
+		$this->assertContains( $publish_job->ID, $active_ids );
+		$this->assertContains( $future_job->ID, $active_ids );
+		$this->assertContains( $pending_job->ID, $pending_ids );
+		$this->assertContains( $pending_pay->ID, $pending_ids );
+		$this->assertContains( $draft_job->ID, $pending_ids );
+		$this->assertContains( $expired_job->ID, $inactive_ids );
+	}
+
+	/**
+	 * Test that a filled publish job stays in the active group.
+	 */
+	public function test_filled_job_stays_in_active_group() {
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_status' => 'publish',
+				'post_author' => get_current_user_id(),
+				'meta_input'  => [ '_filled' => 1 ],
+			]
+		);
+		$job = get_post( $job_id );
+
+		$method = new \ReflectionMethod( $this->shortcode, 'group_jobs_by_status' );
+		$method->setAccessible( true );
+		$groups = $method->invoke( $this->shortcode, [ $job ] );
+
+		$this->assertCount( 1, $groups['active'], 'Filled publish job should be in active' );
+		$this->assertCount( 0, $groups['pending'] );
+		$this->assertCount( 0, $groups['inactive'] );
+	}
+
+	/**
+	 * Test that empty groups are not rendered in the template output.
+	 */
+	public function test_empty_groups_hidden() {
+		$this->factory->job_listing->create_many( 2, [ 'post_status' => 'publish', 'post_author' => get_current_user_id() ] );
+
+		$output = $this->shortcode->output_job_dashboard( [ 'group_by_status' => 'yes' ] );
+
+		// Only Active group should be present.
+		$this->assertStringContainsString( 'jm-dashboard-group--active', $output );
+		$this->assertStringNotContainsString( 'jm-dashboard-group--pending', $output );
+		$this->assertStringNotContainsString( 'jm-dashboard-group--inactive', $output );
+	}
+
+	/**
+	 * Test that search works across groups.
+	 */
+	public function test_search_filters_all_groups() {
+		$this->factory->job_listing->create(
+			[
+				'post_title'  => 'Unique Search Target',
+				'post_author' => get_current_user_id(),
+			]
+		);
+		$this->factory->job_listing->create(
+			[
+				'post_status' => 'pending',
+				'post_title'  => 'Another Job',
+				'post_author' => get_current_user_id(),
+			]
+		);
+		$this->factory->job_listing->create(
+			[
+				'post_status' => 'expired',
+				'post_title'  => 'Yet Another',
+				'post_author' => get_current_user_id(),
+			]
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test env.
+		$_GET['search'] = 'Unique Search Target';
+
+		try {
+			$output = $this->shortcode->output_job_dashboard( [ 'group_by_status' => 'yes' ] );
+
+			// Should find the matching job in the active group.
+			$this->assertStringContainsString( 'jm-dashboard-group--active', $output );
+
+			// Empty groups (pending, inactive) should be hidden.
+			$this->assertStringNotContainsString( 'jm-dashboard-group--pending', $output );
+			$this->assertStringNotContainsString( 'jm-dashboard-group--inactive', $output );
+		} finally {
+			unset( $_GET['search'] );
+		}
+	}
+
+	/**
+	 * Test that the flat (non-grouped) path still works for backward compatibility.
+	 */
+	public function test_flat_non_grouped_default_is_backward_compatible() {
+		$this->factory->job_listing->create_many( 3, [ 'post_author' => get_current_user_id() ] );
+
+		$output = $this->shortcode->output_job_dashboard( [] );
+
+		$this->assertStringContainsString( 'jm-dashboard-rows', $output );
+		$this->assertStringNotContainsString( 'jm-dashboard-group', $output );
+	}
+
+}

--- a/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
+++ b/tests/php/tests/includes/test_class.job-dashboard-shortcode.php
@@ -156,6 +156,17 @@ class WP_Test_Job_Dashboard_Shortcode extends \WPJM_BaseTest {
 	}
 
 	/**
+	 * Test zero listings shows empty state CTA when grouping is on.
+	 */
+	public function test_zero_listings_shows_empty_state_when_grouping() {
+		$output = $this->shortcode->output_job_dashboard( [ 'group_by_status' => 'yes' ] );
+
+		// Empty state should show CTA, not grouped view.
+		$this->assertStringContainsString( 'jm-dashboard-empty', $output );
+		$this->assertStringNotContainsString( 'jm-dashboard-group', $output );
+	}
+
+	/**
 	 * Test that the flat (non-grouped) path still works for backward compatibility.
 	 */
 	public function test_flat_non_grouped_default_is_backward_compatible() {


### PR DESCRIPTION
## Summary

Adds `group_by_status` shortcode attribute to `[job_dashboard]`. When enabled, jobs render in Active / Pending / Inactive collapsible sections instead of a flat paginated list. Closes #2742.

## Changes

### `includes/class-job-dashboard-shortcode.php`
- Added `group_by_status` shortcode att (default `no`, parsed to bool)
- When grouping, fetches all jobs (`posts_per_page = -1`) since flat pagination is incoherent across 3 groups
- Guard after filter reasserts `-1` in case `job_manager_get_dashboard_jobs_args` overrides
- New `group_jobs_by_status()` private method buckets posts: `publish`/`future` → active, `pending`/`pending_payment`/`draft`/`preview` → pending, `expired` → inactive
- Template args pass `group_by_status`, `job_groups`, and `max_num_pages = 1` when grouping

### `templates/job-dashboard.php`
- Extracted row markup into `$render_row` closure (single source of truth)
- Grouped branch: iterates groups in order, renders `<details>` with `<summary>` header (label + count), column headers, then rows
- Active/Pending default `open`; Inactive collapsed; empty groups skipped
- Flat branch unchanged but uses shared `$render_row`

### `assets/css/job-dashboard.scss`
- `.jm-dashboard-group` styles: hidden native marker, chevron indicator via `--jm-ui-svg-arrow-down` rotated on `[open]`, reuse existing design tokens

## Testing

**Test 1: Grouped view**
1. Add `[job_dashboard group_by_status="yes"]` to a page
2. Log in as employer with mixed-status jobs
3. Expect: Active/Pending/Inactive sections, each with label and count
4. Click header to expand/collapse

**Test 2: Filled jobs**
1. Mark a published job as Filled
2. Expect: stays in Active section with Filled chip visible

**Test 3: Empty groups**
1. If employer has only published jobs
2. Expect: only Active section renders

**Test 4: Search**
1. Use search field
2. Expect: results filter across all groups; empty groups hidden

**Test 5: Backward compat**
1. Use `[job_dashboard]` (no att)
2. Expect: flat list with pagination, identical to pre-change behavior

## Screenshots
| Before | After |
| ------ | ------ |
|<img width="1509" height="487" alt="SCR-20260713-cdga" src="https://github.com/user-attachments/assets/b7c9400e-721d-4d08-9825-ad7d074eba4e" />|<img width="1532" height="695" alt="SCR-20260713-cdmp" src="https://github.com/user-attachments/assets/c1c72b3d-ff2a-433d-91e1-94dc2e153c20" />|