### PR TITLE
fix(wpml): make rewrite slugs stable for translation

### DIFF
--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -14,6 +14,7 @@ function wpml_wpjm_init() {
 	add_action( 'get_job_listings_init', 'wpml_wpjm_set_language' );
 	add_filter( 'wpjm_lang', 'wpml_wpjm_get_job_listings_lang' );
 	add_filter( 'wpjm_page_id', 'wpml_wpjm_page_id' );
+	add_filter( 'job_manager_permalink_structure', 'wpml_wpjm_force_static_slugs' );
 
 	$default_lang = apply_filters( 'wpml_default_language', null );
 	$current_lang = apply_filters( 'wpml_current_language', null );
@@ -74,6 +75,38 @@ function wpml_wpjm_get_job_listings_lang( $lang ) {
  */
 function wpml_wpjm_page_id( $page_id ) {
 	return apply_filters( 'wpml_object_id', $page_id, 'page', true );
+}
+
+/**
+ * Forces stable rewrite slugs so WPML can register the post type and taxonomies as translatable.
+ *
+ * WPML captures the source rewrite slug at `register_post_type()` / `register_taxonomy()` time. When
+ * the slug is dynamic (per-site permalink option), WPML cannot find a stable source to translate
+ * against, which breaks translated URLs and the AJAX request used by the [jobs] shortcode.
+ *
+ * See https://wpml.org/errata/wp-job-manager-job-incorrect-slug-translation-for-job-listings/ (compsupp-7570).
+ *
+ * @since 2.4.6
+ *
+ * @param array $permalinks The resolved permalink structure.
+ *
+ * @return array
+ */
+function wpml_wpjm_force_static_slugs( $permalinks ) {
+	if ( empty( $permalinks['job_base'] ) ) {
+		$permalinks['job_rewrite_slug'] = 'job';
+	}
+	if ( empty( $permalinks['category_base'] ) ) {
+		$permalinks['category_rewrite_slug'] = 'job-category';
+	}
+	if ( empty( $permalinks['type_base'] ) ) {
+		$permalinks['type_rewrite_slug'] = 'job-type';
+	}
+	if ( empty( $permalinks['jobs_archive'] ) ) {
+		$permalinks['jobs_archive_rewrite_slug'] = 'job-listings';
+	}
+
+	return $permalinks;
 }
 
 /**

--- a/includes/3rd-party/wpml.php
+++ b/includes/3rd-party/wpml.php
@@ -26,7 +26,7 @@ function wpml_wpjm_init() {
 }
 
 add_action( 'wpml_loaded', 'wpml_wpjm_init' );
-add_action( 'wpml_loaded', 'wpml_wpjm_set_language' );
+add_action( 'wpml_loaded', 'wpml_wpjm_set_language' ); // Intentional: see docblock above (WPML 3.7.1 ordering).
 
 /**
  * Sets WPJM's language if it is sent in the Ajax request.
@@ -86,7 +86,7 @@ function wpml_wpjm_page_id( $page_id ) {
  *
  * See https://wpml.org/errata/wp-job-manager-job-incorrect-slug-translation-for-job-listings/ (compsupp-7570).
  *
- * @since 2.4.6
+ * @since $$next-version$$
  *
  * @param array $permalinks The resolved permalink structure.
  *

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1604,7 +1604,18 @@ class WP_Job_Manager_Post_Types {
 		if ( function_exists( 'restore_current_locale' ) && did_action( 'admin_init' ) ) {
 			restore_current_locale();
 		}
-		return $permalinks;
+
+		/**
+		 * Filters the resolved permalink structure used to register the job_listing post type and its taxonomies.
+		 *
+		 * Third-party multilingual plugins (e.g. WPML) can use this to force stable rewrite slugs so they
+		 * can register the post type and taxonomies as translatable.
+		 *
+		 * @since 2.4.6
+		 *
+		 * @param array $permalinks The resolved permalink structure.
+		 */
+		return apply_filters( 'job_manager_permalink_structure', $permalinks );
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1606,12 +1606,13 @@ class WP_Job_Manager_Post_Types {
 		}
 
 		/**
-		 * Filters the resolved permalink structure used to register the job_listing post type and its taxonomies.
+		 * Filters the resolved rewrite-slug map returned by `get_permalink_structure()`.
 		 *
-		 * Third-party multilingual plugins (e.g. WPML) can use this to force stable rewrite slugs so they
-		 * can register the post type and taxonomies as translatable.
+		 * The filtered array replaces the `rewrite` input to `register_post_type()` and
+		 * `register_taxonomy()` calls downstream, so third-party multilingual plugins
+		 * (e.g. WPML) can pin a stable source slug for translation.
 		 *
-		 * @since 2.4.6
+		 * @since $$next-version$$
 		 *
 		 * @param array $permalinks The resolved permalink structure.
 		 */

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -759,7 +759,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.4.6
+	 * @since $$next-version$$
 	 * @covers WP_Job_Manager_Post_Types::get_permalink_structure
 	 */
 	public function test_get_permalink_structure_filter_no_callbacks() {
@@ -773,7 +773,7 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since 2.4.6
+	 * @since $$next-version$$
 	 * @covers WP_Job_Manager_Post_Types::get_permalink_structure
 	 */
 	public function test_get_permalink_structure_filter_overrides_slugs() {

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -759,6 +759,44 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @since 2.4.6
+	 * @covers WP_Job_Manager_Post_Types::get_permalink_structure
+	 */
+	public function test_get_permalink_structure_filter_no_callbacks() {
+		$permalinks = WP_Job_Manager_Post_Types::get_permalink_structure();
+
+		$this->assertSame( $permalinks, WP_Job_Manager_Post_Types::get_permalink_structure() );
+		$this->assertArrayHasKey( 'job_rewrite_slug', $permalinks );
+		$this->assertArrayHasKey( 'category_rewrite_slug', $permalinks );
+		$this->assertArrayHasKey( 'type_rewrite_slug', $permalinks );
+		$this->assertArrayHasKey( 'jobs_archive_rewrite_slug', $permalinks );
+	}
+
+	/**
+	 * @since 2.4.6
+	 * @covers WP_Job_Manager_Post_Types::get_permalink_structure
+	 */
+	public function test_get_permalink_structure_filter_overrides_slugs() {
+		$callback = function ( $permalinks ) {
+			$permalinks['job_rewrite_slug']          = 'careers';
+			$permalinks['category_rewrite_slug']     = 'career-categories';
+			$permalinks['type_rewrite_slug']         = 'career-types';
+			$permalinks['jobs_archive_rewrite_slug'] = 'careers-archive';
+			return $permalinks;
+		};
+		add_filter( 'job_manager_permalink_structure', $callback );
+
+		$permalinks = WP_Job_Manager_Post_Types::get_permalink_structure();
+
+		remove_filter( 'job_manager_permalink_structure', $callback );
+
+		$this->assertEquals( 'careers', $permalinks['job_rewrite_slug'] );
+		$this->assertEquals( 'career-categories', $permalinks['category_rewrite_slug'] );
+		$this->assertEquals( 'career-types', $permalinks['type_rewrite_slug'] );
+		$this->assertEquals( 'careers-archive', $permalinks['jobs_archive_rewrite_slug'] );
+	}
+
+	/**
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::update_post_meta
 	 */


### PR DESCRIPTION
## Summary
WPML captures the source rewrite slug at `register_post_type()` / `register_taxonomy()` time and tries to translate it per language. WPJM derives the post type and taxonomy rewrite slugs at runtime from the `job_manager_permalinks` option, so the source WPML sees is dynamic and varies per site. Without a stable source WPML cannot register the post type or taxonomies as translatable, producing 404s on translated category and type URLs and breaking the AJAX request used by the `[jobs]` shortcode (variable mismatch error).

This adds a new `job_manager_permalink_structure` filter on the return value of `get_permalink_structure()` and registers a WPML-side callback that forces the four rewrite slugs to their stable defaults when WPML is active. Non-WPML sites are unaffected; the filter is a no-op without a registered callback.

Fixes #2354

## Changes

### `includes/class-wp-job-manager-post-types.php`
**After:**
```php
/**
 * Filters the resolved permalink structure used to register the job_listing post type and its taxonomies.
 *
 * Third-party multilingual plugins (e.g. WPML) can use this to force stable rewrite slugs so they
 * can register the post type and taxonomies as translatable.
 *
 * @since 2.4.6
 *
 * @param array $permalinks The resolved permalink structure.
 */
return apply_filters( 'job_manager_permalink_structure', $permalinks );
```
**Why:** exposes the permalink array WPJM uses to register the post type and taxonomies, so multilingual plugins can pin a stable source slug for translation.

### `includes/3rd-party/wpml.php`
**After:**
```php
add_filter( 'job_manager_permalink_structure', 'wpml_wpjm_force_static_slugs' );

function wpml_wpjm_force_static_slugs( $permalinks ) {
    if ( empty( $permalinks['job_base'] ) ) {
        $permalinks['job_rewrite_slug'] = 'job';
    }
    if ( empty( $permalinks['category_base'] ) ) {
        $permalinks['category_rewrite_slug'] = 'job-category';
    }
    if ( empty( $permalinks['type_base'] ) ) {
        $permalinks['type_rewrite_slug'] = 'job-type';
    }
    if ( empty( $permalinks['jobs_archive'] ) ) {
        $permalinks['jobs_archive_rewrite_slug'] = 'job-listings';
    }
    return $permalinks;
}
```
**Why:** when WPML is active, force the four rewrite slugs to their defaults so WPML has a stable source to register against. Each slug is only overridden if the corresponding `_base` permalink option is empty, so any custom permalink value the admin set before installing WPML is preserved.

### `tests/php/tests/includes/test_class.wp-job-manager-post-types.php`
**Why:** covers the new filter both as a no-op (no callback registered, output equals input) and as an override (callback registered, output reflects the override).

## Testing
- `phpunit --filter test_get_permalink_structure` — 3 pass (existing + 2 new).
- `phpcs` — clean.
- `psalm` — clean on supported PHP versions (pre-existing local PHP 8.5 amphp/amp deprecation noise is unrelated; CI matrix covers 7.4 / 8.3 / 8.4).
- CodeRabbit — actionable finding (preserve configured `_base` values) applied.

## Manual repro
1. Install WPML Multilingual CMS, set primary language German, add Italian as secondary.
2. In WPML → Settings, mark `job_listing` and the two `job_listing_*` taxonomies as translatable.
3. Create a Jobs page (e.g. `stellenangebote`) containing the `[jobs]` shortcode, publish.
4. Translate the page to Italian with a different slug (e.g. `offerte-di-lavoro`).
5. Add a job category widget to the page sidebar.
6. Visit the page in the primary language: listings and widget render correctly.
7. Use the WPML language switcher to switch to Italian.

Before this fix: switcher lands on `…/it/stellenangebote/`, translated page renders as a default archive with no widgets, AJAX `?jm-ajax=get_job_listings` returns HTTP 400.

After this fix: switcher lands on `…/it/offerte-di-lavoro/`, translated page renders the same listings and widget, AJAX returns HTTP 200.

## Notes
- WPML users who previously customised `job_base` / `category_base` / `type_base` / `jobs_archive` and then install WPML will see those values reset to the defaults. This is unavoidable: WPML cannot translate a slug it never registered against. Sites that need custom slugs alongside WPML should set the permalinks after installing WPML, then translate the slug per language via WPML's slug translation UI.
- No changes to non-WPML users: the filter is a no-op without a registered callback, and the WPML callback is only registered on `wpml_loaded`.