### PR TITLE
fix: emit a full ISO 8601 instant from rel_time()'s datetime attribute

### DIFF
--- a/includes/ui/class-ui-elements.php
+++ b/includes/ui/class-ui-elements.php
@@ -201,8 +201,10 @@ HTML;
 			return '';
 		}
 
-		// `datetime` must be machine-readable (a valid HTML date string); `title` is the localized display date.
-		$machine_time = wp_date( 'Y-m-d', $timestamp );
+		// `datetime` must be machine-readable (a valid HTML datetime string); `title` is the localized display date.
+		// Emit a full ISO 8601 value with the site's UTC offset rather than a date-only one: the relative text is
+		// accurate to the hour, and a floating date would be resolved to midnight in the consumer's own timezone.
+		$machine_time = wp_date( 'c', $timestamp );
 		$abs_time     = wp_date( get_option( 'date_format' ), $timestamp );
 		$rel_time     = human_time_diff( $timestamp );
 

--- a/tests/php/tests/includes/test_class.ui-elements.php
+++ b/tests/php/tests/includes/test_class.ui-elements.php
@@ -29,8 +29,6 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 		$this->original_date_format = get_option( 'date_format' );
 		$this->original_timezone    = get_option( 'timezone_string' );
 		$this->original_gmt_offset  = get_option( 'gmt_offset' );
-		// Use an unambiguous calendar-date format so assertions compare the date directly.
-		update_option( 'date_format', 'Y-m-d' );
 	}
 
 	public function tearDown(): void {
@@ -56,29 +54,30 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	}
 
 	/**
-	 * Extract the value of the datetime attribute from rel_time() output.
+	 * Extract the value of an attribute from rel_time() output.
 	 *
 	 * @param string $html rel_time() output.
+	 * @param string $name Attribute name.
 	 *
 	 * @return string
 	 */
