### PR TITLE
Emit a machine-readable datetime attribute from rel_time()

### DIFF
--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -201,10 +201,12 @@ HTML;
 			return '';
 		}
 
-		$abs_time = wp_date( get_option( 'date_format' ), $timestamp );
-		$rel_time = human_time_diff( $timestamp );
+		// `datetime` must be machine-readable (a valid HTML date string); `title` is the localized display date.
+		$machine_time = wp_date( 'Y-m-d', $timestamp );
+		$abs_time     = wp_date( get_option( 'date_format' ), $timestamp );
+		$rel_time     = human_time_diff( $timestamp );
 
-		return '<time datetime="' . esc_attr( $abs_time ) . '" title="' . esc_attr( $abs_time ) . '">' . esc_html( sprintf( $format_string, $rel_time ) ) . '</time>';
+		return '<time datetime="' . esc_attr( $machine_time ) . '" title="' . esc_attr( $abs_time ) . '">' . esc_html( sprintf( $format_string, $rel_time ) ) . '</time>';
 
 	}
 

--- a/tests/php/tests/includes/test_class.ui-elements.php
+++ b/tests/php/tests/includes/test_class.ui-elements.php
@@ -69,6 +69,19 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	}
 
 	/**
+	 * Extract the value of the title attribute from rel_time() output.
+	 *
+	 * @param string $html rel_time() output.
+	 *
+	 * @return string
+	 */
+	private function get_title_attr( $html ) {
+		$this->assertMatchesRegularExpression( '/title="([^"]+)"/', $html );
+		preg_match( '/title="([^"]+)"/', $html, $matches );
+		return $matches[1];
+	}
+
+	/**
 	 * Timezones spanning negative, positive, and zero UTC offsets, configured both
 	 * ways WP Settings > General allows: as an Olson timezone_string, and as a manual
 	 * gmt_offset with an empty timezone_string (including a half-hour offset, where
@@ -152,6 +165,22 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	 */
 	public function test_rel_time_unparseable_string_renders_nothing() {
 		$this->assertSame( '', UI_Elements::rel_time( 'not a date' ) );
+	}
+
+	/**
+	 * The datetime attribute must be a machine-readable HTML date string (Y-m-d)
+	 * regardless of the site's display date_format, while the title attribute keeps
+	 * the localized display date. A non-ISO date_format is used so the two diverge.
+	 */
+	public function test_rel_time_datetime_attribute_is_machine_readable() {
+		update_option( 'date_format', 'F j, Y' );
+		$this->set_site_timezone( 'America/Panama', -5 );
+
+		$expiration = new \DateTimeImmutable( '2026-08-13 23:59:59', wp_timezone() );
+		$html       = UI_Elements::rel_time( $expiration );
+
+		$this->assertSame( '2026-08-13', $this->get_datetime_attr( $html ), 'datetime must be machine-readable Y-m-d.' );
+		$this->assertSame( 'August 13, 2026', $this->get_title_attr( $html ), 'title must be the localized display date.' );
 	}
 
 	/**


### PR DESCRIPTION
## What

Fixes #3062. `WP_Job_Manager\UI\UI_Elements::rel_time()` rendered the `<time>` element's `datetime` attribute using the site's **localized** `date_format`, e.g.:

```html
<time datetime="August 13, 2026" title="August 13, 2026">Expires in 4 weeks</time>
```

`August 13, 2026` is not a valid HTML `datetime` value ([spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)), so assistive tech, crawlers, and any JS reading the attribute get an unparseable string.

## Change

`includes/ui/class-ui-elements.php` — `datetime` now uses a machine-readable `Y-m-d` value; `title` keeps the localized display date:

```html
<time datetime="2026-08-13" title="August 13, 2026">Expires in 4 weeks</time>
```

## Testing

- New test `test_rel_time_datetime_attribute_is_machine_readable` sets a non-ISO `date_format` (`F j, Y`) so the two attributes diverge, and asserts `datetime` is `2026-08-13` while `title` is `August 13, 2026`.
- Full `WP_Test_UI_Elements` suite passes (19 tests); `phpcs` clean.

## Notes

- Surfaced during code review of #3061 and split out as agreed, so it wasn't lost.
- The displayed text (the relative string) and the localized `title` are unchanged; only the `datetime` machine value changes.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 144595e5ef74265822d645da84656b34bad50a5e <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3067-144595e5.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3067-144595e5)             |

<!-- /wpjm:plugin-zip -->
