### PR TITLE
fix: render job dashboard expiry date correctly on sites west of UTC

### DIFF
--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -173,7 +173,7 @@ HTML;
 	/**
 	 * Generate HTML for a relative time string.
 	 *
-	 * @param string|\DateTimeInterface|int $time Time string, DateTime object, or timestamp.
+	 * @param string|\DateTimeInterface|int $time DateTime object, Unix timestamp, or a date string. Strings without an explicit UTC offset are interpreted in the site timezone.
 	 * @param string                        $format_string Sprintf-compatible format string. Should contain a %s placeholder for the time.
 	 *
 	 * @return string
@@ -181,6 +181,8 @@ HTML;
 	public static function rel_time( $time, $format_string = '%s' ) {
 
 		// The three input kinds are mutually exclusive; resolve each to a true Unix timestamp.
+		$timestamp = false;
+
 		if ( $time instanceof \DateTimeInterface ) {
 			$timestamp = $time->getTimestamp();
 		} elseif ( is_numeric( $time ) ) {
@@ -188,8 +190,11 @@ HTML;
 		} elseif ( is_string( $time ) && '' !== trim( $time ) ) {
 			// Interpret a bare date string as a floating calendar date in the site timezone,
 			// so wp_date() renders the same calendar date regardless of the site's UTC offset.
-			$datetime  = date_create( $time, wp_timezone() );
-			$timestamp = $datetime ? $datetime->getTimestamp() : false;
+			$datetime = date_create( $time, wp_timezone() );
+
+			if ( $datetime ) {
+				$timestamp = $datetime->getTimestamp();
+			}
 		}
 
 		if ( empty( $timestamp ) ) {

--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -180,8 +180,11 @@ HTML;
 	 */
 	public static function rel_time( $time, $format_string = '%s' ) {
 
-		if ( is_string( $time ) ) {
-			$timestamp = strtotime( $time );
+		if ( is_string( $time ) && ! is_numeric( $time ) && '' !== trim( $time ) ) {
+			// Interpret a bare date string as a floating calendar date in the site timezone,
+			// so wp_date() renders the same calendar date regardless of the site's UTC offset.
+			$datetime  = date_create( $time, wp_timezone() );
+			$timestamp = $datetime ? $datetime->getTimestamp() : false;
 		}
 
 		if ( $time instanceof \DateTimeInterface ) {
@@ -196,7 +199,7 @@ HTML;
 			return '';
 		}
 
-		$abs_time = date_i18n( get_option( 'date_format' ), $timestamp );
+		$abs_time = wp_date( get_option( 'date_format' ), $timestamp );
 		$rel_time = human_time_diff( $timestamp );
 
 		return '<time datetime="' . esc_attr( $abs_time ) . '" title="' . esc_attr( $abs_time ) . '">' . esc_html( sprintf( $format_string, $rel_time ) ) . '</time>';

--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -180,19 +180,16 @@ HTML;
 	 */
 	public static function rel_time( $time, $format_string = '%s' ) {
 
-		if ( is_string( $time ) && ! is_numeric( $time ) && '' !== trim( $time ) ) {
+		// The three input kinds are mutually exclusive; resolve each to a true Unix timestamp.
+		if ( $time instanceof \DateTimeInterface ) {
+			$timestamp = $time->getTimestamp();
+		} elseif ( is_numeric( $time ) ) {
+			$timestamp = (int) $time;
+		} elseif ( is_string( $time ) && '' !== trim( $time ) ) {
 			// Interpret a bare date string as a floating calendar date in the site timezone,
 			// so wp_date() renders the same calendar date regardless of the site's UTC offset.
 			$datetime  = date_create( $time, wp_timezone() );
 			$timestamp = $datetime ? $datetime->getTimestamp() : false;
-		}
-
-		if ( $time instanceof \DateTimeInterface ) {
-			$timestamp = $time->getTimestamp();
-		}
-
-		if ( is_numeric( $time ) ) {
-			$timestamp = $time;
 		}
 
 		if ( empty( $timestamp ) ) {

--- a/tests/php/tests/includes/test_class.ui-elements.php
+++ b/tests/php/tests/includes/test_class.ui-elements.php
@@ -19,10 +19,16 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	 */
 	private $original_timezone;
 
+	/**
+	 * @var string Original gmt_offset option, restored in tearDown.
+	 */
+	private $original_gmt_offset;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->original_date_format = get_option( 'date_format' );
 		$this->original_timezone    = get_option( 'timezone_string' );
+		$this->original_gmt_offset  = get_option( 'gmt_offset' );
 		// Use an unambiguous calendar-date format so assertions compare the date directly.
 		update_option( 'date_format', 'Y-m-d' );
 	}
@@ -30,7 +36,23 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	public function tearDown(): void {
 		update_option( 'date_format', $this->original_date_format );
 		update_option( 'timezone_string', $this->original_timezone );
+		update_option( 'gmt_offset', $this->original_gmt_offset );
 		parent::tearDown();
+	}
+
+	/**
+	 * Set the site timezone the way WP Settings > General does.
+	 *
+	 * Both options must be written together: wp_timezone() prefers timezone_string
+	 * and only falls back to gmt_offset when it is empty, so a stale value in either
+	 * one would silently decide the timezone for the test.
+	 *
+	 * @param string $timezone_string Olson timezone identifier, or '' for a manual offset.
+	 * @param float  $gmt_offset      Offset in hours, used only when $timezone_string is ''.
+	 */
+	private function set_site_timezone( $timezone_string, $gmt_offset ) {
+		update_option( 'timezone_string', $timezone_string );
+		update_option( 'gmt_offset', $gmt_offset );
 	}
 
 	/**
@@ -47,15 +69,20 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	}
 
 	/**
-	 * Timezones spanning negative, positive, and zero UTC offsets.
+	 * Timezones spanning negative, positive, and zero UTC offsets, configured both
+	 * ways WP Settings > General allows: as an Olson timezone_string, and as a manual
+	 * gmt_offset with an empty timezone_string (including a half-hour offset, where
+	 * wp_timezone() returns a fixed offset zone rather than a named one).
 	 *
 	 * @return array
 	 */
 	public function data_timezones() {
 		return [
-			'negative offset (UTC-5)' => [ 'America/Panama' ],
-			'positive offset (UTC+9)' => [ 'Asia/Tokyo' ],
-			'zero offset (UTC)'       => [ 'UTC' ],
+			'negative offset (UTC-5)'            => [ 'America/Panama', 0 ],
+			'positive offset (UTC+9)'            => [ 'Asia/Tokyo', 0 ],
+			'zero offset (UTC)'                  => [ 'UTC', 0 ],
+			'manual negative offset (UTC-5)'     => [ '', -5 ],
+			'manual half-hour offset (UTC+5:30)' => [ '', 5.5 ],
 		];
 	}
 
@@ -70,10 +97,11 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	 *
 	 * @dataProvider data_timezones
 	 *
-	 * @param string $timezone Timezone string.
+	 * @param string $timezone_string Timezone string, or '' for a manual offset.
+	 * @param float  $gmt_offset      Manual offset in hours.
 	 */
-	public function test_rel_time_datetime_interface_renders_calendar_date( $timezone ) {
-		update_option( 'timezone_string', $timezone );
+	public function test_rel_time_datetime_interface_renders_calendar_date( $timezone_string, $gmt_offset ) {
+		$this->set_site_timezone( $timezone_string, $gmt_offset );
 
 		$expiration = new \DateTimeImmutable( '2026-08-13 23:59:59', wp_timezone() );
 
@@ -86,10 +114,11 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	 *
 	 * @dataProvider data_timezones
 	 *
-	 * @param string $timezone Timezone string.
+	 * @param string $timezone_string Timezone string, or '' for a manual offset.
+	 * @param float  $gmt_offset      Manual offset in hours.
 	 */
-	public function test_rel_time_date_string_renders_calendar_date( $timezone ) {
-		update_option( 'timezone_string', $timezone );
+	public function test_rel_time_date_string_renders_calendar_date( $timezone_string, $gmt_offset ) {
+		$this->set_site_timezone( $timezone_string, $gmt_offset );
 
 		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( '2026-08-13' ) ) );
 	}
@@ -98,7 +127,7 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	 * The human-readable relative text (wrapped by the format string) is preserved.
 	 */
 	public function test_rel_time_preserves_relative_text_format() {
-		update_option( 'timezone_string', 'America/Panama' );
+		$this->set_site_timezone( 'America/Panama', 0 );
 
 		$expiration = new \DateTimeImmutable( '2026-08-13 23:59:59', wp_timezone() );
 		$html       = UI_Elements::rel_time( $expiration, 'Expires in %s' );
@@ -129,17 +158,21 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	 * A numeric timestamp is honored whether passed as an int or a numeric string:
 	 * both resolve via the is_numeric branch and render the same calendar date.
 	 *
+	 * The instant is built at midday site time so it sits well inside the local
+	 * calendar day on every offset, letting the expected date be asserted literally
+	 * rather than recomputed with the same wp_date() call the code under test makes.
+	 *
 	 * @dataProvider data_timezones
 	 *
-	 * @param string $timezone Timezone string.
+	 * @param string $timezone_string Timezone string, or '' for a manual offset.
+	 * @param float  $gmt_offset      Manual offset in hours.
 	 */
-	public function test_rel_time_numeric_timestamp_renders_calendar_date( $timezone ) {
-		update_option( 'timezone_string', $timezone );
+	public function test_rel_time_numeric_timestamp_renders_calendar_date( $timezone_string, $gmt_offset ) {
+		$this->set_site_timezone( $timezone_string, $gmt_offset );
 
 		$timestamp = ( new \DateTimeImmutable( '2026-08-13 12:00:00', wp_timezone() ) )->getTimestamp();
-		$expected  = wp_date( 'Y-m-d', $timestamp );
 
-		$this->assertSame( $expected, $this->get_datetime_attr( UI_Elements::rel_time( $timestamp ) ) );
-		$this->assertSame( $expected, $this->get_datetime_attr( UI_Elements::rel_time( (string) $timestamp ) ) );
+		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( $timestamp ) ) );
+		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( (string) $timestamp ) ) );
 	}
 }

--- a/tests/php/tests/includes/test_class.ui-elements.php
+++ b/tests/php/tests/includes/test_class.ui-elements.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace WP_Job_Manager;
+
+use WP_Job_Manager\UI\UI_Elements;
+
+/**
+ * @group ui
+ */
+class WP_Test_UI_Elements extends \WPJM_BaseTest {
+
+	/**
+	 * @var string Original date_format option, restored in tearDown.
+	 */
+	private $original_date_format;
+
+	/**
+	 * @var string Original timezone_string option, restored in tearDown.
+	 */
+	private $original_timezone;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->original_date_format = get_option( 'date_format' );
+		$this->original_timezone    = get_option( 'timezone_string' );
+		// Use an unambiguous calendar-date format so assertions compare the date directly.
+		update_option( 'date_format', 'Y-m-d' );
+	}
+
+	public function tearDown(): void {
+		update_option( 'date_format', $this->original_date_format );
+		update_option( 'timezone_string', $this->original_timezone );
+		parent::tearDown();
+	}
+
+	/**
+	 * Extract the value of the datetime attribute from rel_time() output.
+	 *
+	 * @param string $html rel_time() output.
+	 *
+	 * @return string
+	 */
+	private function get_datetime_attr( $html ) {
+		$this->assertMatchesRegularExpression( '/datetime="([^"]+)"/', $html );
+		preg_match( '/datetime="([^"]+)"/', $html, $matches );
+		return $matches[1];
+	}
+
+	/**
+	 * Timezones spanning negative, positive, and zero UTC offsets.
+	 *
+	 * @return array
+	 */
+	public function data_timezones() {
+		return [
+			'negative offset (UTC-5)' => [ 'America/Panama' ],
+			'positive offset (UTC+9)' => [ 'Asia/Tokyo' ],
+			'zero offset (UTC)'       => [ 'UTC' ],
+		];
+	}
+
+	/**
+	 * A DateTimeInterface built end-of-day in site time (as core listing expiry is)
+	 * must render its own calendar date, not the next day, on any offset.
+	 *
+	 * @dataProvider data_timezones
+	 *
+	 * @param string $timezone Timezone string.
+	 */
+	public function test_rel_time_datetime_interface_renders_calendar_date( $timezone ) {
+		update_option( 'timezone_string', $timezone );
+
+		$expiration = new \DateTimeImmutable( '2026-08-13 23:59:59', wp_timezone() );
+
+		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( $expiration ) ) );
+	}
+
+	/**
+	 * A bare Y-m-d string (as the Application Deadline add-on passes its closing date)
+	 * is a floating calendar date and must render as-is, not shifted one day earlier.
+	 *
+	 * @dataProvider data_timezones
+	 *
+	 * @param string $timezone Timezone string.
+	 */
+	public function test_rel_time_date_string_renders_calendar_date( $timezone ) {
+		update_option( 'timezone_string', $timezone );
+
+		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( '2026-08-13' ) ) );
+	}
+
+	/**
+	 * The human-readable relative text (wrapped by the format string) is preserved.
+	 */
+	public function test_rel_time_preserves_relative_text_format() {
+		update_option( 'timezone_string', 'America/Panama' );
+
+		$expiration = new \DateTimeImmutable( '2026-08-13 23:59:59', wp_timezone() );
+		$html       = UI_Elements::rel_time( $expiration, 'Expires in %s' );
+
+		$this->assertStringContainsString( 'Expires in ', $html );
+		$this->assertStringContainsString( human_time_diff( $expiration->getTimestamp() ), $html );
+	}
+
+	/**
+	 * An empty or whitespace-only string yields no output, rather than rendering
+	 * the current time (which date_create() would otherwise return).
+	 */
+	public function test_rel_time_empty_string_renders_nothing() {
+		$this->assertSame( '', UI_Elements::rel_time( '' ) );
+		$this->assertSame( '', UI_Elements::rel_time( '   ' ) );
+	}
+
+	/**
+	 * A numeric timestamp is honored whether passed as an int or a numeric string:
+	 * both resolve via the is_numeric branch and render the same calendar date.
+	 *
+	 * @dataProvider data_timezones
+	 *
+	 * @param string $timezone Timezone string.
+	 */
+	public function test_rel_time_numeric_timestamp_renders_calendar_date( $timezone ) {
+		update_option( 'timezone_string', $timezone );
+
+		$timestamp = ( new \DateTimeImmutable( '2026-08-13 12:00:00', wp_timezone() ) )->getTimestamp();
+		$expected  = wp_date( 'Y-m-d', $timestamp );
+
+		$this->assertSame( $expected, $this->get_datetime_attr( UI_Elements::rel_time( $timestamp ) ) );
+		$this->assertSame( $expected, $this->get_datetime_attr( UI_Elements::rel_time( (string) $timestamp ) ) );
+	}
+}

