### PR TITLE
feat: 'wp jm dedupe-logos' — collapse duplicate company-logo attachments

### DIFF
--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -19,11 +19,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Two attachments are candidates for merging when they have identical file
  * contents and the same owner. Identical content is *not* on its own proof that
  * an attachment is a logo, though: an owner may have uploaded the same image
- * again for something this class knows nothing about. So no attachment is ever
+ * again for something this class knows nothing about. So an attachment is not
  * deleted while anything outside the two reference types handled here (listing
  * featured images and the `_company_logo` user default) still points at it —
  * see `find_protected_ids()`. Unrecognised reference means "keep", so the
  * failure mode is a duplicate left behind rather than a broken image.
+ *
+ * What that sweep can see has limits worth knowing before running it live:
+ *
+ * - It reads meta rows whose *key* looks like it could hold an attachment
+ *   reference, so a reference stored under a name with no media-ish word in it
+ *   is missed. `job_manager_dedupe_reference_meta_key_patterns` and
+ *   `job_manager_dedupe_protected_attachment_ids` exist for that.
+ * - It runs once, before any deletion. A reference created while the run is in
+ *   progress is not protected by it, other than the two handled keys, which are
+ *   re-checked immediately before deleting. Run `--live` in maintenance mode.
+ * - Nothing here is multisite-aware; run it per site with `wp --url=`.
  *
  * Attachments belonging to different users are never merged, mirroring the
  * runtime dedup boundary. Guest uploads (`post_author` 0) are skipped outright:
