### PR TITLE
Allow reusing a listing's existing logo on edit when authored by another user

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -970,7 +970,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				foreach ( array_filter( $file_urls ) as $file_url ) {
 					if ( is_numeric( $file_url ) ) {
 						$attachment_id = absint( $file_url );
-						if ( $attachment_id && ! $this->is_attachment_authorized_for_current_user( $attachment_id ) ) {
+						if (
+								$attachment_id
+								&& ! $this->is_attachment_authorized_for_current_user( $attachment_id )
+								&& ! $this->is_existing_listing_attachment( $attachment_id, $key )
+							) {
 							return new WP_Error( 'validation-error', __( 'Invalid attachment provided.', 'wp-job-manager' ) );
 						}
 					}
@@ -1008,6 +1012,40 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		// Or has the capability to edit it (e.g. an admin editing another user's listing).
 		return current_user_can( 'edit_post', $attachment_id );
+	}
+
+	/**
+	 * Determines whether an attachment is already the persisted value of a file
+	 * field on the listing currently being edited.
+	 *
+	 * A user who passed the edit-permission gate for a listing ($this->job_id is
+	 * only set for listings the current user may edit or is mid-submitting) is
+	 * allowed to carry that listing's existing attachment forward on save, even
+	 * when they are not the attachment's author — e.g. when a site admin uploaded
+	 * or replaced the logo on their behalf. This is not an arbitrary foreign ID:
+	 * it is the value already bound to a listing the user is authorized to edit.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $key           Field key (e.g. 'company_logo').
+	 * @return bool True when the attachment is the listing's existing value for the field.
+	 */
+	protected function is_existing_listing_attachment( $attachment_id, $key ) {
+		if ( ! $this->job_id ) {
+			return false;
+		}
+
+		// Mirrors how the edit form pre-populates the field value in get_fields().
+		if ( 'company_logo' === $key && has_post_thumbnail( $this->job_id ) ) {
+			$existing = get_post_thumbnail_id( $this->job_id );
+		} else {
+			$existing = get_post_meta( $this->job_id, '_' . $key, true );
+		}
+
+		$existing_ids = array_map( 'absint', is_array( $existing ) ? $existing : [ $existing ] );
+
+		return in_array( absint( $attachment_id ), $existing_ids, true );
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -970,6 +970,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				foreach ( array_filter( $file_urls ) as $file_url ) {
 					if ( is_numeric( $file_url ) ) {
 						$attachment_id = absint( $file_url );
+						// The third condition is only safe because $this->job_id is pre-gated: it
+						// is set only for a listing the current user may edit (or is mid-submitting).
+						// It permits reusing the listing's own saved attachment, NOT any attachment
+						// already on the post — do not loosen it to accept arbitrary foreign IDs.
 						if (
 								$attachment_id
 								&& ! $this->is_attachment_authorized_for_current_user( $attachment_id )

--- a/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
@@ -235,6 +235,80 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Regression (#2995 follow-up): the existing-listing allowance also covers logos
+	 * stored in `_company_logo` meta rather than as the featured image (older listings,
+	 * or when no post thumbnail is set). This exercises the meta branch of
+	 * is_existing_listing_attachment(), which the featured-image tests above do not.
+	 */
+	public function test_existing_listing_logo_in_meta_is_accepted_on_edit() {
+		$this->login_as_admin();
+		$admin_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		$job_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => get_current_user_id(),
+			]
+		);
+		// Stored in meta, with no featured image — forces the else branch.
+		update_post_meta( $job_id, '_company_logo', $admin_attachment );
+		$this->assertFalse( has_post_thumbnail( $job_id ) );
+
+		$this->assertTrue(
+			$this->validate_company_logo_editing_job( (string) $admin_attachment, $job_id ),
+			"A listing's existing meta-stored logo must remain valid on edit even when authored by another user."
+		);
+	}
+
+	/**
+	 * The meta branch is still scoped to the saved value: with the logo in
+	 * `_company_logo` meta, a different foreign attachment is rejected on edit.
+	 */
+	public function test_foreign_attachment_rejected_when_logo_in_meta_on_edit() {
+		$this->login_as_admin();
+		$listing_logo     = $this->create_attachment_owned_by( get_current_user_id() );
+		$other_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		$job_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => get_current_user_id(),
+			]
+		);
+		update_post_meta( $job_id, '_company_logo', $listing_logo );
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo_editing_job( (string) $other_attachment, $job_id );
+	}
+
+	/**
+	 * Guard against the empty-stored-value edge: with job_id set but no featured
+	 * image and no `_company_logo` meta, the existing value resolves to [0], so a
+	 * submitted foreign attachment ID (always >= 1) must still be rejected — setting
+	 * job_id on a listing with no saved logo is not a bypass.
+	 */
+	public function test_empty_stored_logo_does_not_authorize_foreign_attachment_on_edit() {
+		$this->login_as_admin();
+		$foreign_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		$job_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => get_current_user_id(),
+			]
+		);
+		// No thumbnail, no _company_logo meta: existing value is empty.
+		$this->assertFalse( has_post_thumbnail( $job_id ) );
+		$this->assertSame( '', get_post_meta( $job_id, '_company_logo', true ) );
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo_editing_job( (string) $foreign_attachment, $job_id );
+	}
+
+	/**
 	 * Drives WP_Job_Manager_Form_Submit_Job::submit_handler() for a "Save draft"
 	 * POST binding the given company_logo value, the way the draft-save POST does.
 	 *

--- a/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
@@ -76,6 +76,51 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Runs the form's field validation against a company_logo value while editing
+	 * an existing listing (form job_id set), mirroring the edit / re-save flow.
+	 *
+	 * @param mixed $logo_value Value to validate for the company_logo field.
+	 * @param int   $job_id     Listing being edited.
+	 * @throws Exception When validation rejects the value.
+	 * @return bool|WP_Error validate_fields() result.
+	 */
+	private function validate_company_logo_editing_job( $logo_value, $job_id ) {
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$fields_prop = $class->getProperty( 'fields' );
+		$fields_prop->setAccessible( true );
+		$fields_prop->setValue(
+			$form,
+			[
+				'company' => [
+					'company_logo' => [
+						'label'              => 'Logo',
+						'type'               => 'file',
+						'required'           => false,
+						'file_limit'         => 1,
+						'allowed_mime_types' => [ 'png' => 'image/png' ],
+					],
+				],
+			]
+		);
+
+		$job_id_prop = $class->getProperty( 'job_id' );
+		$job_id_prop->setAccessible( true );
+		$job_id_prop->setValue( $form, $job_id );
+
+		$validate = $class->getMethod( 'validate_fields' );
+		$validate->setAccessible( true );
+
+		try {
+			return $validate->invoke( $form, [ 'company' => [ 'company_logo' => $logo_value ] ] );
+		} finally {
+			// Reset singleton edit state so it does not leak into other tests.
+			$job_id_prop->setValue( $form, 0 );
+		}
+	}
+
+	/**
 	 * A submitter cannot validate a company_logo pointing at an attachment owned
 	 * by another user.
 	 */
