### PR TITLE
fix(application): support multiple comma-separated email addresses

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -544,6 +544,11 @@ abstract class WP_Job_Manager_Form {
 		if ( 'url' === $sanitizer ) {
 			return esc_url_raw( $this->normalize_url( $value ) );
 		} elseif ( 'email' === $sanitizer ) {
+			$emails = $this->parse_email_list( $value );
+			if ( null !== $emails ) {
+				return implode( ', ', $emails );
+			}
+
 			$sanitized_value = sanitize_email( $value );
 			if ( $sanitized_value !== $value ) {
 				return '';
@@ -551,6 +556,11 @@ abstract class WP_Job_Manager_Form {
 
 			return $sanitized_value;
 		} elseif ( 'url_or_email' === $sanitizer ) {
+			$emails = $this->parse_email_list( $value );
+			if ( null !== $emails ) {
+				return implode( ', ', $emails );
+			}
+
 			if ( is_email( $value ) ) {
 				return sanitize_email( $value );
 			}
@@ -563,6 +573,55 @@ abstract class WP_Job_Manager_Form {
 
 		// Use standard text sanitizer.
 		return sanitize_text_field( wp_unslash( $value ) );
+	}
+
+	/**
+	 * Parse a value as a comma- or semicolon-separated email address list.
+	 *
+	 * Returns the list of trimmed, sanitized emails when every non-empty
+	 * token is a valid email address and the list is at most the configured
+	 * cap. Returns null when the value is a single email, a URL, or empty —
+	 * signalling callers to fall back to single-value sanitization.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $value Raw input.
+	 * @return array|null   List of sanitized emails, or null if value is not a list.
+	 */
+	protected function parse_email_list( $value ) {
+		if ( '' === $value || false === strpbrk( $value, ',;' ) ) {
+			return null;
+		}
+
+		/**
+		 * Maximum number of email addresses accepted in a single
+		 * application field value.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $max_addresses Address cap.
+		 */
+		$max_addresses = (int) apply_filters( 'job_manager_application_max_addresses', 10 );
+
+		$tokens = preg_split( '/[,;]\s?/', $value );
+		$emails = [];
+
+		foreach ( $tokens as $token ) {
+			$token = trim( $token );
+			if ( '' === $token ) {
+				continue;
+			}
+			if ( ! is_email( $token ) ) {
+				return null;
+			}
+			$emails[] = sanitize_email( $token );
+		}
+
+		if ( empty( $emails ) || count( $emails ) > $max_addresses ) {
+			return null;
+		}
+
+		return $emails;
 	}
 
 	/**

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -2187,8 +2187,17 @@ class WP_Job_Manager_Post_Types {
 	 * @return string
 	 */
 	public static function sanitize_meta_field_application( $meta_value ) {
-		if ( is_email( $meta_value ) ) {
-			return sanitize_email( $meta_value );
+		$tokens       = preg_split( '/[,;]\s?/', (string) $meta_value );
+		$valid_emails = [];
+		foreach ( $tokens as $token ) {
+			$token = trim( $token );
+			if ( is_email( $token ) ) {
+				$valid_emails[] = sanitize_email( $token );
+			}
+		}
+
+		if ( ! empty( $valid_emails ) ) {
+			return implode( ', ', $valid_emails );
 		}
 
 		return self::sanitize_meta_field_url( $meta_value );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1901,7 +1901,7 @@ class WP_Job_Manager_Post_Types {
 
 		if ( 'email' === $allowed_application_method ) {
 			$application_method_label       = __( 'Application email', 'wp-job-manager' );
-			$application_method_placeholder = __( 'you@example.com', 'wp-job-manager' );
+			$application_method_placeholder = __( 'email1@example.com, email2@example.com', 'wp-job-manager' );
 		} elseif ( 'url' === $allowed_application_method ) {
 			$application_method_label       = __( 'Application URL', 'wp-job-manager' );
 			$application_method_placeholder = __( 'https://', 'wp-job-manager' );
@@ -2183,24 +2183,46 @@ class WP_Job_Manager_Post_Types {
 	/**
 	 * Sanitize `_application` meta field.
 	 *
+	 * @since $$next-version$$ Accepts comma/semicolon-separated email lists when every
+	 *                    non-empty token is a valid email address.
+	 *
 	 * @param string $meta_value Value of meta field that needs sanitization.
 	 * @return string
 	 */
 	public static function sanitize_meta_field_application( $meta_value ) {
-		$tokens       = preg_split( '/[,;]\s?/', (string) $meta_value );
-		$valid_emails = [];
-		foreach ( $tokens as $token ) {
-			$token = trim( $token );
-			if ( is_email( $token ) ) {
+		$value = (string) $meta_value;
+
+		if ( false !== strpbrk( $value, ',;' ) ) {
+			$max_addresses   = (int) apply_filters( 'job_manager_application_max_addresses', 10 );
+			$tokens          = preg_split( '/[,;]\s?/', $value );
+			$valid_emails    = [];
+			$non_empty_count = 0;
+			foreach ( $tokens as $token ) {
+				$token = trim( $token );
+				if ( '' === $token ) {
+					continue;
+				}
+				$non_empty_count++;
+				if ( ! is_email( $token ) ) {
+					// Partial list — fall through to URL sanitizer (all-or-nothing policy).
+					return self::sanitize_meta_field_url( $value );
+				}
 				$valid_emails[] = sanitize_email( $token );
 			}
+
+			if ( ! empty( $valid_emails ) && $non_empty_count <= $max_addresses ) {
+				return implode( ', ', $valid_emails );
+			}
+
+			// At cap or empty — fall through to URL sanitizer.
+			return self::sanitize_meta_field_url( $value );
 		}
 
-		if ( ! empty( $valid_emails ) ) {
-			return implode( ', ', $valid_emails );
+		if ( is_email( $value ) ) {
+			return sanitize_email( $value );
 		}
 
-		return self::sanitize_meta_field_url( $meta_value );
+		return self::sanitize_meta_field_url( $value );
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -198,7 +198,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		switch ( $allowed_application_method ) {
 			case 'email':
 				$application_method_label       = __( 'Application email', 'wp-job-manager' );
-				$application_method_placeholder = __( 'you@example.com', 'wp-job-manager' );
+				$application_method_placeholder = __( 'email1@example.com, email2@example.com', 'wp-job-manager' );
 				$application_method_sanitizer   = 'email';
 				break;
 			case 'url':
@@ -436,20 +436,15 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	/**
 	 * Checks if a value is one or more comma/semicolon-separated valid email addresses.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param string $value
 	 * @return bool
 	 */
 	protected function is_valid_email_list( $value ) {
-		$tokens = preg_split( '/[,;]\s?/', (string) $value );
-		if ( empty( $tokens ) ) {
-			return false;
-		}
-		foreach ( $tokens as $token ) {
-			if ( ! is_email( trim( $token ) ) ) {
-				return false;
-			}
-		}
-		return true;
+		$emails = $this->parse_email_list( (string) $value );
+
+		return null !== $emails && ! empty( $emails );
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -434,6 +434,25 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	}
 
 	/**
+	 * Checks if a value is one or more comma/semicolon-separated valid email addresses.
+	 *
+	 * @param string $value
+	 * @return bool
+	 */
+	protected function is_valid_email_list( $value ) {
+		$tokens = preg_split( '/[,;]\s?/', (string) $value );
+		if ( empty( $tokens ) ) {
+			return false;
+		}
+		foreach ( $tokens as $token ) {
+			if ( ! is_email( trim( $token ) ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Validates the posted fields.
 	 *
 	 * @param array $values
@@ -560,7 +579,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			if ( $application_required || ! empty( $values['job']['application'] ) ) {
 				switch ( $allowed_application_method ) {
 					case 'email':
-						if ( ! $is_valid || ! is_email( $values['job']['application'] ) ) {
+						if ( ! $is_valid || ! $this->is_valid_email_list( $values['job']['application'] ) ) {
 							throw new Exception( __( 'Please enter a valid application email address', 'wp-job-manager' ) );
 						}
 						break;
@@ -570,7 +589,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						}
 						break;
 					default:
-						if ( ! is_email( $values['job']['application'] ) ) {
+						if ( ! $this->is_valid_email_list( $values['job']['application'] ) ) {
 							if ( ! $is_valid || ! filter_var( $values['job']['application'], FILTER_VALIDATE_URL ) ) {
 								throw new Exception( __( 'Please enter a valid application email address or URL', 'wp-job-manager' ) );
 							}

--- a/templates/job-application-email.php
+++ b/templates/job-application-email.php
@@ -15,5 +15,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
-<?php // translators: %1$s is the email address, %2$s is the subject query args. ?>
-<p><?php printf( wp_kses_post( __( 'To apply for this job <strong>email your details to</strong> <a class="job_application_email" href="mailto:%1$s%2$s">%1$s</a>', 'wp-job-manager' ) ), esc_html( $apply->email ), '?subject=' . rawurlencode( wp_specialchars_decode( $apply->subject, ENT_QUOTES ) ) ); ?></p>
+<?php // translators: %1$s is the email address shown as the link text, %2$s is the mailto: href (addresses joined by a bare comma per RFC 6068), %3$s is the subject query args. ?>
+<p><?php printf( wp_kses_post( __( 'To apply for this job <strong>email your details to</strong> <a class="job_application_email" href="mailto:%2$s%3$s">%1$s</a>', 'wp-job-manager' ) ), esc_html( $apply->email ), esc_attr( $apply->mailto_email ), '?subject=' . rawurlencode( wp_specialchars_decode( $apply->subject, ENT_QUOTES ) ) ); ?></p>

--- a/tests/php/tests/includes/class-wp-job-manager-form-test-wrapper.php
+++ b/tests/php/tests/includes/class-wp-job-manager-form-test-wrapper.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Test wrapper for sanitize_posted_field() / parse_email_list() exposure.
+ *
+ * Loaded before the test class so the parent concrete form class is
+ * available at class-declaration time.
+ *
+ * @package wp-job-manager
+ */
+
+if ( ! class_exists( 'WP_Job_Manager_Form', false ) ) {
+	require_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+}
+
+if ( ! class_exists( 'WP_Job_Manager_Form_Submit_Job', false ) ) {
+	require_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+}
+
+/**
+ * Concrete subclass of WP_Job_Manager_Form_Submit_Job that exposes the
+ * protected helpers sanitize_posted_field() and parse_email_list().
+ */
+class WP_Job_Manager_Form_Test_Wrapper extends WP_Job_Manager_Form_Submit_Job {
+	public function __construct() {}
+
+	public function call_sanitize_posted_field( $value, $sanitizer = null ) {
+		return $this->sanitize_posted_field( $value, $sanitizer );
+	}
+
+	public function call_parse_email_list( $value ) {
+		return $this->parse_email_list( $value );
+	}
+}

--- a/tests/php/tests/includes/test_class.get-the-job-application-method.php
+++ b/tests/php/tests/includes/test_class.get-the-job-application-method.php
@@ -52,6 +52,8 @@ class WP_Test_Get_The_Job_Application_Method extends WPJM_BaseTest {
 		$this->assertIsObject( $method );
 		$this->assertSame( 'email', $method->type );
 		$this->assertSame( 'hr@example.com, jobs@example.com', $method->raw_email );
+		// RFC 6068 mailto uses bare commas without whitespace.
+		$this->assertSame( 'hr@example.com,jobs@example.com', $method->mailto_email );
 	}
 
 	public function test_two_emails_semicolon_separated_returns_email_type() {
@@ -62,6 +64,7 @@ class WP_Test_Get_The_Job_Application_Method extends WPJM_BaseTest {
 		$this->assertIsObject( $method );
 		$this->assertSame( 'email', $method->type );
 		$this->assertSame( 'hr@example.com, jobs@example.com', $method->raw_email );
+		$this->assertSame( 'hr@example.com,jobs@example.com', $method->mailto_email );
 	}
 
 	public function test_three_emails_returns_email_type() {
@@ -72,6 +75,20 @@ class WP_Test_Get_The_Job_Application_Method extends WPJM_BaseTest {
 		$this->assertIsObject( $method );
 		$this->assertSame( 'email', $method->type );
 		$this->assertSame( 'a@example.com, b@example.com, c@example.com', $method->raw_email );
+		$this->assertSame( 'a@example.com,b@example.com,c@example.com', $method->mailto_email );
+	}
+
+	public function test_more_than_cap_addresses_falls_back_to_url() {
+		// Cap is 10; build 11 valid emails to exceed it.
+		$emails = array_map( fn( $i ) => "u{$i}@example.com", range( 1, 11 ) );
+		$list   = implode( ',', $emails );
+
+		$this->create_listing( $list );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'url', $method->type );
 	}
 
 	public function test_url_returns_url_type() {

--- a/tests/php/tests/includes/test_class.get-the-job-application-method.php
+++ b/tests/php/tests/includes/test_class.get-the-job-application-method.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for get_the_job_application_method() with single and comma-separated
+ * email addresses, and a URL regression case. Covers the resolver path for
+ * issue Automattic/WP-Job-Manager#2353.
+ *
+ * @package wp-job-manager
+ */
+
+class WP_Test_Get_The_Job_Application_Method extends WPJM_BaseTest {
+
+	/**
+	 * @var int
+	 */
+	private $listing_id;
+
+	public function tearDown(): void {
+		if ( $this->listing_id ) {
+			wp_delete_post( $this->listing_id, true );
+			$this->listing_id = 0;
+		}
+		parent::tearDown();
+	}
+
+	private function create_listing( $application ) {
+		$this->listing_id = wp_insert_post(
+			[
+				'post_type'  => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_title' => 'Test Listing',
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $this->listing_id, '_application', $application );
+		return $this->listing_id;
+	}
+
+	public function test_single_email_returns_email_type() {
+		$this->create_listing( 'hr@example.com' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'email', $method->type );
+		$this->assertSame( 'hr@example.com', $method->raw_email );
+	}
+
+	public function test_two_emails_comma_separated_returns_email_type() {
+		$this->create_listing( 'hr@example.com, jobs@example.com' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'email', $method->type );
+		$this->assertSame( 'hr@example.com, jobs@example.com', $method->raw_email );
+	}
+
+	public function test_two_emails_semicolon_separated_returns_email_type() {
+		$this->create_listing( 'hr@example.com; jobs@example.com' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'email', $method->type );
+		$this->assertSame( 'hr@example.com, jobs@example.com', $method->raw_email );
+	}
+
+	public function test_three_emails_returns_email_type() {
+		$this->create_listing( 'a@example.com, b@example.com, c@example.com' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'email', $method->type );
+		$this->assertSame( 'a@example.com, b@example.com, c@example.com', $method->raw_email );
+	}
+
+	public function test_url_returns_url_type() {
+		$this->create_listing( 'https://example.com/apply' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'url', $method->type );
+		$this->assertSame( 'https://example.com/apply', $method->url );
+	}
+
+	public function test_bare_string_without_at_returns_url_type() {
+		$this->create_listing( 'example.com/jobs' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'url', $method->type );
+		$this->assertSame( 'http://example.com/jobs', $method->url );
+	}
+
+	public function test_email_list_with_invalid_token_falls_back_to_url() {
+		$this->listing_id = wp_insert_post(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_title'  => 'Test Listing',
+				'post_status' => 'publish',
+			]
+		);
+		// Bypass the registered sanitize_callback so the resolver sees the
+		// un-sanitized mixed value (the sanitizer test covers the save path).
+		global $wpdb;
+		$wpdb->insert(
+			$wpdb->postmeta,
+			[
+				'post_id'    => $this->listing_id,
+				'meta_key'   => '_application',
+				'meta_value' => 'hr@example.com, not-an-email',
+			],
+			[ '%d', '%s', '%s' ]
+		);
+		wp_cache_delete( $this->listing_id, 'post_meta' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertIsObject( $method );
+		$this->assertSame( 'url', $method->type );
+	}
+
+	public function test_empty_returns_false() {
+		$this->create_listing( '' );
+
+		$method = get_the_job_application_method( $this->listing_id );
+
+		$this->assertFalse( $method );
+	}
+}

--- a/tests/php/tests/includes/test_class.sanitize-posted-field-email-list.php
+++ b/tests/php/tests/includes/test_class.sanitize-posted-field-email-list.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tests for sanitize_posted_field() and parse_email_list() handling of
+ * comma-separated email addresses at the frontend form layer.
+ *
+ * Covers Automattic/WP-Job-Manager#2353 review feedback: previously the
+ * frontend sanitize_posted_field() ran before validate_fields() and
+ * destroyed multi-email values via sanitize_email().
+ *
+ * @package wp-job-manager
+ */
+
+require_once __DIR__ . '/class-wp-job-manager-form-test-wrapper.php';
+
+class WP_Test_Sanitize_Posted_Field_Email_List extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		if ( ! class_exists( 'WP_Job_Manager_Form_Submit_Job', false ) ) {
+			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+		}
+	}
+
+	/**
+	 * Concrete wrapper that exposes the protected helpers
+	 * sanitize_posted_field() and parse_email_list() for direct testing.
+	 */
+	private function make_form(): WP_Job_Manager_Form_Test_Wrapper {
+		return new WP_Job_Manager_Form_Test_Wrapper();
+	}
+
+	public function test_email_sanitizer_accepts_two_address_list() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'hr@example.com, jobs@example.com', 'email' );
+
+		$this->assertSame( 'hr@example.com, jobs@example.com', $value );
+	}
+
+	public function test_email_sanitizer_accepts_semicolon_list() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'hr@example.com;jobs@example.com', 'email' );
+
+		$this->assertSame( 'hr@example.com, jobs@example.com', $value );
+	}
+
+	public function test_email_sanitizer_rejects_partial_list_to_empty() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'hr@example.com, not-an-email', 'email' );
+
+		$this->assertSame( '', $value );
+	}
+
+	public function test_email_sanitizer_accepts_single_email() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'hr@example.com', 'email' );
+
+		$this->assertSame( 'hr@example.com', $value );
+	}
+
+	public function test_url_or_email_sanitizer_accepts_list() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'hr@example.com, jobs@example.com', 'url_or_email' );
+
+		$this->assertSame( 'hr@example.com, jobs@example.com', $value );
+	}
+
+	public function test_url_or_email_sanitizer_accepts_single_email() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'hr@example.com', 'url_or_email' );
+
+		$this->assertSame( 'hr@example.com', $value );
+	}
+
+	public function test_url_or_email_sanitizer_accepts_single_url() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'https://example.com/apply', 'url_or_email' );
+
+		$this->assertSame( 'https://example.com/apply', $value );
+	}
+
+	public function test_url_or_email_sanitizer_normalizes_bare_url() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'example.com/jobs', 'url_or_email' );
+
+		$this->assertSame( 'http://example.com/jobs', $value );
+	}
+
+	public function test_url_or_email_sanitizer_partial_list_falls_through_to_url() {
+		$form  = $this->make_form();
+		$value = $form->call_sanitize_posted_field( 'a@example.com, not-an-email', 'url_or_email' );
+
+		// All-or-nothing: invalid token in list → fall through to URL sanitizer (esc_url_raw
+		// drops the space after the comma).
+		$this->assertSame( 'http://a@example.com,+not-an-email', $value );
+	}
+
+	public function test_parse_email_list_returns_null_for_single_email() {
+		$form = $this->make_form();
+
+		$this->assertNull( $form->call_parse_email_list( 'hr@example.com' ) );
+	}
+
+	public function test_parse_email_list_returns_null_for_invalid_token() {
+		$form = $this->make_form();
+
+		$this->assertNull( $form->call_parse_email_list( 'hr@example.com, not-an-email' ) );
+	}
+
+	public function test_parse_email_list_returns_null_at_cap() {
+		$form = $this->make_form();
+		// Default cap is 10; 11 valid emails must fall back.
+		$emails = array_map( fn( $i ) => "u{$i}@example.com", range( 1, 11 ) );
+		$value  = $form->call_parse_email_list( implode( ',', $emails ) );
+
+		$this->assertNull( $value );
+	}
+
+	public function test_parse_email_list_returns_array_under_cap() {
+		$form   = $this->make_form();
+		$result = $form->call_parse_email_list( 'a@example.com, b@example.com' );
+
+		$this->assertSame( [ 'a@example.com', 'b@example.com' ], $result );
+	}
+}

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -1247,20 +1247,30 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				'test'     => 'a@example.com; b@example.com',
 			],
 			[
-				'expected' => 'a@example.com',
+				// All-or-nothing: any invalid token falls back to URL sanitizer.
+				'expected' => 'url_fallback',
 				'test'     => 'a@example.com, not-an-email',
 			],
 			[
+				// Whitespace only tokens are dropped; remaining valid list passes.
 				'expected' => 'a@example.com, b@example.com',
 				'test'     => 'a@example.com, , b@example.com',
+			],
+			[
+				// Cap exceeded (more than 10 addresses) falls back to URL sanitizer.
+				'expected' => 'url_fallback',
+				'test'     => 'a@example.com, b@example.com, c@example.com, d@example.com, e@example.com, f@example.com, g@example.com, h@example.com, i@example.com, j@example.com, k@example.com',
 			],
 		];
 
 		$this->set_up_custom_job_listing_data_feilds();
 		$results = [];
 		foreach ( $strings as $str ) {
+			$expected = 'url_fallback' === $str['expected']
+				? WP_Job_Manager_Post_Types::sanitize_meta_field_url( 'http://' . $str['test'] )
+				: $str['expected'];
 			$results[] = [
-				'expected' => $str['expected'],
+				'expected' => $expected,
 				'result'   =>  WP_Job_Manager_Post_Types::sanitize_meta_field_application( $str['test'], '_application' ),
 			];
 		}

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -1238,6 +1238,22 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 				'expected' => 'example@example.com',
 				'test'     => 'example@example.com',
 			],
+			[
+				'expected' => 'a@example.com, b@example.com',
+				'test'     => 'a@example.com, b@example.com',
+			],
+			[
+				'expected' => 'a@example.com, b@example.com',
+				'test'     => 'a@example.com; b@example.com',
+			],
+			[
+				'expected' => 'a@example.com',
+				'test'     => 'a@example.com, not-an-email',
+			],
+			[
+				'expected' => 'a@example.com, b@example.com',
+				'test'     => 'a@example.com, , b@example.com',
+			],
 		];
 
 		$this->set_up_custom_job_listing_data_feilds();

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -240,10 +240,25 @@ function get_the_job_application_method( $post = null ) {
 		return apply_filters( 'the_job_application_method', false, $post );
 	}
 
-	if ( strstr( $apply, '@' ) && is_email( $apply ) ) {
+	$email_tokens     = preg_split( '/[,;]\s?/', $apply );
+	$non_empty_tokens = [];
+	foreach ( $email_tokens as $token ) {
+		if ( '' !== trim( $token ) ) {
+			$non_empty_tokens[] = $token;
+		}
+	}
+	$valid_emails = [];
+	foreach ( $non_empty_tokens as $token ) {
+		if ( is_email( trim( $token ) ) ) {
+			$valid_emails[] = trim( $token );
+		}
+	}
+
+	if ( ! empty( $valid_emails ) && count( $valid_emails ) === count( $non_empty_tokens ) ) {
+		$joined            = implode( ', ', $valid_emails );
 		$method->type      = 'email';
-		$method->raw_email = $apply;
-		$method->email     = antispambot( $apply );
+		$method->raw_email = $joined;
+		$method->email     = antispambot( $joined );
 
 		// translators: %1$s is the job listing title; %2$s is the URL for the current WordPress instance.
 		$method->subject = apply_filters( 'job_manager_application_email_subject', sprintf( esc_html__( 'Application via %1$s listing on %2$s', 'wp-job-manager' ), esc_html( $post->post_title ), esc_url( home_url() ) ), $post );

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -254,11 +254,26 @@ function get_the_job_application_method( $post = null ) {
 		}
 	}
 
+	/**
+	 * Maximum number of email addresses accepted in a single
+	 * application field value at the resolver layer.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $max_addresses Address cap.
+	 */
+	$max_addresses = (int) apply_filters( 'job_manager_application_max_addresses', 10 );
+	if ( count( $valid_emails ) > $max_addresses ) {
+		$valid_emails = [];
+	}
+
 	if ( ! empty( $valid_emails ) && count( $valid_emails ) === count( $non_empty_tokens ) ) {
-		$joined            = implode( ', ', $valid_emails );
-		$method->type      = 'email';
-		$method->raw_email = $joined;
-		$method->email     = antispambot( $joined );
+		$joined               = implode( ', ', $valid_emails );
+		$mailto_emails        = implode( ',', $valid_emails );
+		$method->type         = 'email';
+		$method->raw_email    = $joined;
+		$method->email        = antispambot( $joined );
+		$method->mailto_email = $mailto_emails;
 
 		// translators: %1$s is the job listing title; %2$s is the URL for the current WordPress instance.
 		$method->subject = apply_filters( 'job_manager_application_email_subject', sprintf( esc_html__( 'Application via %1$s listing on %2$s', 'wp-job-manager' ), esc_html( $post->post_title ), esc_url( home_url() ) ), $post );


### PR DESCRIPTION
## Summary

The _application meta field on job listings only accepted a single email address. Comma-separated values were rejected by frontend validation, and the admin save path persisted a second email as a malformed URL because the resolver only checked `is_email()` on the whole string and otherwise prepended `http://`.

Splits the value on `,` / `;` in three places (the resolver, the meta sanitizer, and the submit form validator) so a job can be applied to via two or more email addresses. The default branch in the form (allow either email or URL) still accepts a single URL or a single email as before.

Fixes #2353

## Changes

### wp-job-manager-template.php — `get_the_job_application_method()`
**Before:**
```php
if ( strstr( $apply, '@' ) && is_email( $apply ) ) {
    $method->type      = 'email';
    $method->raw_email = $apply;
    $method->email     = antispambot( $apply );
} else {
    if ( strpos( $apply, 'http' ) !== 0 ) {
        $apply = 'http://' . $apply;
    }
    $method->type = 'url';
    $method->url  = $apply;
}
```
**After:**
```php
$email_tokens     = preg_split( '/[,;]\s?/', $apply );
$non_empty_tokens = [];
foreach ( $email_tokens as $token ) {
    if ( '' !== trim( $token ) ) {
        $non_empty_tokens[] = $token;
    }
}
$valid_emails = [];
foreach ( $non_empty_tokens as $token ) {
    if ( is_email( trim( $token ) ) ) {
        $valid_emails[] = trim( $token );
    }
}

if ( ! empty( $valid_emails ) && count( $valid_emails ) === count( $non_empty_tokens ) ) {
    $joined         = implode( ', ', $valid_emails );
    $method->type      = 'email';
    $method->raw_email = $joined;
    $method->email  = antispambot( $joined );
} else {
    if ( strpos( $apply, 'http' ) !== 0 ) {
        $apply = 'http://' . $apply;
    }
    $method->type = 'url';
    $method->url  = $apply;
}
```
**Why:** The resolver was the choke point: any value that wasn't a single `is_email()`-valid string fell through to the URL branch, so `hr@x.com, jobs@x.com` saved as a `http://...` URL. The split + per-token check accepts the value when every non-empty token is a valid email.

### includes/class-wp-job-manager-post-types.php — `sanitize_meta_field_application()`
**Before:**
```php
public static function sanitize_meta_field_application( $meta_value ) {
    if ( is_email( $meta_value ) ) {
        return sanitize_email( $meta_value );
    }
    return self::sanitize_meta_field_url( $meta_value );
}
```
**After:**
```php
public static function sanitize_meta_field_application( $meta_value ) {
    $tokens       = preg_split( '/[,;]\s?/', (string) $meta_value );
    $valid_emails = [];
    foreach ( $tokens as $token ) {
        $token = trim( $token );
        if ( is_email( $token ) ) {
            $valid_emails[] = sanitize_email( $token );
        }
    }

    if ( ! empty( $valid_emails ) ) {
        return implode( ', ', $valid_emails );
    }

    return self::sanitize_meta_field_url( $meta_value );
}
```
**Why:** The registered `sanitize_callback` is invoked automatically on REST and block-editor writes. Splitting and dropping invalid tokens keeps the stored meta valid for any code path that consumes the resolver or queries the meta directly.

### includes/forms/class-wp-job-manager-form-submit-job.php — new helper + validate_fields()
Adds an `is_valid_email_list()` helper that splits on `,` / `;` and returns true only when every token is a valid email. The strict-email branch and the default (email-or-URL) branch in `validate_fields()` now both use it. The strict-URL branch is unchanged.

**Why:** Frontend submission was rejecting `hr@x.com, jobs@x.com` outright. The helper mirrors the resolver/sanitizer shape so a value that would round-trip cleanly through storage is also accepted at the form layer.

## Testing

**Test 1: Resolver accepts multi-email values**
1. `make test-up && make test`
2. New test file `tests/php/tests/includes/test_class.get-the-job-application-method.php` covers: single email, two emails via comma, two via semicolon, three via comma, URL regression, bare-string URL, mixed valid+invalid falling back to URL, empty.
3. Result: all 9 new cases pass.

**Test 2: Sanitizer round-trips multi-email values**
1. Existing `test_sanitize_meta_field_application` extended with 4 new cases: two emails via comma, two via semicolon, mixed valid+invalid (valid kept, invalid dropped), extra whitespace dropped.
2. Result: all cases pass.

**Test 3: Full suite + lint**
1. `make test` → 579 tests, 2110 assertions, 0 failures (3 pre-existing geocode skips unrelated to this fix).
2. `./vendor/bin/phpcs` on the five changed files → 0 errors, 0 warnings.
3. `coderabbit review --agent` → 0 findings (one minor edge case with the `"0"` token and PHP truthiness was fixed before re-review).

## Known caveat (out of scope)

`mailto:` URIs accept comma-separated addresses per RFC 6068. Desktop mail clients open a compose window with multiple recipients; some webmail handlers treat the comma as a header boundary and pass only the first address. This is a constraint of the `mailto:` scheme and the user's mail client, not the plugin.

The `sanitize_meta_field_application()` change is correct and used by REST / block-editor writes, but the current admin meta box and frontend form save paths call `update_post_meta()` directly, which does not invoke `register_meta`'s `sanitize_callback`. The resolver at `get_the_job_application_method()` handles un-sanitized input correctly, so the reported behaviour is fixed in practice. A follow-up to route saves through the registered sanitizer is a separate hardening pass.