@@ -189,6 +200,21 @@ class Attachment_Deduplicator {
 	 * one, re-pointing every reference before deleting the redundant copies.
 	 * Dry-run by default; pass --live to apply.
 	 *
+	 * ## RUN THIS WITH THE SITE IN MAINTENANCE MODE
+	 *
+	 * Which attachments are safe to delete is worked out once, up front, and on the
+	 * libraries this exists for that scan takes a while — every image the logo owners
+	 * hold is hashed and every post's content is read. A reference created after that
+	 * scan and before the matching delete is not protected by it.
+	 *
+	 * Re-points are verified immediately before deleting, so a listing or user default
+	 * that changed in the meantime is left alone. Anything else — a new gallery entry,
+	 * a page edited to embed the image, a logo set in the Customizer — is not covered,
+	 * and deletion is not reversible unless the site defines MEDIA_TRASH.
+	 *
+	 * So: take a backup, put the site in maintenance mode, run it. On a live site the
+	 * dry run is safe at any time; --live is not.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--live]
@@ -248,8 +274,9 @@ class Attachment_Deduplicator {
 		$report_path = \WP_CLI\Utils\get_flag_value( $assoc_args, 'report', '' );
 
 		if ( ! $dry_run ) {
-			// Deletion is not reversible on sites without MEDIA_TRASH.
-			\WP_CLI::confirm( 'This will delete redundant logo attachments. Run without --live first to preview. Continue?', $assoc_args );
+			// Deletion is not reversible on sites without MEDIA_TRASH, and references
+			// created while the run is in progress are not protected by its scan.
+			\WP_CLI::confirm( 'This will delete redundant logo attachments, and is not reversible unless MEDIA_TRASH is on. Run without --live first to preview, and run this one with the site in maintenance mode. Continue?', $assoc_args );
 		}
 
 		// Discovery hashes every image the logo owners hold and scans post content, so

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -294,6 +294,7 @@ class Attachment_Deduplicator {
 		// on the libraries this exists for it is minutes of silence otherwise.
 		\WP_CLI::log( 'Scanning for duplicate logos…' );
 
+		$started  = microtime( true );
 		$progress = null;
 		$report   = ( new self() )->run(
 			[
@@ -333,6 +334,17 @@ class Attachment_Deduplicator {
 		// What the run does not cover, counted: whether the site's remaining bloat
 		// is inside or outside this command's reach should be a number, not a guess.
 		\WP_CLI::log( sprintf( 'Not examined:            %d guest-owned image(s), %d image(s) matching no currently-referenced logo', $report['skipped_guest'], $report['skipped_unmatched'] ) );
+
+		// Elapsed time and peak memory are the two numbers a synthetic benchmark
+		// cannot supply; printing them makes every real-site run a data point.
+		$elapsed = microtime( true ) - $started;
+		\WP_CLI::log(
+			sprintf(
+				'Took %s; peak memory %s.',
+				$elapsed >= 60 ? sprintf( '%dm %ds', (int) ( $elapsed / 60 ), (int) $elapsed % 60 ) : sprintf( '%.1fs', $elapsed ),
+				size_format( memory_get_peak_usage( true ) )
+			)
+		);
 
 		// Print the mapping so a dry run can be audited, and a live run leaves a
 		// record of what was collapsed into what. Past a few screenfuls the CSV is

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -16,9 +16,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  * example by re-uploading the same logo on every submission) down to one,
  * re-pointing every reference before deleting the redundant copies.
  *
- * Scoped to logos only (listing featured images and the `_company_logo` user
- * meta) and to a single owner per group, mirroring the runtime dedup boundary:
- * attachments belonging to different users are never merged.
+ * Two attachments are candidates for merging when they have identical file
+ * contents and the same owner. Identical content is *not* on its own proof that
+ * an attachment is a logo, though: an owner may have uploaded the same image
+ * again for something this class knows nothing about. So no attachment is ever
+ * deleted while anything outside the two reference types handled here (listing
+ * featured images and the `_company_logo` user default) still points at it —
+ * see `find_protected_ids()`. Unrecognised reference means "keep", so the
+ * failure mode is a duplicate left behind rather than a broken image.
+ *
+ * Attachments belonging to different users are never merged, mirroring the
+ * runtime dedup boundary. Guest uploads (`post_author` 0) are skipped outright:
+ * 0 is not an owner, so unrelated submitters would otherwise collapse together.
+ *
+ * @since $$next-version$$
  *
  * @internal
  */
@@ -31,7 +42,55 @@ class Attachment_Deduplicator {
 	const HASH_META_KEY = '_wpjm_attachment_hash';
 
 	/**
+	 * Meta keys this class knows how to re-point. A reference through any other
+	 * key blocks deletion.
+	 */
+	const HANDLED_POST_META_KEY = '_thumbnail_id';
+	const HANDLED_USER_META_KEY = '_company_logo';
+
+	/**
+	 * Meta-key patterns treated as possibly holding an attachment reference.
+	 *
+	 * The veto cannot simply match any meta row whose value equals the attachment
+	 * ID: plenty of unrelated meta stores small integers (`wp_user_level` is 10 for
+	 * an administrator), so every attachment whose ID collided with one would be
+	 * protected forever and the command would quietly stop de-duplicating. Matching
+	 * on key shape keeps the check meaningful. Add-ons follow these conventions too
+	 * (`_candidate_photo`, `_company_logo`).
+	 */
+	const REFERENCE_KEY_PATTERNS = [
+		'%thumb%',
+		'%logo%',
+		'%image%',
+		'%photo%',
+		'%picture%',
+		'%avatar%',
+		'%attach%',
+		'%media%',
+		'%gallery%',
+		'%icon%',
+		'%banner%',
+		'%cover%',
+		'%file%',
+	];
+
+	/**
+	 * Rows per batch when streaming post content looking for inline references.
+	 */
+	const CONTENT_SCAN_BATCH = 200;
+
+	/**
+	 * Memoised content signatures, keyed by attachment ID. Hashing is the
+	 * expensive part of a run and the same attachment is examined more than once.
+	 *
+	 * @var array<int, string>
+	 */
+	private $signature_cache = [];
+
+	/**
 	 * Registers the WP-CLI command.
+	 *
+	 * @since $$next-version$$
 	 */
 	public static function init() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -52,8 +111,13 @@ class Attachment_Deduplicator {
 	 * [--live]
 	 * : Apply the changes. Without this flag the command only reports (dry run).
 	 *
-	 * [--user=<id>]
-	 * : Limit de-duplication to a single owner (user ID).
+	 * [--yes]
+	 * : Skip the confirmation prompt for --live.
+	 *
+	 * [--owner=<id>]
+	 * : Limit de-duplication to the attachments owned by a single user ID.
+	 *   Named --owner rather than --user because --user is a reserved WP-CLI
+	 *   global parameter: it sets the acting user and never reaches this command.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -64,38 +128,93 @@ class Attachment_Deduplicator {
 	 *     wp jm dedupe-logos --live
 	 *
 	 *     # Just one owner.
-	 *     wp jm dedupe-logos --user=42 --live
+	 *     wp jm dedupe-logos --owner=42 --live
 	 *
 	 * @when after_wp_load
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $args       Positional arguments (unused).
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public static function cli( $args, $assoc_args ) {
-		$dry_run = empty( $assoc_args['live'] );
-		$user_id = isset( $assoc_args['user'] ) ? absint( $assoc_args['user'] ) : 0;
+		$dry_run = ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'live', false );
+		$user_id = 0;
 
-		$report = ( new self() )->run(
+		if ( isset( $assoc_args['owner'] ) ) {
+			$user_id = absint( $assoc_args['owner'] );
+			// Without this, a typo silently becomes 0 — i.e. the whole site.
+			if ( ! $user_id || ! get_userdata( $user_id ) ) {
+				\WP_CLI::error( sprintf( 'No such user: %s', $assoc_args['owner'] ) );
+			}
+		}
+
+		if ( ! $dry_run ) {
+			// Deletion is not reversible on sites without MEDIA_TRASH.
+			\WP_CLI::confirm( 'This will delete redundant logo attachments. Run without --live first to preview. Continue?', $assoc_args );
+		}
+
+		$progress = null;
+		$report   = ( new self() )->run(
 			[
 				'dry_run' => $dry_run,
 				'user_id' => $user_id,
+				'on_plan' => function ( $total ) use ( &$progress ) {
+					if ( $total ) {
+						$progress = \WP_CLI\Utils\make_progress_bar( 'Merging duplicates', $total );
+					}
+				},
+				'on_tick' => function () use ( &$progress ) {
+					if ( $progress ) {
+						$progress->tick();
+					}
+				},
 			]
 		);
+
+		if ( $progress ) {
+			$progress->finish();
+		}
 
 		\WP_CLI::log( $dry_run ? 'DRY RUN — no changes made.' : 'LIVE' );
 		\WP_CLI::log( sprintf( 'Duplicate groups found:  %d', $report['groups'] ) );
 		\WP_CLI::log( sprintf( 'Redundant attachments:   %d', $report['duplicates'] ) );
 
+		if ( $report['skipped_referenced'] ) {
+			\WP_CLI::log( sprintf( 'Kept (referenced elsewhere): %d', $report['skipped_referenced'] ) );
+		}
+
+		// Print the mapping so a dry run can be audited, and a live run leaves a
+		// record of what was collapsed into what.
+		foreach ( $report['plan'] as $group ) {
+			\WP_CLI::log( sprintf( '  %d <- %s', $group['canonical'], implode( ', ', $group['duplicates'] ) ) );
+		}
+
 		if ( $dry_run ) {
 			\WP_CLI::success( sprintf( 'Would re-point references and delete %d attachment(s). Re-run with --live to apply.', $report['duplicates'] ) );
-		} else {
-			\WP_CLI::success( sprintf( 'Re-pointed %d reference(s); deleted %d attachment(s).', $report['references_repointed'], $report['attachments_deleted'] ) );
+			return;
 		}
+
+		if ( $report['delete_failures'] ) {
+			\WP_CLI::error(
+				sprintf(
+					'Re-pointed %d reference(s); deleted %d attachment(s), but %d deletion(s) failed: %s. References were moved first, so nothing is left pointing at a deleted attachment — re-run to retry.',
+					$report['references_repointed'],
+					$report['attachments_deleted'],
+					count( $report['delete_failures'] ),
+					implode( ', ', $report['delete_failures'] )
+				)
+			);
+		}
+
+		\WP_CLI::success( sprintf( 'Re-pointed %d reference(s); deleted %d attachment(s).', $report['references_repointed'], $report['attachments_deleted'] ) );
 	}
 
 	/**
 	 * Finds groups of identical logo attachments and, unless this is a dry run,
 	 * merges each group into its oldest attachment.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $args Optional arguments: 'dry_run' (bool, default true) only
 	 *                    reports what would change; 'user_id' (int, default 0)
@@ -109,6 +228,8 @@ class Attachment_Deduplicator {
 			[
 				'dry_run' => true,
 				'user_id' => 0,
+				'on_plan' => null,
+				'on_tick' => null,
 			]
 		);
 
@@ -117,23 +238,87 @@ class Attachment_Deduplicator {
 			'duplicates'           => 0,
 			'references_repointed' => 0,
 			'attachments_deleted'  => 0,
+			'skipped_referenced'   => 0,
+			'delete_failures'      => [],
+			'plan'                 => [],
 		];
 
-		foreach ( $this->find_duplicate_logo_groups( (int) $args['user_id'] ) as $group ) {
+		$groups = $this->find_duplicate_logo_groups( (int) $args['user_id'] );
+
+		// Resolve which candidates are off-limits in one batched pass over the whole
+		// run, rather than re-querying the same tables for every duplicate.
+		$candidates = [];
+		foreach ( $groups as $group ) {
+			foreach ( $group['duplicates'] as $duplicate ) {
+				$candidates[] = $duplicate;
+			}
+		}
+		$protected = $this->find_protected_ids( $candidates );
+
+		$repoint_map = [];
+
+		foreach ( $groups as $group ) {
+			$canonical = $group['canonical'];
+
+			// Attachments referenced through anything this class cannot re-point are
+			// dropped from the group before it is reported or applied, so a dry run
+			// describes exactly what --live would do.
+			$deletable = [];
+			foreach ( $group['duplicates'] as $duplicate ) {
+				if ( isset( $protected[ $duplicate ] ) ) {
+					++$report['skipped_referenced'];
+					continue;
+				}
+				$deletable[] = $duplicate;
+			}
+
+			if ( ! $deletable ) {
+				continue;
+			}
+
 			++$report['groups'];
-			$report['duplicates'] += count( $group['duplicates'] );
+			$report['duplicates'] += count( $deletable );
+			$report['plan'][]      = [
+				'canonical'  => $canonical,
+				'duplicates' => $deletable,
+			];
 
 			if ( $args['dry_run'] ) {
 				continue;
 			}
 
-			$canonical = $group['canonical'];
 			$this->backfill_hash( $canonical );
 
-			foreach ( $group['duplicates'] as $duplicate ) {
-				$report['references_repointed'] += $this->repoint_references( $duplicate, $canonical );
-				wp_delete_attachment( $duplicate, true );
+			foreach ( $deletable as $duplicate ) {
+				$repoint_map[ $duplicate ] = $canonical;
+			}
+		}
+
+		if ( $args['dry_run'] || ! $repoint_map ) {
+			return $report;
+		}
+
+		if ( is_callable( $args['on_plan'] ) ) {
+			call_user_func( $args['on_plan'], count( $repoint_map ) );
+		}
+
+		// Move every reference first, then delete: a run that dies partway leaves an
+		// un-deleted duplicate rather than a listing pointing at a deleted post.
+		$report['references_repointed'] = $this->repoint_all( $repoint_map );
+
+		foreach ( $repoint_map as $duplicate => $canonical ) {
+			$this->carry_over_metadata( $duplicate, $canonical );
+
+			if ( $this->delete_attachment( $duplicate ) ) {
 				++$report['attachments_deleted'];
+			} else {
+				// Its references already point at the canonical, so the site is intact
+				// — this is a duplicate left behind, not a broken reference.
+				$report['delete_failures'][] = $duplicate;
+			}
+
+			if ( is_callable( $args['on_tick'] ) ) {
+				call_user_func( $args['on_tick'] );
 			}
 		}
 
@@ -156,7 +341,14 @@ class Attachment_Deduplicator {
 		// Content signatures ("author:hash") of currently-referenced logos.
 		$logo_signatures = [];
 		$owner_ids       = [];
-		foreach ( $this->collect_referenced_logo_ids( $user_id ) as $attachment_id ) {
+
+		$referenced_ids = $this->collect_referenced_logo_ids();
+
+		// Queries above ask for IDs only, which does not prime the post cache — so
+		// without this every signature costs a get_post() round trip.
+		_prime_post_caches( $referenced_ids, false, true );
+
+		foreach ( $referenced_ids as $attachment_id ) {
 			$signature = $this->attachment_signature( $attachment_id, $user_id );
 			if ( $signature ) {
 				$logo_signatures[ $signature ]                                      = true;
@@ -171,7 +363,10 @@ class Attachment_Deduplicator {
 		// Group every image attachment those owners hold by signature, keeping
 		// only signatures that match a referenced logo (folds in orphaned copies).
 		$by_signature = [];
-		foreach ( $this->collect_owner_image_ids( array_keys( $owner_ids ) ) as $attachment_id ) {
+		$owner_images = $this->collect_owner_image_ids( array_keys( $owner_ids ) );
+		_prime_post_caches( $owner_images, false, true );
+
+		foreach ( $owner_images as $attachment_id ) {
 			$signature = $this->attachment_signature( $attachment_id, $user_id );
 			if ( $signature && isset( $logo_signatures[ $signature ] ) ) {
 				$by_signature[ $signature ][] = (int) $attachment_id;
@@ -203,11 +398,39 @@ class Attachment_Deduplicator {
 	 * @return string Signature, or '' to skip.
 	 */
 	private function attachment_signature( $attachment_id, $user_id = 0 ) {
+		$attachment_id = (int) $attachment_id;
+
+		if ( ! isset( $this->signature_cache[ $attachment_id ] ) ) {
+			$this->signature_cache[ $attachment_id ] = $this->compute_signature( $attachment_id );
+		}
+
+		$signature = $this->signature_cache[ $attachment_id ];
+
+		// Scoping is by the owner of the attachment, not of whatever references it:
+		// since #3060 a listing can carry a logo owned by a different user.
+		if ( $signature && $user_id && (int) get_post_field( 'post_author', $attachment_id ) !== $user_id ) {
+			return '';
+		}
+
+		return $signature;
+	}
+
+	/**
+	 * Computes an attachment's "author:content-hash" signature.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return string Signature, or '' to skip.
+	 */
+	private function compute_signature( $attachment_id ) {
 		$attachment = get_post( $attachment_id );
 		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
 			return '';
 		}
-		if ( $user_id && (int) $attachment->post_author !== $user_id ) {
+
+		// Guest uploads all carry author 0, which is not an owner. Merging on it would
+		// collapse unrelated anonymous submitters together, so guests are never merged
+		// — the runtime dedup refuses them for the same reason.
+		if ( 0 === (int) $attachment->post_author ) {
 			return '';
 		}
 
@@ -224,42 +447,62 @@ class Attachment_Deduplicator {
 	}
 
 	/**
+	 * Every registered post status, so listings in statuses WP_Query's 'any'
+	 * shorthand hides are still seen. 'any' excludes any status registered with
+	 * exclude_from_search, which covers WPJM's own `expired` and `preview` — an
+	 * expired listing is a normal end state and still references its logo.
+	 *
+	 * @return string[]
+	 */
+	private function all_post_statuses() {
+		return array_values( get_post_stati() );
+	}
+
+	/**
 	 * Collects attachment IDs currently used as a logo: listing featured images
 	 * and the `_company_logo` user meta default.
 	 *
-	 * @param int $user_id Limit to one owner (0 = all).
 	 * @return int[] Unique attachment IDs.
 	 */
-	private function collect_referenced_logo_ids( $user_id = 0 ) {
+	private function collect_referenced_logo_ids() {
+		global $wpdb;
+
 		$ids = [];
 
-		$job_args = [
-			'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
-			'post_status'    => 'any',
-			'posts_per_page' => -1,
-			'fields'         => 'ids',
-			'no_found_rows'  => true,
-			'meta_key'       => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		];
-		if ( $user_id ) {
-			$job_args['author'] = $user_id;
-		}
-		foreach ( get_posts( $job_args ) as $job_id ) {
-			$thumbnail_id = (int) get_post_meta( $job_id, '_thumbnail_id', true );
-			if ( $thumbnail_id ) {
-				$ids[] = $thumbnail_id;
+		// Deliberately unfiltered by author: a listing authored by one user can carry
+		// a logo owned by another, so ownership is applied to the attachment in
+		// attachment_signature() rather than to whatever references it.
+		//
+		// Read as one join rather than a get_posts( fields => ids ) loop calling
+		// get_post_meta() per listing, which costs a query per listing on a site with
+		// tens of thousands of them.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one query per listing.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+		$thumbnail_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT pm.meta_value
+				 FROM {$wpdb->postmeta} pm
+				 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+				 WHERE pm.meta_key = %s AND p.post_type = %s",
+				self::HANDLED_POST_META_KEY,
+				\WP_Job_Manager_Post_Types::PT_LISTING
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		foreach ( $thumbnail_ids as $thumbnail_id ) {
+			if ( (int) $thumbnail_id ) {
+				$ids[] = (int) $thumbnail_id;
 			}
 		}
 
 		$user_args = [
 			'fields'   => 'ID',
-			'meta_key' => '_company_logo', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_key' => self::HANDLED_USER_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		];
-		if ( $user_id ) {
-			$user_args['include'] = [ $user_id ];
-		}
 		foreach ( get_users( $user_args ) as $owner_id ) {
-			$logo_id = (int) get_user_meta( $owner_id, '_company_logo', true );
+			$logo_id = (int) get_user_meta( $owner_id, self::HANDLED_USER_META_KEY, true );
 			if ( $logo_id ) {
 				$ids[] = $logo_id;
 			}
@@ -297,44 +540,359 @@ class Attachment_Deduplicator {
 	}
 
 	/**
-	 * Re-points every known logo reference from a duplicate to the canonical.
+	 * Re-points every known logo reference according to a duplicate => canonical map.
 	 *
-	 * @param int $duplicate Duplicate attachment ID.
-	 * @param int $canonical Canonical attachment ID to point at.
+	 * Batched: two reads for the whole run rather than two per duplicate. Writes are
+	 * still per affected row, which is proportional to real references rather than to
+	 * the size of the media library.
+	 *
+	 * @param array<int, int> $map Duplicate attachment ID => canonical attachment ID.
 	 * @return int Number of references updated.
 	 */
-	private function repoint_references( $duplicate, $canonical ) {
-		$count = 0;
+	private function repoint_all( array $map ) {
+		if ( ! $map ) {
+			return 0;
+		}
+
+		$count      = 0;
+		$duplicates = array_keys( $map );
 
 		$jobs = get_posts(
 			[
 				'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
-				'post_status'    => 'any',
+				'post_status'    => $this->all_post_statuses(),
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 				'no_found_rows'  => true,
-				'meta_key'       => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value'     => (string) $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => self::HANDLED_POST_META_KEY,
+						'value'   => $duplicates,
+						'compare' => 'IN',
+					],
+				],
 			]
 		);
 		foreach ( $jobs as $job_id ) {
-			update_post_meta( $job_id, '_thumbnail_id', $canonical );
-			++$count;
+			$current = (int) get_post_meta( $job_id, self::HANDLED_POST_META_KEY, true );
+			if ( isset( $map[ $current ] ) ) {
+				update_post_meta( $job_id, self::HANDLED_POST_META_KEY, $map[ $current ] );
+				++$count;
+			}
 		}
 
 		$users = get_users(
 			[
 				'fields'     => 'ID',
-				'meta_key'   => '_company_logo', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value' => (string) $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => self::HANDLED_USER_META_KEY,
+						'value'   => $duplicates,
+						'compare' => 'IN',
+					],
+				],
 			]
 		);
 		foreach ( $users as $owner_id ) {
-			update_user_meta( $owner_id, '_company_logo', $canonical );
-			++$count;
+			$current = (int) get_user_meta( $owner_id, self::HANDLED_USER_META_KEY, true );
+			if ( isset( $map[ $current ] ) ) {
+				update_user_meta( $owner_id, self::HANDLED_USER_META_KEY, $map[ $current ] );
+				++$count;
+			}
 		}
 
 		return $count;
+	}
+
+	/**
+	 * Returns the subset of the given attachments that something this class cannot
+	 * re-point still references, as an [ id => true ] lookup.
+	 *
+	 * The candidate set is content-identical images, which is broader than "logos":
+	 * the same file may also be a blog post's featured image, sit inline in someone's
+	 * content, or be the site logo. Deleting those would strip an image with nothing
+	 * left to repair it, so an unrecognised reference vetoes the deletion.
+	 *
+	 * Every check is batched across the whole candidate set — this command targets
+	 * sites with tens of thousands of attachments, where a per-attachment sweep of
+	 * these tables would not finish.
+	 *
+	 * @param int[] $candidate_ids Attachment IDs being considered for deletion.
+	 * @return array<int, true> Protected IDs.
+	 */
+	private function find_protected_ids( array $candidate_ids ) {
+		global $wpdb;
+
+		$candidate_ids = array_values( array_unique( array_map( 'intval', $candidate_ids ) ) );
+		if ( ! $candidate_ids ) {
+			return [];
+		}
+
+		$protected = [];
+		$id_list   = implode( ',', $candidate_ids );
+		$key_sql   = $this->reference_key_sql();
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reference sweep across core tables has no API equivalent.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration; a cached answer would be worse than none.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is ints; $key_sql is built from a class constant.
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Raw SQL, not a WP_Query meta arg; the scan is the point of the command.
+
+		// Post meta. `_thumbnail_id` on a listing is the one case repoint_references()
+		// handles; the same key on any other post type is not.
+		$rows = $wpdb->get_results(
+			"SELECT pm.meta_value, pm.meta_key, p.post_type
+			 FROM {$wpdb->postmeta} pm
+			 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+			 WHERE pm.meta_value IN ( {$id_list} )
+			   AND pm.post_id NOT IN ( {$id_list} )
+			   AND ( {$key_sql} )"
+		);
+		foreach ( $rows as $row ) {
+			$handled = self::HANDLED_POST_META_KEY === $row->meta_key
+				&& \WP_Job_Manager_Post_Types::PT_LISTING === $row->post_type;
+			if ( ! $handled ) {
+				$protected[ (int) $row->meta_value ] = true;
+			}
+		}
+
+		// User meta, other than the `_company_logo` default that is handled.
+		$rows = $wpdb->get_results(
+			"SELECT meta_value, meta_key FROM {$wpdb->usermeta}
+			 WHERE meta_value IN ( {$id_list} ) AND ( {$key_sql} )"
+		);
+		foreach ( $rows as $row ) {
+			if ( self::HANDLED_USER_META_KEY !== $row->meta_key ) {
+				$protected[ (int) $row->meta_value ] = true;
+			}
+		}
+
+		// Term meta.
+		$term_values = $wpdb->get_col(
+			"SELECT meta_value FROM {$wpdb->termmeta}
+			 WHERE meta_value IN ( {$id_list} ) AND ( {$key_sql} )"
+		);
+		foreach ( $term_values as $value ) {
+			$protected[ (int) $value ] = true;
+		}
+
+		// Options storing a bare attachment ID.
+		$option_values = $wpdb->get_col(
+			"SELECT option_value FROM {$wpdb->options}
+			 WHERE option_name IN ( 'site_logo', 'site_icon' ) AND option_value IN ( {$id_list} )"
+		);
+		foreach ( $option_values as $value ) {
+			$protected[ (int) $value ] = true;
+		}
+
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		return $protected + $this->find_inline_content_references( $candidate_ids );
+	}
+
+	/**
+	 * Finds candidates referenced from inside post content: the block editor's
+	 * {"id":N}, the classic editor's wp-image-N class, and plain URLs to the file.
+	 *
+	 * Content cannot be indexed for this, so it is one streamed pass over the posts
+	 * that contain any image marker at all, matched in PHP — rather than one LIKE
+	 * scan per candidate.
+	 *
+	 * @param int[] $candidate_ids Attachment IDs being considered for deletion.
+	 * @return array<int, true> Protected IDs.
+	 */
+	private function find_inline_content_references( array $candidate_ids ) {
+		global $wpdb;
+
+		$protected = [];
+		$by_id     = array_fill_keys( $candidate_ids, true );
+		$basenames = $this->attachment_basenames( $candidate_ids );
+		$offset    = 0;
+
+		do {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Content scan has no API equivalent.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, post_content FROM {$wpdb->posts}
+					 WHERE post_content LIKE %s OR post_content LIKE %s OR post_content LIKE %s
+					 ORDER BY ID LIMIT %d OFFSET %d",
+					'%' . $wpdb->esc_like( 'wp-image-' ) . '%',
+					'%' . $wpdb->esc_like( '"id":' ) . '%',
+					'%' . $wpdb->esc_like( '/uploads/' ) . '%',
+					self::CONTENT_SCAN_BATCH,
+					$offset
+				)
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+			foreach ( $rows as $row ) {
+				$content = (string) $row->post_content;
+
+				if ( preg_match_all( '/(?:wp-image-|"id":\s*)(\d+)/', $content, $matches ) ) {
+					foreach ( $matches[1] as $found ) {
+						$found = (int) $found;
+						if ( isset( $by_id[ $found ] ) && (int) $row->ID !== $found ) {
+							$protected[ $found ] = true;
+						}
+					}
+				}
+
+				foreach ( $basenames as $attachment_id => $basename ) {
+					if ( (int) $row->ID !== $attachment_id && false !== strpos( $content, $basename ) ) {
+						$protected[ $attachment_id ] = true;
+					}
+				}
+			}
+
+			$fetched = count( $rows );
+			$offset += self::CONTENT_SCAN_BATCH;
+		} while ( self::CONTENT_SCAN_BATCH === $fetched );
+
+		return $protected;
+	}
+
+	/**
+	 * Maps attachment IDs to their file basename in one query.
+	 *
+	 * @param int[] $attachment_ids Attachment IDs.
+	 * @return array<int, string>
+	 */
+	private function attachment_basenames( array $attachment_ids ) {
+		global $wpdb;
+
+		if ( ! $attachment_ids ) {
+			return [];
+		}
+
+		$id_list = implode( ',', array_map( 'intval', $attachment_ids ) );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one get_post_meta() per attachment.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is ints.
+		$rows = $wpdb->get_results(
+			"SELECT post_id, meta_value FROM {$wpdb->postmeta}
+			 WHERE meta_key = '_wp_attached_file' AND post_id IN ( {$id_list} )"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$basenames = [];
+		foreach ( $rows as $row ) {
+			if ( $row->meta_value ) {
+				$basenames[ (int) $row->post_id ] = wp_basename( $row->meta_value );
+			}
+		}
+
+		return $basenames;
+	}
+
+	/**
+	 * SQL fragment matching meta keys that may hold an attachment reference.
+	 *
+	 * @return string
+	 */
+	private function reference_key_sql() {
+		global $wpdb;
+
+		$clauses = [];
+		foreach ( self::REFERENCE_KEY_PATTERNS as $pattern ) {
+			$clauses[] = $wpdb->prepare( 'meta_key LIKE %s', $pattern );
+		}
+
+		return implode( ' OR ', $clauses );
+	}
+
+	/**
+	 * Copies curated fields onto the canonical where it has none of its own.
+	 *
+	 * The canonical is the oldest copy, which is typically the auto-generated
+	 * submission upload; alt text and captions an editor wrote tend to live on a
+	 * later copy that is about to be deleted.
+	 *
+	 * @param int $duplicate Attachment about to be deleted.
+	 * @param int $canonical Attachment being kept.
+	 */
+	private function carry_over_metadata( $duplicate, $canonical ) {
+		$alt = get_post_meta( $duplicate, '_wp_attachment_image_alt', true );
+		if ( $alt && ! get_post_meta( $canonical, '_wp_attachment_image_alt', true ) ) {
+			update_post_meta( $canonical, '_wp_attachment_image_alt', $alt );
+		}
+
+		$duplicate_post = get_post( $duplicate );
+		$canonical_post = get_post( $canonical );
+		if ( ! $duplicate_post || ! $canonical_post ) {
+			return;
+		}
+
+		$update = [];
+		foreach ( [ 'post_excerpt', 'post_content' ] as $field ) {
+			if ( '' !== trim( (string) $duplicate_post->$field ) && '' === trim( (string) $canonical_post->$field ) ) {
+				$update[ $field ] = $duplicate_post->$field;
+			}
+		}
+		if ( $update ) {
+			$update['ID'] = $canonical;
+			wp_update_post( $update );
+		}
+	}
+
+	/**
+	 * Deletes a redundant attachment without taking any file the canonical (or any
+	 * other attachment) still needs with it.
+	 *
+	 * Two attachment rows can share one `_wp_attached_file`, and core's file cleanup
+	 * does no reference counting — so unlinking on behalf of the duplicate would
+	 * leave the survivor as a row whose file is gone. `force_delete` is left off so
+	 * sites with MEDIA_TRASH keep an undo.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return bool Whether the attachment was deleted.
+	 */
+	private function delete_attachment( $attachment_id ) {
+		if ( ! $this->file_is_shared( $attachment_id ) ) {
+			return (bool) wp_delete_attachment( $attachment_id );
+		}
+
+		$veto = '__return_empty_string';
+		add_filter( 'wp_delete_file', $veto );
+		$deleted = wp_delete_attachment( $attachment_id );
+		remove_filter( 'wp_delete_file', $veto );
+
+		return (bool) $deleted;
+	}
+
+	/**
+	 * Whether another attachment row points at the same file on disk.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return bool
+	 */
+	private function file_is_shared( $attachment_id ) {
+		global $wpdb;
+
+		$relative_path = get_post_meta( $attachment_id, '_wp_attached_file', true );
+		if ( ! $relative_path ) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- No API for finding attachments by file path.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+		$shared = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attached_file' AND meta_value = %s AND post_id <> %d",
+				$relative_path,
+				(int) $attachment_id
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		return $shared > 0;
 	}
 
 	/**

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -975,14 +975,19 @@ class Attachment_Deduplicator {
 			return;
 		}
 
-		$update = [];
-		foreach ( [ 'post_excerpt', 'post_content' ] as $field ) {
-			if ( '' !== trim( (string) $duplicate_post->$field ) && '' === trim( (string) $canonical_post->$field ) ) {
-				$update[ $field ] = $duplicate_post->$field;
-			}
+		// Spelled out per field rather than looped over a list of field names, so the
+		// array keys stay literal and match the shape wp_update_post() declares.
+		$update = [ 'ID' => $canonical ];
+
+		if ( '' !== trim( (string) $duplicate_post->post_excerpt ) && '' === trim( (string) $canonical_post->post_excerpt ) ) {
+			$update['post_excerpt'] = (string) $duplicate_post->post_excerpt;
 		}
-		if ( $update ) {
-			$update['ID'] = $canonical;
+
+		if ( '' !== trim( (string) $duplicate_post->post_content ) && '' === trim( (string) $canonical_post->post_content ) ) {
+			$update['post_content'] = (string) $duplicate_post->post_content;
+		}
+
+		if ( count( $update ) > 1 ) {
 			wp_update_post( $update );
 		}
 	}

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -280,16 +280,19 @@ class Attachment_Deduplicator {
 			return [];
 		}
 
-		return get_posts(
-			[
-				'post_type'      => 'attachment',
-				'post_status'    => 'inherit',
-				'post_mime_type' => 'image',
-				'author__in'     => array_map( 'intval', $owner_ids ),
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-			]
+		return array_map(
+			'intval',
+			get_posts(
+				[
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					'post_mime_type' => 'image',
+					'author__in'     => array_map( 'intval', $owner_ids ),
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'no_found_rows'  => true,
+				]
+			)
 		);
 	}
 
@@ -311,7 +314,7 @@ class Attachment_Deduplicator {
 				'fields'         => 'ids',
 				'no_found_rows'  => true,
 				'meta_key'       => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value'     => $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value'     => (string) $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			]
 		);
 		foreach ( $jobs as $job_id ) {
@@ -323,7 +326,7 @@ class Attachment_Deduplicator {
 			[
 				'fields'     => 'ID',
 				'meta_key'   => '_company_logo', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value' => $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value' => (string) $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			]
 		);
 		foreach ( $users as $owner_id ) {

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -216,11 +216,18 @@ class Attachment_Deduplicator {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $args Optional arguments: 'dry_run' (bool, default true) only
-	 *                    reports what would change; 'user_id' (int, default 0)
-	 *                    limits de-duplication to a single owner.
-	 * @return array Report counts: groups, duplicates, references_repointed,
-	 *               attachments_deleted.
+	 * @param array $args Optional arguments:
+	 *                    'dry_run' (bool, default true) only reports what would change;
+	 *                    'user_id' (int, default 0) limits to one attachment owner;
+	 *                    'on_plan' (callable|null) called once with the number of
+	 *                    attachments about to be merged, before any mutation;
+	 *                    'on_tick' (callable|null) called after each attachment.
+	 * @return array Report: 'groups' and 'duplicates' (counts of what will be or was
+	 *               merged), 'skipped_referenced' (candidates kept because something
+	 *               unrecognised still references them), 'plan' (the canonical =>
+	 *               duplicates mapping), and, for a live run, 'references_repointed',
+	 *               'attachments_deleted' and 'delete_failures' (IDs that could not
+	 *               be deleted).
 	 */
 	public function run( array $args = [] ) {
 		$args = wp_parse_args(
@@ -344,8 +351,8 @@ class Attachment_Deduplicator {
 
 		$referenced_ids = $this->collect_referenced_logo_ids();
 
-		// Queries above ask for IDs only, which does not prime the post cache — so
-		// without this every signature costs a get_post() round trip.
+		// The lookups above return bare IDs, which leaves the post cache cold — so
+		// without this every signature would cost a get_post() round trip.
 		_prime_post_caches( $referenced_ids, false, true );
 
 		foreach ( $referenced_ids as $attachment_id ) {
@@ -447,18 +454,6 @@ class Attachment_Deduplicator {
 	}
 
 	/**
-	 * Every registered post status, so listings in statuses WP_Query's 'any'
-	 * shorthand hides are still seen. 'any' excludes any status registered with
-	 * exclude_from_search, which covers WPJM's own `expired` and `preview` — an
-	 * expired listing is a normal end state and still references its logo.
-	 *
-	 * @return string[]
-	 */
-	private function all_post_statuses() {
-		return array_values( get_post_stati() );
-	}
-
-	/**
 	 * Collects attachment IDs currently used as a logo: listing featured images
 	 * and the `_company_logo` user meta default.
 	 *
@@ -497,14 +492,22 @@ class Attachment_Deduplicator {
 			}
 		}
 
-		$user_args = [
-			'fields'   => 'ID',
-			'meta_key' => self::HANDLED_USER_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		];
-		foreach ( get_users( $user_args ) as $owner_id ) {
-			$logo_id = (int) get_user_meta( $owner_id, self::HANDLED_USER_META_KEY, true );
-			if ( $logo_id ) {
-				$ids[] = $logo_id;
+		// Likewise one read rather than get_users() followed by a get_user_meta() per
+		// user, which is a query for every user who has ever set a company logo.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one query per user.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+		$logo_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT meta_value FROM {$wpdb->usermeta} WHERE meta_key = %s",
+				self::HANDLED_USER_META_KEY
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		foreach ( $logo_ids as $logo_id ) {
+			if ( (int) $logo_id ) {
+				$ids[] = (int) $logo_id;
 			}
 		}
 
@@ -542,61 +545,64 @@ class Attachment_Deduplicator {
 	/**
 	 * Re-points every known logo reference according to a duplicate => canonical map.
 	 *
-	 * Batched: two reads for the whole run rather than two per duplicate. Writes are
-	 * still per affected row, which is proportional to real references rather than to
-	 * the size of the media library.
+	 * Two reads for the whole run, then one write per reference actually affected.
+	 * Reads go straight to the meta tables: a get_posts( fields => ids ) plus a
+	 * get_post_meta() per row would cost a query for every affected listing, and
+	 * reading the rows directly also sidesteps WP_Query's `post_status` shorthand,
+	 * which hides statuses registered with exclude_from_search — WPJM's own
+	 * `expired` and `preview` among them. An expired listing is a normal end state
+	 * and still references its logo, so it must be re-pointed like any other.
 	 *
 	 * @param array<int, int> $map Duplicate attachment ID => canonical attachment ID.
 	 * @return int Number of references updated.
 	 */
 	private function repoint_all( array $map ) {
+		global $wpdb;
+
 		if ( ! $map ) {
 			return 0;
 		}
 
-		$count      = 0;
-		$duplicates = array_keys( $map );
+		$count   = 0;
+		$id_list = implode( ',', array_map( 'intval', array_keys( $map ) ) );
 
-		$jobs = get_posts(
-			[
-				'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
-				'post_status'    => $this->all_post_statuses(),
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					[
-						'key'     => self::HANDLED_POST_META_KEY,
-						'value'   => $duplicates,
-						'compare' => 'IN',
-					],
-				],
-			]
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one query per affected row.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is ints.
+		$jobs = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT pm.post_id, pm.meta_value
+				 FROM {$wpdb->postmeta} pm
+				 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+				 WHERE pm.meta_key = %s AND p.post_type = %s AND pm.meta_value IN ( {$id_list} )",
+				self::HANDLED_POST_META_KEY,
+				\WP_Job_Manager_Post_Types::PT_LISTING
+			)
 		);
-		foreach ( $jobs as $job_id ) {
-			$current = (int) get_post_meta( $job_id, self::HANDLED_POST_META_KEY, true );
+
+		$owners = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT user_id, meta_value FROM {$wpdb->usermeta}
+				 WHERE meta_key = %s AND meta_value IN ( {$id_list} )",
+				self::HANDLED_USER_META_KEY
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		foreach ( $jobs as $job ) {
+			$current = (int) $job->meta_value;
 			if ( isset( $map[ $current ] ) ) {
-				update_post_meta( $job_id, self::HANDLED_POST_META_KEY, $map[ $current ] );
+				update_post_meta( (int) $job->post_id, self::HANDLED_POST_META_KEY, $map[ $current ] );
 				++$count;
 			}
 		}
 
-		$users = get_users(
-			[
-				'fields'     => 'ID',
-				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					[
-						'key'     => self::HANDLED_USER_META_KEY,
-						'value'   => $duplicates,
-						'compare' => 'IN',
-					],
-				],
-			]
-		);
-		foreach ( $users as $owner_id ) {
-			$current = (int) get_user_meta( $owner_id, self::HANDLED_USER_META_KEY, true );
+		foreach ( $owners as $owner ) {
+			$current = (int) $owner->meta_value;
 			if ( isset( $map[ $current ] ) ) {
-				update_user_meta( $owner_id, self::HANDLED_USER_META_KEY, $map[ $current ] );
+				update_user_meta( (int) $owner->user_id, self::HANDLED_USER_META_KEY, $map[ $current ] );
 				++$count;
 			}
 		}

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -80,12 +80,63 @@ class Attachment_Deduplicator {
 	const CONTENT_SCAN_BATCH = 200;
 
 	/**
+	 * Attachments handled per batch: how many are hashed, looked up, or deleted
+	 * before the object cache is released.
+	 *
+	 * This command exists for libraries with tens of thousands of attachments, so
+	 * nothing may hold all of them in memory at once — priming 20,000 posts and
+	 * their meta alone runs to hundreds of megabytes. It also bounds the size of
+	 * the `IN ( ... )` lists sent to MySQL.
+	 */
+	const DEFAULT_CHUNK_SIZE = 500;
+
+	/**
+	 * Attachments handled per batch.
+	 *
+	 * @var int
+	 */
+	private $chunk_size;
+
+	/**
 	 * Memoised content signatures, keyed by attachment ID. Hashing is the
 	 * expensive part of a run and the same attachment is examined more than once.
 	 *
 	 * @var array<int, string>
 	 */
 	private $signature_cache = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $chunk_size Attachments handled per batch. Lower values trade
+	 *                        queries for peak memory; mainly a test seam.
+	 */
+	public function __construct( $chunk_size = self::DEFAULT_CHUNK_SIZE ) {
+		$this->chunk_size = max( 1, (int) $chunk_size );
+	}
+
+	/**
+	 * Releases the object cache built up while processing a batch.
+	 *
+	 * Without this the cache grows monotonically for the whole run, which is the
+	 * usual way a long WP-CLI job runs out of memory.
+	 */
+	private function free_memory() {
+		global $wpdb, $wp_object_cache;
+
+		$wpdb->queries = [];
+
+		if ( is_object( $wp_object_cache ) ) {
+			if ( property_exists( $wp_object_cache, 'cache' ) ) {
+				$wp_object_cache->cache = [];
+			}
+			if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
+				$wp_object_cache->__remoteset();
+			}
+		}
+	}
 
 	/**
 	 * Registers the WP-CLI command.
@@ -313,6 +364,7 @@ class Attachment_Deduplicator {
 		// un-deleted duplicate rather than a listing pointing at a deleted post.
 		$report['references_repointed'] = $this->repoint_all( $repoint_map );
 
+		$processed = 0;
 		foreach ( $repoint_map as $duplicate => $canonical ) {
 			$this->carry_over_metadata( $duplicate, $canonical );
 
@@ -326,6 +378,12 @@ class Attachment_Deduplicator {
 
 			if ( is_callable( $args['on_tick'] ) ) {
 				call_user_func( $args['on_tick'] );
+			}
+
+			// wp_delete_attachment() populates the cache for every post it touches.
+			++$processed;
+			if ( 0 === $processed % $this->chunk_size ) {
+				$this->free_memory();
 			}
 		}
 
@@ -349,36 +407,41 @@ class Attachment_Deduplicator {
 		$logo_signatures = [];
 		$owner_ids       = [];
 
-		$referenced_ids = $this->collect_referenced_logo_ids();
-
-		// The lookups above return bare IDs, which leaves the post cache cold — so
-		// without this every signature would cost a get_post() round trip.
-		_prime_post_caches( $referenced_ids, false, true );
-
-		foreach ( $referenced_ids as $attachment_id ) {
-			$signature = $this->attachment_signature( $attachment_id, $user_id );
-			if ( $signature ) {
-				$logo_signatures[ $signature ]                                      = true;
-				$owner_ids[ (int) get_post_field( 'post_author', $attachment_id ) ] = true;
+		// Both passes stream a page at a time. Materialising every attachment ID first
+		// is what puts a large library over the memory limit, so the full set is never
+		// held: each page is primed, reduced to signatures, then released.
+		$this->each_referenced_logo_page(
+			function ( array $page ) use ( &$logo_signatures, &$owner_ids, $user_id ) {
+				foreach ( $page as $attachment_id ) {
+					$signature = $this->attachment_signature( $attachment_id, $user_id );
+					if ( $signature ) {
+						$logo_signatures[ $signature ]                                      = true;
+						$owner_ids[ (int) get_post_field( 'post_author', $attachment_id ) ] = true;
+					}
+				}
 			}
-		}
+		);
 
 		if ( ! $logo_signatures ) {
 			return [];
 		}
 
-		// Group every image attachment those owners hold by signature, keeping
-		// only signatures that match a referenced logo (folds in orphaned copies).
+		// Group every image attachment those owners hold by signature, keeping only
+		// signatures that match a referenced logo (folds in orphaned copies). Only
+		// matching IDs are retained, so this holds the duplicates rather than the
+		// whole media library.
 		$by_signature = [];
-		$owner_images = $this->collect_owner_image_ids( array_keys( $owner_ids ) );
-		_prime_post_caches( $owner_images, false, true );
-
-		foreach ( $owner_images as $attachment_id ) {
-			$signature = $this->attachment_signature( $attachment_id, $user_id );
-			if ( $signature && isset( $logo_signatures[ $signature ] ) ) {
-				$by_signature[ $signature ][] = (int) $attachment_id;
+		$this->each_owner_image_page(
+			array_keys( $owner_ids ),
+			function ( array $page ) use ( &$by_signature, $logo_signatures, $user_id ) {
+				foreach ( $page as $attachment_id ) {
+					$signature = $this->attachment_signature( $attachment_id, $user_id );
+					if ( $signature && isset( $logo_signatures[ $signature ] ) ) {
+						$by_signature[ $signature ][] = (int) $attachment_id;
+					}
+				}
 			}
-		}
+		);
 
 		$groups = [];
 		foreach ( $by_signature as $ids ) {
@@ -394,6 +457,121 @@ class Attachment_Deduplicator {
 		}
 
 		return $groups;
+	}
+
+	/**
+	 * Streams attachment IDs currently used as a logo, a page at a time: listing
+	 * featured images and the `_company_logo` user meta default.
+	 *
+	 * Each page is primed and then released, so the caller never holds more than
+	 * one page of posts in the object cache.
+	 *
+	 * @param callable $handle Receives each page as an array of attachment IDs.
+	 */
+	private function each_referenced_logo_page( callable $handle ) {
+		global $wpdb;
+
+		$sources = [
+			// Deliberately unfiltered by author: a listing authored by one user can
+			// carry a logo owned by another, so ownership is applied to the attachment
+			// in attachment_signature() rather than to whatever references it.
+			$wpdb->prepare(
+				"SELECT pm.meta_value
+				 FROM {$wpdb->postmeta} pm
+				 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+				 WHERE pm.meta_key = %s AND p.post_type = %s
+				 ORDER BY pm.meta_id",
+				self::HANDLED_POST_META_KEY,
+				\WP_Job_Manager_Post_Types::PT_LISTING
+			),
+			$wpdb->prepare(
+				"SELECT meta_value FROM {$wpdb->usermeta} WHERE meta_key = %s ORDER BY umeta_id",
+				self::HANDLED_USER_META_KEY
+			),
+		];
+
+		foreach ( $sources as $sql ) {
+			$offset = 0;
+
+			do {
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Paged bulk read; no API equivalent that avoids loading everything.
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $sql is already prepared; the limit clause is bound here.
+				$values = $wpdb->get_col(
+					$wpdb->prepare( $sql . ' LIMIT %d OFFSET %d', $this->chunk_size, $offset )
+				);
+				// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+				// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+				$page = [];
+				foreach ( $values as $value ) {
+					if ( (int) $value ) {
+						$page[] = (int) $value;
+					}
+				}
+
+				if ( $page ) {
+					_prime_post_caches( $page, false, true );
+					$handle( $page );
+					$this->free_memory();
+				}
+
+				$fetched = count( $values );
+				$offset += $this->chunk_size;
+			} while ( $this->chunk_size === $fetched );
+		}
+	}
+
+	/**
+	 * Streams every image attachment owned by the given users, a page at a time, so
+	 * orphaned duplicate copies (referenced by nothing) are considered for merging.
+	 *
+	 * @param int[]    $owner_ids Owner user IDs.
+	 * @param callable $handle    Receives each page as an array of attachment IDs.
+	 */
+	private function each_owner_image_page( array $owner_ids, callable $handle ) {
+		global $wpdb;
+
+		if ( ! $owner_ids ) {
+			return;
+		}
+
+		$author_list = implode( ',', array_map( 'intval', $owner_ids ) );
+		$offset      = 0;
+
+		do {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Paged bulk read; get_posts() would load the whole library.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $author_list is ints.
+			$ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts}
+					 WHERE post_type = 'attachment'
+					   AND post_status = 'inherit'
+					   AND post_mime_type LIKE %s
+					   AND post_author IN ( {$author_list} )
+					 ORDER BY ID LIMIT %d OFFSET %d",
+					$wpdb->esc_like( 'image/' ) . '%',
+					$this->chunk_size,
+					$offset
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+			$page = array_map( 'intval', $ids );
+
+			if ( $page ) {
+				_prime_post_caches( $page, false, true );
+				$handle( $page );
+				$this->free_memory();
+			}
+
+			$fetched = count( $ids );
+			$offset += $this->chunk_size;
+		} while ( $this->chunk_size === $fetched );
 	}
 
 	/**
@@ -454,95 +632,6 @@ class Attachment_Deduplicator {
 	}
 
 	/**
-	 * Collects attachment IDs currently used as a logo: listing featured images
-	 * and the `_company_logo` user meta default.
-	 *
-	 * @return int[] Unique attachment IDs.
-	 */
-	private function collect_referenced_logo_ids() {
-		global $wpdb;
-
-		$ids = [];
-
-		// Deliberately unfiltered by author: a listing authored by one user can carry
-		// a logo owned by another, so ownership is applied to the attachment in
-		// attachment_signature() rather than to whatever references it.
-		//
-		// Read as one join rather than a get_posts( fields => ids ) loop calling
-		// get_post_meta() per listing, which costs a query per listing on a site with
-		// tens of thousands of them.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one query per listing.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
-		$thumbnail_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT pm.meta_value
-				 FROM {$wpdb->postmeta} pm
-				 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
-				 WHERE pm.meta_key = %s AND p.post_type = %s",
-				self::HANDLED_POST_META_KEY,
-				\WP_Job_Manager_Post_Types::PT_LISTING
-			)
-		);
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
-
-		foreach ( $thumbnail_ids as $thumbnail_id ) {
-			if ( (int) $thumbnail_id ) {
-				$ids[] = (int) $thumbnail_id;
-			}
-		}
-
-		// Likewise one read rather than get_users() followed by a get_user_meta() per
-		// user, which is a query for every user who has ever set a company logo.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one query per user.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
-		$logo_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT meta_value FROM {$wpdb->usermeta} WHERE meta_key = %s",
-				self::HANDLED_USER_META_KEY
-			)
-		);
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
-
-		foreach ( $logo_ids as $logo_id ) {
-			if ( (int) $logo_id ) {
-				$ids[] = (int) $logo_id;
-			}
-		}
-
-		return array_values( array_unique( $ids ) );
-	}
-
-	/**
-	 * Collects every image attachment owned by the given users, so orphaned
-	 * duplicate copies (referenced by nothing) are considered for merging.
-	 *
-	 * @param int[] $owner_ids Owner user IDs.
-	 * @return int[] Attachment IDs.
-	 */
-	private function collect_owner_image_ids( $owner_ids ) {
-		if ( ! $owner_ids ) {
-			return [];
-		}
-
-		return array_map(
-			'intval',
-			get_posts(
-				[
-					'post_type'      => 'attachment',
-					'post_status'    => 'inherit',
-					'post_mime_type' => 'image',
-					'author__in'     => array_map( 'intval', $owner_ids ),
-					'posts_per_page' => -1,
-					'fields'         => 'ids',
-					'no_found_rows'  => true,
-				]
-			)
-		);
-	}
-
-	/**
 	 * Re-points every known logo reference according to a duplicate => canonical map.
 	 *
 	 * Two reads for the whole run, then one write per reference actually affected.
@@ -563,8 +652,28 @@ class Attachment_Deduplicator {
 			return 0;
 		}
 
+		$count = 0;
+
+		foreach ( array_chunk( array_map( 'intval', array_keys( $map ) ), $this->chunk_size ) as $chunk ) {
+			$count += $this->repoint_chunk( $map, $chunk );
+			$this->free_memory();
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Re-points one batch of duplicates.
+	 *
+	 * @param array<int, int> $map   Duplicate attachment ID => canonical attachment ID.
+	 * @param int[]           $chunk Duplicate IDs in this batch.
+	 * @return int Number of references updated.
+	 */
+	private function repoint_chunk( array $map, array $chunk ) {
+		global $wpdb;
+
 		$count   = 0;
-		$id_list = implode( ',', array_map( 'intval', array_keys( $map ) ) );
+		$id_list = implode( ',', $chunk );
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one query per affected row.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
@@ -627,12 +736,29 @@ class Attachment_Deduplicator {
 	 * @return array<int, true> Protected IDs.
 	 */
 	private function find_protected_ids( array $candidate_ids ) {
-		global $wpdb;
-
 		$candidate_ids = array_values( array_unique( array_map( 'intval', $candidate_ids ) ) );
 		if ( ! $candidate_ids ) {
 			return [];
 		}
+
+		$protected = [];
+
+		// Chunked so the IN ( ... ) lists stay a sane size on a large library.
+		foreach ( array_chunk( $candidate_ids, $this->chunk_size ) as $chunk ) {
+			$protected += $this->find_protected_ids_in_meta( $chunk );
+		}
+
+		return $protected + $this->find_inline_content_references( $candidate_ids );
+	}
+
+	/**
+	 * The meta/option half of the reference sweep, for one batch of candidates.
+	 *
+	 * @param int[] $candidate_ids Attachment IDs being considered for deletion.
+	 * @return array<int, true> Protected IDs.
+	 */
+	private function find_protected_ids_in_meta( array $candidate_ids ) {
+		global $wpdb;
 
 		$protected = [];
 		$id_list   = implode( ',', $candidate_ids );
@@ -695,7 +821,7 @@ class Attachment_Deduplicator {
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
 
-		return $protected + $this->find_inline_content_references( $candidate_ids );
+		return $protected;
 	}
 
 	/**
@@ -714,8 +840,15 @@ class Attachment_Deduplicator {
 
 		$protected = [];
 		$by_id     = array_fill_keys( $candidate_ids, true );
-		$basenames = $this->attachment_basenames( $candidate_ids );
 		$offset    = 0;
+
+		// Keyed by filename so a post is matched against the names it actually
+		// contains. Looping every candidate for every post instead would be
+		// candidates x posts string searches — hundreds of millions on a large site.
+		$by_basename = [];
+		foreach ( $this->attachment_basenames( $candidate_ids ) as $attachment_id => $basename ) {
+			$by_basename[ strtolower( $basename ) ][] = $attachment_id;
+		}
 
 		do {
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Content scan has no API equivalent.
@@ -747,9 +880,17 @@ class Attachment_Deduplicator {
 					}
 				}
 
-				foreach ( $basenames as $attachment_id => $basename ) {
-					if ( (int) $row->ID !== $attachment_id && false !== strpos( $content, $basename ) ) {
-						$protected[ $attachment_id ] = true;
+				if ( $by_basename && preg_match_all( '/[^\/"\'\s>]+\.(?:png|jpe?g|gif|webp|avif|bmp|tiff?|svg)/i', $content, $files ) ) {
+					foreach ( $files[0] as $filename ) {
+						$filename = strtolower( $filename );
+						if ( ! isset( $by_basename[ $filename ] ) ) {
+							continue;
+						}
+						foreach ( $by_basename[ $filename ] as $attachment_id ) {
+							if ( (int) $row->ID !== $attachment_id ) {
+								$protected[ $attachment_id ] = true;
+							}
+						}
 					}
 				}
 			}
@@ -774,23 +915,26 @@ class Attachment_Deduplicator {
 			return [];
 		}
 
-		$id_list = implode( ',', array_map( 'intval', $attachment_ids ) );
-
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one get_post_meta() per attachment.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is ints.
-		$rows = $wpdb->get_results(
-			"SELECT post_id, meta_value FROM {$wpdb->postmeta}
-			 WHERE meta_key = '_wp_attached_file' AND post_id IN ( {$id_list} )"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
-
 		$basenames = [];
-		foreach ( $rows as $row ) {
-			if ( $row->meta_value ) {
-				$basenames[ (int) $row->post_id ] = wp_basename( $row->meta_value );
+
+		foreach ( array_chunk( array_map( 'intval', $attachment_ids ), $this->chunk_size ) as $chunk ) {
+			$id_list = implode( ',', $chunk );
+
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk read replacing one get_post_meta() per attachment.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is ints.
+			$rows = $wpdb->get_results(
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta}
+				 WHERE meta_key = '_wp_attached_file' AND post_id IN ( {$id_list} )"
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+			foreach ( $rows as $row ) {
+				if ( $row->meta_value ) {
+					$basenames[ (int) $row->post_id ] = wp_basename( $row->meta_value );
+				}
 			}
 		}
 

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -40,6 +40,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * runtime dedup boundary. Guest uploads (`post_author` 0) are skipped outright:
  * 0 is not an owner, so unrelated submitters would otherwise collapse together.
  *
+ * What is skipped is still counted: the report says how many image attachments
+ * were left unexamined (guest-owned, or matching no currently-referenced logo),
+ * so the size of the residue outside this command's reach is measured rather
+ * than guessed at.
+ *
  * @since $$next-version$$
  *
  * @internal
@@ -200,6 +205,12 @@ class Attachment_Deduplicator {
 	 * one, re-pointing every reference before deleting the redundant copies.
 	 * Dry-run by default; pass --live to apply.
 	 *
+	 * The summary also counts the image attachments the command does not examine:
+	 * guest uploads (post_author 0, so no owner to merge within) and images whose
+	 * content matches no currently-referenced logo. Those are outside this
+	 * command's safety envelope and are never touched — the counts exist so the
+	 * size of that residue is known, not guessed at.
+	 *
 	 * ## RUN THIS WITH THE SITE IN MAINTENANCE MODE
 	 *
 	 * Which attachments are safe to delete is worked out once, up front, and on the
@@ -319,6 +330,10 @@ class Attachment_Deduplicator {
 			\WP_CLI::log( sprintf( 'Kept (referenced elsewhere): %d', $report['skipped_referenced'] ) );
 		}
 
+		// What the run does not cover, counted: whether the site's remaining bloat
+		// is inside or outside this command's reach should be a number, not a guess.
+		\WP_CLI::log( sprintf( 'Not examined:            %d guest-owned image(s), %d image(s) matching no currently-referenced logo', $report['skipped_guest'], $report['skipped_unmatched'] ) );
+
 		// Print the mapping so a dry run can be audited, and a live run leaves a
 		// record of what was collapsed into what. Past a few screenfuls the CSV is
 		// the usable record, so don't bury the summary under thousands of lines.
@@ -401,11 +416,15 @@ class Attachment_Deduplicator {
 	 *                    'on_tick' (callable|null) called after each attachment.
 	 * @return array Report: 'groups' and 'duplicates' (counts of what will be or was
 	 *               merged), 'skipped_referenced' (candidates kept because something
-	 *               unrecognised still references them), 'plan' (the canonical =>
-	 *               duplicates mapping), and, for a live run, 'references_repointed',
-	 *               'attachments_deleted', 'repoint_failures' (IDs kept because their
-	 *               references could not be moved) and 'delete_failures' (IDs that
-	 *               could not be deleted).
+	 *               unrecognised still references them), 'skipped_guest' (image
+	 *               attachments never examined because they are guest-owned —
+	 *               post_author 0 — and so have no owner to merge within),
+	 *               'skipped_unmatched' (image attachments whose content matches no
+	 *               currently-referenced logo, so nothing anchors them as logo
+	 *               duplicates), 'plan' (the canonical => duplicates mapping), and,
+	 *               for a live run, 'references_repointed', 'attachments_deleted',
+	 *               'repoint_failures' (IDs kept because their references could not
+	 *               be moved) and 'delete_failures' (IDs that could not be deleted).
 	 */
 	public function run( array $args = [] ) {
 		$args = wp_parse_args(
@@ -425,12 +444,23 @@ class Attachment_Deduplicator {
 			'references_repointed' => 0,
 			'attachments_deleted'  => 0,
 			'skipped_referenced'   => 0,
+			'skipped_guest'        => 0,
+			'skipped_unmatched'    => 0,
 			'delete_failures'      => [],
 			'repoint_failures'     => [],
 			'plan'                 => [],
 		];
 
-		$groups = $this->find_duplicate_logo_groups( (int) $args['user_id'] );
+		$discovery = $this->find_duplicate_logo_groups( (int) $args['user_id'] );
+		$groups    = $discovery['groups'];
+
+		// Count what discovery did not examine. Everything not matched to a
+		// referenced logo is either guest-owned or unanchored; two COUNT queries
+		// give both, so the residue outside the run's reach is reported as a
+		// number. max() because an upload landing mid-run can skew the totals.
+		$totals                      = $this->count_image_attachments( (int) $args['user_id'] );
+		$report['skipped_guest']     = $totals['guest'];
+		$report['skipped_unmatched'] = max( 0, $totals['total'] - $totals['guest'] - $discovery['matched'] );
 
 		// Resolve which candidates are off-limits in one batched pass over the whole
 		// run, rather than re-querying the same tables for every duplicate.
@@ -543,12 +573,16 @@ class Attachment_Deduplicator {
 	 * longer reference anything) are collapsed alongside the in-use ones.
 	 *
 	 * @param int $user_id Limit to one owner (0 = all).
-	 * @return array[] Each: [ 'canonical' => int, 'duplicates' => int[] ].
+	 * @return array 'groups' (each: [ 'canonical' => int, 'duplicates' => int[] ])
+	 *               and 'matched' (how many image attachments shared a
+	 *               referenced logo's signature — i.e. were examined as
+	 *               potential duplicates, whether or not they had any).
 	 */
 	private function find_duplicate_logo_groups( $user_id = 0 ) {
 		// Content signatures ("author:hash") of currently-referenced logos.
 		$logo_signatures = [];
 		$owner_ids       = [];
+		$matched         = 0;
 
 		// Both passes stream a page at a time. Materialising every attachment ID first
 		// is what puts a large library over the memory limit, so the full set is never
@@ -566,7 +600,10 @@ class Attachment_Deduplicator {
 		);
 
 		if ( ! $logo_signatures ) {
-			return [];
+			return [
+				'groups'  => [],
+				'matched' => 0,
+			];
 		}
 
 		// Group every image attachment those owners hold by signature, keeping only
@@ -576,11 +613,12 @@ class Attachment_Deduplicator {
 		$by_signature = [];
 		$this->each_owner_image_page(
 			array_keys( $owner_ids ),
-			function ( array $page ) use ( &$by_signature, $logo_signatures, $user_id ) {
+			function ( array $page ) use ( &$by_signature, &$matched, $logo_signatures, $user_id ) {
 				foreach ( $page as $attachment_id ) {
 					$signature = $this->attachment_signature( $attachment_id, $user_id );
 					if ( $signature && isset( $logo_signatures[ $signature ] ) ) {
 						$by_signature[ $signature ][] = (int) $attachment_id;
+						++$matched;
 					}
 				}
 			}
@@ -599,7 +637,72 @@ class Attachment_Deduplicator {
 			];
 		}
 
-		return $groups;
+		return [
+			'groups'  => $groups,
+			'matched' => $matched,
+		];
+	}
+
+	/**
+	 * Counts image attachments, in total and guest-owned, so the report can say
+	 * how much of the library the run never examined.
+	 *
+	 * Everything the discovery pass visits is bounded by these totals: matched
+	 * attachments are examined, guest-owned ones are skipped by policy, and the
+	 * remainder matched no currently-referenced logo.
+	 *
+	 * @param int $user_id Limit to one owner (0 = all).
+	 * @return array 'total' and 'guest' counts. Scoped to $user_id when given, in
+	 *               which case 'guest' is 0 by construction.
+	 */
+	private function count_image_attachments( $user_id = 0 ) {
+		global $wpdb;
+
+		$mime = $wpdb->esc_like( 'image/' ) . '%';
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Two COUNT queries; wp_count_attachments() cannot filter by author.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+		if ( $user_id ) {
+			$total = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$wpdb->posts}
+					 WHERE post_type = 'attachment' AND post_status = 'inherit'
+					   AND post_mime_type LIKE %s AND post_author = %d",
+					$mime,
+					$user_id
+				)
+			);
+
+			return [
+				'total' => $total,
+				'guest' => 0,
+			];
+		}
+
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts}
+				 WHERE post_type = 'attachment' AND post_status = 'inherit'
+				   AND post_mime_type LIKE %s",
+				$mime
+			)
+		);
+
+		$guest = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts}
+				 WHERE post_type = 'attachment' AND post_status = 'inherit'
+				   AND post_mime_type LIKE %s AND post_author = 0",
+				$mime
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		return [
+			'total' => $total,
+			'guest' => $guest,
+		];
 	}
 
 	/**

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -1,0 +1,355 @@
+<?php
+/**
+ * Retroactive de-duplication of company-logo attachments.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Collapses identical company-logo attachments a single owner accumulated (for
+ * example by re-uploading the same logo on every submission) down to one,
+ * re-pointing every reference before deleting the redundant copies.
+ *
+ * Scoped to logos only (listing featured images and the `_company_logo` user
+ * meta) and to a single owner per group, mirroring the runtime dedup boundary:
+ * attachments belonging to different users are never merged.
+ *
+ * @internal
+ */
+class Attachment_Deduplicator {
+
+	/**
+	 * Meta key storing an attachment's content hash, shared with the runtime
+	 * dedup so canonical attachments keep de-duplicating future uploads.
+	 */
+	const HASH_META_KEY = '_wpjm_attachment_hash';
+
+	/**
+	 * Registers the WP-CLI command.
+	 */
+	public static function init() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::add_command( 'jm dedupe-logos', [ self::class, 'cli' ] );
+		}
+	}
+
+	/**
+	 * De-duplicates company-logo attachments a single owner uploaded repeatedly.
+	 *
+	 * Collapses identical logo attachments (listing featured images and the
+	 * `_company_logo` user default), including orphaned copies, down to the oldest
+	 * one, re-pointing every reference before deleting the redundant copies.
+	 * Dry-run by default; pass --live to apply.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--live]
+	 * : Apply the changes. Without this flag the command only reports (dry run).
+	 *
+	 * [--user=<id>]
+	 * : Limit de-duplication to a single owner (user ID).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Preview what would be de-duplicated across the whole site.
+	 *     wp jm dedupe-logos
+	 *
+	 *     # Apply it.
+	 *     wp jm dedupe-logos --live
+	 *
+	 *     # Just one owner.
+	 *     wp jm dedupe-logos --user=42 --live
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public static function cli( $args, $assoc_args ) {
+		$dry_run = empty( $assoc_args['live'] );
+		$user_id = isset( $assoc_args['user'] ) ? absint( $assoc_args['user'] ) : 0;
+
+		$report = ( new self() )->run(
+			[
+				'dry_run' => $dry_run,
+				'user_id' => $user_id,
+			]
+		);
+
+		\WP_CLI::log( $dry_run ? 'DRY RUN — no changes made.' : 'LIVE' );
+		\WP_CLI::log( sprintf( 'Duplicate groups found:  %d', $report['groups'] ) );
+		\WP_CLI::log( sprintf( 'Redundant attachments:   %d', $report['duplicates'] ) );
+
+		if ( $dry_run ) {
+			\WP_CLI::success( sprintf( 'Would re-point references and delete %d attachment(s). Re-run with --live to apply.', $report['duplicates'] ) );
+		} else {
+			\WP_CLI::success( sprintf( 'Re-pointed %d reference(s); deleted %d attachment(s).', $report['references_repointed'], $report['attachments_deleted'] ) );
+		}
+	}
+
+	/**
+	 * Finds groups of identical logo attachments and, unless this is a dry run,
+	 * merges each group into its oldest attachment.
+	 *
+	 * @param array $args Optional arguments: 'dry_run' (bool, default true) only
+	 *                    reports what would change; 'user_id' (int, default 0)
+	 *                    limits de-duplication to a single owner.
+	 * @return array Report counts: groups, duplicates, references_repointed,
+	 *               attachments_deleted.
+	 */
+	public function run( array $args = [] ) {
+		$args = wp_parse_args(
+			$args,
+			[
+				'dry_run' => true,
+				'user_id' => 0,
+			]
+		);
+
+		$report = [
+			'groups'               => 0,
+			'duplicates'           => 0,
+			'references_repointed' => 0,
+			'attachments_deleted'  => 0,
+		];
+
+		foreach ( $this->find_duplicate_logo_groups( (int) $args['user_id'] ) as $group ) {
+			++$report['groups'];
+			$report['duplicates'] += count( $group['duplicates'] );
+
+			if ( $args['dry_run'] ) {
+				continue;
+			}
+
+			$canonical = $group['canonical'];
+			$this->backfill_hash( $canonical );
+
+			foreach ( $group['duplicates'] as $duplicate ) {
+				$report['references_repointed'] += $this->repoint_references( $duplicate, $canonical );
+				wp_delete_attachment( $duplicate, true );
+				++$report['attachments_deleted'];
+			}
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Groups logo attachments by owner and content, returning one entry per set
+	 * of duplicates with the oldest (lowest ID) chosen as the canonical.
+	 *
+	 * A "logo" content signature is derived from attachments currently referenced
+	 * as a logo; every image attachment owned by those owners that shares a
+	 * signature is folded into the group, so orphaned duplicate copies (which no
+	 * longer reference anything) are collapsed alongside the in-use ones.
+	 *
+	 * @param int $user_id Limit to one owner (0 = all).
+	 * @return array[] Each: [ 'canonical' => int, 'duplicates' => int[] ].
+	 */
+	private function find_duplicate_logo_groups( $user_id = 0 ) {
+		// Content signatures ("author:hash") of currently-referenced logos.
+		$logo_signatures = [];
+		$owner_ids       = [];
+		foreach ( $this->collect_referenced_logo_ids( $user_id ) as $attachment_id ) {
+			$signature = $this->attachment_signature( $attachment_id, $user_id );
+			if ( $signature ) {
+				$logo_signatures[ $signature ]                                      = true;
+				$owner_ids[ (int) get_post_field( 'post_author', $attachment_id ) ] = true;
+			}
+		}
+
+		if ( ! $logo_signatures ) {
+			return [];
+		}
+
+		// Group every image attachment those owners hold by signature, keeping
+		// only signatures that match a referenced logo (folds in orphaned copies).
+		$by_signature = [];
+		foreach ( $this->collect_owner_image_ids( array_keys( $owner_ids ) ) as $attachment_id ) {
+			$signature = $this->attachment_signature( $attachment_id, $user_id );
+			if ( $signature && isset( $logo_signatures[ $signature ] ) ) {
+				$by_signature[ $signature ][] = (int) $attachment_id;
+			}
+		}
+
+		$groups = [];
+		foreach ( $by_signature as $ids ) {
+			$ids = array_values( array_unique( $ids ) );
+			if ( count( $ids ) < 2 ) {
+				continue;
+			}
+			sort( $ids );
+			$groups[] = [
+				'canonical'  => $ids[0],
+				'duplicates' => array_slice( $ids, 1 ),
+			];
+		}
+
+		return $groups;
+	}
+
+	/**
+	 * Returns an attachment's "author:content-hash" signature, or empty string
+	 * when it is not a usable local attachment (or not owned by $user_id).
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @param int $user_id       When set, require this owner.
+	 * @return string Signature, or '' to skip.
+	 */
+	private function attachment_signature( $attachment_id, $user_id = 0 ) {
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return '';
+		}
+		if ( $user_id && (int) $attachment->post_author !== $user_id ) {
+			return '';
+		}
+
+		$file = get_attached_file( $attachment_id );
+		if ( ! $file || ! is_file( $file ) ) {
+			return '';
+		}
+		$hash = md5_file( $file );
+		if ( ! $hash ) {
+			return '';
+		}
+
+		return $attachment->post_author . ':' . $hash;
+	}
+
+	/**
+	 * Collects attachment IDs currently used as a logo: listing featured images
+	 * and the `_company_logo` user meta default.
+	 *
+	 * @param int $user_id Limit to one owner (0 = all).
+	 * @return int[] Unique attachment IDs.
+	 */
+	private function collect_referenced_logo_ids( $user_id = 0 ) {
+		$ids = [];
+
+		$job_args = [
+			'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
+			'post_status'    => 'any',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+			'meta_key'       => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		];
+		if ( $user_id ) {
+			$job_args['author'] = $user_id;
+		}
+		foreach ( get_posts( $job_args ) as $job_id ) {
+			$thumbnail_id = (int) get_post_meta( $job_id, '_thumbnail_id', true );
+			if ( $thumbnail_id ) {
+				$ids[] = $thumbnail_id;
+			}
+		}
+
+		$user_args = [
+			'fields'   => 'ID',
+			'meta_key' => '_company_logo', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		];
+		if ( $user_id ) {
+			$user_args['include'] = [ $user_id ];
+		}
+		foreach ( get_users( $user_args ) as $owner_id ) {
+			$logo_id = (int) get_user_meta( $owner_id, '_company_logo', true );
+			if ( $logo_id ) {
+				$ids[] = $logo_id;
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Collects every image attachment owned by the given users, so orphaned
+	 * duplicate copies (referenced by nothing) are considered for merging.
+	 *
+	 * @param int[] $owner_ids Owner user IDs.
+	 * @return int[] Attachment IDs.
+	 */
+	private function collect_owner_image_ids( $owner_ids ) {
+		if ( ! $owner_ids ) {
+			return [];
+		}
+
+		return get_posts(
+			[
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image',
+				'author__in'     => array_map( 'intval', $owner_ids ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			]
+		);
+	}
+
+	/**
+	 * Re-points every known logo reference from a duplicate to the canonical.
+	 *
+	 * @param int $duplicate Duplicate attachment ID.
+	 * @param int $canonical Canonical attachment ID to point at.
+	 * @return int Number of references updated.
+	 */
+	private function repoint_references( $duplicate, $canonical ) {
+		$count = 0;
+
+		$jobs = get_posts(
+			[
+				'post_type'      => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_key'       => '_thumbnail_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+		foreach ( $jobs as $job_id ) {
+			update_post_meta( $job_id, '_thumbnail_id', $canonical );
+			++$count;
+		}
+
+		$users = get_users(
+			[
+				'fields'     => 'ID',
+				'meta_key'   => '_company_logo', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $duplicate, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+		foreach ( $users as $owner_id ) {
+			update_user_meta( $owner_id, '_company_logo', $canonical );
+			++$count;
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Stores the canonical attachment's content hash so the runtime dedup reuses
+	 * it for future identical uploads.
+	 *
+	 * @param int $canonical Canonical attachment ID.
+	 */
+	private function backfill_hash( $canonical ) {
+		if ( get_post_meta( $canonical, self::HASH_META_KEY, true ) ) {
+			return;
+		}
+		$file = get_attached_file( $canonical );
+		if ( $file && is_file( $file ) ) {
+			$hash = md5_file( $file );
+			if ( $hash ) {
+				update_post_meta( $canonical, self::HASH_META_KEY, $hash );
+			}
+		}
+	}
+}

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -75,13 +75,9 @@ class Attachment_Deduplicator {
 	];
 
 	/**
-	 * Rows per batch when streaming post content looking for inline references.
-	 */
-	const CONTENT_SCAN_BATCH = 200;
-
-	/**
-	 * Attachments handled per batch: how many are hashed, looked up, or deleted
-	 * before the object cache is released.
+	 * Rows handled per batch: how many attachments are hashed, looked up, or
+	 * deleted — and how many posts are scanned for inline references — before the
+	 * object cache is released.
 	 *
 	 * This command exists for libraries with tens of thousands of attachments, so
 	 * nothing may hold all of them in memory at once — priming 20,000 posts and
@@ -861,7 +857,7 @@ class Attachment_Deduplicator {
 					'%' . $wpdb->esc_like( 'wp-image-' ) . '%',
 					'%' . $wpdb->esc_like( '"id":' ) . '%',
 					'%' . $wpdb->esc_like( '/uploads/' ) . '%',
-					self::CONTENT_SCAN_BATCH,
+					$this->chunk_size,
 					$offset
 				)
 			);
@@ -896,8 +892,8 @@ class Attachment_Deduplicator {
 			}
 
 			$fetched = count( $rows );
-			$offset += self::CONTENT_SCAN_BATCH;
-		} while ( self::CONTENT_SCAN_BATCH === $fetched );
+			$offset += $this->chunk_size;
+		} while ( $this->chunk_size === $fetched );
 
 		return $protected;
 	}

--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -57,6 +57,10 @@ class Attachment_Deduplicator {
 	 * protected forever and the command would quietly stop de-duplicating. Matching
 	 * on key shape keeps the check meaningful. Add-ons follow these conventions too
 	 * (`_candidate_photo`, `_company_logo`).
+	 *
+	 * Filterable, because a site storing references under a key with no media-ish
+	 * word in its name (`company_brand`) would otherwise have to patch the plugin to
+	 * protect itself.
 	 */
 	const REFERENCE_KEY_PATTERNS = [
 		'%thumb%',
@@ -72,7 +76,39 @@ class Attachment_Deduplicator {
 		'%banner%',
 		'%cover%',
 		'%file%',
+		'%img%',
+		'%pic%',
+		'%upload%',
+		'%featured%',
 	];
+
+	/**
+	 * Core's own attachment plumbing, excluded from the reference sweep.
+	 *
+	 * These match the key patterns above but describe the attachment itself rather
+	 * than a reference to it — and their values are file paths, so leaving them in
+	 * would make every attachment sharing a filename stem protect its own siblings.
+	 */
+	const SELF_DESCRIBING_META_KEYS = [
+		'_wp_attached_file',
+		'_wp_attachment_metadata',
+		'_wp_attachment_backup_sizes',
+		'_wp_attachment_image_alt',
+		'_wp_attachment_is_custom_background',
+		'_wp_attachment_is_custom_header',
+		'_wp_attachment_context',
+	];
+
+	/**
+	 * How deep to walk a serialized value looking for attachment references.
+	 */
+	const MAX_VALUE_DEPTH = 8;
+
+	/**
+	 * How many plan lines to print before deferring to `--report`. Twenty thousand
+	 * lines of scrollback is not a record of anything.
+	 */
+	const MAX_PLAN_LINES = 50;
 
 	/**
 	 * Rows handled per batch: how many attachments are hashed, looked up, or
@@ -166,10 +202,18 @@ class Attachment_Deduplicator {
 	 *   Named --owner rather than --user because --user is a reserved WP-CLI
 	 *   global parameter: it sets the acting user and never reaches this command.
 	 *
+	 * [--report=<path>]
+	 * : Write the canonical <- duplicates mapping to a CSV file before anything is
+	 *   deleted. On a library with tens of thousands of attachments the terminal is
+	 *   not a usable record of an irreversible operation.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Preview what would be de-duplicated across the whole site.
 	 *     wp jm dedupe-logos
+	 *
+	 *     # Preview it, keeping the plan for review.
+	 *     wp jm dedupe-logos --report=dedupe-plan.csv
 	 *
 	 *     # Apply it.
 	 *     wp jm dedupe-logos --live
@@ -189,6 +233,11 @@ class Attachment_Deduplicator {
 		$user_id = 0;
 
 		if ( isset( $assoc_args['owner'] ) ) {
+			// A bare --owner arrives as true, and absint( true ) is 1: a destructive
+			// command must not quietly pick a user out of a malformed flag.
+			if ( ! is_numeric( $assoc_args['owner'] ) ) {
+				\WP_CLI::error( 'The --owner flag needs a user ID, e.g. --owner=42.' );
+			}
 			$user_id = absint( $assoc_args['owner'] );
 			// Without this, a typo silently becomes 0 — i.e. the whole site.
 			if ( ! $user_id || ! get_userdata( $user_id ) ) {
@@ -196,24 +245,36 @@ class Attachment_Deduplicator {
 			}
 		}
 
+		$report_path = \WP_CLI\Utils\get_flag_value( $assoc_args, 'report', '' );
+
 		if ( ! $dry_run ) {
 			// Deletion is not reversible on sites without MEDIA_TRASH.
 			\WP_CLI::confirm( 'This will delete redundant logo attachments. Run without --live first to preview. Continue?', $assoc_args );
 		}
 
+		// Discovery hashes every image the logo owners hold and scans post content, so
+		// on the libraries this exists for it is minutes of silence otherwise.
+		\WP_CLI::log( 'Scanning for duplicate logos…' );
+
 		$progress = null;
 		$report   = ( new self() )->run(
 			[
-				'dry_run' => $dry_run,
-				'user_id' => $user_id,
-				'on_plan' => function ( $total ) use ( &$progress ) {
+				'dry_run'  => $dry_run,
+				'user_id'  => $user_id,
+				'on_plan'  => function ( $total ) use ( &$progress ) {
 					if ( $total ) {
 						$progress = \WP_CLI\Utils\make_progress_bar( 'Merging duplicates', $total );
 					}
 				},
-				'on_tick' => function () use ( &$progress ) {
+				'on_tick'  => function () use ( &$progress ) {
 					if ( $progress ) {
 						$progress->tick();
+					}
+				},
+				'on_ready' => function ( $plan ) use ( $report_path ) {
+					if ( $report_path ) {
+						self::write_plan_csv( $report_path, $plan );
+						\WP_CLI::log( sprintf( 'Wrote plan for %d group(s) to %s', count( $plan ), $report_path ) );
 					}
 				},
 			]
@@ -232,14 +293,29 @@ class Attachment_Deduplicator {
 		}
 
 		// Print the mapping so a dry run can be audited, and a live run leaves a
-		// record of what was collapsed into what.
-		foreach ( $report['plan'] as $group ) {
-			\WP_CLI::log( sprintf( '  %d <- %s', $group['canonical'], implode( ', ', $group['duplicates'] ) ) );
+		// record of what was collapsed into what. Past a few screenfuls the CSV is
+		// the usable record, so don't bury the summary under thousands of lines.
+		if ( count( $report['plan'] ) <= self::MAX_PLAN_LINES ) {
+			foreach ( $report['plan'] as $group ) {
+				\WP_CLI::log( sprintf( '  %d <- %s', $group['canonical'], implode( ', ', $group['duplicates'] ) ) );
+			}
+		} elseif ( ! $report_path ) {
+			\WP_CLI::log( sprintf( '  (%d groups — re-run with --report=<path> for the full mapping)', count( $report['plan'] ) ) );
 		}
 
 		if ( $dry_run ) {
 			\WP_CLI::success( sprintf( 'Would re-point references and delete %d attachment(s). Re-run with --live to apply.', $report['duplicates'] ) );
 			return;
+		}
+
+		if ( $report['repoint_failures'] ) {
+			\WP_CLI::warning(
+				sprintf(
+					'%d attachment(s) were kept because their references could not be moved: %s. Nothing was deleted for those — re-run to retry.',
+					count( $report['repoint_failures'] ),
+					implode( ', ', $report['repoint_failures'] )
+				)
+			);
 		}
 
 		if ( $report['delete_failures'] ) {
@@ -258,6 +334,31 @@ class Attachment_Deduplicator {
 	}
 
 	/**
+	 * Writes the plan to a CSV file, so an irreversible run leaves a record that
+	 * outlives the terminal buffer.
+	 *
+	 * @param string  $path Destination path.
+	 * @param array[] $plan Plan entries.
+	 */
+	private static function write_plan_csv( $path, array $plan ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- Writing an operator-specified CLI report file; WP_Filesystem is not loaded under WP-CLI.
+		$handle = fopen( $path, 'w' );
+		if ( ! $handle ) {
+			\WP_CLI::error( sprintf( 'Could not write the report to %s', $path ) );
+		}
+
+		fputcsv( $handle, [ 'canonical', 'duplicate' ] );
+		foreach ( $plan as $group ) {
+			foreach ( $group['duplicates'] as $duplicate ) {
+				fputcsv( $handle, [ $group['canonical'], $duplicate ] );
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- Matches the fopen above.
+		fclose( $handle );
+	}
+
+	/**
 	 * Finds groups of identical logo attachments and, unless this is a dry run,
 	 * merges each group into its oldest attachment.
 	 *
@@ -266,6 +367,8 @@ class Attachment_Deduplicator {
 	 * @param array $args Optional arguments:
 	 *                    'dry_run' (bool, default true) only reports what would change;
 	 *                    'user_id' (int, default 0) limits to one attachment owner;
+	 *                    'on_ready' (callable|null) called once with the finished plan,
+	 *                    before anything is mutated;
 	 *                    'on_plan' (callable|null) called once with the number of
 	 *                    attachments about to be merged, before any mutation;
 	 *                    'on_tick' (callable|null) called after each attachment.
@@ -273,17 +376,19 @@ class Attachment_Deduplicator {
 	 *               merged), 'skipped_referenced' (candidates kept because something
 	 *               unrecognised still references them), 'plan' (the canonical =>
 	 *               duplicates mapping), and, for a live run, 'references_repointed',
-	 *               'attachments_deleted' and 'delete_failures' (IDs that could not
-	 *               be deleted).
+	 *               'attachments_deleted', 'repoint_failures' (IDs kept because their
+	 *               references could not be moved) and 'delete_failures' (IDs that
+	 *               could not be deleted).
 	 */
 	public function run( array $args = [] ) {
 		$args = wp_parse_args(
 			$args,
 			[
-				'dry_run' => true,
-				'user_id' => 0,
-				'on_plan' => null,
-				'on_tick' => null,
+				'dry_run'  => true,
+				'user_id'  => 0,
+				'on_ready' => null,
+				'on_plan'  => null,
+				'on_tick'  => null,
 			]
 		);
 
@@ -294,6 +399,7 @@ class Attachment_Deduplicator {
 			'attachments_deleted'  => 0,
 			'skipped_referenced'   => 0,
 			'delete_failures'      => [],
+			'repoint_failures'     => [],
 			'plan'                 => [],
 		];
 
@@ -337,15 +443,15 @@ class Attachment_Deduplicator {
 				'duplicates' => $deletable,
 			];
 
-			if ( $args['dry_run'] ) {
-				continue;
-			}
-
-			$this->backfill_hash( $canonical );
-
 			foreach ( $deletable as $duplicate ) {
 				$repoint_map[ $duplicate ] = $canonical;
 			}
+		}
+
+		// The plan is complete and nothing has been touched yet, which is the only
+		// point at which it can be recorded as what the run is about to do.
+		if ( is_callable( $args['on_ready'] ) ) {
+			call_user_func( $args['on_ready'], $report['plan'] );
 		}
 
 		if ( $args['dry_run'] || ! $repoint_map ) {
@@ -356,9 +462,23 @@ class Attachment_Deduplicator {
 			call_user_func( $args['on_plan'], count( $repoint_map ) );
 		}
 
+		foreach ( $report['plan'] as $group ) {
+			$this->backfill_hash( $group['canonical'] );
+		}
+
 		// Move every reference first, then delete: a run that dies partway leaves an
 		// un-deleted duplicate rather than a listing pointing at a deleted post.
 		$report['references_repointed'] = $this->repoint_all( $repoint_map );
+
+		// Then prove it landed. `update_post_meta()` reports failure by return value,
+		// and core's wp_delete_attachment() deletes every `_thumbnail_id` row pointing
+		// at the attachment — so a re-point that silently failed would turn into a
+		// listing that lost its logo, counted as a success. Anything still referenced
+		// is dropped from this run rather than deleted; re-running retries it.
+		foreach ( $this->surviving_reference_ids( array_keys( $repoint_map ) ) as $unmoved ) {
+			unset( $repoint_map[ $unmoved ] );
+			$report['repoint_failures'][] = $unmoved;
+		}
 
 		$processed = 0;
 		foreach ( $repoint_map as $duplicate => $canonical ) {
@@ -472,38 +592,39 @@ class Attachment_Deduplicator {
 			// carry a logo owned by another, so ownership is applied to the attachment
 			// in attachment_signature() rather than to whatever references it.
 			$wpdb->prepare(
-				"SELECT pm.meta_value
+				"SELECT pm.meta_id AS cursor_id, pm.meta_value AS value
 				 FROM {$wpdb->postmeta} pm
 				 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
-				 WHERE pm.meta_key = %s AND p.post_type = %s
-				 ORDER BY pm.meta_id",
+				 WHERE pm.meta_key = %s AND p.post_type = %s AND pm.meta_id > ",
 				self::HANDLED_POST_META_KEY,
 				\WP_Job_Manager_Post_Types::PT_LISTING
 			),
 			$wpdb->prepare(
-				"SELECT meta_value FROM {$wpdb->usermeta} WHERE meta_key = %s ORDER BY umeta_id",
+				"SELECT umeta_id AS cursor_id, meta_value AS value FROM {$wpdb->usermeta} WHERE meta_key = %s AND umeta_id > ",
 				self::HANDLED_USER_META_KEY
 			),
 		];
 
 		foreach ( $sources as $sql ) {
-			$offset = 0;
+			$last = 0;
 
 			do {
 				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Paged bulk read; no API equivalent that avoids loading everything.
 				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
-				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $sql is already prepared; the limit clause is bound here.
-				$values = $wpdb->get_col(
-					$wpdb->prepare( $sql . ' LIMIT %d OFFSET %d', $this->chunk_size, $offset )
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $sql is already prepared; the cursor and limit are bound here.
+				// Keyset rather than OFFSET, which re-reads every earlier row per page.
+				$rows = $wpdb->get_results(
+					$wpdb->prepare( $sql . '%d ORDER BY cursor_id LIMIT %d', $last, $this->chunk_size )
 				);
 				// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
 				// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
 
 				$page = [];
-				foreach ( $values as $value ) {
-					if ( (int) $value ) {
-						$page[] = (int) $value;
+				foreach ( $rows as $row ) {
+					$last = (int) $row->cursor_id;
+					if ( (int) $row->value ) {
+						$page[] = (int) $row->value;
 					}
 				}
 
@@ -513,8 +634,7 @@ class Attachment_Deduplicator {
 					$this->free_memory();
 				}
 
-				$fetched = count( $values );
-				$offset += $this->chunk_size;
+				$fetched = count( $rows );
 			} while ( $this->chunk_size === $fetched );
 		}
 	}
@@ -533,41 +653,47 @@ class Attachment_Deduplicator {
 			return;
 		}
 
-		$author_list = implode( ',', array_map( 'intval', $owner_ids ) );
-		$offset      = 0;
+		// Chunked: this command exists for sites with thousands of employers, and one
+		// owner per logo means the whole set would otherwise become a single
+		// IN ( ... ) list re-sent on every page.
+		foreach ( array_chunk( array_map( 'intval', $owner_ids ), $this->chunk_size ) as $owner_chunk ) {
+			$author_list = implode( ',', $owner_chunk );
+			$last        = 0;
 
-		do {
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Paged bulk read; get_posts() would load the whole library.
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $author_list is ints.
-			$ids = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->posts}
-					 WHERE post_type = 'attachment'
-					   AND post_status = 'inherit'
-					   AND post_mime_type LIKE %s
-					   AND post_author IN ( {$author_list} )
-					 ORDER BY ID LIMIT %d OFFSET %d",
-					$wpdb->esc_like( 'image/' ) . '%',
-					$this->chunk_size,
-					$offset
-				)
-			);
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
-			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+			do {
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Paged bulk read; get_posts() would load the whole library.
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $author_list is ints.
+				$ids = $wpdb->get_col(
+					$wpdb->prepare(
+						"SELECT ID FROM {$wpdb->posts}
+						 WHERE post_type = 'attachment'
+						   AND post_status = 'inherit'
+						   AND post_mime_type LIKE %s
+						   AND post_author IN ( {$author_list} )
+						   AND ID > %d
+						 ORDER BY ID LIMIT %d",
+						$wpdb->esc_like( 'image/' ) . '%',
+						$last,
+						$this->chunk_size
+					)
+				);
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+				// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
 
-			$page = array_map( 'intval', $ids );
+				$page = array_map( 'intval', $ids );
 
-			if ( $page ) {
-				_prime_post_caches( $page, false, true );
-				$handle( $page );
-				$this->free_memory();
-			}
+				if ( $page ) {
+					$last = end( $page );
+					_prime_post_caches( $page, false, true );
+					$handle( $page );
+					$this->free_memory();
+				}
 
-			$fetched = count( $ids );
-			$offset += $this->chunk_size;
-		} while ( $this->chunk_size === $fetched );
+				$fetched = count( $ids );
+			} while ( $this->chunk_size === $fetched );
+		}
 	}
 
 	/**
@@ -716,6 +842,59 @@ class Attachment_Deduplicator {
 	}
 
 	/**
+	 * Of the given attachments, those something still references through one of the
+	 * two keys this class re-points.
+	 *
+	 * Run after re-pointing, as the precondition for deleting: an ID coming back here
+	 * means its re-point did not land, and deleting it would strip the reference
+	 * rather than move it. Two queries per batch, so the check does not scale with
+	 * the number of duplicates.
+	 *
+	 * @param int[] $ids Attachment IDs about to be deleted.
+	 * @return int[] IDs that are still referenced.
+	 */
+	private function surviving_reference_ids( array $ids ) {
+		global $wpdb;
+
+		$surviving = [];
+
+		foreach ( array_chunk( array_map( 'intval', $ids ), $this->chunk_size ) as $chunk ) {
+			$id_list = implode( ',', $chunk );
+
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Bulk verification replacing one query per attachment.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration; a cached answer would defeat the check.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is ints.
+			$still_used = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT DISTINCT pm.meta_value
+					 FROM {$wpdb->postmeta} pm
+					 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+					 WHERE pm.meta_key = %s AND p.post_type = %s AND pm.meta_value IN ( {$id_list} )",
+					self::HANDLED_POST_META_KEY,
+					\WP_Job_Manager_Post_Types::PT_LISTING
+				)
+			);
+
+			$still_default = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT DISTINCT meta_value FROM {$wpdb->usermeta}
+					 WHERE meta_key = %s AND meta_value IN ( {$id_list} )",
+					self::HANDLED_USER_META_KEY
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+			foreach ( array_merge( $still_used, $still_default ) as $id ) {
+				$surviving[ (int) $id ] = true;
+			}
+		}
+
+		return array_keys( $surviving );
+	}
+
+	/**
 	 * Returns the subset of the given attachments that something this class cannot
 	 * re-point still references, as an [ id => true ] lookup.
 	 *
@@ -737,87 +916,280 @@ class Attachment_Deduplicator {
 			return [];
 		}
 
-		$protected = [];
+		$by_id = array_fill_keys( $candidate_ids, true );
 
-		// Chunked so the IN ( ... ) lists stay a sane size on a large library.
-		foreach ( array_chunk( $candidate_ids, $this->chunk_size ) as $chunk ) {
-			$protected += $this->find_protected_ids_in_meta( $chunk );
+		// Filenames are how a reference that stores a URL rather than an ID — legacy
+		// `_company_logo` post meta, a hand-written <img>, a page builder printing a
+		// custom field — is recognised at all.
+		$by_stem = [];
+		foreach ( $this->attachment_stems( $candidate_ids ) as $attachment_id => $stem ) {
+			$by_stem[ $stem ][] = $attachment_id;
 		}
 
-		return $protected + $this->find_inline_content_references( $candidate_ids );
+		$protected = $this->find_protected_ids_in_meta( $by_id, $by_stem )
+			+ $this->find_protected_ids_in_options( $by_id, $by_stem )
+			+ $this->find_inline_content_references( $by_id, $by_stem );
+
+		/**
+		 * Filters the attachments the logo de-duplicator refuses to delete.
+		 *
+		 * The sweep recognises the storage shapes core and the common plugins use;
+		 * a site storing references some other way can add its own here. Adding an
+		 * ID keeps that attachment, it never causes a deletion.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array<int, true> $protected     Protected attachment IDs, as an [ id => true ] lookup.
+		 * @param int[]            $candidate_ids Attachment IDs being considered for deletion.
+		 */
+		$protected = apply_filters( 'job_manager_dedupe_protected_attachment_ids', $protected, $candidate_ids );
+
+		// A filter returning junk must not be able to widen the deletion set.
+		$result = [];
+		foreach ( array_keys( (array) $protected ) as $id ) {
+			if ( isset( $by_id[ (int) $id ] ) ) {
+				$result[ (int) $id ] = true;
+			}
+		}
+
+		return $result;
 	}
 
 	/**
-	 * The meta/option half of the reference sweep, for one batch of candidates.
+	 * The meta half of the reference sweep: one streamed pass over the meta rows whose
+	 * key looks like it could hold an attachment reference, matched in PHP.
 	 *
-	 * @param int[] $candidate_ids Attachment IDs being considered for deletion.
+	 * Reading the values rather than comparing them to the candidate IDs in SQL is what
+	 * makes serialized arrays (ACF galleries and repeaters), comma-separated lists
+	 * (`_product_image_gallery`) and stored URLs (legacy `_company_logo`) visible at
+	 * all: `meta_value IN ( 12,34 )` is an exact match against a LONGTEXT column, so
+	 * MySQL coerces `a:1:{i:0;i:34;}` to 0 and `"12,34"` to 12 — matching nothing, or
+	 * only the first ID, while looking like the key was covered.
+	 *
+	 * It is also one pass instead of one per batch of candidates. `meta_value` has no
+	 * index and the key patterns have a leading wildcard, so each of these is a full
+	 * table scan; doing it per batch is what stops the command finishing.
+	 *
+	 * @param array<int, true>     $by_id   Candidate IDs, as a lookup.
+	 * @param array<string, int[]> $by_stem Candidate IDs keyed by file stem.
 	 * @return array<int, true> Protected IDs.
 	 */
-	private function find_protected_ids_in_meta( array $candidate_ids ) {
+	private function find_protected_ids_in_meta( array $by_id, array $by_stem ) {
 		global $wpdb;
 
 		$protected = [];
-		$id_list   = implode( ',', $candidate_ids );
-		$key_sql   = $this->reference_key_sql();
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reference sweep across core tables has no API equivalent.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration; a cached answer would be worse than none.
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is ints; $key_sql is built from a class constant.
-		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Raw SQL, not a WP_Query meta arg; the scan is the point of the command.
+		$sources = [
+			// `_thumbnail_id` on a listing is the one post-meta case repoint_all()
+			// handles; the same key on any other post type is not. The post_id is
+			// selected so an attachment's own meta cannot protect it.
+			[
+				'sql'      => "SELECT pm.meta_id AS cursor_id, pm.post_id AS owner_id, pm.meta_key, pm.meta_value, p.post_type
+					 FROM {$wpdb->postmeta} pm
+					 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id",
+				'table'    => 'pm',
+				'cursor'   => 'pm.meta_id',
+				'key_col'  => 'pm.meta_key',
+				'is_owner' => true,
+			],
+			[
+				'sql'      => "SELECT umeta_id AS cursor_id, 0 AS owner_id, meta_key, meta_value, '' AS post_type FROM {$wpdb->usermeta}",
+				'cursor'   => 'umeta_id',
+				'key_col'  => 'meta_key',
+				'is_owner' => false,
+			],
+			[
+				'sql'      => "SELECT meta_id AS cursor_id, 0 AS owner_id, meta_key, meta_value, '' AS post_type FROM {$wpdb->termmeta}",
+				'cursor'   => 'meta_id',
+				'key_col'  => 'meta_key',
+				'is_owner' => false,
+			],
+		];
 
-		// Post meta. `_thumbnail_id` on a listing is the one case repoint_references()
-		// handles; the same key on any other post type is not.
-		$rows = $wpdb->get_results(
-			"SELECT pm.meta_value, pm.meta_key, p.post_type
-			 FROM {$wpdb->postmeta} pm
-			 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
-			 WHERE pm.meta_value IN ( {$id_list} )
-			   AND pm.post_id NOT IN ( {$id_list} )
-			   AND ( {$key_sql} )"
-		);
-		foreach ( $rows as $row ) {
-			$handled = self::HANDLED_POST_META_KEY === $row->meta_key
+		foreach ( $sources as $source ) {
+			$last = 0;
+
+			do {
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reference sweep across core tables has no API equivalent.
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration; a cached answer would be worse than none.
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Key clauses are built with prepare(); the cursor is bound below.
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $source is a literal from the array above; the key clauses are prepared.
+				// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Raw SQL, not a WP_Query meta arg; the scan is the point of the command.
+				$rows = $wpdb->get_results(
+					$wpdb->prepare(
+						$source['sql']
+						. ' WHERE ( ' . $this->reference_key_sql( $source['key_col'] ) . ' )'
+						. ' AND ' . $this->excluded_key_sql( $source['key_col'] )
+						// Keyset rather than OFFSET: paging an unindexed scan by offset
+						// re-reads and discards every earlier row on every page.
+						. ' AND ' . $source['cursor'] . ' > %d'
+						. ' ORDER BY ' . $source['cursor'] . ' LIMIT %d',
+						$last,
+						$this->chunk_size
+					)
+				);
+				// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+				// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+				foreach ( $rows as $row ) {
+					$last = (int) $row->cursor_id;
+
+					if ( $this->is_handled_reference( $row, $source['is_owner'] ) ) {
+						continue;
+					}
+
+					foreach ( $this->referenced_ids_in_value( $row->meta_value, $by_id, $by_stem ) as $id ) {
+						// An attachment's own meta describes it rather than referencing
+						// it; another candidate's meta is a reference like any other.
+						if ( $source['is_owner'] && (int) $row->owner_id === $id ) {
+							continue;
+						}
+						$protected[ $id ] = true;
+					}
+				}
+
+				$fetched = count( $rows );
+			} while ( $this->chunk_size === $fetched );
+
+			$this->free_memory();
+		}
+
+		return $protected;
+	}
+
+	/**
+	 * Whether a meta row is one of the two reference types this class re-points, and
+	 * so does not block deletion.
+	 *
+	 * @param object $row      Row with meta_key and post_type.
+	 * @param bool   $is_owner Whether the row came from post meta.
+	 * @return bool
+	 */
+	private function is_handled_reference( $row, $is_owner ) {
+		if ( $is_owner ) {
+			return self::HANDLED_POST_META_KEY === $row->meta_key
 				&& \WP_Job_Manager_Post_Types::PT_LISTING === $row->post_type;
-			if ( ! $handled ) {
-				$protected[ (int) $row->meta_value ] = true;
-			}
 		}
 
-		// User meta, other than the `_company_logo` default that is handled.
+		// User meta only: the same key on a *post* is the pre-1.24.0 listing logo,
+		// which holds a URL and is re-pointed by nothing.
+		return self::HANDLED_USER_META_KEY === $row->meta_key;
+	}
+
+	/**
+	 * The options half of the sweep.
+	 *
+	 * Deliberately a short, named list rather than the meta key patterns: option names
+	 * like `medium_size_w` would match `%media%`-ish patterns and hold a bare number
+	 * (300, 150, 1024), so every attachment whose ID collided with an image dimension
+	 * would be protected forever.
+	 *
+	 * @param array<int, true>     $by_id   Candidate IDs, as a lookup.
+	 * @param array<string, int[]> $by_stem Candidate IDs keyed by file stem.
+	 * @return array<int, true> Protected IDs.
+	 */
+	private function find_protected_ids_in_options( array $by_id, array $by_stem ) {
+		global $wpdb;
+
+		$protected = [];
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- No API for scanning options by name pattern.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- One-shot CLI migration.
 		$rows = $wpdb->get_results(
-			"SELECT meta_value, meta_key FROM {$wpdb->usermeta}
-			 WHERE meta_value IN ( {$id_list} ) AND ( {$key_sql} )"
+			"SELECT option_name, option_value FROM {$wpdb->options}
+			 WHERE option_name IN ( 'site_logo', 'site_icon' )
+			    OR option_name LIKE 'theme_mods\_%'
+			    OR option_name LIKE 'widget\_%'"
 		);
-		foreach ( $rows as $row ) {
-			if ( self::HANDLED_USER_META_KEY !== $row->meta_key ) {
-				$protected[ (int) $row->meta_value ] = true;
-			}
-		}
-
-		// Term meta.
-		$term_values = $wpdb->get_col(
-			"SELECT meta_value FROM {$wpdb->termmeta}
-			 WHERE meta_value IN ( {$id_list} ) AND ( {$key_sql} )"
-		);
-		foreach ( $term_values as $value ) {
-			$protected[ (int) $value ] = true;
-		}
-
-		// Options storing a bare attachment ID.
-		$option_values = $wpdb->get_col(
-			"SELECT option_value FROM {$wpdb->options}
-			 WHERE option_name IN ( 'site_logo', 'site_icon' ) AND option_value IN ( {$id_list} )"
-		);
-		foreach ( $option_values as $value ) {
-			$protected[ (int) $value ] = true;
-		}
-
-		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
 
+		foreach ( $rows as $row ) {
+			foreach ( $this->referenced_ids_in_value( $row->option_value, $by_id, $by_stem ) as $id ) {
+				$protected[ $id ] = true;
+			}
+		}
+
 		return $protected;
+	}
+
+	/**
+	 * Extracts the candidate attachment IDs a stored value refers to.
+	 *
+	 * Handles the shapes references are actually stored in: a bare ID, a
+	 * comma-separated list of them, an ID nested anywhere inside a serialized array
+	 * (`theme_mods_*`'s `custom_logo`, an ACF gallery), and a URL or path, matched by
+	 * filename. Anything else is ignored — pulling every integer out of arbitrary text
+	 * would protect an attachment because a post happened to mention its ID.
+	 *
+	 * @param mixed                $value   Stored value.
+	 * @param array<int, true>     $by_id   Candidate IDs, as a lookup.
+	 * @param array<string, int[]> $by_stem Candidate IDs keyed by file stem.
+	 * @return int[] Referenced candidate IDs.
+	 */
+	private function referenced_ids_in_value( $value, array $by_id, array $by_stem ) {
+		$found = [];
+		$this->collect_referenced_ids( maybe_unserialize( $value ), $by_id, $by_stem, $found, 0 );
+
+		return array_keys( $found );
+	}
+
+	/**
+	 * Walks one value (recursing into serialized structures) collecting candidate IDs.
+	 *
+	 * @param mixed                $value   Value to inspect.
+	 * @param array<int, true>     $by_id   Candidate IDs, as a lookup.
+	 * @param array<string, int[]> $by_stem Candidate IDs keyed by file stem.
+	 * @param array<int, true>     $found   Accumulator, by reference.
+	 * @param int                  $depth   Current recursion depth.
+	 */
+	private function collect_referenced_ids( $value, array $by_id, array $by_stem, array &$found, $depth ) {
+		if ( $depth > self::MAX_VALUE_DEPTH ) {
+			return;
+		}
+
+		if ( is_array( $value ) || is_object( $value ) ) {
+			foreach ( (array) $value as $item ) {
+				$this->collect_referenced_ids( $item, $by_id, $by_stem, $found, $depth + 1 );
+			}
+			return;
+		}
+
+		if ( is_bool( $value ) || null === $value ) {
+			return;
+		}
+
+		$string = trim( (string) $value );
+		if ( '' === $string ) {
+			return;
+		}
+
+		// A bare ID, or a comma-separated list of them.
+		if ( preg_match( '/^\d+(\s*,\s*\d+)*$/', $string ) ) {
+			foreach ( explode( ',', $string ) as $part ) {
+				$id = (int) trim( $part );
+				if ( isset( $by_id[ $id ] ) ) {
+					$found[ $id ] = true;
+				}
+			}
+			return;
+		}
+
+		if ( ! $by_stem ) {
+			return;
+		}
+
+		foreach ( $this->file_stems_in( $string ) as $stem ) {
+			if ( ! isset( $by_stem[ $stem ] ) ) {
+				continue;
+			}
+			foreach ( $by_stem[ $stem ] as $id ) {
+				$found[ $id ] = true;
+			}
+		}
 	}
 
 	/**
@@ -828,23 +1200,15 @@ class Attachment_Deduplicator {
 	 * that contain any image marker at all, matched in PHP — rather than one LIKE
 	 * scan per candidate.
 	 *
-	 * @param int[] $candidate_ids Attachment IDs being considered for deletion.
+	 * @param array<int, true>     $by_id   Candidate IDs, as a lookup.
+	 * @param array<string, int[]> $by_stem Candidate IDs keyed by file stem.
 	 * @return array<int, true> Protected IDs.
 	 */
-	private function find_inline_content_references( array $candidate_ids ) {
+	private function find_inline_content_references( array $by_id, array $by_stem ) {
 		global $wpdb;
 
 		$protected = [];
-		$by_id     = array_fill_keys( $candidate_ids, true );
-		$offset    = 0;
-
-		// Keyed by filename so a post is matched against the names it actually
-		// contains. Looping every candidate for every post instead would be
-		// candidates x posts string searches — hundreds of millions on a large site.
-		$by_basename = [];
-		foreach ( $this->attachment_basenames( $candidate_ids ) as $attachment_id => $basename ) {
-			$by_basename[ strtolower( $basename ) ][] = $attachment_id;
-		}
+		$last      = 0;
 
 		do {
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Content scan has no API equivalent.
@@ -852,66 +1216,76 @@ class Attachment_Deduplicator {
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT ID, post_content FROM {$wpdb->posts}
-					 WHERE post_content LIKE %s OR post_content LIKE %s OR post_content LIKE %s
-					 ORDER BY ID LIMIT %d OFFSET %d",
+					 WHERE ( post_content LIKE %s OR post_content LIKE %s OR post_content LIKE %s OR post_content LIKE %s )
+					   AND ID > %d
+					 ORDER BY ID LIMIT %d",
 					'%' . $wpdb->esc_like( 'wp-image-' ) . '%',
-					'%' . $wpdb->esc_like( '"id":' ) . '%',
+					// Not just `"id":` — a block attribute nested inside another block
+					// is stored JSON-escaped, and kses rewrites the escaped quotes to
+					// ", so the same marker has three shapes on disk.
+					'%' . $wpdb->esc_like( '"id' ) . '%',
+					'%' . $wpdb->esc_like( 'u0022id' ) . '%',
 					'%' . $wpdb->esc_like( '/uploads/' ) . '%',
-					$this->chunk_size,
-					$offset
+					$last,
+					$this->chunk_size
 				)
 			);
 			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
 			// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
 
 			foreach ( $rows as $row ) {
+				$last    = (int) $row->ID;
 				$content = (string) $row->post_content;
 
-				if ( preg_match_all( '/(?:wp-image-|"id":\s*)(\d+)/', $content, $matches ) ) {
+				// A block attribute nested inside another block is stored JSON-escaped
+				// (\"id\"), and kses rewrites those quotes again ("id"), so
+				// the same marker has to be recognised in all three shapes.
+				$quote = '(?:"|\\\\"|\\\\u0022)';
+				if ( preg_match_all( '/(?:wp-image-|' . $quote . 'id' . $quote . '\s*:\s*' . $quote . '?)(\d+)/', $content, $matches ) ) {
 					foreach ( $matches[1] as $found ) {
 						$found = (int) $found;
-						if ( isset( $by_id[ $found ] ) && (int) $row->ID !== $found ) {
+						if ( isset( $by_id[ $found ] ) && $last !== $found ) {
 							$protected[ $found ] = true;
 						}
 					}
 				}
 
-				if ( $by_basename && preg_match_all( '/[^\/"\'\s>]+\.(?:png|jpe?g|gif|webp|avif|bmp|tiff?|svg)/i', $content, $files ) ) {
-					foreach ( $files[0] as $filename ) {
-						$filename = strtolower( $filename );
-						if ( ! isset( $by_basename[ $filename ] ) ) {
-							continue;
-						}
-						foreach ( $by_basename[ $filename ] as $attachment_id ) {
-							if ( (int) $row->ID !== $attachment_id ) {
-								$protected[ $attachment_id ] = true;
-							}
+				if ( ! $by_stem ) {
+					continue;
+				}
+
+				foreach ( $this->file_stems_in( $content ) as $stem ) {
+					if ( ! isset( $by_stem[ $stem ] ) ) {
+						continue;
+					}
+					foreach ( $by_stem[ $stem ] as $attachment_id ) {
+						if ( $last !== $attachment_id ) {
+							$protected[ $attachment_id ] = true;
 						}
 					}
 				}
 			}
 
 			$fetched = count( $rows );
-			$offset += $this->chunk_size;
 		} while ( $this->chunk_size === $fetched );
 
 		return $protected;
 	}
 
 	/**
-	 * Maps attachment IDs to their file basename in one query.
+	 * Maps attachment IDs to the stem of their file, in one query per batch.
 	 *
 	 * @param int[] $attachment_ids Attachment IDs.
 	 * @return array<int, string>
 	 */
-	private function attachment_basenames( array $attachment_ids ) {
+	private function attachment_stems( array $attachment_ids ) {
 		global $wpdb;
 
 		if ( ! $attachment_ids ) {
 			return [];
 		}
 
-		$basenames = [];
+		$stems = [];
 
 		foreach ( array_chunk( array_map( 'intval', $attachment_ids ), $this->chunk_size ) as $chunk ) {
 			$id_list = implode( ',', $chunk );
@@ -929,28 +1303,114 @@ class Attachment_Deduplicator {
 
 			foreach ( $rows as $row ) {
 				if ( $row->meta_value ) {
-					$basenames[ (int) $row->post_id ] = wp_basename( $row->meta_value );
+					$stems[ (int) $row->post_id ] = $this->file_stem( $row->meta_value );
 				}
 			}
 		}
 
-		return $basenames;
+		return $stems;
+	}
+
+	/**
+	 * Every image filename mentioned in a string, reduced to its stem.
+	 *
+	 * @param string $string Text to scan.
+	 * @return string[] Stems, in order of appearance.
+	 */
+	private function file_stems_in( $string ) {
+		if ( ! preg_match_all( '/[^\/"\'\s>\\\\]+\.(?:png|jpe?g|gif|webp|avif|bmp|tiff?|svg)/i', $string, $matches ) ) {
+			return [];
+		}
+
+		$stems = [];
+		foreach ( $matches[0] as $filename ) {
+			$stems[] = $this->file_stem( $filename );
+		}
+
+		return $stems;
+	}
+
+	/**
+	 * Reduces a filename to the stem shared by every file core generates from one
+	 * upload, so a reference to a thumbnail protects the attachment it belongs to.
+	 *
+	 * Content that prints an image from a custom field carries neither `wp-image-N`
+	 * nor a block id — only a URL, and usually a resized one. Matching the original
+	 * filename alone misses those, and deleting the attachment takes the resized files
+	 * with it. The extension is kept: a resized variant shares it, while `logo.png` and
+	 * `logo.jpg` are unrelated files that must not protect each other.
+	 *
+	 * @param string $filename File name, path or URL.
+	 * @return string Lowercased stem.
+	 */
+	private function file_stem( $filename ) {
+		$name = strtolower( wp_basename( (string) $filename ) );
+
+		if ( ! preg_match( '/^(.+)(\.[a-z0-9]+)$/', $name, $matches ) ) {
+			return $name;
+		}
+
+		// -150x150 (intermediate size), -scaled (big-image threshold), -e1699999999
+		// (edited in the media editor).
+		$base = preg_replace( '/-\d+x\d+$/', '', $matches[1] );
+		$base = preg_replace( '/-scaled$/', '', $base );
+		$base = preg_replace( '/-e\d{10,}$/', '', $base );
+
+		return $base . $matches[2];
 	}
 
 	/**
 	 * SQL fragment matching meta keys that may hold an attachment reference.
 	 *
+	 * @param string $column Column to match against.
 	 * @return string
 	 */
-	private function reference_key_sql() {
+	private function reference_key_sql( $column ) {
 		global $wpdb;
 
+		/**
+		 * Filters the meta-key patterns treated as possibly holding a reference to an
+		 * attachment, and so blocking its deletion.
+		 *
+		 * Patterns are SQL LIKE expressions matched against the meta key. Adding one
+		 * only ever protects more attachments; it cannot cause a deletion.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string[] $patterns LIKE patterns.
+		 */
+		$patterns = apply_filters( 'job_manager_dedupe_reference_meta_key_patterns', self::REFERENCE_KEY_PATTERNS );
+
 		$clauses = [];
-		foreach ( self::REFERENCE_KEY_PATTERNS as $pattern ) {
-			$clauses[] = $wpdb->prepare( 'meta_key LIKE %s', $pattern );
+		foreach ( (array) $patterns as $pattern ) {
+			if ( is_string( $pattern ) && '' !== $pattern ) {
+				// The column name is a class-controlled literal and stays outside
+				// prepare(); only the pattern, which is filterable, is bound.
+				$clauses[] = $column . ' LIKE ' . $wpdb->prepare( '%s', $pattern );
+			}
+		}
+
+		if ( ! $clauses ) {
+			return '1=0';
 		}
 
 		return implode( ' OR ', $clauses );
+	}
+
+	/**
+	 * SQL fragment excluding core's own attachment plumbing from the sweep.
+	 *
+	 * @param string $column Column to match against.
+	 * @return string
+	 */
+	private function excluded_key_sql( $column ) {
+		global $wpdb;
+
+		$placeholders = implode( ', ', array_fill( 0, count( self::SELF_DESCRIBING_META_KEYS ), '%s' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $column is a class-controlled column name and $placeholders is generated from a class constant; the key values are bound.
+		return $wpdb->prepare( $column . " NOT IN ( {$placeholders} )", self::SELF_DESCRIBING_META_KEYS );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 	}
 
 	/**
@@ -964,6 +1424,8 @@ class Attachment_Deduplicator {
 	 * @param int $canonical Attachment being kept.
 	 */
 	private function carry_over_metadata( $duplicate, $canonical ) {
+		global $wpdb;
+
 		$alt = get_post_meta( $duplicate, '_wp_attachment_image_alt', true );
 		if ( $alt && ! get_post_meta( $canonical, '_wp_attachment_image_alt', true ) ) {
 			update_post_meta( $canonical, '_wp_attachment_image_alt', $alt );
@@ -976,8 +1438,8 @@ class Attachment_Deduplicator {
 		}
 
 		// Spelled out per field rather than looped over a list of field names, so the
-		// array keys stay literal and match the shape wp_update_post() declares.
-		$update = [ 'ID' => $canonical ];
+		// array keys stay literal.
+		$update = [];
 
 		if ( '' !== trim( (string) $duplicate_post->post_excerpt ) && '' === trim( (string) $canonical_post->post_excerpt ) ) {
 			$update['post_excerpt'] = (string) $duplicate_post->post_excerpt;
@@ -987,9 +1449,18 @@ class Attachment_Deduplicator {
 			$update['post_content'] = (string) $duplicate_post->post_content;
 		}
 
-		if ( count( $update ) > 1 ) {
-			wp_update_post( $update );
+		if ( ! $update ) {
+			return;
 		}
+
+		// Written directly rather than through wp_update_post(): under CLI there is no
+		// current user, so every save would run the caption and description through
+		// wp_filter_post_kses and strip markup out of text this command is only moving
+		// from one row to another.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Copying two columns verbatim; a filtered save would alter them. The cache is cleared below.
+		$wpdb->update( $wpdb->posts, $update, [ 'ID' => $canonical ] );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		clean_post_cache( $canonical );
 	}
 
 	/**
@@ -1009,10 +1480,19 @@ class Attachment_Deduplicator {
 			return (bool) wp_delete_attachment( $attachment_id );
 		}
 
-		$veto = '__return_empty_string';
+		// A closure rather than a shared callback so removing it cannot take another
+		// consumer's identical filter with it, and try/finally so a fatal inside the
+		// delete cannot leave file deletion vetoed for the rest of the process.
+		$veto = static function () {
+			return '';
+		};
+
 		add_filter( 'wp_delete_file', $veto );
-		$deleted = wp_delete_attachment( $attachment_id );
-		remove_filter( 'wp_delete_file', $veto );
+		try {
+			$deleted = wp_delete_attachment( $attachment_id );
+		} finally {
+			remove_filter( 'wp_delete_file', $veto );
+		}
 
 		return (bool) $deleted;
 	}
@@ -1050,13 +1530,23 @@ class Attachment_Deduplicator {
 	 * Stores the canonical attachment's content hash so the runtime dedup reuses
 	 * it for future identical uploads.
 	 *
+	 * Hashes the file as uploaded, not whatever `get_attached_file()` currently
+	 * returns: for images over `big_image_size_threshold` core replaces the attached
+	 * file with a `-scaled` copy, while the runtime dedup hashes the upload before
+	 * that happens. Hashing the scaled file would store a value its lookup can never
+	 * match — permanently, since this backfill skips attachments that already have
+	 * a hash.
+	 *
 	 * @param int $canonical Canonical attachment ID.
 	 */
 	private function backfill_hash( $canonical ) {
 		if ( get_post_meta( $canonical, self::HASH_META_KEY, true ) ) {
 			return;
 		}
-		$file = get_attached_file( $canonical );
+		$file = wp_get_original_image_path( $canonical );
+		if ( ! $file ) {
+			$file = get_attached_file( $canonical );
+		}
 		if ( $file && is_file( $file ) ) {
 			$hash = md5_file( $file );
 			if ( $hash ) {

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -114,6 +114,7 @@ class WP_Job_Manager {
 		$this->stats      = WP_Job_Manager\Stats::instance();
 
 		WP_Job_Manager\Dev_Tools::init();
+		WP_Job_Manager\Attachment_Deduplicator::init();
 
 		// Schedule cron jobs.
 		add_action( 'init', [ __CLASS__, 'maybe_schedule_cron_jobs' ] );

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,6 +29,15 @@
 				<referencedClass name="WP_CLI" />
 			</errorLevel>
 		</UndefinedClass>
+		<!-- WP-CLI is not a dependency, so its namespaced helpers are undefined here
+		     the same way the WP_CLI class above is. Both are only ever called behind
+		     a `defined( 'WP_CLI' )` guard. -->
+		<UndefinedFunction>
+			<errorLevel type="suppress">
+				<referencedFunction name="WP_CLI\Utils\get_flag_value" />
+				<referencedFunction name="WP_CLI\Utils\make_progress_bar" />
+			</errorLevel>
+		</UndefinedFunction>
 		<InvalidArgument>
 			<errorLevel type="suppress">
 				<referencedFunction name="esc_attr" />

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Tests the retroactive company-logo attachment de-duplicator: it collapses
+ * identical logo attachments a single owner accumulated (e.g. from re-uploading
+ * the same logo on every submission) down to one, re-pointing every reference
+ * before deleting the redundant copies.
+ *
+ * @package wp-job-manager
+ */
+
+use WP_Job_Manager\Attachment_Deduplicator;
+
+class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
+
+	/**
+	 * Files written into the uploads dir, removed on teardown.
+	 *
+	 * @var string[]
+	 */
+	private $created_files = [];
+
+	public function tearDown(): void {
+		foreach ( $this->created_files as $path ) {
+			if ( file_exists( $path ) ) {
+				unlink( $path );
+			}
+		}
+		$this->created_files = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * A minimal but valid 1x1 PNG.
+	 *
+	 * @return string Raw PNG bytes.
+	 */
+	private function png_bytes() {
+		return base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' );
+	}
+
+	/**
+	 * Creates an image attachment owned by a user with a real file on disk (so its
+	 * content hash can be computed) and no dedup hash meta, mirroring a legacy
+	 * duplicate created before the runtime dedup fix.
+	 *
+	 * @param int    $author   Owner user ID.
+	 * @param string $bytes    Raw file bytes.
+	 * @param string $filename File name.
+	 * @return int Attachment ID.
+	 */
+	private function create_logo_attachment( $author, $bytes, $filename ) {
+		$upload_dir = wp_upload_dir();
+		$path       = trailingslashit( $upload_dir['path'] ) . $filename;
+		file_put_contents( $path, $bytes );
+		$this->created_files[] = $path;
+
+		return (int) wp_insert_attachment(
+			[
+				'post_mime_type' => 'image/png',
+				'post_title'     => $filename,
+				'post_status'    => 'inherit',
+				'post_author'    => $author,
+			],
+			$path
+		);
+	}
+
+	/**
+	 * Creates a job listing owned by a user with the given featured image.
+	 *
+	 * @param int $author        Owner user ID.
+	 * @param int $attachment_id Featured image attachment.
+	 * @return int Listing ID.
+	 */
+	private function create_listing_with_logo( $author, $attachment_id ) {
+		$job_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => $author,
+			]
+		);
+		set_post_thumbnail( $job_id, $attachment_id );
+
+		return $job_id;
+	}
+
+	/**
+	 * A live run collapses a user's identical logo attachments to the oldest one,
+	 * re-points listings' featured images to it, and deletes the redundant copies.
+	 */
+	public function test_live_run_merges_identical_logos_and_repoints_thumbnails() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );   // Older (lower ID).
+		$duplicate = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' ); // Newer identical copy.
+
+		$job_canonical = $this->create_listing_with_logo( $author, $canonical );
+		$job_duplicate = $this->create_listing_with_logo( $author, $duplicate );
+
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertNull( get_post( $duplicate ), 'The redundant duplicate attachment must be deleted.' );
+		$this->assertInstanceOf( WP_Post::class, get_post( $canonical ), 'The canonical attachment must survive.' );
+		$this->assertEquals( $canonical, get_post_thumbnail_id( $job_duplicate ), 'The listing on the duplicate must be re-pointed to the canonical.' );
+		$this->assertEquals( $canonical, get_post_thumbnail_id( $job_canonical ), 'The listing already on the canonical is unchanged.' );
+		$this->assertSame( 1, $report['attachments_deleted'], 'Exactly one duplicate attachment should be deleted.' );
+	}
+
+	/**
+	 * Identical logos owned by different users are never merged: cross-user reuse
+	 * is exactly the ownership boundary the runtime dedup preserves.
+	 */
+	public function test_identical_logos_of_different_users_are_not_merged() {
+		$user_a = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$user_b = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo_a = $this->create_logo_attachment( $user_a, $bytes, 'a.png' );
+		$logo_b = $this->create_logo_attachment( $user_b, $bytes, 'b.png' );
+		$this->create_listing_with_logo( $user_a, $logo_a );
+		$this->create_listing_with_logo( $user_b, $logo_b );
+
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $logo_a ), "User A's logo must survive." );
+		$this->assertInstanceOf( WP_Post::class, get_post( $logo_b ), "User B's identical logo must survive — not merged across users." );
+		$this->assertSame( 0, $report['attachments_deleted'] );
+	}
+
+	/**
+	 * A dry run (the default) reports the duplicates it would collapse but mutates
+	 * nothing — no attachment deleted, no reference re-pointed.
+	 */
+	public function test_dry_run_is_the_default_and_mutates_nothing() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$duplicate = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$job       = $this->create_listing_with_logo( $author, $duplicate );
+
+		$report = ( new Attachment_Deduplicator() )->run();
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $duplicate ), 'Dry run must not delete the duplicate.' );
+		$this->assertEquals( $duplicate, get_post_thumbnail_id( $job ), 'Dry run must not re-point references.' );
+		$this->assertSame( 1, $report['duplicates'], 'Dry run still reports the duplicate it would collapse.' );
+		$this->assertSame( 0, $report['attachments_deleted'] );
+	}
+
+	/**
+	 * The user_id argument limits de-duplication to a single owner, leaving other
+	 * owners' duplicates untouched.
+	 */
+	public function test_user_id_limits_dedupe_to_one_owner() {
+		$user_a = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$user_b = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$a1 = $this->create_logo_attachment( $user_a, $bytes, 'a1.png' );
+		$a2 = $this->create_logo_attachment( $user_a, $bytes, 'a2.png' );
+		$b1 = $this->create_logo_attachment( $user_b, $bytes, 'b1.png' );
+		$b2 = $this->create_logo_attachment( $user_b, $bytes, 'b2.png' );
+		$this->create_listing_with_logo( $user_a, $a1 );
+		$this->create_listing_with_logo( $user_a, $a2 );
+		$this->create_listing_with_logo( $user_b, $b1 );
+		$this->create_listing_with_logo( $user_b, $b2 );
+
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false, 'user_id' => $user_a ] );
+
+		$this->assertSame( 1, $report['attachments_deleted'], "Only user A's duplicate is deleted." );
+		$this->assertInstanceOf( WP_Post::class, get_post( $b1 ), "User B's duplicates are untouched." );
+		$this->assertInstanceOf( WP_Post::class, get_post( $b2 ), "User B's duplicates are untouched." );
+	}
+
+	/**
+	 * The reporter's real shape: many identical copies, only some still referenced
+	 * and the rest orphaned. A live run collapses them all to the canonical and
+	 * re-points the referenced listing onto it — even when the canonical is one of
+	 * the orphans.
+	 */
+	public function test_live_run_collapses_orphaned_duplicate_copies() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical  = $this->create_logo_attachment( $author, $bytes, 'logo.png' );   // Oldest — orphan, becomes canonical.
+		$orphan     = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' ); // Orphan copy.
+		$referenced = $this->create_logo_attachment( $author, $bytes, 'logo-2.png' ); // In-use copy.
+		$job        = $this->create_listing_with_logo( $author, $referenced );
+
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $canonical ), 'The canonical survives.' );
+		$this->assertNull( get_post( $orphan ), 'The orphaned copy is deleted.' );
+		$this->assertNull( get_post( $referenced ), 'The redundant in-use copy is deleted after re-pointing.' );
+		$this->assertEquals( $canonical, get_post_thumbnail_id( $job ), 'The listing is re-pointed onto the canonical.' );
+		$this->assertSame( 2, $report['attachments_deleted'], 'Both redundant copies are deleted.' );
+	}
+}

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -196,4 +196,264 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 		$this->assertEquals( $canonical, get_post_thumbnail_id( $job ), 'The listing is re-pointed onto the canonical.' );
 		$this->assertSame( 2, $report['attachments_deleted'], 'Both redundant copies are deleted.' );
 	}
+
+	/**
+	 * An attachment that happens to share a logo's bytes but is referenced somewhere
+	 * the de-duplicator does not know how to re-point (here: the featured image of an
+	 * ordinary post) must never be deleted. Content-identical is not logo-identical,
+	 * and deleting it would silently strip that post's featured image.
+	 */
+	public function test_attachment_referenced_outside_listings_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo       = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$blog_image = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$blog_post = $this->factory->post->create( [ 'post_type' => 'post', 'post_author' => $author ] );
+		set_post_thumbnail( $blog_post, $blog_image );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $blog_image ), "An image used as another post type's featured image must survive." );
+		$this->assertEquals( $blog_image, get_post_thumbnail_id( $blog_post ), "The blog post's featured image must be untouched." );
+	}
+
+	/**
+	 * An attachment referenced inline in another post's content must not be deleted:
+	 * nothing re-points post_content, so deleting it 404s the image in that post.
+	 */
+	public function test_attachment_referenced_in_post_content_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo   = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$inline = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$this->factory->post->create(
+			[
+				'post_type'    => 'post',
+				'post_content' => '<img src="' . wp_get_attachment_url( $inline ) . '" class="wp-image-' . $inline . '" />',
+			]
+		);
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $inline ), 'An image referenced inline in post content must survive.' );
+	}
+
+	/**
+	 * Expired listings still reference their logo and must be re-pointed like any
+	 * other. WP_Query's 'any' excludes statuses registered exclude_from_search, so a
+	 * scan using it treats an expired listing's logo as an orphan, deletes it, and
+	 * leaves the listing pointing at a deleted attachment. Expired is the normal end
+	 * state of a listing, not an edge case.
+	 */
+	public function test_expired_listing_references_are_repointed_not_orphaned() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$duplicate = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+
+		$this->create_listing_with_logo( $author, $canonical );
+
+		$expired = $this->create_listing_with_logo( $author, $duplicate );
+		wp_update_post( [ 'ID' => $expired, 'post_status' => 'expired' ] );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertEquals( $canonical, get_post_thumbnail_id( $expired ), 'The expired listing must be re-pointed onto the canonical, not left dangling.' );
+	}
+
+	/**
+	 * Guest submissions all have post_author = 0, which is not an owner. Merging on
+	 * it collapses unrelated anonymous submitters' logos together — the inverse of
+	 * the ownership boundary the runtime dedup enforces by refusing guests outright.
+	 */
+	public function test_guest_owned_attachments_are_never_merged() {
+		$bytes = $this->png_bytes();
+
+		$guest_a = $this->create_logo_attachment( 0, $bytes, 'guest-a.png' );
+		$guest_b = $this->create_logo_attachment( 0, $bytes, 'guest-b.png' );
+		$this->create_listing_with_logo( 0, $guest_a );
+		$this->create_listing_with_logo( 0, $guest_b );
+
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $guest_a ), "One guest's logo must survive." );
+		$this->assertInstanceOf( WP_Post::class, get_post( $guest_b ), "Another guest's identical logo must survive — guests are not a shared owner." );
+		$this->assertSame( 0, $report['attachments_deleted'] );
+	}
+
+	/**
+	 * Two attachment rows can point at the same file on disk. Deleting one with
+	 * force_delete unlinks the shared file, leaving the canonical as a row whose
+	 * file no longer exists.
+	 */
+	public function test_deleting_a_duplicate_never_removes_a_file_the_canonical_still_uses() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'shared.png' );
+		$path      = get_attached_file( $canonical );
+
+		// A second row over the same file, as pre-dedup submission flows could produce.
+		$duplicate = (int) wp_insert_attachment(
+			[
+				'post_mime_type' => 'image/png',
+				'post_title'     => 'shared-copy',
+				'post_status'    => 'inherit',
+				'post_author'    => $author,
+			],
+			$path
+		);
+
+		$this->create_listing_with_logo( $author, $canonical );
+		$this->create_listing_with_logo( $author, $duplicate );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $canonical ), 'The canonical attachment survives.' );
+		$this->assertFileExists( $path, "The canonical's file must not be unlinked by deleting a row that shared its path." );
+	}
+
+	/**
+	 * The canonical is the oldest attachment, which is typically the auto-generated
+	 * upload with no alt text. Alt text an editor curated on a later copy is about to
+	 * be deleted, so carry it over rather than losing it.
+	 */
+	public function test_curated_alt_text_is_carried_over_to_the_canonical() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$curated   = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		update_post_meta( $curated, '_wp_attachment_image_alt', 'Acme Corporation logo' );
+
+		$this->create_listing_with_logo( $author, $canonical );
+		$this->create_listing_with_logo( $author, $curated );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertSame( 'Acme Corporation logo', get_post_meta( $canonical, '_wp_attachment_image_alt', true ), 'Curated alt text must be carried onto the canonical before the copy is deleted.' );
+	}
+
+	/**
+	 * The canonical is given the content hash the runtime dedup looks up, so future
+	 * identical uploads are de-duplicated against it instead of starting a new pile.
+	 */
+	public function test_canonical_is_backfilled_with_the_runtime_dedup_hash() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $canonical );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertSame( md5( $bytes ), get_post_meta( $canonical, Attachment_Deduplicator::HASH_META_KEY, true ), 'The canonical must carry the runtime dedup hash.' );
+	}
+
+	/**
+	 * Scoping to one owner means the owner of the *attachments*, not of the listings
+	 * referencing them. Since #3060 a listing authored by one user can carry a logo
+	 * owned by another, so scoping by listing author makes the owner's own duplicates
+	 * invisible and reports a confidently-wrong "nothing to do".
+	 */
+	public function test_user_scope_follows_attachment_owner_not_listing_author() {
+		$owner     = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$publisher = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes     = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $owner, $bytes, 'logo.png' );
+		$duplicate = $this->create_logo_attachment( $owner, $bytes, 'logo-1.png' );
+
+		// Both listings are authored by someone other than the attachments' owner.
+		$this->create_listing_with_logo( $publisher, $canonical );
+		$this->create_listing_with_logo( $publisher, $duplicate );
+
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false, 'user_id' => $owner ] );
+
+		$this->assertSame( 1, $report['attachments_deleted'], "The owner's duplicate must be found even though the listings belong to someone else." );
+		$this->assertNull( get_post( $duplicate ) );
+	}
+
+	/**
+	 * Work per duplicate must not scale as a fixed multiple of queries: this command
+	 * targets sites with tens of thousands of attachments, where a handful of queries
+	 * per duplicate is the difference between finishing and timing out. The budget is
+	 * deliberately loose — it exists to catch a return to per-duplicate scanning, not
+	 * to pin an exact number.
+	 */
+	public function test_query_count_does_not_scale_with_the_number_of_duplicates() {
+		global $wpdb;
+
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$this->create_listing_with_logo( $author, $canonical );
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$duplicate = $this->create_logo_attachment( $author, $bytes, "logo-{$i}.png" );
+			$this->create_listing_with_logo( $author, $duplicate );
+		}
+
+		$before = $wpdb->num_queries;
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => true ] );
+		$used   = $wpdb->num_queries - $before;
+
+		$this->assertSame( 10, $report['duplicates'], 'All ten duplicates are found. Report: ' . wp_json_encode( $report ) );
+		$this->assertLessThan( 15, $used, sprintf( 'A dry run over 10 duplicates used %d queries; reference scanning should be batched, not per-duplicate.', $used ) );
+	}
+
+	/**
+	 * A failed deletion is reported rather than counted as a success. Because
+	 * references are moved before anything is deleted, a failure leaves a redundant
+	 * attachment behind — never a listing pointing at a post that no longer exists.
+	 */
+	public function test_failed_deletion_is_reported_and_leaves_references_intact() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$duplicate = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+
+		$this->create_listing_with_logo( $author, $canonical );
+		$job = $this->create_listing_with_logo( $author, $duplicate );
+
+		$fail = static function () {
+			return false;
+		};
+		add_filter( 'pre_delete_attachment', $fail );
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+		remove_filter( 'pre_delete_attachment', $fail );
+
+		$this->assertSame( 0, $report['attachments_deleted'], 'A failed delete must not be counted as deleted.' );
+		$this->assertSame( [ $duplicate ], $report['delete_failures'], 'The failed attachment must be reported.' );
+		$this->assertEquals( $canonical, get_post_thumbnail_id( $job ), 'References were moved first, so the listing points at the canonical regardless.' );
+	}
+
+	/**
+	 * The `_company_logo` user default is a logo reference in its own right and must
+	 * be re-pointed before its attachment is deleted.
+	 */
+	public function test_company_logo_user_meta_is_repointed() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$duplicate = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+
+		$this->create_listing_with_logo( $author, $canonical );
+		update_user_meta( $author, '_company_logo', $duplicate );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertEquals( $canonical, (int) get_user_meta( $author, '_company_logo', true ), 'The user default must be re-pointed onto the canonical.' );
+		$this->assertNull( get_post( $duplicate ), 'The duplicate is deleted once its reference has moved.' );
+	}
 }

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -447,6 +447,48 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Batching exists so a library with tens of thousands of attachments does not
+	 * have to be held in memory at once. The result must not depend on where the
+	 * batch boundaries happen to fall, including protections and re-points for
+	 * candidates that land in different batches from each other.
+	 */
+	public function test_results_are_identical_across_batch_boundaries() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'batch.png' );
+		$this->create_listing_with_logo( $author, $canonical );
+
+		$duplicates = [];
+		for ( $i = 1; $i <= 7; $i++ ) {
+			$duplicates[] = $this->create_logo_attachment( $author, $bytes, "batch-{$i}.png" );
+		}
+		foreach ( $duplicates as $duplicate ) {
+			$this->create_listing_with_logo( $author, $duplicate );
+		}
+
+		// One protected candidate, deliberately mid-run rather than first or last.
+		$protected = $duplicates[4];
+		$blog_post = $this->factory->post->create( [ 'post_type' => 'post', 'post_author' => $author ] );
+		set_post_thumbnail( $blog_post, $protected );
+
+		// A batch size well below the number of candidates forces several batches.
+		$report = ( new Attachment_Deduplicator( 2 ) )->run( [ 'dry_run' => false ] );
+
+		$this->assertSame( 6, $report['attachments_deleted'], 'Every unprotected duplicate is deleted regardless of batching.' );
+		$this->assertSame( 1, $report['skipped_referenced'], 'The protected candidate is kept even though it sits mid-batch.' );
+		$this->assertInstanceOf( WP_Post::class, get_post( $protected ), 'The protected attachment survives.' );
+		$this->assertEquals( $protected, get_post_thumbnail_id( $blog_post ), "The blog post's featured image is untouched." );
+
+		foreach ( $duplicates as $duplicate ) {
+			if ( $duplicate === $protected ) {
+				continue;
+			}
+			$this->assertNull( get_post( $duplicate ), "Duplicate {$duplicate} is deleted." );
+		}
+	}
+
+	/**
 	 * The `_company_logo` user default is a logo reference in its own right and must
 	 * be re-pointed before its attachment is deleted.
 	 */

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -505,6 +505,341 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Plenty of plugins store attachment IDs inside a serialized array rather than as
+	 * a bare value — an ACF gallery or repeater field, for one. A sweep that compares
+	 * `meta_value` to the candidate ID never matches those, so the reference is
+	 * invisible and the image is deleted out from under it.
+	 */
+	public function test_attachment_referenced_from_a_serialized_meta_value_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo    = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$gallery = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$page = $this->factory->post->create( [ 'post_type' => 'page' ] );
+		update_post_meta( $page, '_gallery_images', [ 4242, $gallery ] );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $gallery ), 'An attachment referenced from inside a serialized meta value must survive.' );
+	}
+
+	/**
+	 * The other common shape is a comma-separated list of IDs (WooCommerce's
+	 * `_product_image_gallery`). MySQL coerces `"4242,53"` to 4242, so every ID after
+	 * the first looks unreferenced — protection that is silently partial is worse
+	 * than none, because the key looks covered.
+	 */
+	public function test_attachment_referenced_from_a_comma_separated_meta_value_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo    = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$gallery = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$page = $this->factory->post->create( [ 'post_type' => 'page' ] );
+		update_post_meta( $page, '_product_image_gallery', '4242,' . $gallery );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $gallery ), 'An attachment listed in a comma-separated meta value must survive.' );
+	}
+
+	/**
+	 * Listings created before 1.24.0 store `_company_logo` on the post as a URL rather
+	 * than an attachment ID, and still render from it. A URL never equals an ID, so
+	 * the sweep has to recognise the file it points at.
+	 */
+	public function test_attachment_referenced_by_url_in_legacy_company_logo_meta_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo   = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$legacy = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$listing = $this->factory->post->create( [ 'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING ] );
+		update_post_meta( $listing, '_company_logo', wp_get_attachment_url( $legacy ) );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $legacy ), 'A legacy listing renders its logo from a URL; that attachment must survive.' );
+	}
+
+	/**
+	 * Core's Site Identity logo lives in `theme_mods_<theme>` as a serialized array,
+	 * not in an option named after it. An admin who is also an employer can easily own
+	 * both the site logo and a content-identical company logo.
+	 */
+	public function test_attachment_used_as_the_customizer_site_logo_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo      = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$site_logo = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		set_theme_mod( 'custom_logo', $site_logo );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		remove_theme_mod( 'custom_logo' );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $site_logo ), "The Customizer's site logo must survive." );
+	}
+
+	/**
+	 * Content that prints a bare `<img>` from a custom field carries no `wp-image-N`
+	 * class and no block `{"id":N}` — only a URL, and often a resized one. Matching
+	 * the original filename alone misses it, and deleting the attachment takes the
+	 * resized file with it.
+	 */
+	public function test_attachment_referenced_by_a_resized_filename_in_content_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo   = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$inline = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$thumbnail_url = str_replace( 'logo-1.png', 'logo-1-150x150.png', wp_get_attachment_url( $inline ) );
+		$this->factory->post->create(
+			[
+				'post_type'    => 'post',
+				'post_content' => '<img src="' . $thumbnail_url . '" alt="" />',
+			]
+		);
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $inline ), 'An attachment referenced by a resized filename must survive.' );
+	}
+
+	/**
+	 * Block attributes nested inside another block are stored JSON-escaped, so the
+	 * `"id":N` marker appears as `\"id\":N`.
+	 */
+	public function test_attachment_referenced_by_an_escaped_block_id_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo   = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$inline = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		// Doubled: wp_insert_post() unslashes, so a single backslash would not survive
+		// into the stored content the way the block editor's own escaping does.
+		$this->factory->post->create(
+			[
+				'post_type'    => 'post',
+				'post_content' => '<!-- wp:group {"inner":"{\\\\"id\\\\":' . $inline . '}"} --><!-- /wp:group -->',
+			]
+		);
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $inline ), 'An attachment referenced by an escaped block id must survive.' );
+	}
+
+	/**
+	 * Moving references before deleting only protects the site if the move actually
+	 * landed. `update_post_meta()` returns false on a failed write, and core's
+	 * `wp_delete_attachment()` then deletes every `_thumbnail_id` row pointing at the
+	 * attachment — so an unchecked write turns a failed re-point into a listing that
+	 * silently loses its logo, reported as a success.
+	 */
+	public function test_a_duplicate_is_not_deleted_when_its_reference_could_not_be_repointed() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$duplicate = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+
+		$this->create_listing_with_logo( $author, $canonical );
+		$job = $this->create_listing_with_logo( $author, $duplicate );
+
+		// A write that reports failure without touching the row, as a DB error would.
+		$block = static function ( $check, $object_id, $meta_key ) {
+			return '_thumbnail_id' === $meta_key ? false : $check;
+		};
+		add_filter( 'update_post_metadata', $block, 10, 3 );
+		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+		remove_filter( 'update_post_metadata', $block, 10 );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $duplicate ), 'A duplicate whose reference could not be moved must not be deleted.' );
+		$this->assertEquals( $duplicate, get_post_thumbnail_id( $job ), 'The listing must still point at an attachment that exists.' );
+		$this->assertSame( 0, $report['attachments_deleted'] );
+	}
+
+	/**
+	 * The runtime dedup hashes the file as uploaded, before core replaces it with a
+	 * `-scaled` copy for images over the big-image threshold. Backfilling the hash of
+	 * whatever `get_attached_file()` returns therefore stores a value the runtime
+	 * lookup can never match — permanently, since the backfill skips attachments that
+	 * already have a hash.
+	 */
+	public function test_backfilled_hash_is_of_the_original_upload_not_the_scaled_copy() {
+		$author   = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$original = $this->png_bytes();
+		$scaled   = $this->png_bytes() . "\0scaled";
+
+		$canonical = $this->create_logo_attachment( $author, $scaled, 'big-scaled.png' );
+		$this->create_logo_attachment( $author, $scaled, 'big-scaled-1.png' );
+		$this->create_listing_with_logo( $author, $canonical );
+
+		// The pre-scale upload core keeps alongside the scaled file it now serves.
+		$upload_dir    = wp_upload_dir();
+		$original_path = trailingslashit( $upload_dir['path'] ) . 'big.png';
+		file_put_contents( $original_path, $original );
+		$this->created_files[] = $original_path;
+		wp_update_attachment_metadata( $canonical, [ 'original_image' => 'big.png' ] );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertSame( md5( $original ), get_post_meta( $canonical, Attachment_Deduplicator::HASH_META_KEY, true ), 'The backfilled hash must match what the runtime dedup computes for the original upload.' );
+	}
+
+	/**
+	 * One candidate's meta referencing another candidate is an unrecognised reference
+	 * like any other. Suppressing it by excluding the current batch makes the outcome
+	 * depend on which batch each ID landed in.
+	 */
+	public function test_a_candidate_referenced_from_another_candidates_meta_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo       = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$referrer   = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$referenced = $this->create_logo_attachment( $author, $bytes, 'logo-2.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		update_post_meta( $referrer, '_linked_image', $referenced );
+
+		// A batch size that puts both candidates in the same batch; the outcome must
+		// not differ from one that separates them.
+		( new Attachment_Deduplicator( 50 ) )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $referenced ), "An attachment referenced from another attachment's meta must survive regardless of batching." );
+	}
+
+	/**
+	 * A media-ish meta key on a post this class does not re-point is the mechanism the
+	 * whole veto rests on, and the case add-ons actually produce (`_candidate_photo`).
+	 */
+	public function test_attachment_referenced_by_a_media_shaped_meta_key_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo  = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$photo = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$resume = $this->factory->post->create( [ 'post_type' => 'post' ] );
+		update_post_meta( $resume, '_candidate_photo', $photo );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $photo ), 'An attachment referenced through a media-shaped meta key must survive.' );
+	}
+
+	/**
+	 * Term meta is one of the surfaces the sweep claims to cover.
+	 */
+	public function test_attachment_referenced_from_term_meta_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo  = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$badge = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		$term = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
+		update_term_meta( $term, 'category_image', $badge );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $badge ), 'An attachment referenced from term meta must survive.' );
+	}
+
+	/**
+	 * `site_logo` holds a bare attachment ID and nothing re-points it.
+	 */
+	public function test_attachment_used_as_the_site_logo_is_never_deleted() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$logo      = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$site_logo = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $logo );
+
+		update_option( 'site_logo', $site_logo );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		delete_option( 'site_logo' );
+
+		$this->assertInstanceOf( WP_Post::class, get_post( $site_logo ), 'The site logo must survive.' );
+	}
+
+	/**
+	 * The dry run's plan is the only record of what --live will collapse into what, so
+	 * it has to be the actual mapping rather than a count.
+	 */
+	public function test_dry_run_reports_the_canonical_to_duplicates_mapping() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$first     = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$second    = $this->create_logo_attachment( $author, $bytes, 'logo-2.png' );
+		$this->create_listing_with_logo( $author, $canonical );
+
+		$report = ( new Attachment_Deduplicator() )->run();
+
+		$this->assertSame(
+			[
+				[
+					'canonical'  => $canonical,
+					'duplicates' => [ $first, $second ],
+				],
+			],
+			$report['plan'],
+			'The dry run must report which attachments collapse into which canonical.'
+		);
+	}
+
+	/**
+	 * A caption and description an editor wrote on a later copy are lost with it
+	 * unless they are carried over, exactly like alt text.
+	 */
+	public function test_curated_caption_and_description_are_carried_over_to_the_canonical() {
+		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$curated   = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		wp_update_post(
+			[
+				'ID'           => $curated,
+				'post_excerpt' => 'Acme Corporation, est. 1984',
+				'post_content' => 'The full-colour logo used on job listings.',
+			]
+		);
+
+		$this->create_listing_with_logo( $author, $canonical );
+		$this->create_listing_with_logo( $author, $curated );
+
+		( new Attachment_Deduplicator() )->run( [ 'dry_run' => false ] );
+
+		$survivor = get_post( $canonical );
+		$this->assertSame( 'Acme Corporation, est. 1984', $survivor->post_excerpt, 'A curated caption must be carried onto the canonical.' );
+		$this->assertSame( 'The full-colour logo used on job listings.', $survivor->post_content, 'A curated description must be carried onto the canonical.' );
+	}
+
+	/**
 	 * The `_company_logo` user default is a logo reference in its own right and must
 	 * be re-pointed before its attachment is deleted.
 	 */

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -392,22 +392,31 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 	public function test_query_count_does_not_scale_with_the_number_of_duplicates() {
 		global $wpdb;
 
-		$author = $this->factory->user->create( [ 'role' => 'employer' ] );
-		$bytes  = $this->png_bytes();
+		$bytes = $this->png_bytes();
 
-		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
-		$this->create_listing_with_logo( $author, $canonical );
-		for ( $i = 1; $i <= 10; $i++ ) {
-			$duplicate = $this->create_logo_attachment( $author, $bytes, "logo-{$i}.png" );
-			$this->create_listing_with_logo( $author, $duplicate );
+		// Several owners, each with their own duplicate pile and a `_company_logo`
+		// default: the cost must not scale with owners either, which a single-owner
+		// fixture would not catch.
+		for ( $owner = 0; $owner < 3; $owner++ ) {
+			$author = $this->factory->user->create( [ 'role' => 'employer' ] );
+			$bytes  = $this->png_bytes() . str_repeat( "\0", $owner + 1 );
+
+			$canonical = $this->create_logo_attachment( $author, $bytes, "o{$owner}-logo.png" );
+			$this->create_listing_with_logo( $author, $canonical );
+			update_user_meta( $author, '_company_logo', $canonical );
+
+			for ( $i = 1; $i <= 10; $i++ ) {
+				$duplicate = $this->create_logo_attachment( $author, $bytes, "o{$owner}-logo-{$i}.png" );
+				$this->create_listing_with_logo( $author, $duplicate );
+			}
 		}
 
 		$before = $wpdb->num_queries;
 		$report = ( new Attachment_Deduplicator() )->run( [ 'dry_run' => true ] );
 		$used   = $wpdb->num_queries - $before;
 
-		$this->assertSame( 10, $report['duplicates'], 'All ten duplicates are found. Report: ' . wp_json_encode( $report ) );
-		$this->assertLessThan( 15, $used, sprintf( 'A dry run over 10 duplicates used %d queries; reference scanning should be batched, not per-duplicate.', $used ) );
+		$this->assertSame( 30, $report['duplicates'], 'All duplicates across all owners are found. Report: ' . wp_json_encode( $report ) );
+		$this->assertLessThan( 15, $used, sprintf( 'A dry run over 30 duplicates across 3 owners used %d queries; scanning should be batched, not per-duplicate or per-owner.', $used ) );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -467,18 +467,34 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 			$this->create_listing_with_logo( $author, $duplicate );
 		}
 
-		// One protected candidate, deliberately mid-run rather than first or last.
+		// One protected candidate, deliberately mid-run rather than first or last, and
+		// protected via inline content — the same batch size drives the content scan,
+		// so the protecting post must be found even when it lands on a later page.
 		$protected = $duplicates[4];
-		$blog_post = $this->factory->post->create( [ 'post_type' => 'post', 'post_author' => $author ] );
-		set_post_thumbnail( $blog_post, $protected );
+
+		// Filler posts carrying an image marker so they are scanned, pushing the real
+		// reference past the first content-scan page.
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->factory->post->create(
+				[
+					'post_type'    => 'post',
+					'post_content' => '<img src="https://example.test/wp-content/uploads/filler-' . $i . '.png" />',
+				]
+			);
+		}
+		$this->factory->post->create(
+			[
+				'post_type'    => 'post',
+				'post_content' => '<img src="' . wp_get_attachment_url( $protected ) . '" class="wp-image-' . $protected . '" />',
+			]
+		);
 
 		// A batch size well below the number of candidates forces several batches.
 		$report = ( new Attachment_Deduplicator( 2 ) )->run( [ 'dry_run' => false ] );
 
 		$this->assertSame( 6, $report['attachments_deleted'], 'Every unprotected duplicate is deleted regardless of batching.' );
 		$this->assertSame( 1, $report['skipped_referenced'], 'The protected candidate is kept even though it sits mid-batch.' );
