### PR TITLE
Validate form uploads against the field's own allowed mime types

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -755,10 +755,11 @@ abstract class WP_Job_Manager_Form {
 		$value = null;
 
 		if ( isset( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ]['name'] ) ) {
+			$upload_args = [ 'file_key' => $field_key ];
+
+			// Without an explicit list, job_manager_upload_file() looks up the types allowed for this field.
 			if ( ! empty( $field['allowed_mime_types'] ) ) {
-				$allowed_mime_types = $field['allowed_mime_types'];
-			} else {
-				$allowed_mime_types = job_manager_get_allowed_mime_types();
+				$upload_args['allowed_mime_types'] = $field['allowed_mime_types'];
 			}
 
 			$file_urls       = [];
@@ -767,10 +768,7 @@ abstract class WP_Job_Manager_Form {
 			foreach ( $files_to_upload as $file_to_upload ) {
 				$uploaded_file = job_manager_upload_file(
 					$file_to_upload,
-					[
-						'file_key'           => $field_key,
-						'allowed_mime_types' => $allowed_mime_types,
-					]
+					$upload_args
 				);
 
 				if ( is_wp_error( $uploaded_file ) ) {

--- a/tests/php/tests/includes/abstracts/test_class.wp-job-manager-form.php
+++ b/tests/php/tests/includes/abstracts/test_class.wp-job-manager-form.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Covers includes/abstracts/abstract-wp-job-manager-form.php.
+ *
+ * @package wp-job-manager
+ */
+
+require_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+
+/**
+ * Concrete form exposing the protected upload handler.
+ */
+class WPJM_Upload_Test_Form extends WP_Job_Manager_Form {
+	public function do_upload_file( $field_key, $field ) {
+		return $this->upload_file( $field_key, $field );
+	}
+}
+
+class WP_Test_WP_Job_Manager_Form extends WPJM_BaseTest {
+
+	/**
+	 * Field key the uploads under test use.
+	 *
+	 * @var string
+	 */
+	private $field_key = 'company_logo';
+
+	/**
+	 * Field key the `job_manager_mime_types` filter was last called with.
+	 *
+	 * @var string|null
+	 */
+	private $captured_mime_types_field = null;
+
+	public function tearDown(): void {
+		unset( $_FILES[ $this->field_key ] );
+		remove_filter( 'submit_job_wp_handle_upload_overrides', [ $this, 'override_upload_action' ] );
+		remove_filter( 'job_manager_mime_types', [ $this, 'capture_mime_types_field' ], 10 );
+		parent::tearDown();
+	}
+
+	/**
+	 * A field with no `allowed_mime_types` of its own is validated against the types allowed for that field, not the
+	 * generic list. Without this, a `company_logo` upload was checked against the pdf/doc defaults, so the webp the
+	 * form itself advertises was rejected on the non-AJAX path.
+	 */
+	public function test_upload_file_uses_the_field_specific_allowed_mime_types() {
+		$this->stage_upload( DIR_TESTDATA . '/images/test-image.webp', 'test-image.webp', 'image/webp' );
+
+		$url = $this->upload_file( [] );
+
+		$this->assertStringEndsWith( '.webp', $url );
+	}
+
+	/**
+	 * An explicit `allowed_mime_types` on the field still wins over the field's defaults.
+	 */
+	public function test_upload_file_honours_an_explicit_allowed_mime_types() {
+		$this->stage_upload( DIR_TESTDATA . '/images/test-image.webp', 'test-image.webp', 'image/webp' );
+
+		$this->expectException( Exception::class );
+
+		$this->upload_file( [ 'allowed_mime_types' => [ 'png' => 'image/png' ] ] );
+	}
+
+	/**
+	 * The field key reaches the `job_manager_mime_types` filter, so a site can vary the allowed types per field.
+	 */
+	public function test_upload_file_passes_the_field_key_to_the_mime_types_filter() {
+		$this->stage_upload( DIR_TESTDATA . '/images/test-image.webp', 'test-image.webp', 'image/webp' );
+		add_filter( 'job_manager_mime_types', [ $this, 'capture_mime_types_field' ], 10, 2 );
+
+		$this->upload_file( [] );
+
+		$this->assertSame( $this->field_key, $this->captured_mime_types_field );
+	}
+
+	public function capture_mime_types_field( $allowed_mime_types, $field ) {
+		$this->captured_mime_types_field = $field;
+
+		return $allowed_mime_types;
+	}
+
+	public function override_upload_action( $args ) {
+		$args['action'] = 'test-wpjm-upload';
+
+		return $args;
+	}
+
+	/**
+	 * Put a copy of a test image in $_FILES, as a form submission would.
+	 */
+	private function stage_upload( $path, $name, $type ) {
+		$tmp_name = wp_tempnam( $path );
+		copy( $path, $tmp_name );
+
+		$_FILES[ $this->field_key ] = [
+			'tmp_name' => $tmp_name,
+			'name'     => $name,
+			'type'     => $type,
+			'error'    => 0,
+			'size'     => filesize( $path ),
+		];
+
+		add_filter( 'submit_job_wp_handle_upload_overrides', [ $this, 'override_upload_action' ] );
+	}
+
+	/**
+	 * Run the form's upload handler for the field under test.
+	 *
+	 * @param array $field Field definition.
+	 * @return string|array Uploaded file URL(s).
+	 */
+	private function upload_file( $field ) {
+		$form = new WPJM_Upload_Test_Form();
+
+		return $form->do_upload_file( $this->field_key, $field );
+	}
+}


### PR DESCRIPTION
Spun out of review on #3025, which surfaced the inconsistency but shouldn't carry the fix — that PR only changes a picker hint, this one changes what the server accepts.

### Changes Proposed in this Pull Request

`WP_Job_Manager_Form::upload_file()` has the field key in hand and passes it to `job_manager_upload_file()` as `file_key`, but it built the default allowed-types list one line earlier with a **keyless** `job_manager_get_allowed_mime_types()`. Two consequences on the non-AJAX submission path:

- A field with no `allowed_mime_types` of its own was validated against the generic list (`jpg/jpeg/jpe, gif, png, pdf, doc, docx`) no matter which field it was — so a `company_logo` upload was checked against the pdf/doc defaults and rejected the `webp` the field itself advertises.
- The `job_manager_mime_types` filter received an empty `$field` argument, so a site couldn't vary allowed types per field on this path, despite the filter documenting that parameter.

The AJAX path (`WP_Job_Manager_Ajax::upload_file()`) already gets this right: it passes only `file_key` and lets `job_manager_upload_file()` do the keyed lookup itself (`wp-job-manager-functions.php:1579`). This PR does the same in the form path and drops the duplicated default.

### Impact

Core WPJM's `company_logo` field sets `allowed_mime_types` explicitly, so the default branch never fires for it and stock installs are unaffected. This reaches add-ons or sites that register a file field — or unset that key — and rely on the defaults: such a `company_logo` field now accepts `webp` and stops accepting `pdf`/`doc` on the non-AJAX path, matching the AJAX path.

### Testing Instructions

1. `vendor/bin/phpunit --filter WP_Test_WP_Job_Manager_Form::` — 3 tests. Two of them fail on `trunk` and pass here; the third (an explicit `allowed_mime_types` still wins) is a control that passes either way.
2. With AJAX uploads disabled, register a file field keyed `company_logo` with no `allowed_mime_types` and submit a `.webp`. Before: rejected as a disallowed file type. After: accepted.

### Release Notes

Non-AJAX file uploads are now validated against the types allowed for that specific field, matching the AJAX path.

### New or Updated Hooks and Templates

The `job_manager_mime_types` filter now receives the field key in its `$field` argument on the non-AJAX upload path, as documented. No template changes.

### Deprecated Code

None.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 28d1cab5c8dd7994384096fbbf8ecf67254a134c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3053-28d1cab5.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3053-28d1cab5)             |

<!-- /wpjm:plugin-zip -->
