### PR TITLE
feat: Tools → Logo Cleanup admin page (batched logo de-duplication)

### DIFF
--- a/includes/class-attachment-deduplicator.php
+++ b/includes/class-attachment-deduplicator.php
@@ -576,6 +576,33 @@ class Attachment_Deduplicator {
 	}
 
 	/**
+	 * Lists the owner IDs that have at least one referenced logo, sorted, so a
+	 * batched caller (e.g. the admin tools page) can de-duplicate one owner at a
+	 * time via run( [ 'user_id' => ... ] ).
+	 *
+	 * @return int[] Sorted owner user IDs.
+	 */
+	public function get_logo_owner_ids() {
+		$owner_ids = [];
+
+		$this->each_referenced_logo_page(
+			function ( array $page ) use ( &$owner_ids ) {
+				foreach ( $page as $attachment_id ) {
+					$author = (int) get_post_field( 'post_author', $attachment_id );
+					if ( $author ) {
+						$owner_ids[ $author ] = true;
+					}
+				}
+			}
+		);
+
+		$owner_ids = array_keys( $owner_ids );
+		sort( $owner_ids );
+
+		return $owner_ids;
+	}
+
+	/**
 	 * Groups logo attachments by owner and content, returning one entry per set
 	 * of duplicates with the oldest (lowest ID) chosen as the canonical.
 	 *

--- a/includes/class-logo-cleanup-admin.php
+++ b/includes/class-logo-cleanup-admin.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Tools → Logo Cleanup admin page: a batched UI over Attachment_Deduplicator for
+ * admins who cannot run WP-CLI.
+ *
+ * @package wp-job-manager
+ */
+
+namespace WP_Job_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers a Tools → Logo Cleanup page that scans for and removes duplicate
+ * company-logo attachments in batches over AJAX.
+ *
+ * @internal
+ */
+class Logo_Cleanup_Admin {
+
+	const PAGE_SLUG   = 'wpjm-logo-cleanup';
+	const AJAX_ACTION = 'wpjm_dedupe_logos';
+	const NONCE       = 'wpjm_logo_cleanup';
+
+	/**
+	 * Owners processed per AJAX batch.
+	 */
+	const OWNERS_PER_BATCH = 10;
+
+	/**
+	 * Capability required to run the tool.
+	 */
+	const CAPABILITY = 'manage_options';
+
+	/**
+	 * Hooks the admin page and its AJAX handler.
+	 */
+	public static function init() {
+		add_action( 'admin_menu', [ self::class, 'register_page' ] );
+		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ self::class, 'handle_ajax' ] );
+	}
+
+	/**
+	 * Registers the page under the core Tools menu.
+	 */
+	public static function register_page() {
+		add_management_page(
+			__( 'Logo Cleanup', 'wp-job-manager' ),
+			__( 'Logo Cleanup', 'wp-job-manager' ),
+			self::CAPABILITY,
+			self::PAGE_SLUG,
+			[ self::class, 'render_page' ]
+		);
+	}
+
+	/**
+	 * Renders the tool page and enqueues its inline script.
+	 */
+	public static function render_page() {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'wp-job-manager' ) );
+		}
+
+		wp_register_script( 'wpjm-logo-cleanup', false, [ 'jquery' ], JOB_MANAGER_VERSION, true );
+		wp_enqueue_script( 'wpjm-logo-cleanup' );
+		wp_localize_script(
+			'wpjm-logo-cleanup',
+			'wpjmLogoCleanup',
+			[
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( self::NONCE ),
+				'action'  => self::AJAX_ACTION,
+				'i18n'    => [
+					'scanning'   => __( 'Scanning…', 'wp-job-manager' ),
+					'removing'   => __( 'Removing duplicates…', 'wp-job-manager' ),
+					'scanDone'   => __( 'Scan complete.', 'wp-job-manager' ),
+					'doneClean'  => __( 'Cleanup complete.', 'wp-job-manager' ),
+					'error'      => __( 'Something went wrong. Please try again.', 'wp-job-manager' ),
+					// translators: %d is a number of duplicate attachments.
+					'foundFmt'   => __( 'Found %d duplicate logo attachment(s) that can be safely removed.', 'wp-job-manager' ),
+					// translators: %d is a number of deleted attachments.
+					'removedFmt' => __( 'Removed %d duplicate logo attachment(s).', 'wp-job-manager' ),
+					'confirm'    => __( 'This permanently deletes the duplicate attachments after re-pointing every listing to the copy that is kept. Continue?', 'wp-job-manager' ),
+				],
+			]
+		);
+		wp_add_inline_script( 'wpjm-logo-cleanup', self::inline_script() );
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Logo Cleanup', 'wp-job-manager' ); ?></h1>
+			<p>
+				<?php esc_html_e( 'Company logos uploaded through the job submission form can accumulate duplicate copies in the Media Library. This tool finds identical logos owned by the same user and collapses them to a single attachment, re-pointing every listing before deleting the redundant copies.', 'wp-job-manager' ); ?>
+			</p>
+			<p>
+				<button type="button" class="button button-secondary" id="wpjm-logo-scan"><?php esc_html_e( 'Scan for duplicates', 'wp-job-manager' ); ?></button>
+				<button type="button" class="button button-primary" id="wpjm-logo-remove" disabled><?php esc_html_e( 'Remove duplicates', 'wp-job-manager' ); ?></button>
+			</p>
+			<p>
+				<progress id="wpjm-logo-progress" value="0" max="100" style="width:320px;display:none;"></progress>
+			</p>
+			<p id="wpjm-logo-status" role="status" aria-live="polite"></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Processes one batch of owners and returns progress as JSON.
+	 */
+	public static function handle_ajax() {
+		check_ajax_referer( self::NONCE, 'nonce' );
+
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_send_json_error( [ 'message' => __( 'You do not have permission to run this tool.', 'wp-job-manager' ) ], 403 );
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Verified via check_ajax_referer above.
+		$offset = isset( $_POST['offset'] ) ? absint( $_POST['offset'] ) : 0;
+		$live   = ! empty( $_POST['live'] );
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$deduplicator = new Attachment_Deduplicator();
+		$owner_ids    = $deduplicator->get_logo_owner_ids();
+		$total        = count( $owner_ids );
+		$batch        = array_slice( $owner_ids, $offset, self::OWNERS_PER_BATCH );
+
+		$tally = [
+			'groups'     => 0,
+			'duplicates' => 0,
+			'repointed'  => 0,
+			'deleted'    => 0,
+		];
+		foreach ( $batch as $owner_id ) {
+			$report               = $deduplicator->run(
+				[
+					'dry_run' => ! $live,
+					'user_id' => (int) $owner_id,
+				]
+			);
+			$tally['groups']     += $report['groups'];
+			$tally['duplicates'] += $report['duplicates'];
+			$tally['repointed']  += $report['references_repointed'];
+			$tally['deleted']    += $report['attachments_deleted'];
+		}
+
+		$processed = min( $offset + self::OWNERS_PER_BATCH, $total );
+
+		wp_send_json_success(
+			array_merge(
+				$tally,
+				[
+					'processed' => $processed,
+					'total'     => $total,
+					'done'      => $processed >= $total,
+				]
+			)
+		);
+	}
+
+	/**
+	 * The inline batching script.
+	 *
+	 * @return string JavaScript.
+	 */
+	private static function inline_script() {
+		return <<<'JS'
+( function ( $ ) {
+	var cfg = window.wpjmLogoCleanup || {};
+	var $scan = $( '#wpjm-logo-scan' );
+	var $remove = $( '#wpjm-logo-remove' );
+	var $progress = $( '#wpjm-logo-progress' );
+	var $status = $( '#wpjm-logo-status' );
+
+	function run( live, onDone ) {
+		var totals = { groups: 0, duplicates: 0, repointed: 0, deleted: 0 };
+		$scan.prop( 'disabled', true );
+		$remove.prop( 'disabled', true );
+		$progress.show().attr( 'value', 0 );
+		$status.text( live ? cfg.i18n.removing : cfg.i18n.scanning );
+
+		function batch( offset ) {
+			$.post( cfg.ajaxUrl, {
+				action: cfg.action,
+				nonce: cfg.nonce,
+				offset: offset,
+				live: live ? 1 : 0
+			} ).done( function ( res ) {
+				if ( ! res || ! res.success ) {
+					$status.text( cfg.i18n.error );
+					$scan.prop( 'disabled', false );
+					return;
+				}
+				var d = res.data;
+				totals.groups += d.groups;
+				totals.duplicates += d.duplicates;
+				totals.repointed += d.repointed;
+				totals.deleted += d.deleted;
+				$progress.attr( 'value', d.total ? Math.round( ( d.processed / d.total ) * 100 ) : 100 );
+				if ( d.done ) {
+					onDone( totals );
+				} else {
+					batch( d.processed );
+				}
+			} ).fail( function () {
+				$status.text( cfg.i18n.error );
+				$scan.prop( 'disabled', false );
+			} );
+		}
+		batch( 0 );
+	}
+
+	$scan.on( 'click', function () {
+		run( false, function ( totals ) {
+			$status.text( cfg.i18n.foundFmt.replace( '%d', totals.duplicates ) );
+			$scan.prop( 'disabled', false );
+			$remove.prop( 'disabled', totals.duplicates === 0 );
+		} );
+	} );
+
+	$remove.on( 'click', function () {
+		if ( ! window.confirm( cfg.i18n.confirm ) ) {
+			return;
+		}
+		run( true, function ( totals ) {
+			$status.text( cfg.i18n.removedFmt.replace( '%d', totals.deleted ) );
+			$scan.prop( 'disabled', false );
+			$remove.prop( 'disabled', true );
+		} );
+	} );
+}( jQuery ) );
+JS;
+	}
+}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -100,6 +100,7 @@ class WP_Job_Manager {
 
 		if ( is_admin() ) {
 			include_once JOB_MANAGER_PLUGIN_DIR . '/includes/admin/class-wp-job-manager-admin.php';
+			WP_Job_Manager\Logo_Cleanup_Admin::init();
 		}
 
 		\WP_Job_Manager\UI\UI::instance();

--- a/tests/php/tests/includes/test_class.attachment-deduplicator.php
+++ b/tests/php/tests/includes/test_class.attachment-deduplicator.php
@@ -925,4 +925,32 @@ class WP_Test_Attachment_Deduplicator extends WPJM_BaseTest {
 		$this->assertEquals( $canonical, (int) get_user_meta( $author, '_company_logo', true ), 'The user default must be re-pointed onto the canonical.' );
 		$this->assertNull( get_post( $duplicate ), 'The duplicate is deleted once its reference has moved.' );
 	}
+
+	/**
+	 * get_logo_owner_ids() lists the owners that have at least one referenced logo,
+	 * sorted, so the admin page can process de-duplication one owner-batch at a time.
+	 * Owners with no logo are excluded.
+	 */
+	public function test_get_logo_owner_ids_lists_owners_with_logos_sorted() {
+		$user_a   = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$user_b   = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$user_none = $this->factory->user->create( [ 'role' => 'employer' ] );
+		$bytes    = $this->png_bytes();
+
+		$this->create_listing_with_logo( $user_a, $this->create_logo_attachment( $user_a, $bytes, 'a.png' ) );
+		$this->create_listing_with_logo( $user_b, $this->create_logo_attachment( $user_b, $bytes, 'b.png' ) );
+		// user_none owns a listing but no logo.
+		$this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => $user_none,
+			]
+		);
+
+		$owner_ids = ( new Attachment_Deduplicator() )->get_logo_owner_ids();
+
+		$expected = [ $user_a, $user_b ];
+		sort( $expected );
+		$this->assertSame( $expected, $owner_ids, 'Only owners with a referenced logo are listed, sorted.' );
+	}
 }


