### PR TITLE
fix: dedupe frontend logo uploads instead of creating a duplicate attachment every submission

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1145,7 +1145,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			]
 		);
 
-		return $existing ? (int) $existing[0] : 0;
+		return empty( $existing ) ? 0 : absint( reset( $existing ) );
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -18,6 +18,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 	/**
+	 * Meta key storing the content hash of an attachment created from a frontend
+	 * upload, used to reuse the uploader's existing identical attachment instead
+	 * of creating a duplicate on every submission.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const ATTACHMENT_HASH_META_KEY = '_wpjm_attachment_hash';
+
+	/**
 	 * Form name.
 	 *
 	 * @var string
@@ -1061,6 +1072,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			return 0;
 		}
 
+		// Reuse an identical attachment the current user already owns rather than
+		// inserting a duplicate. Prevents unbounded Media Library growth from the
+		// same logo being uploaded on every submission.
+		$reusable_id = $this->find_reusable_attachment( $attachment_url );
+		if ( $reusable_id ) {
+			return $reusable_id;
+		}
+
 		$attachment = [
 			'post_title'   => wpjm_get_the_job_title( $this->job_id ),
 			'post_content' => '',
@@ -1077,11 +1096,56 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$attachment_id = wp_insert_attachment( $attachment, $attachment_url, $this->job_id );
 
 		if ( ! is_wp_error( $attachment_id ) ) {
+			$hash = md5_file( $attachment_url );
+			if ( $hash ) {
+				update_post_meta( $attachment_id, self::ATTACHMENT_HASH_META_KEY, $hash );
+			}
 			wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $attachment_url ) );
 			return $attachment_id;
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Finds an existing attachment owned by the current user whose file content
+	 * matches the given local file, so an identical re-upload reuses it instead
+	 * of creating a duplicate.
+	 *
+	 * Reuse is scoped to the current user's own attachments: a guest (no user ID)
+	 * always gets a fresh attachment, and one user's upload can never be bound to
+	 * another user's attachment, preserving the attachment-ownership boundary.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $file_path Absolute path to the uploaded file.
+	 * @return int Attachment ID to reuse, or 0 when none matches.
+	 */
+	protected function find_reusable_attachment( $file_path ) {
+		$user_id = get_current_user_id();
+		if ( ! $user_id || ! is_file( $file_path ) ) {
+			return 0;
+		}
+
+		$hash = md5_file( $file_path );
+		if ( ! $hash ) {
+			return 0;
+		}
+
+		$existing = get_posts(
+			[
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'author'         => $user_id,
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_key'       => self::ATTACHMENT_HASH_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $hash, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+
+		return $existing ? (int) $existing[0] : 0;
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.submit-job-attachment-dedup.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-dedup.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests that the frontend job submission form reuses an existing attachment the
+ * current user already owns instead of creating a duplicate every time an
+ * identical file is uploaded, preventing unbounded Media Library / attachment
+ * bloat from repeated logo uploads.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Submit_Job_Attachment_Dedup extends WPJM_BaseTest {
+
+	/**
+	 * Absolute paths of files written into the uploads dir, removed on teardown.
+	 *
+	 * @var string[]
+	 */
+	private $created_files = [];
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+
+		// create_attachment() normalises upload URLs to scheme://host/path, dropping any
+		// port. The test site runs on a non-standard port (e.g. localhost:8889), which no
+		// production uploads URL has, so strip it to mirror a real port-less environment
+		// and let the URL resolve to a local upload the way it does on live sites.
+		add_filter( 'upload_dir', [ $this, 'strip_upload_url_port' ] );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'upload_dir', [ $this, 'strip_upload_url_port' ] );
+		foreach ( $this->created_files as $path ) {
+			if ( file_exists( $path ) ) {
+				unlink( $path );
+			}
+		}
+		$this->created_files = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * upload_dir filter: removes the port from the upload URLs (paths untouched).
+	 *
+	 * @param array $dirs Upload directory data.
+	 * @return array
+	 */
+	public function strip_upload_url_port( $dirs ) {
+		foreach ( [ 'url', 'baseurl' ] as $key ) {
+			$dirs[ $key ] = preg_replace( '#^(https?://[^/:]+):\d+#', '$1', $dirs[ $key ] );
+		}
+		return $dirs;
+	}
+
+	/**
+	 * A minimal but valid 1x1 PNG so wp_generate_attachment_metadata() runs cleanly.
+	 *
+	 * @return string Raw PNG bytes.
+	 */
+	private function png_bytes() {
+		return base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' );
+	}
+
+	/**
+	 * Writes a file with the given content into the current uploads dir and
+	 * returns its public URL (mirroring a completed frontend upload).
+	 *
+	 * @param string $filename File name to write.
+	 * @param string $content  Raw bytes.
+	 * @return string Attachment URL.
+	 */
+	private function write_upload( $filename, $content ) {
+		$upload_dir = wp_upload_dir();
+		$path       = trailingslashit( $upload_dir['path'] ) . $filename;
+		file_put_contents( $path, $content );
+		$this->created_files[] = $path;
+
+		return trailingslashit( $upload_dir['url'] ) . $filename;
+	}
+
+	/**
+	 * Invokes the protected create_attachment() on the form with a given listing.
+	 *
+	 * @param string $attachment_url Uploaded file URL.
+	 * @param int    $job_id         Listing the attachment belongs to.
+	 * @return int Attachment ID.
+	 */
+	private function create_attachment_for( $attachment_url, $job_id ) {
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$job_id_prop = $class->getProperty( 'job_id' );
+		$job_id_prop->setAccessible( true );
+		$job_id_prop->setValue( $form, $job_id );
+
+		$create = $class->getMethod( 'create_attachment' );
+		$create->setAccessible( true );
+
+		try {
+			return $create->invoke( $form, $attachment_url );
+		} finally {
+			$job_id_prop->setValue( $form, 0 );
+		}
+	}
+
+	/**
+	 * Creates a listing owned by the current user.
+	 *
+	 * @return int Listing ID.
+	 */
+	private function create_listing() {
+		return $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => get_current_user_id(),
+			]
+		);
+	}
+
+	/**
+	 * Re-uploading the identical file (different name, same bytes — as
+	 * wp_handle_upload() produces on a filename collision) must reuse the
+	 * attachment the user already owns rather than inserting a duplicate.
+	 */
+	public function test_identical_upload_reuses_existing_owned_attachment() {
+		$this->login_as_employer();
+		$job_id = $this->create_listing();
+		$bytes  = $this->png_bytes();
+
+		$first_url  = $this->write_upload( 'company-logo.png', $bytes );
+		$first_id   = $this->create_attachment_for( $first_url, $job_id );
+
+		// Second listing, identical logo re-uploaded (collision-renamed on disk).
+		$second_job = $this->create_listing();
+		$second_url = $this->write_upload( 'company-logo-1.png', $bytes );
+		$second_id  = $this->create_attachment_for( $second_url, $second_job );
+
+		$this->assertGreaterThan( 0, $first_id, 'The first upload must create an attachment.' );
+		$this->assertSame(
+			$first_id,
+			$second_id,
+			'Re-uploading identical content the user already owns must reuse the existing attachment, not duplicate it.'
+		);
+	}
+
+	/**
+	 * Dedup is scoped to the current user: a different user uploading identical
+	 * content must get their own attachment, never silently bound to another
+	 * user's attachment (guards the #2995 / #3060 ownership boundary).
+	 */
+	public function test_identical_upload_by_different_user_is_not_reused() {
+		$this->login_as_employer();
+		$job_id    = $this->create_listing();
+		$bytes     = $this->png_bytes();
+		$owner_url = $this->write_upload( 'shared-logo.png', $bytes );
+		$owner_id  = $this->create_attachment_for( $owner_url, $job_id );
+
+		// A different employer uploads a byte-identical file.
+		$this->login_as_employer_b();
+		$other_job = $this->create_listing();
+		$other_url = $this->write_upload( 'shared-logo-1.png', $bytes );
+		$other_id  = $this->create_attachment_for( $other_url, $other_job );
+
+		$this->assertGreaterThan( 0, $owner_id );
+		$this->assertNotSame(
+			$owner_id,
+			$other_id,
+			'A different user must not be given another user\'s attachment even for identical content.'
+		);
+	}
+}