-		$this->assertInstanceOf( WP_Post::class, get_post( $protected ), 'The protected attachment survives.' );
-		$this->assertEquals( $protected, get_post_thumbnail_id( $blog_post ), "The blog post's featured image is untouched." );
+		$this->assertInstanceOf( WP_Post::class, get_post( $protected ), 'The protected attachment survives, found by a content scan on a later page.' );
 
 		foreach ( $duplicates as $duplicate ) {
 			if ( $duplicate === $protected ) {

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -286,6 +286,71 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 		$this->assertInstanceOf( WP_Post::class, get_post( $guest_a ), "One guest's logo must survive." );
 		$this->assertInstanceOf( WP_Post::class, get_post( $guest_b ), "Another guest's identical logo must survive — guests are not a shared owner." );
 		$this->assertSame( 0, $report['attachments_deleted'] );
+		$this->assertSame( 2, $report['skipped_guest'], 'Both guest uploads are counted as unexamined, so the residue outside the run is measured, not silent.' );
+		$this->assertSame( 0, $report['skipped_unmatched'], 'Guest uploads are counted once, as guest-owned — not again as unmatched.' );
+	}
+
+	/**
+	 * The report counts the image attachments the run never examined — guest
+	 * uploads, and images matching no currently-referenced logo — separately from
+	 * the duplicates it found. Those counts are what tells an operator whether the
+	 * library's remaining bloat is inside or outside this command's reach.
+	 */
+	public function test_report_counts_unexamined_images_by_reason() {
+		$author   = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$stranger = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes    = $this->png_bytes();
+
+		// A referenced logo with one duplicate: both match, one is redundant.
+		$canonical = $this->create_logo_attachment( $author, $bytes, 'logo.png' );
+		$duplicate = $this->create_logo_attachment( $author, $bytes, 'logo-1.png' );
+		$this->create_listing_with_logo( $author, $canonical );
+		$this->create_listing_with_logo( $author, $duplicate );
+
+		// Unanchored: different bytes from any referenced logo, so nothing marks
+		// them as logo duplicates — one owned by the logo owner, one by a user
+		// with no listings at all.
+		$unrelated = $this->create_logo_attachment( $author, $bytes . "\0", 'photo.png' );
+		$abandoned = $this->create_logo_attachment( $stranger, $bytes . "\0\0", 'old-logo.png' );
+
+		// Guest-owned: counted under its own reason, not as unmatched.
+		$guest = $this->create_logo_attachment( 0, $bytes, 'guest.png' );
+
+		$report = ( new Attachment_Deduplicator() )->run();
+
+		$this->assertSame( 1, $report['duplicates'], 'The matched duplicate is planned for collapse, not counted as skipped. Report: ' . wp_json_encode( $report ) );
+		$this->assertSame( 1, $report['skipped_guest'] );
+		$this->assertSame( 2, $report['skipped_unmatched'], 'Both unanchored images are counted, whether their owner has listings or not.' );
+		$this->assertInstanceOf( WP_Post::class, get_post( $unrelated ), 'Counting an image as unexamined must not touch it.' );
+		$this->assertInstanceOf( WP_Post::class, get_post( $abandoned ) );
+		$this->assertInstanceOf( WP_Post::class, get_post( $guest ) );
+	}
+
+	/**
+	 * With user_id set, the unexamined counts describe that owner's library, not
+	 * the whole site — a per-owner run reports a per-owner residue.
+	 */
+	public function test_unexamined_counts_are_scoped_to_the_requested_owner() {
+		$user_a = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$user_b = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes  = $this->png_bytes();
+
+		$a1 = $this->create_logo_attachment( $user_a, $bytes, 'a1.png' );
+		$a2 = $this->create_logo_attachment( $user_a, $bytes, 'a2.png' );
+		$this->create_listing_with_logo( $user_a, $a1 );
+		$this->create_listing_with_logo( $user_a, $a2 );
+		$this->create_logo_attachment( $user_a, $bytes . "\0", 'a-photo.png' );
+
+		// Outside the requested scope entirely: another owner's unanchored image
+		// and a guest upload.
+		$this->create_logo_attachment( $user_b, $bytes . "\0\0", 'b-photo.png' );
+		$this->create_logo_attachment( 0, $bytes, 'guest.png' );
+
+		$report = ( new Attachment_Deduplicator() )->run( [ 'user_id' => $user_a ] );
+
+		$this->assertSame( 1, $report['duplicates'] );
+		$this->assertSame( 1, $report['skipped_unmatched'], "Only owner A's unanchored image is counted. Report: " . wp_json_encode( $report ) );
+		$this->assertSame( 0, $report['skipped_guest'], 'Guest uploads are outside a per-owner scope, not part of its residue.' );
 	}
 
 	/**
@@ -416,7 +481,9 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 		$used   = $wpdb->num_queries - $before;
 
 		$this->assertSame( 30, $report['duplicates'], 'All duplicates across all owners are found. Report: ' . wp_json_encode( $report ) );
-		$this->assertLessThan( 15, $used, sprintf( 'A dry run over 30 duplicates across 3 owners used %d queries; scanning should be batched, not per-duplicate or per-owner.', $used ) );
+		// 18 covers the batched scans plus fixed overhead (the two unexamined-image
+		// COUNTs among it); per-duplicate scanning would use several times this.
+		$this->assertLessThan( 18, $used, sprintf( 'A dry run over 30 duplicates across 3 owners used %d queries; scanning should be batched, not per-duplicate or per-owner.', $used ) );
 	}
 
 	/**


### PR DESCRIPTION
## What

Retroactive companion to #3064 (runtime logo-upload dedup). Sites that ran for years before that fix accumulated large numbers of duplicate company-logo attachments — one new attachment per re-upload of the same logo. This adds a WP-CLI command to collapse the existing duplicates.

Context: forum report [Core bug: massive logo duplication / bloat server space](https://wordpress.org/support/topic/core-bug-massive-logo-duplication-bloat-server-space/) (~20k duplicate images; reporter confirmed they span 2018→present, i.e. long-tail accumulation, not a recent regression). #3064 stops new growth; this cleans up what's already there.

## Command

```
wp jm dedupe-logos                      # dry run (default): report only
wp jm dedupe-logos --report=plan.csv    # dry run, keeping the plan for review
wp jm dedupe-logos --live               # apply (prompts; --yes to skip)
wp jm dedupe-logos --owner=42 --live    # limit to one attachment owner
```

Note `--owner`, not `--user`: `--user` is a reserved WP-CLI global parameter that sets the acting user and never reaches the command.

**Run `--live` with the site in maintenance mode.** See Safety below for why.

## How it works

`WP_Job_Manager\Attachment_Deduplicator`:

1. Derives "logo" content signatures (`author:md5`) from attachments **currently referenced** as a logo — listing featured images (`_thumbnail_id`, across all listing statuses) and the `_company_logo` user default.
2. Groups **every image attachment those owners hold** by signature, keeping only signatures that match a referenced logo. This **folds in orphaned duplicate copies** that no longer reference anything (the bulk of the bloat).
3. Filters the group through `find_protected_ids()` — see Safety below.
4. Per group: keeps the **oldest** attachment as canonical, **re-points every reference to it, verifies the re-point landed**, and only then deletes the redundant copies.
5. Carries curated alt text / caption / description onto the canonical (as the oldest copy, it is usually the bare auto-generated upload).
6. Backfills `_wpjm_attachment_hash` on the canonical so the #3064 runtime dedup keeps de-duplicating future uploads against it.

### Safety

Identical content is **not** proof that an attachment is a logo — an owner may have uploaded the same image again for something this command knows nothing about. The candidate set is therefore treated as candidates only.

**Nothing is deleted while a reference this command cannot re-point still points at it.** `find_protected_ids()` makes one streamed pass over the meta rows whose *key* looks like it could hold an attachment reference, and reads each value in PHP rather than comparing it to the candidate IDs in SQL. That distinction is the whole check: `meta_value IN ( 12,34 )` is an exact match against a LONGTEXT column, so MySQL coerces a serialized ACF gallery to 0 (matching nothing) and a comma-separated `_product_image_gallery` to its first ID only — while the key looks covered. Reading the value instead recognises:

- a bare ID;
- a comma-separated list of them;
- an ID nested anywhere inside a serialized structure (an ACF gallery or repeater, `theme_mods_<theme>`'s `custom_logo`, a media widget);
- a URL or path, matched by filename — which is how the pre-1.24.0 `_company_logo` post meta, and content that prints a bare `<img>` from a custom field, are seen at all.

Filenames are matched by *stem*, so a reference to `logo-150x150.png` protects `logo.png`. Post content is scanned the same way, for `wp-image-N`, block `{"id":N}` in all three shapes it is stored in (plain, JSON-escaped, and kses-rewritten to `"`), and plain URLs.

**References are moved before anything is deleted, and the move is verified.** `update_post_meta()` reports failure by return value, and core's `wp_delete_attachment()` deletes every `_thumbnail_id` row pointing at the attachment — so an unchecked write would turn a failed re-point into a listing that silently lost its logo, counted as a success. The run re-queries for surviving references after re-pointing and drops anything still referenced from the delete set, reporting it rather than deleting it.

Also:

- **Dry-run by default**, and `--live` confirms before touching anything. The dry run mutates nothing at all — the hash backfill now happens after the plan is complete, not during it.
- **`--report=<path>`** writes the full mapping to CSV before any mutation. On a 20k-attachment library terminal scrollback is not a record of an irreversible operation.
- **Per-owner only** (`author:hash`): identical logos belonging to different users are never merged, preserving the ownership boundary from #2995/#3060. **Guest uploads (`post_author` 0) are skipped entirely** — 0 is not an owner, as the runtime dedup already recognises.
- **Shared files are protected.** Two attachment rows can point at one `_wp_attached_file`; core's cleanup does no reference counting, so file deletion is vetoed when the path is still in use.
- **`force_delete` is off**, so sites with `MEDIA_TRASH` keep an undo.
- Two filters — `job_manager_dedupe_reference_meta_key_patterns` and `job_manager_dedupe_protected_attachment_ids` — so a site storing references under an unusual key can protect itself without patching the plugin. Both can only ever protect more; neither can widen the deletion set.

**What the sweep does not cover**, and why `--live` wants maintenance mode: protection is worked out once, before any deletion, and on the libraries this exists for that scan takes a while. A reference created after the scan and before the matching delete is not protected by it. The two handled keys are re-checked immediately before deleting; a new gallery entry, an edited page, or a logo set in the Customizer mid-run is not. Nothing here is multisite-aware either — run it per site with `wp --url=`.

### Performance

Sized for the libraries this exists for. Every pass **streams a page at a time** and pages by keyset (`WHERE id > ?`) rather than `OFFSET`, which over an unindexed scan re-reads and discards every earlier row on each page. Each page is primed, reduced, and released before the next is fetched; meta lookups, re-points, deletions and the owner list are chunked, and the object cache is released between batches.

The reference sweep is one pass over the meta rows whose key matches, intersected against the candidate set in PHP. `meta_value` has no index and the key patterns have a leading wildcard, so each of those is a full table scan — doing it once per batch of candidates, as the first version did, is what stops the command finishing on a large site.

Measured, not extrapolated. Fixture: N owners x 100 identical-bytes attachments each (distinct files on disk), a listing on every third one, and a `_company_logo` default per owner. Dry run, seeded and measured in separate processes so the seed's allocations do not set the peak. `wp-cli` plus WordPress is a 55.31 MB floor before the command starts.

| attachments | duplicates found | peak memory | over baseline | queries | queries before |
| ----------- | ---------------- | ----------- | ------------- | ------- | -------------- |
| 2,000       | 1,980            | 57.31 MB    | 2.00 MB       | 32      | 43             |
| 4,000       | 3,960            | 59.31 MB    | 4.00 MB       | 54      | 78             |
| 20,000      | 19,800           | 75.31 MB    | 20.00 MB      | 236     | 367            |

Memory over baseline grows at ~1 MB per 1,000 attachments, linearly. That residual is `$signature_cache` — one entry per image examined, held for the whole run — plus the duplicate ID list, and it is the thing to watch on a very large library rather than the content scan I had originally worried about. At 20,000 the whole run is 20 MB over an idle `wp` process, so the earlier "would not finish" concern is settled.

Query count scales with the number of *pages*, not with the number of duplicates: 236 queries for 19,800 duplicates. Against the previous implementation on the same fixture it is 36% fewer, which is the four-scans-per-batch reference sweep collapsing into one pass.

Two caveats on these numbers. Elapsed time is not meaningful here — the fixture is a 1x1 PNG, so `md5_file()` costs nothing and the tables are small enough that the full scans are cheap in a way they will not be on a real 20k-image library. And peak memory understates real attachment meta for the same reason.

One incidental finding from running the old code against the same fixture: it reported 1,979 duplicates and 1 "kept, referenced elsewhere", where the current code finds 1,980. The extra protection was spurious — `_wp_attached_file` matches the `%file%` key pattern, and MySQL coerced the path `2026/08/...` to the integer 2026, so attachment 2026 protected itself forever. That is the numeric-coercion failure mode the sweep rewrite removes, showing up on its own in a synthetic fixture.

## Scope / follow-ups

- **Logos only** (featured images + `_company_logo`), as agreed — the reported surface and lowest risk. Broadening to all file-field attachments is a possible follow-up.
- Depends on the `_wpjm_attachment_hash` meta key introduced in #3064.
- Multisite support, and re-checking protection per chunk rather than once per run, are both deliberately left out. The docblock says so.

## Testing

`WP_Test_Attachment_Deduplicator` (31 tests), including:

- merge + re-point featured images and the `_company_logo` user default;
- collapse orphaned duplicate copies (the reporter's real shape);
- an image is never deleted when it is referenced by: another post type's featured image, inline content, a serialized meta value, a comma-separated meta value, a legacy `_company_logo` URL, a resized filename in content, an escaped block id, a media-shaped meta key, term meta, `site_logo`, or the Customizer's `custom_logo`;
- a duplicate whose re-point could not be written is kept, not deleted;
- **expired** listings are re-pointed, not treated as orphans;
- identical logos of different users are not merged; guest-owned attachments are not merged;
- deleting a duplicate never removes a file the canonical still uses;
- curated alt text, caption and description survive; the canonical is backfilled with the runtime dedup hash, taken from the original upload rather than the `-scaled` copy;
- owner scoping follows attachment ownership, not listing authorship;
- a failed deletion is reported rather than counted as a success;
- the dry run reports the actual canonical → duplicates mapping, and mutates nothing;
- query count does not scale with the number of duplicates or owners;
- results are identical across batch boundaries, including a protected candidate landing mid-batch.

Also verified end-to-end via the actual CLI against a real database: seeded three identical logos on a published listing and an expired one, ran `--live`, confirmed both duplicates deleted, **both** listings re-pointed to the canonical, hash backfilled, and the canonical's file intact on disk. Full suite green; `phpcs` and `psalm` clean.

## Review history

The first implementation had several data-loss paths (non-logo references deleted unrepaired, expired listings orphaned, guests merged, shared files unlinked) and a scan that would not have finished on a 20k-attachment site. Those were fixed in 6a2ffdd..8198112.

A second review found two more, both fixed in 4318203:

1. The protection sweep matched `meta_value` exactly, so serialized and comma-separated references were invisible to it — the ACF-gallery and WooCommerce shapes, plus the Customizer logo and legacy `_company_logo` URLs. Rewritten as described in Safety above.
2. `repoint_all()` never checked whether its writes succeeded, so a failed re-point became a silently broken listing reported as a success. Now verified by re-query before deleting.

That review also flagged the postmeta sweep (four full table scans per batch) and `OFFSET` pagination as the real scaling problems, ahead of the content scan I had been worrying about. Both are fixed.





<!-- wpjm:plugin-zip -->
----

| Plugin build for c1d87f1621763e927f9626a928ab8577f916c726 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/09/wp-job-manager-zip-3065-c1d87f16.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/09/3065-c1d87f16)             |

<!-- /wpjm:plugin-zip -->