-	private function get_datetime_attr( $html ) {
-		$this->assertMatchesRegularExpression( '/datetime="([^"]+)"/', $html );
-		preg_match( '/datetime="([^"]+)"/', $html, $matches );
+	private function get_attr( $html, $name ) {
+		$pattern = '/' . preg_quote( $name, '/' ) . '="([^"]+)"/';
+		$this->assertMatchesRegularExpression( $pattern, $html );
+		preg_match( $pattern, $html, $matches );
 		return $matches[1];
 	}
 
 	/**
-	 * Extract the value of the title attribute from rel_time() output.
+	 * Extract the calendar date from the ISO 8601 datetime attribute, for the tests
+	 * that are about which calendar day is rendered rather than the full instant.
 	 *
 	 * @param string $html rel_time() output.
 	 *
 	 * @return string
 	 */
-	private function get_title_attr( $html ) {
-		$this->assertMatchesRegularExpression( '/title="([^"]+)"/', $html );
-		preg_match( '/title="([^"]+)"/', $html, $matches );
-		return $matches[1];
+	private function get_datetime_date_part( $html ) {
+		return explode( 'T', $this->get_attr( $html, 'datetime' ) )[0];
 	}
 
 	/**
@@ -118,7 +117,7 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 
 		$expiration = new \DateTimeImmutable( '2026-08-13 23:59:59', wp_timezone() );
 
-		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( $expiration ) ) );
+		$this->assertSame( '2026-08-13', $this->get_datetime_date_part( UI_Elements::rel_time( $expiration ) ) );
 	}
 
 	/**
@@ -133,7 +132,7 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	public function test_rel_time_date_string_renders_calendar_date( $timezone_string, $gmt_offset ) {
 		$this->set_site_timezone( $timezone_string, $gmt_offset );
 
-		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( '2026-08-13' ) ) );
+		$this->assertSame( '2026-08-13', $this->get_datetime_date_part( UI_Elements::rel_time( '2026-08-13' ) ) );
 	}
 
 	/**
@@ -168,19 +167,23 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 	}
 
 	/**
-	 * The datetime attribute must be a machine-readable HTML date string (Y-m-d)
+	 * The datetime attribute must be a machine-readable HTML datetime string
 	 * regardless of the site's display date_format, while the title attribute keeps
 	 * the localized display date. A non-ISO date_format is used so the two diverge.
+	 *
+	 * The full ISO 8601 instant is asserted, not just the date: the relative text is
+	 * accurate to the hour, so a date-only value would be resolved to midnight in the
+	 * consumer's own timezone and could disagree with what the element displays.
 	 */
 	public function test_rel_time_datetime_attribute_is_machine_readable() {
 		update_option( 'date_format', 'F j, Y' );
-		$this->set_site_timezone( 'America/Panama', -5 );
+		$this->set_site_timezone( 'America/Panama', 0 );
 
 		$expiration = new \DateTimeImmutable( '2026-08-13 23:59:59', wp_timezone() );
 		$html       = UI_Elements::rel_time( $expiration );
 
-		$this->assertSame( '2026-08-13', $this->get_datetime_attr( $html ), 'datetime must be machine-readable Y-m-d.' );
-		$this->assertSame( 'August 13, 2026', $this->get_title_attr( $html ), 'title must be the localized display date.' );
+		$this->assertSame( '2026-08-13T23:59:59-05:00', $this->get_attr( $html, 'datetime' ), 'datetime must be a machine-readable ISO 8601 instant with the site UTC offset.' );
+		$this->assertSame( 'August 13, 2026', $this->get_attr( $html, 'title' ), 'title must be the localized display date.' );
 	}
 
 	/**
@@ -201,7 +204,7 @@ class WP_Test_UI_Elements extends \WPJM_BaseTest {
 
 		$timestamp = ( new \DateTimeImmutable( '2026-08-13 12:00:00', wp_timezone() ) )->getTimestamp();
 
-		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( $timestamp ) ) );
-		$this->assertSame( '2026-08-13', $this->get_datetime_attr( UI_Elements::rel_time( (string) $timestamp ) ) );
+		$this->assertSame( '2026-08-13', $this->get_datetime_date_part( UI_Elements::rel_time( $timestamp ) ) );
+		$this->assertSame( '2026-08-13', $this->get_datetime_date_part( UI_Elements::rel_time( (string) $timestamp ) ) );
 	}
 }


### PR DESCRIPTION
## What

Follow-up to #3067. That PR fixed the invalid `datetime` attribute (`August 13, 2026`) but emitted a date-only value:

```html
<time datetime="2026-08-13" title="August 13, 2026">Expires in 5 hours</time>
```

Per the HTML spec, a bare `Y-m-d` is a **floating** date — no time, no offset. A consumer (screen reader, scraper, `Intl` reformatter) resolves it to midnight in *its own* timezone, so it can disagree with the visible relative text — which is accurate to the hour — by up to ~24 hours, and a reader in another timezone can land on a different calendar day.

The only production caller (`includes/class-job-dashboard-shortcode.php`) passes a listing expiry that is an *instant* (end-of-day site time), so the precision is available; the date-only value was throwing it away.

## Change

`includes/ui/class-ui-elements.php` — `wp_date( 'Y-m-d', … )` → `wp_date( 'c', … )`:

```html
<time datetime="2026-08-13T23:59:59-05:00" title="August 13, 2026">Expires in 5 hours</time>
```

Equally spec-valid, carries the site's UTC offset, matches the precision of both the data and the relative text. Still `wp_date()`, so the west-of-UTC fix in #3061 is unaffected. Displayed text and the localized `title` are unchanged.

## Testing

- `--group ui`: 19 tests, 49 assertions, all pass; `phpcs` clean.
- **Fail-before verified:** reverting the source to `Y-m-d` fails only the machine-readable test (`'2026-08-13'` vs `'2026-08-13T23:59:59-05:00'`); the other 18 still pass, confirming they test calendar-date behaviour rather than the format string.

Test housekeeping, all from the #3067 review:

- Cross-timezone cases assert the calendar date via a new date-part helper — they're about *which day* renders, not the instant.
- The two attribute extractors are deduplicated into `get_attr( $html, $name )`.
- Dropped the `setUp()` `date_format` override; it no longer affects any assertion, and the one test needing a non-ISO format sets its own.

Refs #3062, #3067.

<!-- wpjm:plugin-zip -->
----

| Plugin build for 38e5938ecb2c89a123fad84c77ebf603bfbe8943 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3068-38e5938e.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3068-38e5938e)             |

<!-- /wpjm:plugin-zip -->