@@ -130,6 +175,63 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 			$this->validate_company_logo( (string) $employer_attachment ),
 			'A user who can edit the attachment must be authorized to reuse it.'
 		);
+	}
+
+	/**
+	 * Regression (#2995 follow-up): when editing an existing listing, a
+	 * company_logo that is already the listing's featured image must be accepted
+	 * even if the current user neither authored the attachment nor can edit_post
+	 * it — e.g. a site admin uploaded/replaced the logo on the user's behalf.
+	 * Carrying an existing logo forward on re-save is not binding an arbitrary
+	 * foreign attachment.
+	 */
+	public function test_existing_listing_logo_is_accepted_on_edit() {
+		// Admin uploads/replaces the logo, so the attachment is authored by the admin.
+		$this->login_as_admin();
+		$admin_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		// The listing belongs to the employer and already uses that logo.
+		$this->login_as_employer();
+		$job_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => get_current_user_id(),
+			]
+		);
+		set_post_thumbnail( $job_id, $admin_attachment );
+
+		// Sanity: the employer is neither the author nor able to edit the
+		// attachment, so without the existing-listing allowance this is rejected.
+		$this->assertNotEquals( get_current_user_id(), (int) get_post_field( 'post_author', $admin_attachment ) );
+		$this->assertFalse( current_user_can( 'edit_post', $admin_attachment ) );
+
+		$this->assertTrue(
+			$this->validate_company_logo_editing_job( (string) $admin_attachment, $job_id ),
+			"A listing's existing logo must remain valid on edit even when authored by another user."
+		);
+	}
+
+	/**
+	 * The existing-listing allowance is scoped to the listing's actual saved logo:
+	 * while editing, a foreign attachment that is NOT the listing's current logo
+	 * is still rejected, so setting job_id does not become a blanket bypass.
+	 */
+	public function test_foreign_attachment_still_rejected_on_edit() {
+		$this->login_as_admin();
+		$listing_logo     = $this->create_attachment_owned_by( get_current_user_id() );
+		$other_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		$job_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => get_current_user_id(),
+			]
+		);
+		set_post_thumbnail( $job_id, $listing_logo );
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo_editing_job( (string) $other_attachment, $job_id );
 	}
 
 	/**


### PR DESCRIPTION
## What

Fixes a regression from #2995 (reported [here](https://github.com/Automattic/WP-Job-Manager/pull/2995#issuecomment-4985398582)). #2995 tightened company-logo attachment validation to reject a numeric attachment ID unless the current user owns it or can `edit_post` it. That broke the edit/re-save flow for listings whose logo was uploaded or replaced by a site admin: the attachment's `post_author` is the admin, so an employer editing **their own** listing hits **"Invalid attachment provided."** on save.

## Why it's safe

Carrying forward an attachment already bound to the listing being edited is not the same as binding an arbitrary foreign ID. By the time validation runs, `$this->job_id` is only set for a listing the current user passed `job_manager_user_can_edit_job()` on (or is mid-submitting via the draft/preview key). So this only permits reusing what is **already** attached to a listing the user is authorized to edit.

## Changes

`includes/forms/class-wp-job-manager-form-submit-job.php`
- Add `is_existing_listing_attachment( $attachment_id, $key )` — true when the ID matches the listing's persisted value for that field, resolved the same way the edit form pre-populates it (post thumbnail / `_company_logo` meta, or `_{key}` meta otherwise).
- `validate_attachment_ownership()` also allows the attachment when it is the listing's existing value.

The original security boundary is unchanged: a foreign attachment that is **not** the listing's saved logo is still rejected, even in edit mode.

## Testing

Adds regression coverage to `WP_Test_Submit_Job_Attachment_Ownership`, verified fail-before / pass-after:
- `test_existing_listing_logo_is_accepted_on_edit` — an admin-authored logo already set as the listing's featured image is accepted on edit. Without the fix this throws the exact reporter error.
- `test_foreign_attachment_still_rejected_on_edit` — a foreign attachment that is *not* the listing's saved logo is still rejected in edit mode (guards against `job_id` becoming a blanket bypass).

Full class passes (8 tests); `phpcs` clean.

Fixes #2995 (follow-up regression).


<!-- wpjm:plugin-zip -->
----

| Plugin build for e61ba7ec64983af0c2e5a50ca66cf8ad618a504e <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3060-e61ba7ec.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3060-e61ba7ec)             |

<!-- /wpjm:plugin-zip -->