--- a/tests/php/tests/includes/test_class.ui-elements.php
+++ b/tests/php/tests/includes/test_class.ui-elements.php
@@ -63,6 +63,11 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	 * A DateTimeInterface built end-of-day in site time (as core listing expiry is)
 	 * must render its own calendar date, not the next day, on any offset.
 	 *
+	 * This is the case that pins the reported bug: the negative-offset (UTC-5)
+	 * row is the one that renders "2026-08-14" under the old date_i18n() code and
+	 * "2026-08-13" after the fix. The positive/zero-offset rows are unaffected by
+	 * the bug and guard against a fix that would break them.
+	 *
 	 * @dataProvider data_timezones
 	 *
 	 * @param string $timezone Timezone string.
@@ -109,6 +114,15 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	public function test_rel_time_empty_string_renders_nothing() {
 		$this->assertSame( '', UI_Elements::rel_time( '' ) );
 		$this->assertSame( '', UI_Elements::rel_time( '   ' ) );
+	}
+
+	/**
+	 * A non-empty but unparseable string yields no output: date_create() returns
+	 * false, so the helper renders nothing rather than falling back to the current
+	 * time or emitting a malformed element.
+	 */
+	public function test_rel_time_unparseable_string_renders_nothing() {
+		$this->assertSame( '', UI_Elements::rel_time( 'not a date' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3057

### Changes Proposed in this Pull Request
On the front-end `[job_dashboard]`, a listing's expiry date rendered one day late on sites with a timezone west of UTC. `UI_Elements::rel_time()` formatted the absolute date with the legacy `date_i18n()`, which mishandles a true Unix timestamp on negative-offset sites and rolls the core end-of-day (23:59:59) expiry instant to the next calendar day.

- Format the absolute date with `wp_date()` instead of `date_i18n()`, bringing `rel_time()` in line with the rest of the dashboard. The inconsistency dates to 08692178 (#2754), which added `rel_time()` using the legacy `date_i18n()` even though the dashboard code beside it already used `wp_date()`.
- Parse bare date-string input in the site timezone (`date_create( $time, wp_timezone() )`) so a floating `Y-m-d` date (e.g. the Application Deadline add-on's closing date) renders the same calendar date and is not shifted one day early by the `wp_date()` switch.

The fix is core-only; no add-on changes are required.

### Testing Instructions
1. Settings → General → set the site timezone west of UTC (e.g. *America/Panama*, UTC−5).
2. Create a published job listing with Listing Expiry Date `2026-08-13`.
3. View a page with `[job_dashboard]` as the listing's author.
4. The expiry tooltip/`<time>` now reads `2026-08-13`, matching wp-admin → Job Data.

Automated: `WP_Test_UI_Elements` asserts that a `DateTimeInterface` expiry, a bare `Y-m-d` string, and a numeric timestamp all render the correct calendar date (18 tests). Each case runs against five timezone configurations — `timezone_string` set to UTC−5, UTC+9 and UTC, plus the manual-offset form (empty `timezone_string` with `gmt_offset`) at UTC−5 and UTC+5:30, where `wp_timezone()` returns a fixed-offset zone. Empty, whitespace-only and unparseable input are covered too.

### Release Notes
Fix job dashboard showing the listing expiry date one day late on sites west of UTC.

### New or Updated Hooks and Templates
None.

### Deprecated Code
None.





<!-- wpjm:plugin-zip -->
----

| Plugin build for d8022a939c37200e8007cebe079903b6ee015c59 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3061-d8022a93.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3061-d8022a93)             |

<!-- /wpjm:plugin-zip -->









