### PR TITLE
fix(submission): add form_id attribute to submit_job_form shortcode

### DIFF
--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -74,6 +74,16 @@ abstract class WP_Job_Manager_Form {
 	public $form_name = '';
 
 	/**
+	 * Active form id (set from shortcode `[submit_job_form form_id="..."]`).
+	 *
+	 * Round-tripped via a hidden field so POST processing rebuilds the same field set.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $current_form_id = '';
+
+	/**
 	 * Cloning is forbidden.
 	 */
 	public function __clone() {
@@ -149,6 +159,10 @@ abstract class WP_Job_Manager_Form {
 		$step_key = $this->get_step_key( $this->step );
 		$this->show_errors();
 		$this->show_messages();
+
+		if ( isset( $atts['form_id'] ) ) {
+			$this->current_form_id = sanitize_text_field( $atts['form_id'] );
+		}
 
 		if ( $step_key && is_callable( $this->steps[ $step_key ]['view'] ) ) {
 			call_user_func( $this->steps[ $step_key ]['view'], $atts );

--- a/includes/abstracts/abstract-wp-job-manager-form.php
+++ b/includes/abstracts/abstract-wp-job-manager-form.php
@@ -26,6 +26,16 @@ abstract class WP_Job_Manager_Form {
 	protected $fields = [];
 
 	/**
+	 * Cache key for `$fields`. Tracks the `current_form_id` value the
+	 * fields were built under so a 2nd `submit_job_form form_id="..."`
+	 * on the same page rebuilds instead of returning the 1st set.
+	 *
+	 * @access protected
+	 * @var string
+	 */
+	protected $fields_cache_key = '';
+
+	/**
 	 * Form action.
 	 *
 	 * @access protected

--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -99,6 +99,13 @@ class WP_Job_Manager_Shortcodes {
 	 * @return string|null
 	 */
 	public function submit_job_form( $atts = [] ) {
+		$atts = shortcode_atts(
+			[
+				'form_id' => '',
+			],
+			$atts,
+			'submit_job_form'
+		);
 		return $GLOBALS['job_manager']->forms->get_form( 'submit-job', $atts );
 	}
 

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -91,13 +91,22 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 		if ( ! empty( $this->save_error ) ) {
 			echo '<div class="job-manager-error">' . wp_kses_post( $this->save_error ) . '</div>';
 		}
+		if ( isset( $atts['form_id'] ) ) {
+			$this->current_form_id = sanitize_text_field( $atts['form_id'] );
+		}
 		$this->submit();
 	}
 
 	/**
 	 * Submit Step
+	 *
+	 * @param array $atts Shortcode attributes forwarded from the shortcode handler.
 	 */
-	public function submit() {
+	public function submit( $atts = [] ) {
+		if ( isset( $atts['form_id'] ) ) {
+			$this->current_form_id = sanitize_text_field( $atts['form_id'] );
+		}
+
 		$job = get_post( $this->job_id );
 
 		if ( empty( $this->job_id ) ) {
@@ -147,6 +156,7 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 			'job-submit.php',
 			[
 				'form'               => $this->form_name,
+				'form_id'            => $this->current_form_id,
 				'job_id'             => $this->get_job_id(),
 				'action'             => $this->get_action(),
 				'job_fields'         => $this->get_fields( 'job' ),
@@ -167,6 +177,16 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 		if ( empty( $_POST['submit_job'] ) ) {
 			return;
 		}
+
+		// Round-trip the active form id so the field set used to validate matches
+		// the one the edit form was rendered with. Only accept a short slug; anything
+		// else is discarded to keep the value out of the `submit_job_form_fields` filter.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce checked below; value is used only to switch field sets.
+		if ( ! empty( $_POST['form_id'] ) ) {
+			$candidate             = sanitize_text_field( wp_unslash( $_POST['form_id'] ) );
+			$this->current_form_id = ( strlen( $candidate ) <= 32 && preg_match( '/\A[A-Za-z0-9_-]+\z/', $candidate ) ) ? $candidate : '';
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		// The edit form only ever updates an existing, editable listing. A zero job_id means no
 		// listing was supplied or the current user is not authorized to edit the requested one

--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -77,6 +77,21 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 				$this->job_id = 0;
 			}
 		}
+
+		// Reuse the originating `form_id` saved at submission so the edit form
+		// keeps the same field set even when the dashboard shortcode doesn't
+		// forward one. POST round-trip in `submit_handler()` still wins over
+		// this when present, so the user's chosen form id isn't downgraded.
+		if ( ! empty( $this->job_id ) ) {
+			$stored_form_id = get_post_meta( $this->job_id, '_form_id', true );
+			if (
+				is_string( $stored_form_id )
+				&& strlen( $stored_form_id ) <= 32
+				&& preg_match( '/\A[A-Za-z0-9_-]+\z/', $stored_form_id )
+			) {
+				$this->current_form_id = $stored_form_id;
+			}
+		}
 	}
 
 	/**
@@ -226,6 +241,15 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 			$post_status  = get_post_status( $this->job_id );
 
 			update_post_meta( $this->job_id, '_job_edited', time() );
+
+			// Mirror the same update/delete handling used in the submit handler so
+			// an edit on the default `[submit_job_form]` page clears a stale
+			// `_form_id` from an earlier `[submit_job_form form_id="..."]` save.
+			if ( $this->current_form_id ) {
+				update_post_meta( $this->job_id, '_form_id', $this->current_form_id );
+			} else {
+				delete_post_meta( $this->job_id, '_form_id' );
+			}
 
 			if ( in_array( $post_status, [ 'future', 'publish' ], true ) ) {
 				$save_message = $save_message . ' <a href="' . get_permalink( $this->job_id ) . '">' . __( 'View &rarr;', 'wp-job-manager' ) . '</a>';

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -190,7 +190,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * Initializes the fields used in the form.
 	 */
 	public function init_fields() {
-		if ( $this->fields ) {
+		// ponytail: cache keyed on the active form id so two `[submit_job_form form_id="…"]`
+		// blocks on one page each rebuild (filtered for their own form id) instead of both
+		// returning the first set. Same form id within a request stays cached — cheap path.
+		$cache_key = $this->current_form_id;
+		if ( $this->fields && $this->fields_cache_key === $cache_key ) {
 			return;
 		}
 
@@ -234,7 +238,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		 * single-arg signature keep working.
 		 *
 		 * @since 1.0.0
-		 * @since 2.4.6 Added the `$form_id` argument.
+		 * @since $$next-version$$ Added the `$form_id` argument.
 		 *
 		 * @param array  $fields  Field groups, keyed by group, then field key.
 		 * @param string $form_id Form id passed to the shortcode (or empty string).
@@ -386,7 +390,8 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			$this->current_form_id
 		);
 
-		$this->fields = $default_fields;
+		$this->fields           = $default_fields;
+		$this->fields_cache_key = $cache_key;
 
 		if ( ! get_option( 'job_manager_enable_categories' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) ) {
 			unset( $this->fields['job']['job_category'] );
@@ -866,6 +871,16 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			// Mark this job as a public submission so the submission hook is fired.
 			update_post_meta( $this->job_id, '_public_submission', true );
 
+			// Store the originating `form_id` so the edit form rebuilds the same field set
+			// even when the dashboard edit page can't thread it through via shortcode `$atts`.
+			// Delete the meta when no form id is active so a stale value from an earlier
+			// submission doesn't bleed into a later edit on the default `[submit_job_form]`.
+			if ( $this->current_form_id ) {
+				update_post_meta( $this->job_id, '_form_id', $this->current_form_id );
+			} else {
+				delete_post_meta( $this->job_id, '_form_id' );
+			}
+
 			if ( $this->job_id ) {
 				// Reset the `_filled` flag.
 				update_post_meta( $this->job_id, '_filled', 0 );
@@ -1331,7 +1346,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
-		wp_nonce_field( 'submit-job-' . $this->job_id, '_wpjm_nonce' );
+		wp_nonce_field( $this->submit_nonce_action(), '_wpjm_nonce' );
 	}
 
 	/**
@@ -1341,13 +1356,34 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
+		$action = $this->submit_nonce_action();
 		if (
 			empty( $_REQUEST['_wpjm_nonce'] )
-			|| ! wp_verify_nonce( wp_unslash( $_REQUEST['_wpjm_nonce'] ), 'submit-job-' . $this->job_id ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
+			|| ! wp_verify_nonce( wp_unslash( $_REQUEST['_wpjm_nonce'] ), $action ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce should not be modified.
 		) {
-			wp_nonce_ays( 'submit-job-' . $this->job_id );
+			wp_nonce_ays( $action );
 			die();
 		}
+	}
+
+	/**
+	 * Build the nonce action string for the submit form.
+	 *
+	 * Binds the active `form_id` (from `[submit_job_form form_id="..."]`) into the
+	 * action so a submitter can't reuse a nonce minted for one form id against a
+	 * different posted form id — the field set rendered has to match the field set
+	 * validated.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private function submit_nonce_action() {
+		$action = 'submit-job-' . $this->job_id;
+		if ( $this->current_form_id ) {
+			$action .= '-form-' . $this->current_form_id;
+		}
+		return $action;
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -226,7 +226,20 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			? sprintf( __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency (%s).', 'wp-job-manager' ), $default_salary_currency )
 			: __( 'Add a salary currency, this field is optional. Leave it empty to use the default salary currency.', 'wp-job-manager' );
 
-		$this->fields = apply_filters(
+		/**
+		 * Filters the fields shown in the job submission form.
+		 *
+		 * The 2nd argument is the active form id (from `[submit_job_form form_id="..."]`),
+		 * or an empty string when the default form is used. Callbacks written for the
+		 * single-arg signature keep working.
+		 *
+		 * @since 1.0.0
+		 * @since 2.4.6 Added the `$form_id` argument.
+		 *
+		 * @param array  $fields  Field groups, keyed by group, then field key.
+		 * @param string $form_id Form id passed to the shortcode (or empty string).
+		 */
+		$default_fields = apply_filters(
 			'submit_job_form_fields',
 			[
 				'job'     => [
@@ -369,8 +382,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						),
 					],
 				],
-			]
+			],
+			$this->current_form_id
 		);
+
+		$this->fields = $default_fields;
 
 		if ( ! get_option( 'job_manager_enable_categories' ) || 0 === intval( wp_count_terms( \WP_Job_Manager_Post_Types::TAX_LISTING_CATEGORY ) ) ) {
 			unset( $this->fields['job']['job_category'] );
@@ -628,8 +644,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 	/**
 	 * Displays the form.
+	 *
+	 * @param array $atts Shortcode attributes forwarded from the shortcode handler.
 	 */
-	public function submit() {
+	public function submit( $atts = [] ) {
+		if ( isset( $atts['form_id'] ) ) {
+			$this->current_form_id = sanitize_text_field( $atts['form_id'] );
+		}
 		$this->init_fields();
 
 		// Load data if necessary.
@@ -691,6 +712,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			'job-submit.php',
 			[
 				'form'               => $this->form_name,
+				'form_id'            => $this->current_form_id,
 				'job_id'             => $this->get_job_id(),
 				'resume_edit'        => $this->resume_edit,
 				'action'             => $this->get_action(),
@@ -710,6 +732,16 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 */
 	public function submit_handler() {
 		try {
+			// Round-trip the active form id (set by the shortcode, echoed in the submit template).
+			// Only accept a short slug; anything else is discarded to keep the value out of
+			// the `submit_job_form_fields` filter.
+			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce checked below; value is used only to switch field sets.
+			if ( ! empty( $_POST['form_id'] ) ) {
+				$candidate             = sanitize_text_field( wp_unslash( $_POST['form_id'] ) );
+				$this->current_form_id = ( strlen( $candidate ) <= 32 && preg_match( '/\A[A-Za-z0-9_-]+\z/', $candidate ) ) ? $candidate : '';
+			}
+			// phpcs:enable WordPress.Security.NonceVerification.Missing
+
 			// Init fields.
 			$this->init_fields();
 

--- a/templates/job-preview.php
+++ b/templates/job-preview.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     2.4.6
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/job-preview.php
+++ b/templates/job-preview.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.41.0
+ * @version     2.4.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -39,6 +39,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input type="hidden" name="job_id" value="<?php echo esc_attr( $form->get_job_id() ); ?>" />
 		<input type="hidden" name="step" value="<?php echo esc_attr( $form->get_step() ); ?>" />
 		<input type="hidden" name="job_manager_form" value="<?php echo esc_attr( $form->get_form_name() ); ?>" />
+		<?php if ( ! empty( $form->current_form_id ) ) : ?>
+			<input type="hidden" name="form_id" value="<?php echo esc_attr( $form->current_form_id ); ?>" />
+		<?php endif; ?>
 	</div>
 	<?php
 	/**

--- a/templates/job-submit.php
+++ b/templates/job-submit.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     2.4.6
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/job-submit.php
+++ b/templates/job-submit.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.34.3
+ * @version     2.4.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -72,6 +72,9 @@ $captcha_version = WP_Job_Manager\WP_Job_Manager_Recaptcha::instance()->get_reca
 
 		<p>
 			<input type="hidden" name="job_manager_form" value="<?php echo esc_attr( $form ); ?>" />
+			<?php if ( ! empty( $form_id ) ) : ?>
+				<input type="hidden" name="form_id" value="<?php echo esc_attr( $form_id ); ?>" />
+			<?php endif; ?>
 			<input type="hidden" name="job_id" value="<?php echo esc_attr( $job_id ); ?>" />
 			<input type="hidden" name="step" value="<?php echo esc_attr( $step ); ?>" />
 			<input type="submit" name="submit_job" class="button"

--- a/tests/php/tests/includes/test_class.submit-job-form-id.php
+++ b/tests/php/tests/includes/test_class.submit-job-form-id.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests the `form_id` shortcode attribute plumbing for `[submit_job_form]`.
+ *
+ * Verifies that the `submit_job_form_fields` filter receives the active form id
+ * (2nd argument) when one is set via the shortcode, that it receives an empty
+ * string when not (backward compatibility), and that the id round-trips through
+ * the submit form template + handler so validation uses the same field set that
+ * rendered.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Submit_Job_Form_Id extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+	}
+
+	public function tearDown(): void {
+		$_POST    = [];
+		$_REQUEST = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a fresh form instance, reset fields cache, and re-prep it.
+	 *
+	 * The form is a singleton, so its `$fields` cache from a previous test
+	 * would otherwise leak across cases.
+	 */
+	private function fresh_form() {
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$fields = $class->getProperty( 'fields' );
+		$fields->setAccessible( true );
+		$fields->setValue( $form, [] );
+
+		$current = $class->getProperty( 'current_form_id' );
+		$current->setAccessible( true );
+		$current->setValue( $form, '' );
+
+		return $form;
+	}
+
+	/**
+	 * The filter receives the shortcode's `form_id` as the 2nd argument.
+	 */
+	public function test_filter_receives_form_id_from_shortcode_atts() {
+		$form    = $this->fresh_form();
+		$capture = [ 'fields' => null, 'form_id' => null ];
+
+		$callback = function ( $fields, $form_id ) use ( &$capture ) {
+			$capture['fields']  = $fields;
+			$capture['form_id'] = $form_id;
+			return $fields;
+		};
+		add_filter( 'submit_job_form_fields', $callback, 10, 2 );
+
+		$form->submit( [ 'form_id' => 'classifieds' ] );
+
+		remove_filter( 'submit_job_form_fields', $callback, 10 );
+
+		$this->assertSame( 'classifieds', $capture['form_id'] );
+		$this->assertIsArray( $capture['fields'] );
+		$this->assertArrayHasKey( 'job', $capture['fields'] );
+	}
+
+	/**
+	 * When no `form_id` is provided, the filter receives an empty string and a
+	 * single-argument callback still works.
+	 */
+	public function test_filter_receives_empty_string_when_no_form_id() {
+		$form    = $this->fresh_form();
+		$capture = [ 'fields' => null, 'form_id' => null ];
+
+		$callback = function ( $fields, $form_id = null ) use ( &$capture ) {
+			$capture['fields']  = $fields;
+			$capture['form_id'] = $form_id;
+			return $fields;
+		};
+		add_filter( 'submit_job_form_fields', $callback, 10, 2 );
+
+		$form->submit( [] );
+
+		remove_filter( 'submit_job_form_fields', $callback, 10 );
+
+		$this->assertSame( '', $capture['form_id'] );
+
+		// Backward compatibility: a single-arg callback (no 2nd parameter) still fires.
+		$bc_seen = false;
+		$bc_cb   = function ( $fields ) use ( &$bc_seen ) {
+			$bc_seen = true;
+			return $fields;
+		};
+		add_filter( 'submit_job_form_fields', $bc_cb, 10, 1 );
+		$this->fresh_form()->submit( [] );
+		remove_filter( 'submit_job_form_fields', $bc_cb, 10 );
+
+		$this->assertTrue( $bc_seen );
+	}
+
+	/**
+	 * `output()` captures the `form_id` from `$atts` onto the instance before
+	 * the view is dispatched, so the field filter sees it.
+	 */
+	public function test_output_stores_form_id_on_instance() {
+		$form  = $this->fresh_form();
+		$class = new ReflectionClass( $form );
+		$prop  = $class->getProperty( 'current_form_id' );
+		$prop->setAccessible( true );
+
+		ob_start();
+		$form->output( [ 'form_id' => 'company-ads' ] );
+		ob_end_clean();
+
+		$this->assertSame( 'company-ads', $prop->getValue( $form ) );
+	}
+
+	/**
+	 * `submit_handler` reads `form_id` from POST so the field set used during
+	 * validation matches the field set used to render the form.
+	 */
+	public function test_submit_handler_round_trips_form_id_from_post() {
+		$form  = $this->fresh_form();
+		$class = new ReflectionClass( $form );
+		$prop  = $class->getProperty( 'current_form_id' );
+		$prop->setAccessible( true );
+
+		// Replicate what the submit template echoes when a form_id is set.
+		$_POST = [ 'form_id' => 'classifieds' ];
+
+		$form->submit_handler();
+
+		$this->assertSame( 'classifieds', $prop->getValue( $form ) );
+	}
+}

--- a/tests/php/tests/includes/test_class.submit-job-form-id.php
+++ b/tests/php/tests/includes/test_class.submit-job-form-id.php
@@ -38,6 +38,10 @@ class WP_Test_Submit_Job_Form_Id extends WPJM_BaseTest {
 		$fields->setAccessible( true );
 		$fields->setValue( $form, [] );
 
+		$cache_key = $class->getProperty( 'fields_cache_key' );
+		$cache_key->setAccessible( true );
+		$cache_key->setValue( $form, '' );
+
 		$current = $class->getProperty( 'current_form_id' );
 		$current->setAccessible( true );
 		$current->setValue( $form, '' );
@@ -135,5 +139,123 @@ class WP_Test_Submit_Job_Form_Id extends WPJM_BaseTest {
 		$form->submit_handler();
 
 		$this->assertSame( 'classifieds', $prop->getValue( $form ) );
+	}
+
+	/**
+	 * Malformed `form_id` POST values are discarded instead of being passed
+	 * through to the `submit_job_form_fields` filter or the nonce action.
+	 */
+	public function test_malformed_form_id_post_value_is_discarded() {
+		$form  = $this->fresh_form();
+		$class = new ReflectionClass( $form );
+		$prop  = $class->getProperty( 'current_form_id' );
+		$prop->setAccessible( true );
+
+		// Disallowed characters: slashes, spaces, dots, longer than 32.
+		$_POST = [ 'form_id' => '../etc/passwd has spaces' ];
+
+		$form->submit_handler();
+
+		$this->assertSame( '', $prop->getValue( $form ) );
+	}
+
+	/**
+	 * A nonce minted for a different `form_id` than the posted one must not
+	 * pass `check_submit_form_nonce_field()` — `die()` is the expected outcome.
+	 */
+	public function test_nonce_with_mismatched_form_id_is_rejected() {
+		// Suppress the wp_die() blast so PHP unit's `expectException` can catch it.
+		// Reuses the helper shipped on WPJM_BaseTest.
+		add_filter( 'wp_die_handler', [ $this, 'return_do_not_die' ] );
+
+		$form = $this->fresh_form();
+		$user = self::factory()->user->create();
+		wp_set_current_user( $user );
+
+		// Render-time form id: "classifieds". We mint the nonce against that.
+		$render_form_id = 'classifieds';
+		$nonce          = wp_create_nonce( 'submit-job-0-form-' . $render_form_id );
+
+		// Submitter posts a different, less-restrictive form id along with the
+		// nonce minted for the rendered form. The check must not let it through.
+		$_POST    = [ 'submit_job' => '1', 'form_id' => 'reduced', '_wpjm_nonce' => $nonce ];
+		$_REQUEST = $_POST;
+
+		// After the nonce check fails, wp_nonce_ays() falls into the
+		// `wp_die()` path which we just suppressed. The signature of
+		// "rejected" is that the handler did not save / validate / proceed;
+		// the simplest observable is that current_form_id stays empty
+		// (the post form_id was tweaked by the test but since we got past
+		// that point we expect no side effects on the form instance).
+		$form->submit_handler();
+
+		remove_filter( 'wp_die_handler', [ $this, 'return_do_not_die' ] );
+
+		// Confirm we did not advance the request: the handler didn't save
+		// anything (a successful handler would have bumped $this->step).
+		$step_prop = ( new ReflectionClass( $form ) )->getProperty( 'step' );
+		$step_prop->setAccessible( true );
+		$this->assertSame( 0, $step_prop->getValue( $form ), 'Step must not advance when nonce mismatches.' );
+	}
+
+	/**
+	 * Cached `$fields` are reused when `current_form_id` matches the cache key,
+	 * and rebuilt when it differs — so two `[submit_job_form form_id="…"]` blocks
+	 * on the same page each render their own field set.
+	 */
+	public function test_init_fields_cache_invalidates_when_form_id_changes() {
+		$form = $this->fresh_form();
+
+		$call_count = 0;
+		$seen_ids   = [];
+		$cb         = function ( $fields, $form_id ) use ( &$call_count, &$seen_ids ) {
+			++$call_count;
+			$seen_ids[] = $form_id;
+			return $fields;
+		};
+		add_filter( 'submit_job_form_fields', $cb, 10, 2 );
+
+		// First render — cache miss, filter runs once with `classifieds`.
+		$form->submit( [ 'form_id' => 'classifieds' ] );
+
+		// Cached on second render with same form id.
+		$form->submit( [ 'form_id' => 'classifieds' ] );
+		$this->assertSame( 1, $call_count, 'Same form id should hit the cache.' );
+
+		// Different form id — cache miss, filter runs again.
+		$form->submit( [ 'form_id' => 'reduced' ] );
+		$this->assertSame( 2, $call_count, 'Different form id should rebuild.' );
+		$this->assertSame( [ 'classifieds', 'reduced' ], $seen_ids );
+
+		remove_filter( 'submit_job_form_fields', $cb, 10 );
+	}
+
+	/**
+	 * When a job listing carries a `_form_id` post meta saved at submission,
+	 * instantiating the edit form seeds `current_form_id` from meta so the
+	 * dashboard edit page renders the same field set without any shortcode
+	 * `form_id` having to be threaded through by the caller.
+	 */
+	public function test_edit_job_reads_form_id_from_post_meta() {
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-edit-job.php';
+
+		// Inject a job post + meta that simulates a listing submitted through
+		// `[submit_job_form form_id="classifieds"]`.
+		$job_id = self::factory()->post->create(
+			[
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_status' => 'publish',
+				'post_author' => self::factory()->user->create(),
+			]
+		);
+		update_post_meta( $job_id, '_form_id', 'classifieds' );
+
+		// Simulate the dashboard's edit link: it forwards `job_id` via `_REQUEST`.
+		$_REQUEST = [ 'job_id' => $job_id ];
+		wp_set_current_user( get_post( $job_id )->post_author );
+
+		$form = WP_Job_Manager_Form_Edit_Job::instance();
+
+		$this->assertSame( 'classifieds', $form->current_form_id );
 	}
 }


### PR DESCRIPTION
Fixes #2236

### Changes Proposed in this Pull Request

The `[submit_job_form]` shortcode now accepts a `form_id` attribute. The active form id is passed as a 2nd argument to the `submit_job_form_fields` filter, so a site can render the form on multiple pages with different field sets by branching on the id:

```php
// Page A: [submit_job_form]
// Page B: [submit_job_form form_id="classifieds"]
add_filter( 'submit_job_form_fields', function ( $fields, $form_id ) {
    if ( 'classifieds' === $form_id ) {
        unset( $fields['job']['job_type'], $fields['job']['job_category'] );
    }
    return $fields;
}, 10, 2 );
```

The form id is round-tripped through a hidden field on both `job-submit.php` and `job-preview.php`, so POST validation uses the same field set that was rendered. The edit form (from `[job_dashboard]`) inherits the same plumbing for consistency.

POST-supplied `form_id` values are validated as a short slug (`[A-Za-z0-9_-]{1,32}`); anything else is discarded. Existing single-argument `submit_job_form_fields` callbacks keep working.

### Testing Instructions

1. Create a page with `[submit_job_form]` and configure it as the Submit Job Form page in WPJM settings. Submit a listing end-to-end (fill, preview, submit) and confirm it saves as before.
2. In a small mu-plugin, add the snippet from the description above, then create a second page with `[submit_job_form form_id="classifieds"]`.
3. Visit the second page. Confirm the `Job type` and `Job category` fields are absent and a hidden `form_id=classifieds` input is present.
4. Click Preview on the second page, view source, confirm the hidden `form_id=classifieds` input is still present, then click Submit Listing. The job saves (or goes to moderation) successfully.
5. Visit the original `[submit_job_form]` page again. Confirm `Job type` and `Job category` are still present and no `form_id` hidden input is emitted.

### Release Notes

* New `form_id` shortcode attribute for `[submit_job_form]`, allowing different field sets per form via the `submit_job_form_fields` filter.

### New or Updated Hooks and Templates

* `submit_job_form_fields` now receives a 2nd argument: the active form id (an empty string when no `form_id` is set). Backward compatible.
* `templates/job-submit.php` and `templates/job-preview.php` echo a hidden `form_id` input when a form id is active. Bumped `@version` to 2.4.6.
* `includes/abstracts/abstract-wp-job-manager-form.php` gains a public `current_form_id` property on the form base class.

### Deprecated Code

*

### Screenshot / Video

*