### PR TITLE
Harden shared release scripts: injection sink, version validation, Linux `open` fix

### DIFF
--- a/scripts/create-release.mjs
+++ b/scripts/create-release.mjs
@@ -35,6 +35,14 @@ const pluginFileContents = fs.readFileSync( cfg.mainFile, 'utf8' );
 const pluginVersion      = pluginFileContents.match( /Version: (.*)/ )[ 1 ].trim();
 const pluginName         = pluginFileContents.match( /Plugin Name: (.*)/ )[ 1 ].trim();
 
+// Validate the parsed version before any git write or shell interpolation: it
+// flows into `git tag`/`git push`/`gh release` via execSync template strings, so
+// a malformed or hostile `Version:` header must abort here rather than reach a
+// shell. Pattern kept in parity with scripts/replace-next-version-tag.sh.
+if ( ! /^\d+(\.\d+)+(-(a|alpha|beta)([-.]?\d+)?)?$/.test( pluginVersion ) ) {
+	throw new Error( `Refusing to release: "${ pluginVersion }" is not a valid version string (parsed from the "Version:" header in ${ cfg.mainFile }).` );
+}
+
 const prNumber = process.argv[ 2 ];
 
 // Parse (and validate) the release notes before any git write, so a malformed
@@ -196,7 +204,9 @@ function buildPluginZip() {
 }
 
 function setWorkflowStepOutput() {
-	execSync( `echo "version=${ pluginVersion }" >> "$GITHUB_OUTPUT"` );
+	// Write straight to the file instead of shelling out `echo`, so the version
+	// never reaches a shell (no command-substitution or word-splitting surface).
+	fs.appendFileSync( process.env.GITHUB_OUTPUT, `version=${ pluginVersion }\n` );
 }
 
 async function createGithubRelease() {

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -39,6 +39,14 @@ if ( ! version ) {
 	process.exit( 1 );
 }
 
+// Validate the version format up front, before any branch is created or file is
+// mutated, so a typo fails fast rather than after a half-done release branch.
+// Pattern kept in parity with scripts/replace-next-version-tag.sh.
+if ( ! /^\d+(\.\d+)+(-(a|alpha|beta)([-.]?\d+)?)?$/.test( version ) ) {
+	console.log( chalk.bold.red( `Error: "${ version }" is not a valid version string. Expected x.y[.z] with an optional -alpha/-beta suffix.` ) );
+	process.exit( 1 );
+}
+
 const ghPrs = `gh pr list -R ${ cfg.repo } --state merged --base ${ BASE_BRANCH } --limit 500 --search "milestone:${ version }"`;
 
 // Confirm release through CLI.
@@ -284,9 +292,16 @@ function createPR( changelog ) {
 	fs.writeFileSync( bodyFile, body, 'utf-8' );
 
 	try {
-		const prLink = execSync( `gh pr create -R ${ cfg.repo } -B ${ BASE_BRANCH } -H ${ releaseBranch } --assignee @me --title "${ title }" --body-file "${ bodyFile }"` );
-		execSync( `open ${ prLink }` );
+		const prLink = execSync( `gh pr create -R ${ cfg.repo } -B ${ BASE_BRANCH } -H ${ releaseBranch } --assignee @me --title "${ title }" --body-file "${ bodyFile }"` ).toString().trim();
 		console.log( `PR: ${ prLink }` );
+		// Best-effort convenience only. `open` is macOS-only, so swallow any
+		// failure: on Linux/CI it must not throw into the caller's rollback path,
+		// which would delete the branch and PR that were just created.
+		try {
+			execSync( `open ${ prLink }`, { stdio: 'ignore' } );
+		} catch {
+			// Non-macOS or no browser available; the PR link is printed above.
+		}
 	} finally {
 		fs.unlinkSync( bodyFile );
 	}


### PR DESCRIPTION
## What

Three fixes to the shared release tooling (`scripts/create-release.mjs`, `scripts/prepare-release.mjs`), surfaced during a review of the same scripts in Jetpack CRM. These files are meant to stay identical across the plugin family (WP Job Manager, WP Super Cache, Crowdsignal Forms, Jetpack CRM), so the same fixes are being upstreamed to each.

### 1. Shell-injection sink in `setWorkflowStepOutput()` — `create-release.mjs`

`execSync( \`echo "version=${ pluginVersion }" >> "$GITHUB_OUTPUT"\` )` interpolates the version (parsed from the plugin's `Version:` header) into a shell. Inside double quotes the shell still evaluates `` `...` `` / `$(...)`, so a crafted header would execute on a runner holding `contents: write` and `GITHUB_TOKEN`. Maintainer-triggered only, but free to close: write via `fs.appendFileSync` with no shell.

### 2. Fail-fast version validation — both scripts

The version string flows into `git tag` / `git push` / `gh release` (create-release) and into branch names / file edits (prepare-release) before anything validates its shape. Added a semver check up front so a malformed or hostile version aborts before any git write, rather than after a half-done release branch. The pattern matches the grammar already accepted by `replace-next-version-tag.sh`.

### 3. `open` failure triggers a spurious rollback — `prepare-release.mjs`

`execSync( \`open ${ prLink }\` )` is macOS-only. On Linux/CI it throws into the outer `catch`, which offers to delete the release branch that was already pushed and the PR that was already created — a confusing half-state. Wrapped so its failure is swallowed; also `.toString().trim()` on the prLink Buffer.

## Notes

- No behaviour change on the happy path on macOS.
- Verified with `node --check` on both files.
- Applied by an identical codemod across wp-job-manager, wp-super-cache, and crowdsignal-forms.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 9500686902a9301074684e00f23b35a2680c4313 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3070-95006869.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3070-95006869)             |

<!-- /wpjm:plugin-zip -->