### PR DESCRIPTION
## What

The frontend job submission form created a **brand-new attachment on every upload**, even when the same user had already uploaded byte-identical content. Repeatedly submitting the same company logo therefore accumulated unbounded duplicate attachments in the Media Library.

Reported on the support forum: [Core bug: massive logo duplication / bloat server space](https://wordpress.org/support/topic/core-bug-massive-logo-duplication-bloat-server-space/) (~20,000 duplicate images).

## Root cause

`create_attachment()` unconditionally called `wp_insert_attachment()` for any URL-valued file field, with no lookup for an existing identical attachment. The only thing preventing logo duplication was the reuse-by-numeric-ID path (`is_numeric( … ) ? absint( … ) : create_attachment( … )`), which only helps when the form carries an attachment **ID**. Every genuine (re-)upload carries a **URL**, so it always produced a new attachment (and `wp_handle_upload` writes `logo-1.png`, `logo-2.png`, … on disk).

This is long-standing behaviour (present since 2016), not a recent regression.

## Change

`includes/forms/class-wp-job-manager-form-submit-job.php`
- `create_attachment()` now calls `find_reusable_attachment()` before inserting: if the current user already owns an attachment whose content hash matches the uploaded file, that attachment is reused instead of creating a duplicate.
- A content hash (`_wpjm_attachment_hash` meta) is stored on every attachment it creates, so future identical uploads dedupe via a single indexed meta lookup (no full-library hashing).

### Why it's safe (ownership boundary)

Reuse is **scoped to the current user's own attachments** (`author => get_current_user_id()`):
- Guests (no user ID) always get a fresh attachment.
- One user's upload can **never** be bound to another user's attachment — preserving the attachment-ownership boundary hardened in #2995 / #3060.

Two different employers uploading a byte-identical file each keep their own copy (mildly redundant, but safe — cross-user sharing is exactly the IDOR to avoid).

## Scope / follow-ups (not in this PR)

- **Retroactive cleanup** of the existing duplicates on affected sites needs a separate WP-CLI/admin tool; this PR only stops the growth going forward (pre-existing attachments have no hash meta and are not dedupe targets until re-uploaded).
- **Cascade-deletion fragility** — a reused logo is parented to the first job (`post_parent`) yet referenced by many; deleting it breaks the others. Tracked as a follow-up.
- **Orphan file on disk** — when an identical re-upload is deduped, the freshly-written file is left on disk (attachment not created). Disk-level cleanup is a possible follow-up.
- **Latent port bug** — `create_attachment()` normalises upload URLs to `scheme://host/path`, dropping any port, so a site on a non-standard port can't attach uploads at all. Out of scope here; noted for a separate fix.

## Testing

`WP_Test_Submit_Job_Attachment_Dedup` (fail-before / pass-after):
- `test_identical_upload_reuses_existing_owned_attachment` — same user re-uploading byte-identical content (collision-renamed on disk) reuses one attachment.
- `test_identical_upload_by_different_user_is_not_reused` — a different user uploading identical content gets their own attachment (ownership guard).

Full suite: 581 tests pass (3 geocode skips, unrelated); `phpcs` clean.



<!-- wpjm:plugin-zip -->
----

| Plugin build for e6534492d9dfdfea77bc3689b061a74b04ce6d3d <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3064-e6534492.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3064-e6534492)             |

<!-- /wpjm:plugin-zip -->