### PR DESCRIPTION
## What

A **Tools → Logo Cleanup** admin page: a batched, no-CLI UI over the `Attachment_Deduplicator` core from #3065, for the many admins who can't run WP-CLI.

Follows the forum report ([massive logo duplication](https://wordpress.org/support/topic/core-bug-massive-logo-duplication-bloat-server-space/)). #3064 stops new duplicates; #3065 adds `wp jm dedupe-logos`; this makes that cleanup reachable from wp-admin.

> **Stacked on #3065.** Base is `add/dedupe-logos-cli`; retarget to `trunk` once #3065 merges. Depends on `Attachment_Deduplicator`.

## The page

Under **Tools → Logo Cleanup** (`manage_options`):
- **Scan for duplicates** — dry run; reports how many duplicate logo attachments would be removed.
- **Remove duplicates** — enabled after a scan; runs live behind a `confirm()`.
- A `<progress>` bar; status via an `aria-live` region.

## Batching (handles 20k+ without timeouts)

- `Attachment_Deduplicator::get_logo_owner_ids()` (new, tested) lists owners with a referenced logo, sorted.
- The AJAX handler processes `OWNERS_PER_BATCH` (10) owners per request, reusing the tested per-owner `run( [ 'user_id' => … ] )`; the JS loops batches by offset until done, accumulating totals. The owner list is stable across live batches (the canonical stays referenced), so offset paging is consistent.

## Safety

- `manage_options` capability + nonce checked on **every** AJAX request.
- Dry-run **scan** first; the live run is gated by a `confirm()`.
- Re-point-before-delete is inherited from the core (no broken-image cascade).
- Inline script via `wp_add_inline_script` — no build/dist dependency, so nothing can go missing from the release zip.

## Testing

- Added `test_get_logo_owner_ids_lists_owners_with_logos_sorted`; the destructive core is covered by `WP_Test_Attachment_Deduplicator` (6 tests total).
- Server flow verified end-to-end on a real DB: menu registration, owner enumeration, and batched live collapse + re-point across multiple owners.
- phpcs + Psalm clean.

**Not yet verified:** the browser UI click-through (buttons → AJAX → progress → confirm) — the JS is straightforward jQuery batching but hasn't been driven in a browser.




<!-- wpjm:plugin-zip -->
----

| Plugin build for 352506ae6f9733d1097fac26b4cfe6405d8f3f6c <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/09/wp-job-manager-zip-3066-352506ae.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/09/3066-352506ae)             |

<!-- /wpjm:plugin-zip -->




