### PR TITLE
Add Workplace Type dropdown (On-Site / Remote / Hybrid)

### DIFF
--- a/assets/js/ajax-filters.js
+++ b/assets/js/ajax-filters.js
@@ -314,6 +314,7 @@ jQuery( document ).ready( function( $ ) {
 			var featured = $target.data( 'featured' );
 			var filled = $target.data( 'filled' );
 			var remote_position = $target.data( 'remote_position' );
+			var workplace_types = $target.data( 'workplace_types' );
 			var job_types = $target.data( 'job_types' );
 			var post_status = $target.data( 'post_status' );
 			var author = $target.data( 'author' );
@@ -354,11 +355,17 @@ jQuery( document ).ready( function( $ ) {
 					} )
 					.get();
 
+				var workplace_type = $form
+					.find( ':input[name^="workplace_type"]' )
+					.map( function() {
+						return $( this ).val();
+					} )
+					.get();
+
 				keywords = '';
 				location = '';
 				var $keywords = $form.find( ':input[name="search_keywords"]' );
 				var $location = $form.find( ':input[name="search_location"]' );
-				var $remote_position = $form.find( ':input[name="remote_position"]' );
 
 				// Workaround placeholder scripts
 				if ( $keywords.val() !== $keywords.attr( 'placeholder' ) ) {
@@ -367,10 +374,6 @@ jQuery( document ).ready( function( $ ) {
 
 				if ( $location.val() !== $location.attr( 'placeholder' ) ) {
 					location = $location.val();
-				}
-
-				if( $remote_position.length ) {
-					remote_position = $remote_position.is( ':checked' ) ? 'true' : null;
 				}
 
 				data = {
@@ -387,7 +390,7 @@ jQuery( document ).ready( function( $ ) {
 					page: page,
 					featured: featured,
 					filled: filled,
-					remote_position: remote_position,
+					workplace_type: workplace_type,
 					author: author,
 					show_pagination: $target.data( 'show_pagination' ),
 					form_data: $form.serialize(),
@@ -418,6 +421,7 @@ jQuery( document ).ready( function( $ ) {
 					featured: featured,
 					filled: filled,
 					remote_position: remote_position,
+					workplace_type: workplace_types,
 					author: author,
 					show_pagination: $target.data( 'show_pagination' ),
 				};
@@ -469,7 +473,7 @@ jQuery( document ).ready( function( $ ) {
 	}
 
 	$(
-		'#search_keywords, #search_location, #remote_position, .job_types :input, #search_categories, .job-manager-filter'
+		'#search_keywords, #search_location, #workplace_type, .job_types :input, #search_categories, .job-manager-filter'
 	)
 		.change( triggerSearch )
 		.on( 'keyup', function( e ) {
@@ -500,9 +504,10 @@ jQuery( document ).ready( function( $ ) {
 				.not( ':input[type="hidden"]' )
 				.prop( 'checked', true );
 			$form
-				.find( ':input[name="remote_position"]' )
+				.find( ':input[name^="workplace_type"]' )
 				.not( ':input[type="hidden"]' )
-				.prop( 'checked', false );
+				.val( '' )
+				.trigger( 'change.select2' );
 
 			$target.triggerHandler( 'reset' );
 			$target.triggerHandler( 'update_results', [ 1, false ] );
@@ -538,7 +543,9 @@ jQuery( document ).ready( function( $ ) {
 	} );
 
 	if ( $.isFunction( $.fn.select2 ) && typeof job_manager_select2_filters_args !== 'undefined' ) {
-		$( 'select[name^="search_categories"]:visible' ).select2( job_manager_select2_filters_args );
+		$(
+			'select[name^="search_categories"]:visible, select[name^="workplace_type"]:visible'
+		).select2( job_manager_select2_filters_args );
 	}
 
 	$( window ).on( 'unload', function() {
@@ -575,9 +582,9 @@ jQuery( document ).ready( function( $ ) {
 				$form.find('input[type=checkbox]').prop('checked', false);
 				$form.deserialize(state.form);
 				$form
-					.find(':input[name^="search_categories"]')
-					.not(':input[type="hidden"]')
-					.trigger('change.select2');
+					.find( ':input[name^="search_categories"], :input[name^="workplace_type"]' )
+					.not( ':input[type="hidden"]' )
+					.trigger( 'change.select2' );
 			}
 		}
 

--- a/includes/admin/class-wp-job-manager-settings.php
+++ b/includes/admin/class-wp-job-manager-settings.php
@@ -276,9 +276,9 @@ class WP_Job_Manager_Settings {
 						[
 							'name'       => 'job_manager_enable_remote_position',
 							'std'        => '1',
-							'label'      => __( 'Remote Position', 'wp-job-manager' ),
-							'cb_label'   => __( 'Enable Remote Position', 'wp-job-manager' ),
-							'desc'       => __( 'This lets users select if the listing is a remote position when submitting a job.', 'wp-job-manager' ),
+							'label'      => __( 'Workplace Type', 'wp-job-manager' ),
+							'cb_label'   => __( 'Enable Workplace Type', 'wp-job-manager' ),
+							'desc'       => __( 'This lets users select whether the listing is on-site, remote, or hybrid when submitting a job.', 'wp-job-manager' ),
 							'type'       => 'checkbox',
 							'attributes' => [],
 							'track'      => 'bool',

--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -157,18 +157,38 @@ class WP_Job_Manager_Writepanels {
 		} elseif ( false === job_manager_multi_job_type() ) {
 			remove_meta_box( 'job_listing_typediv', \WP_Job_Manager_Post_Types::PT_LISTING, 'side' );
 			$job_listing_type = get_taxonomy( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE );
-			add_meta_box( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, $job_listing_type->labels->menu_name, [ $this, 'job_type_single_meta_box' ], \WP_Job_Manager_Post_Types::PT_LISTING, 'side', 'core' );
+			add_meta_box( \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE, $job_listing_type->labels->menu_name, [ $this, 'job_type_single_meta_box' ], \WP_Job_Manager_Post_Types::PT_LISTING, 'side', 'core', [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE ] );
+		}
+
+		if ( ! get_option( 'job_manager_enable_remote_position' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE ) ) ) {
+			remove_meta_box( 'job_listing_workplace_typediv', \WP_Job_Manager_Post_Types::PT_LISTING, 'side' );
+		} else {
+			remove_meta_box( 'job_listing_workplace_typediv', \WP_Job_Manager_Post_Types::PT_LISTING, 'side' );
+			$job_listing_workplace_type = get_taxonomy( \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+			add_meta_box(
+				\WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
+				$job_listing_workplace_type->labels->menu_name,
+				[ $this, 'job_type_single_meta_box' ],
+				\WP_Job_Manager_Post_Types::PT_LISTING,
+				'side',
+				'core',
+				[
+					'taxonomy'  => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
+					'show_none' => true,
+				]
+			);
 		}
 	}
 
 	/**
-	 * Displays job listing metabox.
+	 * Displays job listing metabox for a single-select taxonomy.
 	 *
 	 * @param int|WP_Post $post
+	 * @param array       $box  Meta box args; `$box['args']['taxonomy']` picks the taxonomy, defaults to job type.
 	 */
-	public function job_type_single_meta_box( $post ) {
+	public function job_type_single_meta_box( $post, $box = [] ) {
 		// Set up the taxonomy object and get terms.
-		$taxonomy_name = \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE;
+		$taxonomy_name = $box['args']['taxonomy'] ?? \WP_Job_Manager_Post_Types::TAX_LISTING_TYPE;
 
 		// Get all the terms for this taxonomy.
 		$terms     = get_terms(
@@ -182,11 +202,18 @@ class WP_Job_Manager_Writepanels {
 		$current   = $current ? $current->term_id : 0;
 
 		$field_name = 'tax_input[' . $taxonomy_name . ']';
+		$show_none  = ! empty( $box['args']['show_none'] );
 		?>
 		<div id="taxonomy-<?php echo esc_attr( $taxonomy_name ); ?>" class="categorydiv">
 			<!-- Display taxonomy terms -->
 			<div id="<?php echo esc_attr( $taxonomy_name ); ?>-all" class="editor-post-taxonomies__hierarchical-terms-list">
 				<ul id="<?php echo esc_attr( $taxonomy_name ); ?>checklist" class="list:<?php echo esc_attr( $taxonomy_name ); ?> categorychecklist form-no-clear">
+					<?php if ( $show_none ) : ?>
+						<li id="<?php echo esc_attr( $taxonomy_name ); ?>-0"><label class="selectit">
+							<input type="radio" id="in-<?php echo esc_attr( $taxonomy_name ); ?>-0" name="<?php echo esc_attr( $field_name ); ?>" <?php checked( $current, 0 ); ?> value="0" />
+							<?php esc_html_e( 'None', 'wp-job-manager' ); ?><br />
+						</label></li>
+					<?php endif; ?>
 					<?php
 					foreach ( $terms as $term ) {
 						$id = $taxonomy_name . '-' . $term->term_id;

--- a/includes/class-wp-job-manager-ajax.php
+++ b/includes/class-wp-job-manager-ajax.php
@@ -134,6 +134,7 @@ class WP_Job_Manager_Ajax {
 		$filled             = isset( $_REQUEST['filled'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['filled'] ) ) : null;
 		$featured           = isset( $_REQUEST['featured'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured'] ) ) : null;
 		$remote_position    = isset( $_REQUEST['remote_position'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['remote_position'] ) ) : null;
+		$workplace_type     = isset( $_REQUEST['workplace_type'] ) ? wp_unslash( $_REQUEST['workplace_type'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Input is sanitized below.
 		$show_pagination    = isset( $_REQUEST['show_pagination'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['show_pagination'] ) ) : null;
 		$featured_first     = isset( $_REQUEST['featured_first'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['featured_first'] ) ) : null;
 		if ( ! isset( $_REQUEST['author'] ) ) {
@@ -151,6 +152,8 @@ class WP_Job_Manager_Ajax {
 		} else {
 			$search_categories = array_filter( [ sanitize_text_field( wp_unslash( $search_categories ) ) ] );
 		}
+
+		$workplace_type = array_filter( array_map( 'sanitize_title', (array) $workplace_type ) );
 
 		// Ensure the current user can filter by post_status. Users without the capability may only
 		// narrow the query to publicly visible listings (e.g. the `[jobs post_status="publish"]`
@@ -211,6 +214,10 @@ class WP_Job_Manager_Ajax {
 			$args['remote_position'] = 'true' === $remote_position;
 		}
 
+		if ( ! empty( $workplace_type ) ) {
+			$args['workplace_types'] = $workplace_type;
+		}
+
 		if ( 'true' === $featured || 'false' === $featured ) {
 			$args['featured'] = 'true' === $featured;
 			$args['orderby']  = 'featured' === $orderby ? 'date' : $orderby;
@@ -231,7 +238,7 @@ class WP_Job_Manager_Ajax {
 			'max_num_pages' => $jobs->max_num_pages,
 		];
 
-		if ( ( $search_location || $search_keywords || $search_categories || $job_types_filtered ) ) {
+		if ( ( $search_location || $search_keywords || $search_categories || $job_types_filtered || $workplace_type ) ) {
 			// translators: Placeholder %d is the number of found search results.
 			$message               = sprintf( _n( 'Search completed. Found %d matching record.', 'Search completed. Found %d matching records.', $jobs->found_posts, 'wp-job-manager' ), $jobs->found_posts );
 			$result['showing_all'] = true;

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -57,6 +57,11 @@ class WP_Job_Manager_Install {
 			self::add_employment_types();
 		}
 
+		// Convert the _remote_position checkbox into the workplace type taxonomy.
+		if ( version_compare( get_option( 'wp_job_manager_version', JOB_MANAGER_VERSION ), '2.5.0', '<' ) ) {
+			self::schedule_workplace_type_migration();
+		}
+
 		// Update legacy options.
 		if ( false === get_option( 'job_manager_submit_job_form_page_id', false ) && get_option( 'job_manager_submit_page_slug' ) ) {
 			$page_id = get_page_by_path( get_option( 'job_manager_submit_page_slug' ) )->ID;
@@ -178,7 +183,7 @@ class WP_Job_Manager_Install {
 	 */
 	private static function get_default_taxonomy_terms() {
 		return [
-			\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE => [
+			\WP_Job_Manager_Post_Types::TAX_LISTING_TYPE   => [
 				'Full Time'  => [
 					'employment_type' => 'FULL_TIME',
 				],
@@ -194,6 +199,11 @@ class WP_Job_Manager_Install {
 				'Internship' => [
 					'employment_type' => 'INTERN',
 				],
+			],
+			\WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE => [
+				'On-Site' => [],
+				'Remote'  => [],
+				'Hybrid'  => [],
 			],
 		];
 	}
@@ -214,6 +224,95 @@ class WP_Job_Manager_Install {
 					}
 				}
 			}
+		}
+	}
+
+	/**
+	 * Schedules the background migration of the legacy `_remote_position` checkbox meta onto
+	 * the workplace type taxonomy, unless it has already completed.
+	 *
+	 * Runs as a self-rescheduling background job (see `run_workplace_type_migration_batch()`)
+	 * rather than inline, since a large site's job listings could exceed the request's time
+	 * budget if migrated synchronously during `install()`.
+	 */
+	private static function schedule_workplace_type_migration() {
+		if ( 1 === intval( get_option( 'job_manager_workplace_type_migrated' ) ) ) {
+			return;
+		}
+		if ( ! wp_next_scheduled( 'job_manager_migrate_workplace_type' ) ) {
+			wp_schedule_single_event( time(), 'job_manager_migrate_workplace_type' );
+		}
+	}
+
+	/**
+	 * Processes one batch of the `_remote_position` -> workplace type taxonomy migration, then
+	 * reschedules itself until every listing has been backfilled.
+	 *
+	 * Idempotent and safe to re-run: already-tagged listings are skipped. If the workplace type
+	 * feature is disabled (so the taxonomy isn't registered) or a term fails to save, the batch
+	 * retries later instead of advancing or marking the migration complete.
+	 */
+	public static function run_workplace_type_migration_batch() {
+		$taxonomy = \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE;
+
+		if ( ! get_option( 'job_manager_enable_remote_position' ) || ! taxonomy_exists( $taxonomy ) ) {
+			wp_schedule_single_event( time() + HOUR_IN_SECONDS, 'job_manager_migrate_workplace_type' );
+			return;
+		}
+
+		$terms = self::get_default_taxonomy_terms()[ $taxonomy ];
+		foreach ( array_keys( $terms ) as $term ) {
+			if ( ! get_term_by( 'slug', sanitize_title( $term ), $taxonomy ) ) {
+				wp_insert_term( $term, $taxonomy );
+			}
+		}
+
+		/**
+		 * Filters the number of job listings processed per background migration batch.
+		 *
+		 * @param int $per_batch Batch size. Default 200.
+		 */
+		$per_batch = apply_filters( 'job_manager_workplace_type_migration_batch_size', 200 );
+		$paged     = max( 1, intval( get_option( 'job_manager_workplace_type_migration_cursor', 1 ) ) );
+
+		$query = new WP_Query(
+			[
+				'post_type'              => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_status'            => 'any',
+				'posts_per_page'         => $per_batch,
+				'paged'                  => $paged,
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'update_post_term_cache' => false,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+			]
+		);
+
+		$had_error = false;
+		foreach ( $query->posts as $post_id ) {
+			if ( has_term( '', $taxonomy, $post_id ) ) {
+				continue;
+			}
+			$is_remote = (bool) get_post_meta( $post_id, '_remote_position', true );
+			$result    = wp_set_object_terms( $post_id, $is_remote ? 'remote' : 'on-site', $taxonomy, false );
+			if ( is_wp_error( $result ) ) {
+				$had_error = true;
+			}
+		}
+
+		if ( $had_error ) {
+			// Retry the same page rather than advancing past a failed batch.
+			wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'job_manager_migrate_workplace_type' );
+			return;
+		}
+
+		if ( count( $query->posts ) === $per_batch ) {
+			update_option( 'job_manager_workplace_type_migration_cursor', $paged + 1 );
+			wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'job_manager_migrate_workplace_type' );
+		} else {
+			delete_option( 'job_manager_workplace_type_migration_cursor' );
+			update_option( 'job_manager_workplace_type_migrated', 1 );
 		}
 	}
 }

--- a/includes/class-wp-job-manager-install.php
+++ b/includes/class-wp-job-manager-install.php
@@ -58,7 +58,7 @@ class WP_Job_Manager_Install {
 		}
 
 		// Convert the _remote_position checkbox into the workplace type taxonomy.
-		if ( version_compare( get_option( 'wp_job_manager_version', JOB_MANAGER_VERSION ), '2.5.0', '<' ) ) {
+		if ( version_compare( get_option( 'wp_job_manager_version', JOB_MANAGER_VERSION ), '$$next-version$$', '<' ) ) {
 			self::schedule_workplace_type_migration();
 		}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -228,7 +228,7 @@ class WP_Job_Manager_Post_Types {
 	 * Prepare CPTs for special block editor situations.
 	 */
 	public function prepare_block_editor() {
-		if ( false === job_manager_multi_job_type() || get_option( 'job_manager_enable_remote_position' ) ) {
+		if ( false === job_manager_multi_job_type() ) {
 			add_filter( 'rest_prepare_taxonomy', [ $this, 'hide_job_type_block_editor_selector' ], 10, 3 );
 		}
 	}
@@ -264,12 +264,18 @@ class WP_Job_Manager_Post_Types {
 	 * @return WP_REST_Response
 	 */
 	public function hide_job_type_block_editor_selector( $response, $taxonomy, $request ) {
-		if (
-			in_array( $taxonomy->name, [ self::TAX_LISTING_TYPE, self::TAX_WORKPLACE_TYPE ], true )
-			&& 'edit' === $request->get_param( 'context' )
-		) {
-			$response->data['visibility']['show_ui'] = false;
+		if ( 'edit' !== $request->get_param( 'context' ) ) {
+			return $response;
 		}
+
+		if ( self::TAX_LISTING_TYPE === $taxonomy->name ) {
+			$response->data['visibility']['show_ui'] = false;
+		} elseif ( self::TAX_WORKPLACE_TYPE === $taxonomy->name ) {
+			if ( ! get_option( 'job_manager_enable_remote_position', true ) ) {
+				$response->data['visibility']['show_ui'] = false;
+			}
+		}
+
 		return $response;
 	}
 

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -140,6 +140,11 @@ class WP_Job_Manager_Post_Types {
 	public const TAX_LISTING_TYPE = 'job_listing_type';
 
 	/**
+	 * Constant for the job listing workplace type taxonomy name.
+	 */
+	public const TAX_WORKPLACE_TYPE = 'job_listing_workplace_type';
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var self
@@ -223,7 +228,7 @@ class WP_Job_Manager_Post_Types {
 	 * Prepare CPTs for special block editor situations.
 	 */
 	public function prepare_block_editor() {
-		if ( false === job_manager_multi_job_type() ) {
+		if ( false === job_manager_multi_job_type() || get_option( 'job_manager_enable_remote_position' ) ) {
 			add_filter( 'rest_prepare_taxonomy', [ $this, 'hide_job_type_block_editor_selector' ], 10, 3 );
 		}
 	}
@@ -260,7 +265,7 @@ class WP_Job_Manager_Post_Types {
 	 */
 	public function hide_job_type_block_editor_selector( $response, $taxonomy, $request ) {
 		if (
-			self::TAX_LISTING_TYPE === $taxonomy->name
+			in_array( $taxonomy->name, [ self::TAX_LISTING_TYPE, self::TAX_WORKPLACE_TYPE ], true )
 			&& 'edit' === $request->get_param( 'context' )
 		) {
 			$response->data['visibility']['show_ui'] = false;
@@ -422,6 +427,53 @@ class WP_Job_Manager_Post_Types {
 					]
 				);
 			}
+		}
+
+		if ( get_option( 'job_manager_enable_remote_position' ) ) {
+			$singular = __( 'Workplace type', 'wp-job-manager' );
+			$plural   = __( 'Workplace types', 'wp-job-manager' );
+
+			register_taxonomy(
+				self::TAX_WORKPLACE_TYPE,
+				apply_filters( 'register_taxonomy_job_listing_workplace_type_object_type', [ self::PT_LISTING ] ),
+				apply_filters(
+					'register_taxonomy_job_listing_workplace_type_args',
+					[
+						'hierarchical'         => true,
+						'label'                => $plural,
+						'labels'               => [
+							'name'          => $plural,
+							'singular_name' => $singular,
+							'menu_name'     => __( 'Workplace Types', 'wp-job-manager' ),
+							// translators: Placeholder %s is the plural label of the job listing workplace type taxonomy.
+							'search_items'  => sprintf( __( 'Search %s', 'wp-job-manager' ), $plural ),
+							// translators: Placeholder %s is the plural label of the job listing workplace type taxonomy.
+							'all_items'     => sprintf( __( 'All %s', 'wp-job-manager' ), $plural ),
+							// translators: Placeholder %s is the singular label of the job listing workplace type taxonomy.
+							'edit_item'     => sprintf( __( 'Edit %s', 'wp-job-manager' ), $singular ),
+							// translators: Placeholder %s is the singular label of the job listing workplace type taxonomy.
+							'update_item'   => sprintf( __( 'Update %s', 'wp-job-manager' ), $singular ),
+							// translators: Placeholder %s is the singular label of the job listing workplace type taxonomy.
+							'add_new_item'  => sprintf( __( 'Add New %s', 'wp-job-manager' ), $singular ),
+							// translators: Placeholder %s is the singular label of the job listing workplace type taxonomy.
+							'new_item_name' => sprintf( __( 'New %s Name', 'wp-job-manager' ), $singular ),
+						],
+						'show_ui'              => true,
+						'show_tagcloud'        => false,
+						'public'               => false,
+						'rewrite'              => false,
+						'capabilities'         => [
+							'manage_terms' => $admin_capability,
+							'edit_terms'   => $admin_capability,
+							'delete_terms' => $admin_capability,
+							'assign_terms' => $admin_capability,
+						],
+						'show_in_rest'         => true,
+						'rest_base'            => 'job-workplace-types',
+						'meta_box_sanitize_cb' => [ $this, 'sanitize_job_type_meta_box_input' ],
+					]
+				)
+			);
 		}
 
 		/**
@@ -2005,15 +2057,6 @@ class WP_Job_Manager_Post_Types {
 				'auth_edit_callback' => [ __CLASS__, 'auth_check_can_manage_job_listings' ],
 				'auth_view_callback' => [ __CLASS__, 'auth_check_can_edit_job_listings' ],
 				'sanitize_callback'  => [ __CLASS__, 'sanitize_meta_field_date' ],
-			],
-			'_remote_position'     => [
-				'label'         => __( 'Remote Position', 'wp-job-manager' ),
-				'description'   => __( 'Select if this is a remote position.', 'wp-job-manager' ),
-				'type'          => 'checkbox',
-				'priority'      => 12,
-				'data_type'     => 'integer',
-				'show_in_admin' => (bool) get_option( 'job_manager_enable_remote_position' ),
-				'show_in_rest'  => true,
 			],
 			'_job_salary'          => [
 				'label'         => __( 'Salary', 'wp-job-manager' ),

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -210,6 +210,7 @@ class WP_Job_Manager_Shortcodes {
 					// Limit what jobs are shown based on category, post status, and type.
 					'categories'                => '',
 					'job_types'                 => '',
+					'workplace_types'           => '',
 					'post_status'               => '',
 					'featured'                  => null, // True to show only featured, false to hide featured, leave null to show both.
 					'filled'                    => null, // True to show only filled, false to hide filled, leave null to show both/use the settings.
@@ -279,6 +280,7 @@ class WP_Job_Manager_Shortcodes {
 		$atts['categories']         = is_array( $atts['categories'] ) ? $atts['categories'] : array_filter( array_map( 'trim', explode( ',', $atts['categories'] ) ) );
 		$atts['selected_category']  = is_array( $atts['selected_category'] ) ? $atts['selected_category'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_category'] ) ) );
 		$atts['job_types']          = is_array( $atts['job_types'] ) ? $atts['job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['job_types'] ) ) );
+		$atts['workplace_types']    = is_array( $atts['workplace_types'] ) ? $atts['workplace_types'] : array_filter( array_map( 'trim', explode( ',', $atts['workplace_types'] ) ) );
 		$atts['post_status']        = is_array( $atts['post_status'] ) ? $atts['post_status'] : array_filter( array_map( 'trim', explode( ',', $atts['post_status'] ) ) );
 		$atts['selected_job_types'] = is_array( $atts['selected_job_types'] ) ? $atts['selected_job_types'] : array_filter( array_map( 'trim', explode( ',', $atts['selected_job_types'] ) ) );
 
@@ -319,6 +321,7 @@ class WP_Job_Manager_Shortcodes {
 					'categories'                => $atts['categories'],
 					'selected_category'         => $atts['selected_category'],
 					'job_types'                 => $atts['job_types'],
+					'workplace_types'           => $atts['workplace_types'],
 					'atts'                      => $atts,
 					'location'                  => $atts['location'],
 					'remote_position'           => $atts['remote_position'],
@@ -344,6 +347,7 @@ class WP_Job_Manager_Shortcodes {
 						'post_status'       => $atts['post_status'],
 						'search_categories' => $atts['categories'],
 						'job_types'         => $atts['job_types'],
+						'workplace_types'   => $atts['workplace_types'],
 						'orderby'           => $atts['orderby'],
 						'order'             => $atts['order'],
 						'posts_per_page'    => $atts['per_page'],
@@ -358,6 +362,10 @@ class WP_Job_Manager_Shortcodes {
 
 			if ( ! empty( $atts['job_types'] ) ) {
 				$data_attributes['job_types'] = implode( ',', $atts['job_types'] );
+			}
+
+			if ( ! empty( $atts['workplace_types'] ) ) {
+				$data_attributes['workplace_types'] = implode( ',', $atts['workplace_types'] );
 			}
 
 			if ( $jobs->have_posts() ) {

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -117,6 +117,7 @@ class WP_Job_Manager {
 
 		// Schedule cron jobs.
 		add_action( 'init', [ __CLASS__, 'maybe_schedule_cron_jobs' ] );
+		add_action( 'job_manager_migrate_workplace_type', [ 'WP_Job_Manager_Install', 'run_workplace_type_migration_batch' ] );
 
 		// Switch theme.
 		add_action( 'after_switch_theme', [ 'WP_Job_Manager_Ajax', 'add_endpoint' ], 10 );

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -166,8 +166,10 @@ class WP_Job_Manager {
 		WP_Job_Manager_Ajax::add_endpoint();
 		unregister_post_type( \WP_Job_Manager_Post_Types::PT_LISTING );
 		add_filter( 'pre_option_job_manager_enable_types', '__return_true' );
+		add_filter( 'pre_option_job_manager_enable_remote_position', '__return_true' );
 		$this->post_types->register_post_types();
 		remove_filter( 'pre_option_job_manager_enable_types', '__return_true' );
+		remove_filter( 'pre_option_job_manager_enable_remote_position', '__return_true' );
 		WP_Job_Manager_Install::install();
 		flush_rewrite_rules();
 	}

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -245,12 +245,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'e.g. "London"', 'wp-job-manager' ),
 						'priority'    => 2,
 					],
-					'remote_position'     => [
-						'label'       => __( 'Remote Position', 'wp-job-manager' ),
-						'description' => __( 'Select if this is a remote position.', 'wp-job-manager' ),
-						'type'        => 'checkbox',
+					'workplace_type'      => [
+						'label'       => __( 'Workplace type', 'wp-job-manager' ),
+						'description' => __( 'Select whether this is an on-site, remote, or hybrid position.', 'wp-job-manager' ),
+						'type'        => 'term-select',
 						'required'    => false,
 						'priority'    => 3,
+						'default'     => 'on-site',
+						'taxonomy'    => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
 					],
 					'job_type'            => [
 						'label'       => __( 'Job type', 'wp-job-manager' ),
@@ -388,8 +390,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		} else {
 			unset( $this->fields['job']['job_salary'], $this->fields['job']['job_salary_currency'], $this->fields['job']['job_salary_unit'] );
 		}
-		if ( ! get_option( 'job_manager_enable_remote_position' ) ) {
-			unset( $this->fields['job']['remote_position'] );
+		if ( ! get_option( 'job_manager_enable_remote_position' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE ) ) ) {
+			unset( $this->fields['job']['workplace_type'] );
 		}
 
 		if ( get_option( 'job_manager_enable_scheduled_listings' ) ) {
@@ -656,6 +658,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 							break;
 						case 'job_category':
 							$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY, [ 'fields' => 'ids' ] );
+							break;
+						case 'workplace_type':
+							$workplace_type_ids                          = wp_get_object_terms( $job->ID, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE, [ 'fields' => 'ids' ] );
+							$this->fields[ $group_key ][ $key ]['value'] = ! empty( $workplace_type_ids ) ? current( $workplace_type_ids ) : '';
 							break;
 						case 'company_logo':
 							$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_thumbnail_id( $job->ID ) : get_post_meta( $job->ID, '_' . $key, true );

--- a/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
+++ b/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php
@@ -209,7 +209,8 @@ class WP_Job_Manager_Promoted_Jobs_API {
 		if ( false === $terms ) {
 			$terms = [];
 		}
-		$terms_array = wp_list_pluck( $terms, 'slug' );
+		$terms_array    = wp_list_pluck( $terms, 'slug' );
+		$workplace_type = wpjm_get_the_job_workplace_type( $item );
 
 		return [
 			'id'           => (string) $item->ID,
@@ -220,7 +221,7 @@ class WP_Job_Manager_Promoted_Jobs_API {
 			'permalink'    => get_permalink( $item ),
 			'location'     => get_post_meta( $item->ID, '_job_location', true ),
 			'company_name' => get_post_meta( $item->ID, '_company_name', true ),
-			'is_remote'    => (bool) get_post_meta( $item->ID, '_remote_position', true ),
+			'is_remote'    => $workplace_type && in_array( $workplace_type->slug, [ 'remote', 'hybrid' ], true ),
 			'job_type'     => $terms_array,
 			'salary'       => [
 				'amount'   => get_post_meta( $item->ID, '_job_salary', true ),

--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -48,7 +48,7 @@ do_action( 'job_manager_job_filters_before', $atts );
 						'value'           => 'slug',
 						'multiple'        => false,
 						'show_option_all' => __( 'Any workplace type', 'wp-job-manager' ),
-						'selected'        => ! empty( $workplace_types ) ? reset( $workplace_types ) : '',
+						'selected'        => ! empty( $workplace_types ) ? sanitize_title( reset( $workplace_types ) ) : '',
 						'hide_empty'      => true,
 					]
 				);

--- a/templates/job-filters.php
+++ b/templates/job-filters.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.38.0
+ * @version     2.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -36,10 +36,23 @@ do_action( 'job_manager_job_filters_before', $atts );
 			<input type="text" name="search_location" id="search_location" placeholder="<?php esc_attr_e( 'Location', 'wp-job-manager' ); ?>" value="<?php echo esc_attr( $location ); ?>" />
 		</div>
 
-		<?php if( apply_filters( 'job_manager_job_filters_show_remote_position', get_option('job_manager_enable_remote_position', true ), $atts ) ) : ?>
-			<div class="search_remote_position">
-				<input type="checkbox" class="input-checkbox" name="remote_position" id="remote_position" placeholder="<?php esc_attr_e( 'Location', 'wp-job-manager' ); ?>" value="1" <?php checked(! empty( $remote_position ) ); ?> />
-				<label for="remote_position" id="remote_position_label"><?php esc_html_e( 'Remote positions only', 'wp-job-manager' ); ?></label>
+		<?php if ( apply_filters( 'job_manager_job_filters_show_remote_position', get_option( 'job_manager_enable_remote_position', true ), $atts ) && get_terms( [ 'taxonomy' => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE, 'hide_empty' => true ] ) ) : ?>
+			<div class="search_workplace_type">
+				<label for="workplace_type"><?php esc_html_e( 'Workplace type', 'wp-job-manager' ); ?></label>
+				<?php
+				job_manager_dropdown_categories(
+					[
+						'taxonomy'        => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
+						'name'            => 'workplace_type',
+						'orderby'         => 'name',
+						'value'           => 'slug',
+						'multiple'        => false,
+						'show_option_all' => __( 'Any workplace type', 'wp-job-manager' ),
+						'selected'        => ! empty( $workplace_types ) ? reset( $workplace_types ) : '',
+						'hide_empty'      => true,
+					]
+				);
+				?>
 			</div>
 		<?php endif; ?>
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -70,6 +70,7 @@ class WPJM_Unit_Tests_Bootstrap {
 		error_reporting( E_ALL );
 		update_option( 'job_manager_enable_types', true );
 		update_option( 'job_manager_enable_categories', true );
+		update_option( 'job_manager_enable_remote_position', true );
 
 		require_once $this->plugin_dir . '/wp-job-manager.php';
 	}

--- a/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
+++ b/tests/php/tests/includes/rest-api/test_class.wp-job-manager-job-listings.php
@@ -171,7 +171,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	 * Tests to make sure public meta fields are exposed to guest users and private meta fields are hidden.
 	 */
 	public function test_guest_can_read_only_public_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
 		$private_fields = [ '_job_expires' ];
 		$this->logout();
 		$post_id = $this->get_job_listing();
@@ -192,7 +192,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_same_employer_read_access_to_private_meta_fields() {
-		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
+		$available_fields = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured',  '_job_expires', '_job_salary', '_job_salary_currency', '_job_salary_unit'  ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();
 
@@ -207,7 +207,7 @@ class WP_Test_WP_Job_Manager_Job_Listings_Test extends WPJM_REST_TestCase {
 	}
 
 	public function test_different_employer_read_access_to_private_meta_fields() {
-		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_remote_position', '_job_salary', '_job_salary_currency', '_job_salary_unit' ];
+		$public_fields  = [ '_job_location', '_application', '_company_name', '_company_website', '_company_tagline', '_company_twitter', '_company_video', '_filled', '_featured', '_job_salary', '_job_salary_currency', '_job_salary_unit' ];
 		$private_fields = [ '_job_expires' ];
 		$this->login_as_employer();
 		$post_id = $this->get_job_listing();

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -992,6 +992,63 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Google's JobPosting schema defines TELECOMMUTE as 100% remote only, so `jobLocationType`
+	 * must be set for a Remote listing, but never for Hybrid or On-Site.
+	 *
+	 * @covers ::wpjm_get_job_listing_structured_data
+	 */
+	public function test_structured_data_job_location_type_by_workplace_type() {
+		$expectations = [
+			'on-site' => null,
+			'remote'  => 'TELECOMMUTE',
+			'hybrid'  => null,
+		];
+
+		foreach ( $expectations as $workplace_type => $expected_job_location_type ) {
+			$job_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_job_location' => 'London' ] ] );
+			wp_set_object_terms( $job_id, $workplace_type, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+
+			$structured_data = wpjm_get_job_listing_structured_data( $job_id );
+
+			$this->assertSame( $expected_job_location_type, $structured_data['jobLocationType'] ?? null, "workplace type: {$workplace_type}" );
+		}
+	}
+
+	/**
+	 * The admin edit screen's workplace type metabox posts the term ID (like the job type
+	 * metabox does), via `tax_input[job_listing_workplace_type]`. Core only resolves that as
+	 * an ID for hierarchical taxonomies -- for non-hierarchical ones it's treated as a term
+	 * name/slug, so a numeric ID string would silently create a bogus term instead of
+	 * assigning the existing one. TAX_WORKPLACE_TYPE must stay hierarchical to save correctly.
+	 *
+	 * @covers ::register_post_types
+	 */
+	public function test_workplace_type_taxonomy_is_hierarchical_for_id_based_metabox_save() {
+		$this->assertTrue( is_taxonomy_hierarchical( \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE ) );
+
+		$term = get_term_by( 'slug', 'remote', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+		if ( ! $term ) {
+			$inserted = wp_insert_term( 'Remote', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE, [ 'slug' => 'remote' ] );
+			$term     = get_term( $inserted['term_id'], \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+		}
+		$job_id = $this->factory->job_listing->create();
+
+		// Mirrors what the admin metabox posts and what sanitize_job_type_meta_box_input() returns.
+		wp_update_post(
+			[
+				'ID'        => $job_id,
+				'tax_input' => [ \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE => $term->term_id ],
+			]
+		);
+
+		$assigned = wpjm_get_the_job_workplace_type( $job_id );
+		$this->assertSame( 'remote', $assigned ? $assigned->slug : null );
+
+		$bogus = get_term_by( 'slug', (string) $term->term_id, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+		$this->assertFalse( $bogus, 'Saving must not create a new term named after the posted term ID.' );
+	}
+
+	/**
 	 * @since 1.28.0
 	 * @covers WP_Job_Manager_Post_Types::output_structured_data
 	 */

--- a/tests/php/tests/includes/test_class.wp-job-manager-promoted-jobs-api.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-promoted-jobs-api.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests for WP_Job_Manager_Promoted_Jobs_API.
+ *
+ * @package wp-job-manager
+ */
+class Tests_WP_Job_Manager_Promoted_Jobs_API extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-status-handler.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php';
+	}
+
+	/**
+	 * Returns the `job_data` payload for a listing via the single-item route.
+	 *
+	 * @param int $job_id Job listing ID.
+	 * @return array
+	 */
+	private function get_job_data( $job_id ) {
+		$api     = new WP_Job_Manager_Promoted_Jobs_API( new WP_Job_Manager_Promoted_Jobs_Status_Handler() );
+		$request = new WP_REST_Request( 'GET', '/wpjm-internal/v1/promoted-jobs/' . $job_id );
+		$request->set_param( 'job_id', $job_id );
+
+		$response = $api->get_job_data( $request );
+		$this->assertInstanceOf( 'WP_REST_Response', $response );
+
+		return $response->get_data()['job_data'];
+	}
+
+	/**
+	 * `is_remote` must stay boolean-shaped (true for Remote and Hybrid, false for On-Site),
+	 * now sourced from the workplace type taxonomy instead of the legacy checkbox meta.
+	 *
+	 * @covers WP_Job_Manager_Promoted_Jobs_API::get_job_data
+	 */
+	public function test_is_remote_reflects_workplace_type() {
+		$expectations = [
+			'on-site' => false,
+			'remote'  => true,
+			'hybrid'  => true,
+		];
+
+		foreach ( $expectations as $workplace_type => $expected_is_remote ) {
+			$job_id = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+			wp_set_object_terms( $job_id, $workplace_type, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+
+			$job_data = $this->get_job_data( $job_id );
+
+			$this->assertSame( $expected_is_remote, $job_data['is_remote'], "workplace type: {$workplace_type}" );
+		}
+	}
+
+	/**
+	 * A listing with no workplace type assigned must not be treated as remote.
+	 *
+	 * @covers WP_Job_Manager_Promoted_Jobs_API::get_job_data
+	 */
+	public function test_is_remote_false_when_no_workplace_type_assigned() {
+		$job_id = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+
+		$job_data = $this->get_job_data( $job_id );
+
+		$this->assertFalse( $job_data['is_remote'] );
+	}
+}

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -447,6 +447,62 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_workplace_types() {
+		$this->assertTrue( taxonomy_exists( \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE ) );
+
+		$on_site_id = $this->factory->job_listing->create();
+		$remote_id  = $this->factory->job_listing->create();
+		$hybrid_id  = $this->factory->job_listing->create();
+
+		// wp_set_object_terms() (unlike posting through tax_input) resolves slugs
+		// regardless of the taxonomy's hierarchical setting, so assign directly.
+		wp_set_object_terms( $on_site_id, 'on-site', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+		wp_set_object_terms( $remote_id, 'remote', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+		wp_set_object_terms( $hybrid_id, 'hybrid', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+
+		$remote_only = get_job_listings( [ 'workplace_types' => [ 'remote' ] ] );
+		$this->assertEqualSets( [ $remote_id ], wp_list_pluck( $remote_only->posts, 'ID' ) );
+
+		$remote_and_hybrid = get_job_listings( [ 'workplace_types' => [ 'remote', 'hybrid' ] ] );
+		$this->assertEqualSets( [ $remote_id, $hybrid_id ], wp_list_pluck( $remote_and_hybrid->posts, 'ID' ) );
+
+		$all = get_job_listings( [ 'workplace_types' => [] ] );
+		$this->assertEqualSets( [ $on_site_id, $remote_id, $hybrid_id ], wp_list_pluck( $all->posts, 'ID' ) );
+	}
+
+	/**
+	 * Legacy boolean `remote_position` arg is bridged onto the workplace type taxonomy.
+	 *
+	 * @covers ::get_job_listings
+	 */
+	public function test_get_job_listings_remote_position_legacy_arg() {
+		$on_site_id  = $this->factory->job_listing->create();
+		$remote_id   = $this->factory->job_listing->create();
+		$untagged_id = $this->factory->job_listing->create();
+
+		wp_set_object_terms( $on_site_id, 'on-site', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+		wp_set_object_terms( $remote_id, 'remote', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+
+		$remote_only = get_job_listings( [ 'remote_position' => true ] );
+		$this->assertEqualSets( [ $remote_id ], wp_list_pluck( $remote_only->posts, 'ID' ) );
+
+		// False includes untagged posts by default (matches the legacy NOT-EXISTS fallback).
+		$non_remote = get_job_listings( [ 'remote_position' => false ] );
+		$this->assertEqualSets( [ $on_site_id, $untagged_id ], wp_list_pluck( $non_remote->posts, 'ID' ) );
+
+		// The `job_manager_get_job_listings_remote_position_check_not_exists` filter can exclude untagged posts.
+		add_filter( 'job_manager_get_job_listings_remote_position_check_not_exists', '__return_false' );
+		$non_remote_strict = get_job_listings( [ 'remote_position' => false ] );
+		$this->assertEqualSets( [ $on_site_id ], wp_list_pluck( $non_remote_strict->posts, 'ID' ) );
+		remove_filter( 'job_manager_get_job_listings_remote_position_check_not_exists', '__return_false' );
+
+		$all = get_job_listings( [ 'remote_position' => null ] );
+		$this->assertEqualSets( [ $on_site_id, $remote_id, $untagged_id ], wp_list_pluck( $all->posts, 'ID' ) );
+	}
+
+	/**
 	 * @since 1.27.0
 	 * @covers ::get_job_listings
 	 */

--- a/tests/php/tests/test_class.wp-job-manager-install.php
+++ b/tests/php/tests/test_class.wp-job-manager-install.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for WP_Job_Manager_Install.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_WP_Job_Manager_Install extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		delete_option( 'job_manager_workplace_type_migrated' );
+		delete_option( 'job_manager_workplace_type_migration_cursor' );
+		wp_unschedule_hook( 'job_manager_migrate_workplace_type' );
+	}
+
+	/**
+	 * @return string|false The assigned workplace type term slug, or false if none.
+	 */
+	private function get_workplace_type_slug( $post_id ) {
+		$terms = wp_get_object_terms( $post_id, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+		return empty( $terms ) ? false : $terms[0]->slug;
+	}
+
+	/**
+	 * Existing listings are backfilled from the legacy `_remote_position` checkbox meta:
+	 * truthy meta becomes the Remote term, everything else becomes On-Site.
+	 *
+	 * @covers WP_Job_Manager_Install::run_workplace_type_migration_batch
+	 */
+	public function test_migration_backfills_from_legacy_meta() {
+		$remote_id     = $this->factory->job_listing->create( [ 'meta_input' => [ '_remote_position' => 1 ] ] );
+		$non_remote_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_remote_position' => 0 ] ] );
+		$untagged_id   = $this->factory->job_listing->create();
+
+		WP_Job_Manager_Install::run_workplace_type_migration_batch();
+
+		$this->assertSame( 'remote', $this->get_workplace_type_slug( $remote_id ) );
+		$this->assertSame( 'on-site', $this->get_workplace_type_slug( $non_remote_id ) );
+		$this->assertSame( 'on-site', $this->get_workplace_type_slug( $untagged_id ) );
+		$this->assertSame( 1, intval( get_option( 'job_manager_workplace_type_migrated' ) ), 'a batch smaller than the page size should mark the migration complete' );
+	}
+
+	/**
+	 * Re-running the migration must not overwrite listings that already carry a workplace
+	 * type term (e.g. Hybrid, which has no legacy meta signal to backfill from).
+	 *
+	 * @covers WP_Job_Manager_Install::run_workplace_type_migration_batch
+	 */
+	public function test_migration_is_idempotent_and_preserves_existing_terms() {
+		$hybrid_id = $this->factory->job_listing->create( [ 'meta_input' => [ '_remote_position' => 1 ] ] );
+		wp_set_object_terms( $hybrid_id, 'hybrid', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+
+		WP_Job_Manager_Install::run_workplace_type_migration_batch();
+
+		$this->assertSame( 'hybrid', $this->get_workplace_type_slug( $hybrid_id ) );
+	}
+
+	/**
+	 * The three default workplace type terms are seeded by the migration, even on sites where
+	 * `default_terms()` already ran (and so skipped) before this taxonomy existed.
+	 *
+	 * @covers WP_Job_Manager_Install::run_workplace_type_migration_batch
+	 */
+	public function test_migration_seeds_default_terms() {
+		foreach ( [ 'on-site', 'remote', 'hybrid' ] as $slug ) {
+			$term = get_term_by( 'slug', $slug, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+			if ( $term ) {
+				wp_delete_term( $term->term_id, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+			}
+		}
+
+		WP_Job_Manager_Install::run_workplace_type_migration_batch();
+
+		foreach ( [ 'on-site', 'remote', 'hybrid' ] as $slug ) {
+			$this->assertNotFalse(
+				get_term_by( 'slug', $slug, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE ),
+				"the '{$slug}' workplace type term should exist"
+			);
+		}
+	}
+
+	/**
+	 * A full page of results means there may be more to migrate: the batch must record its
+	 * cursor and reschedule itself instead of marking the migration complete.
+	 *
+	 * @covers WP_Job_Manager_Install::run_workplace_type_migration_batch
+	 */
+	public function test_migration_reschedules_when_a_full_batch_is_processed() {
+		add_filter(
+			'job_manager_workplace_type_migration_batch_size',
+			function () {
+				return 1;
+			}
+		);
+
+		$this->factory->job_listing->create_many( 2 );
+
+		WP_Job_Manager_Install::run_workplace_type_migration_batch();
+
+		$this->assertFalse( (bool) get_option( 'job_manager_workplace_type_migrated' ) );
+		$this->assertSame( 2, intval( get_option( 'job_manager_workplace_type_migration_cursor' ) ) );
+		$this->assertNotFalse( wp_next_scheduled( 'job_manager_migrate_workplace_type' ), 'the next batch should be scheduled' );
+	}
+
+	/**
+	 * When the workplace type feature is disabled the taxonomy isn't registered, so the batch
+	 * must retry later rather than run against a taxonomy that doesn't exist or mark completion.
+	 *
+	 * @covers WP_Job_Manager_Install::run_workplace_type_migration_batch
+	 */
+	public function test_migration_retries_when_taxonomy_unavailable() {
+		update_option( 'job_manager_enable_remote_position', 0 );
+
+		WP_Job_Manager_Install::run_workplace_type_migration_batch();
+
+		$this->assertFalse( (bool) get_option( 'job_manager_workplace_type_migrated' ) );
+		$this->assertNotFalse( wp_next_scheduled( 'job_manager_migrate_workplace_type' ), 'a retry should be scheduled' );
+
+		update_option( 'job_manager_enable_remote_position', 1 );
+	}
+}

--- a/tests/php/tests/test_class.wp-job-manager-widgets.php
+++ b/tests/php/tests/test_class.wp-job-manager-widgets.php
@@ -65,12 +65,8 @@ class WP_Test_WP_Job_Manager_Widgets extends WPJM_BaseTest {
 	 */
 	public function test_recent_jobs_widget_renders_with_remote_position() {
 		update_option( 'job_manager_enable_remote_position', 1 );
-		$this->factory->job_listing->create(
-			[
-				'post_title' => 'Remote Widget Engineer',
-				'meta_input' => [ '_remote_position' => 1 ],
-			]
-		);
+		$post_id = $this->factory->job_listing->create( [ 'post_title' => 'Remote Widget Engineer' ] );
+		wp_set_object_terms( $post_id, 'remote', \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
 
 		$widget   = new WP_Job_Manager_Widget_Recent_Jobs();
 		$instance = [ 'title' => 'Recent Jobs', 'number' => 5, 'remote_position' => 'true' ];

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -38,6 +38,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 				'featured'          => null,
 				'filled'            => null,
 				'remote_position'   => null,
+				'workplace_types'   => [],
 				'fields'            => 'all',
 				'featured_first'    => 0,
 			]
@@ -81,24 +82,35 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			$query_args['no_found_rows'] = true;
 		}
 
-		$remote_position_search = false;
-
-		if ( ! is_null( $args['remote_position'] ) ) {
-			$remote_position_search = [
-				'key'     => '_remote_position',
-				'value'   => '1',
-				'compare' => $args['remote_position'] ? '=' : '!=',
+		if ( ! empty( $args['workplace_types'] ) ) {
+			$query_args['tax_query'][] = [
+				'taxonomy' => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
+				'field'    => 'slug',
+				'terms'    => $args['workplace_types'],
 			];
-
-			if ( '!=' === $remote_position_search['compare'] && apply_filters( 'job_manager_get_job_listings_remote_position_check_not_exists', true, $args ) ) {
-				$remote_position_search = [
-					'relation' => 'OR',
-					$remote_position_search,
-					[
-						'key'     => '_remote_position',
-						'compare' => 'NOT EXISTS',
-					],
+		} elseif ( ! is_null( $args['remote_position'] ) ) {
+			// Legacy boolean arg, bridged onto the workplace type taxonomy for backward compatibility.
+			if ( $args['remote_position'] ) {
+				$query_args['tax_query'][] = [
+					'taxonomy' => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
+					'field'    => 'slug',
+					'terms'    => [ 'remote' ],
 				];
+			} else {
+				// 'NOT IN' naturally includes untagged posts too, matching the legacy NOT-EXISTS fallback.
+				$include_untagged          = apply_filters( 'job_manager_get_job_listings_remote_position_check_not_exists', true, $args );
+				$query_args['tax_query'][] = $include_untagged
+					? [
+						'taxonomy' => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
+						'field'    => 'slug',
+						'terms'    => [ 'remote' ],
+						'operator' => 'NOT IN',
+					]
+					: [
+						'taxonomy' => \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE,
+						'field'    => 'slug',
+						'terms'    => [ 'on-site', 'hybrid' ],
+					];
 			}
 		}
 
@@ -122,18 +134,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 				}
 			}
 
-			if ( $remote_position_search ) {
-				$location_search = [
-					'relation' => 'AND',
-					$remote_position_search,
-					$location_search,
-				];
-			}
-
 			$query_args['meta_query'][] = $location_search;
-
-		} elseif ( $remote_position_search ) {
-			$query_args['meta_query'][] = $remote_position_search;
 		}
 
 		if ( ! is_null( $args['featured'] ) ) {

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -419,7 +419,9 @@ function wpjm_get_job_listing_structured_data( $post = null ) {
 		$data['jobLocation']            = [];
 		$data['jobLocation']['@type']   = 'Place';
 		$data['jobLocation']['address'] = wpjm_get_job_listing_location_structured_data( $post );
-		if ( $post->_remote_position ) {
+		$workplace_type                 = wpjm_get_the_job_workplace_type( $post );
+		// Google's JobPosting schema defines TELECOMMUTE as 100% remote only - never set it for hybrid.
+		if ( $workplace_type && 'remote' === $workplace_type->slug ) {
 			$data['jobLocationType'] = 'TELECOMMUTE';
 		}
 		if ( empty( $data['jobLocation']['address'] ) ) {
@@ -646,6 +648,28 @@ function wpjm_get_the_job_types( $post = null ) {
 }
 
 /**
+ * Gets the workplace type term (On-Site, Remote, Hybrid) for the listing.
+ *
+ * @param int|WP_Post $post (default: null).
+ * @return WP_Term|false
+ */
+function wpjm_get_the_job_workplace_type( $post = null ) {
+	$post = get_post( $post );
+
+	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
+		return false;
+	}
+
+	$terms = get_the_terms( $post->ID, \WP_Job_Manager_Post_Types::TAX_WORKPLACE_TYPE );
+
+	if ( empty( $terms ) || is_wp_error( $terms ) ) {
+		return false;
+	}
+
+	return current( $terms );
+}
+
+/**
  * Displays job categories for the listing.
  *
  * @since 1.31.0
@@ -815,14 +839,24 @@ function get_the_job_publish_date( $post = null ) {
  * @param int|WP_Post $post
  */
 function the_job_location( $map_link = true, $post = null ) {
-	$location = get_the_job_location( $post );
-	$post     = get_post( $post );
-	if ( $post->_remote_position ) {
+	$location       = get_the_job_location( $post );
+	$post           = get_post( $post );
+	$workplace_type = wpjm_get_the_job_workplace_type( $post );
+	$workplace_slug = $workplace_type ? $workplace_type->slug : '';
+	if ( 'remote' === $workplace_slug ) {
 		$remote_label = apply_filters( 'the_job_location_anywhere_text', __( 'Remote', 'wp-job-manager' ) );
 		if ( $location ) {
 			$location = "$location <small>($remote_label)</small>";
 		} else {
 			$location = $remote_label;
+			$map_link = false;
+		}
+	} elseif ( 'hybrid' === $workplace_slug ) {
+		$hybrid_label = apply_filters( 'the_job_location_hybrid_text', __( 'Hybrid', 'wp-job-manager' ) );
+		if ( $location ) {
+			$location = "$location <small>($hybrid_label)</small>";
+		} else {
+			$location = $hybrid_label;
 			$map_link = false;
 		}
 	}


### PR DESCRIPTION
Fixes #2310

### Changes Proposed in this Pull Request
Replaces the boolean "Remote Position" checkbox with a Workplace Type dropdown (On-Site / Remote / Hybrid), backed by a new `job_listing_workplace_type` taxonomy that follows the existing `job_listing_type` pattern.

#### `includes/class-wp-job-manager-post-types.php`
Registers the new taxonomy (hierarchical, single-select via the same radio metabox pattern as job type), removes `_remote_position` from the field registry.

#### `includes/class-wp-job-manager-install.php`
Seeds the three default terms on fresh installs, and adds a versioned migration that backfills the taxonomy for existing listings from `_remote_position` postmeta on upgrade. The postmeta itself is left in place, not deleted.

#### `wp-job-manager-functions.php`
`get_job_listings()` gets a `workplace_types` tax_query arg. The legacy `remote_position` arg still works, now translated into an equivalent tax_query clause instead of a meta_query.

#### `templates/job-filters.php`, `assets/js/ajax-filters.js`
Filter bar's "Remote positions only" checkbox becomes a "Workplace type" dropdown (On-Site / Remote / Hybrid), same UI pattern as the category filter.

#### `includes/forms/class-wp-job-manager-form-submit-job.php`
Submission form field swapped from a checkbox to a term-select dropdown, defaulting to On-Site.

**Why:** a checkbox can only express two states, but employers need to distinguish On-Site, Remote, and Hybrid. Converting to a taxonomy (rather than a new meta field) reuses the admin UI, REST exposure, and tax_query filtering the plugin already has for `job_listing_type`.

### Backward compatibility
- `_remote_position` postmeta stays in the database, unused after migration.
- `get_job_listings( [ 'remote_position' => ... ] )`, `[jobs remote_position="..."]`, and the AJAX `remote_position` param all keep working.
- Recent Jobs widget's `remote_position` setting is unchanged.
- Promoted Jobs API `is_remote` now sources from the taxonomy (`remote` or `hybrid` both resolve to `true`), same boolean contract as before.

### Testing Instructions

**Test 1: Submission form**
1. Submit a new job listing.
2. Workplace type field shows a dropdown (On-Site / Remote / Hybrid), defaults to On-Site.
Result: listing saves with the correct term, location line shows "(Remote)" / "(Hybrid)" as appropriate.

**Test 2: Admin edit screen**
1. Edit a listing, change Workplace Type in the metabox, update.
2. Reload the edit screen.
Result: correct option is saved and pre-selected, no bogus terms created.

**Test 3: Upgrade migration**
1. On a site running the previous version, create listings with "Remote Position" checked and unchecked.
2. Upgrade, trigger `job_manager_migrate_workplace_type` via cron.
Result: checked listings become Remote, unchecked become On-Site. `_remote_position` postmeta untouched.

**Test 4: `[jobs]` filter bar**
1. Filter by each workplace type.
Result: only matching listings show.

**Automated:** `vendor/bin/phpunit` — 582 tests pass. `vendor/bin/phpcs` — clean.

### Release Notes

* Enhancement: Workplace Type dropdown (On-Site / Remote / Hybrid) replaces the Remote Position checkbox, with backfill migration for existing listings.

### Screenshot / Video
<img width="1916" height="612" alt="SCR-20260714-owns" src="https://github.com/user-attachments/assets/b6eda501-b722-4c2b-acd2-965b71f55639" />