### PR TITLE
Allow reusing a submitter's saved company logo on a new listing

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -981,18 +981,31 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				foreach ( array_filter( $file_urls ) as $file_url ) {
 					if ( is_numeric( $file_url ) ) {
 						$attachment_id = absint( $file_url );
-						// The last two conditions are only safe because both consult server-side
+
+						if ( ! $attachment_id ) {
+							continue;
+						}
+
+						// The last two allowances are only safe because both consult server-side
 						// state, never the request: $this->job_id is set only for a listing the
 						// current user may edit (or is mid-submitting), and the user meta is
 						// written by this class only after this same check passed. They permit
 						// reusing a value already offered back to the submitter, NOT an arbitrary
 						// foreign ID — do not loosen either to accept request-supplied values.
-						if (
-								$attachment_id
-								&& ! $this->is_attachment_authorized_for_current_user( $attachment_id )
-								&& ! $this->is_existing_listing_attachment( $attachment_id, $key )
-								&& ! $this->is_saved_user_attachment( $attachment_id, $group_key, $key )
-							) {
+						//
+						// The existence check gates all three: a numeric ID that no longer resolves
+						// to an attachment (the media item was deleted) would otherwise pass on a
+						// stale saved value, fail silently at the sink — set_post_thumbnail()
+						// ignores a dead ID — and then be written straight back to the saved value,
+						// so the listing would publish with no logo and never self-heal.
+						$is_usable = 'attachment' === get_post_type( $attachment_id )
+							&& (
+								$this->is_attachment_authorized_for_current_user( $attachment_id )
+								|| $this->is_existing_listing_attachment( $attachment_id, $key )
+								|| $this->is_saved_user_attachment( $attachment_id, $group_key, $key )
+							);
+
+						if ( ! $is_usable ) {
 							// Tell the submitter how to recover. The rejected value is one the form
 							// offered them (a saved logo), so "invalid" alone leaves them stuck.
 							return new WP_Error(
@@ -1097,9 +1110,12 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	protected function is_saved_user_attachment( $attachment_id, $group_key, $key ) {
 		$user_id = get_current_user_id();
 
-		// Mirrors the scope of the user-meta pre-population in submit(): logged-in
-		// submitters, company group only. Guests have no saved value to reuse.
-		if ( ! $user_id || 'company' !== $group_key ) {
+		// Mirrors the scope of the user-meta pre-population in submit(): a new listing
+		// (no job_id), a logged-in submitter, the company group only. Editing reads from
+		// the listing instead — is_existing_listing_attachment() covers that path — and
+		// guests have no saved value to reuse. Keeping this no broader than the
+		// pre-population it mirrors is what stops it becoming a general-purpose bypass.
+		if ( $this->job_id || ! $user_id || 'company' !== $group_key ) {
 			return false;
 		}
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -981,16 +981,28 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				foreach ( array_filter( $file_urls ) as $file_url ) {
 					if ( is_numeric( $file_url ) ) {
 						$attachment_id = absint( $file_url );
-						// The third condition is only safe because $this->job_id is pre-gated: it
-						// is set only for a listing the current user may edit (or is mid-submitting).
-						// It permits reusing the listing's own saved attachment, NOT any attachment
-						// already on the post — do not loosen it to accept arbitrary foreign IDs.
+						// The last two conditions are only safe because both consult server-side
+						// state, never the request: $this->job_id is set only for a listing the
+						// current user may edit (or is mid-submitting), and the user meta is
+						// written by this class only after this same check passed. They permit
+						// reusing a value already offered back to the submitter, NOT an arbitrary
+						// foreign ID — do not loosen either to accept request-supplied values.
 						if (
 								$attachment_id
 								&& ! $this->is_attachment_authorized_for_current_user( $attachment_id )
 								&& ! $this->is_existing_listing_attachment( $attachment_id, $key )
+								&& ! $this->is_saved_user_attachment( $attachment_id, $group_key, $key )
 							) {
-							return new WP_Error( 'validation-error', __( 'Invalid attachment provided.', 'wp-job-manager' ) );
+							// Tell the submitter how to recover. The rejected value is one the form
+							// offered them (a saved logo), so "invalid" alone leaves them stuck.
+							return new WP_Error(
+								'validation-error',
+								sprintf(
+									// translators: Placeholder %s is the label of the file field, e.g. "Company Logo".
+									__( 'The saved file for "%s" is no longer available to use. Please upload it again, or remove it, and resubmit.', 'wp-job-manager' ),
+									$field['label']
+								)
+							);
 						}
 					}
 				}
@@ -1061,6 +1073,41 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		$existing_ids = array_map( 'absint', is_array( $existing ) ? $existing : [ $existing ] );
 
 		return in_array( absint( $attachment_id ), $existing_ids, true );
+	}
+
+	/**
+	 * Determines whether an attachment is the current user's own saved value for a
+	 * company field, as persisted by one of their previous submissions.
+	 *
+	 * A new submission has no listing to read from, so it pre-populates the company
+	 * fields from the submitter's user meta ({@see submit()}) — their saved company
+	 * logo is offered back to them on the next listing. That meta is written by this
+	 * class alone ({@see update_job_data()}) and only after this same ownership check
+	 * has passed, so it records an attachment the user was already authorized to use,
+	 * even when they did not author it — e.g. a site admin uploaded or replaced the
+	 * logo on their listing. It is server-side state, not a request-supplied ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $group_key     Field group. Only 'company' is pre-populated from user meta.
+	 * @param string $key           Field key (e.g. 'company_logo').
+	 * @return bool True when the attachment is the current user's saved value for the field.
+	 */
+	protected function is_saved_user_attachment( $attachment_id, $group_key, $key ) {
+		$user_id = get_current_user_id();
+
+		// Mirrors the scope of the user-meta pre-population in submit(): logged-in
+		// submitters, company group only. Guests have no saved value to reuse.
+		if ( ! $user_id || 'company' !== $group_key ) {
+			return false;
+		}
+
+		$saved = get_user_meta( $user_id, '_' . $key, true );
+
+		$saved_ids = array_map( 'absint', is_array( $saved ) ? $saved : [ $saved ] );
+
+		return in_array( absint( $attachment_id ), $saved_ids, true );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
@@ -121,6 +121,44 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Runs the form's field validation against an arbitrary file field, so the
+	 * group-scoping of the saved-value allowance can be exercised outside the
+	 * `company` group.
+	 *
+	 * @param string $group_key Field group (e.g. 'job').
+	 * @param string $key       Field key (e.g. 'job_attachment').
+	 * @param mixed  $value     Value to validate for the field.
+	 * @throws Exception When validation rejects the value.
+	 * @return bool|WP_Error validate_fields() result.
+	 */
+	private function validate_file_field( $group_key, $key, $value ) {
+		$form  = WP_Job_Manager_Form_Submit_Job::instance();
+		$class = new ReflectionClass( $form );
+
+		$fields_prop = $class->getProperty( 'fields' );
+		$fields_prop->setAccessible( true );
+		$fields_prop->setValue(
+			$form,
+			[
+				$group_key => [
+					$key => [
+						'label'              => 'Attachment',
+						'type'               => 'file',
+						'required'           => false,
+						'file_limit'         => 1,
+						'allowed_mime_types' => [ 'png' => 'image/png' ],
+					],
+				],
+			]
+		);
+
+		$validate = $class->getMethod( 'validate_fields' );
+		$validate->setAccessible( true );
+
+		return $validate->invoke( $form, [ $group_key => [ $key => $value ] ] );
+	}
+
+	/**
 	 * A submitter cannot validate a company_logo pointing at an attachment owned
 	 * by another user.
 	 */
@@ -399,6 +437,70 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 
 		$this->expectException( Exception::class );
 		$this->validate_company_logo( (string) $foreign_attachment );
+	}
+
+	/**
+	 * The saved-value allowance is scoped to the `company` group, because that is
+	 * the only group submit() pre-populates from user meta. A file field in any
+	 * other group must not consult `_<key>` user meta for an allowance, even when
+	 * such a meta value happens to exist.
+	 */
+	public function test_saved_user_meta_outside_company_group_does_not_authorize_attachment() {
+		$this->login_as_admin();
+		$foreign_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		update_user_meta( get_current_user_id(), '_job_attachment', $foreign_attachment );
+
+		$this->expectException( Exception::class );
+		$this->validate_file_field( 'job', 'job_attachment', (string) $foreign_attachment );
+	}
+
+	/**
+	 * A saved logo whose attachment has since been deleted must be rejected rather
+	 * than allowed through. The stale ID would silently fail at set_post_thumbnail()
+	 * — publishing a listing with no logo and no explanation — and then be written
+	 * straight back into user meta, so it would never self-heal. Rejecting it
+	 * surfaces the "upload it again" message that this condition actually describes.
+	 */
+	public function test_deleted_saved_user_logo_is_rejected() {
+		$this->login_as_admin();
+		$admin_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		update_user_meta( get_current_user_id(), '_company_logo', $admin_attachment );
+
+		// The admin removes the media item; the stale ID stays in the user meta.
+		wp_delete_post( $admin_attachment, true );
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo( (string) $admin_attachment );
+	}
+
+	/**
+	 * The saved-value allowance covers the new-submission path only. While editing a
+	 * listing, submit() pre-populates from the listing itself and never from user
+	 * meta, so the saved value must not authorize an attachment there — that case
+	 * belongs to is_existing_listing_attachment(). Keeping the allowance no broader
+	 * than the pre-population it mirrors is what stops it becoming a blanket bypass.
+	 */
+	public function test_saved_user_logo_does_not_authorize_attachment_while_editing() {
+		$this->login_as_admin();
+		$saved_logo = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		update_user_meta( get_current_user_id(), '_company_logo', $saved_logo );
+
+		// A listing that does not use that logo.
+		$job_id = $this->factory->post->create(
+			[
+				'post_type'   => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_author' => get_current_user_id(),
+			]
+		);
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo_editing_job( (string) $saved_logo, $job_id );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-ownership.php
@@ -309,6 +309,99 @@ class WP_Test_Submit_Job_Attachment_Ownership extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Regression (#3060 follow-up): a *new* submission pre-populates the company
+	 * fields from the submitter's own `_company_logo` user meta (see submit()).
+	 * That saved value is written by the plugin from a logo the user was already
+	 * authorized to use, so it must stay valid on the next submission even when
+	 * the attachment was authored by someone else — e.g. a site admin uploaded or
+	 * replaced the logo on the user's listing. There is no job_id yet, so the
+	 * existing-listing allowance does not cover this path.
+	 */
+	public function test_saved_user_company_logo_is_accepted_on_new_submission() {
+		$this->login_as_admin();
+		$admin_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		// The plugin persisted this as the submitter default logo on a previous save.
+		update_user_meta( get_current_user_id(), '_company_logo', $admin_attachment );
+
+		$this->assertNotEquals( get_current_user_id(), (int) get_post_field( 'post_author', $admin_attachment ) );
+		$this->assertFalse( current_user_can( 'edit_post', $admin_attachment ) );
+
+		$this->assertTrue(
+			$this->validate_company_logo( (string) $admin_attachment ),
+			"The submitter's saved company logo must remain valid on a new submission even when authored by another user."
+		);
+	}
+
+	/**
+	 * The saved-logo allowance is scoped to the submitter's own persisted value:
+	 * a foreign attachment that is NOT their saved `_company_logo` is still
+	 * rejected on a new submission.
+	 */
+	public function test_foreign_attachment_still_rejected_on_new_submission() {
+		$this->login_as_admin();
+		$saved_logo         = $this->create_attachment_owned_by( get_current_user_id() );
+		$foreign_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		update_user_meta( get_current_user_id(), '_company_logo', $saved_logo );
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo( (string) $foreign_attachment );
+	}
+
+	/**
+	 * Guard against the empty-saved-value edge: with no `_company_logo` user meta
+	 * the saved value resolves to 0, so a submitted foreign attachment ID
+	 * (always >= 1) must still be rejected.
+	 */
+	public function test_empty_saved_user_logo_does_not_authorize_foreign_attachment() {
+		$this->login_as_admin();
+		$foreign_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+		delete_user_meta( get_current_user_id(), '_company_logo' );
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo( (string) $foreign_attachment );
+	}
+
+	/**
+	 * The rejection message must name the field and say how to recover. The value
+	 * being rejected is often one the form itself offered back to the submitter, so
+	 * a bare "invalid attachment" leaves them with no way forward.
+	 */
+	public function test_rejection_message_names_the_field_and_is_actionable() {
+		$this->login_as_admin();
+		$foreign_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		$this->login_as_employer();
+
+		try {
+			$this->validate_company_logo( (string) $foreign_attachment );
+			$this->fail( 'A foreign attachment must be rejected.' );
+		} catch ( Exception $e ) {
+			$this->assertStringContainsString( 'Logo', $e->getMessage(), 'The message must name the field that needs attention.' );
+			$this->assertStringContainsString( 'upload it again', $e->getMessage(), 'The message must tell the submitter how to recover.' );
+		}
+	}
+
+	/**
+	 * A logged-out submitter has no user meta to consult, so the saved-logo
+	 * allowance must never fire for guests (get_user_meta( 0, ... ) is empty).
+	 */
+	public function test_guest_submission_rejects_foreign_attachment() {
+		$this->login_as_admin();
+		$foreign_attachment = $this->create_attachment_owned_by( get_current_user_id() );
+
+		wp_set_current_user( 0 );
+
+		$this->expectException( Exception::class );
+		$this->validate_company_logo( (string) $foreign_attachment );
+	}
+
+	/**
 	 * Drives WP_Job_Manager_Form_Submit_Job::submit_handler() for a "Save draft"
 	 * POST binding the given company_logo value, the way the draft-save POST does.
 	 *


### PR DESCRIPTION
## What

Follow-up to #3060, [reported here](https://github.com/Automattic/WP-Job-Manager/pull/3060#issuecomment-5107970143): employers still hit **"Invalid attachment provided."** when submitting a **new** listing whose company logo was uploaded by a site admin. #3060 fixed the edit/relist flow; this fixes the new-submission flow.

## Why it happens

The form offers a logo back to the submitter along two different paths, and #3060 only taught the validation about one:

- **Editing a listing** (`$this->job_id` set) — `submit()` pre-populates from the listing's post thumbnail / `_company_logo` meta. Covered by #3060's `is_existing_listing_attachment()`.
- **A new listing** (no `job_id` yet) — `submit()` pre-populates the company fields from the submitter's own **`_company_logo` user meta**. Not covered: with `job_id` unset, `is_existing_listing_attachment()` returns `false`, so a saved logo authored by someone else is rejected.

#3060 also propagates the condition rather than only exposing it. Re-saving a listing whose logo an admin uploaded now succeeds, and `update_job_data()` writes that admin-owned attachment ID into the *employer's* `_company_logo` user meta. It is then offered back on their next new listing — and rejected. That is exactly the reporter's observation that relisting works but posting a new listing does not.

## Why it's safe

`is_saved_user_attachment()` is the user-meta counterpart to #3060's listing check, and rests on the same property: **it consults server-side state, never the request.**

`_company_logo` user meta has exactly one writer in the plugin — `update_job_data()` — which only runs after the existing validation has already passed. So the saved value records an attachment the submitter was previously authorised to use, even when they do not author it (an admin uploaded or replaced it on their listing). It is not a request-supplied ID, and nothing else in the plugin or its REST surface writes that meta key.

The allowance is scoped to exactly what `submit()` pre-populates and no wider: a new listing (no `job_id`), a logged-in submitter, the `company` group. Editing reads from the listing instead, and `is_existing_listing_attachment()` already covers that path.

The existing validation rules are otherwise unchanged: an attachment that is neither owned/editable, nor the listing's saved logo, nor the submitter's own saved value is still rejected.

## Changes

`includes/forms/class-wp-job-manager-form-submit-job.php`
- Add `is_saved_user_attachment( $attachment_id, $group_key, $key )` — true when the ID matches the current user's saved value for that field, mirroring the pre-population in `submit()` exactly (new listings only, logged-in submitters, `company` group only; guests have no saved value).
- `validate_attachment_ownership()` also allows the attachment when it is the submitter's saved value.
- Require the ID to still resolve to a live attachment before any of the three allowances applies. A stale ID (the admin deleted the media item) would otherwise pass on a saved value, then fail silently at the sink — `set_post_thumbnail()` ignores a dead ID — and be written straight back by `update_job_data()`, so the listing would publish with no logo and never self-heal. This also closes the same hole in `is_existing_listing_attachment()`'s meta branch: core clears `_thumbnail_id` when an attachment is deleted, but not `_company_logo` post meta.
- Make the rejection message recoverable. The rejected value is one the form itself offered back to the submitter, so a bare "Invalid attachment provided." leaves them with no way forward — it now names the field and says to re-upload or remove it. (The reporter was patching this with a `str_ireplace` in `functions.php`.) The malformed-URL throw site keeps the original string; it is a genuinely different condition.

## Testing

Adds coverage to `WP_Test_Submit_Job_Attachment_Ownership`. The first three were verified fail-before / pass-after:

- `test_saved_user_company_logo_is_accepted_on_new_submission` — the reported regression. Without the fix this throws the reporter's exact error.
- `test_deleted_saved_user_logo_is_rejected` — a saved logo whose attachment was deleted must error rather than silently publish a logo-less listing.
- `test_saved_user_logo_does_not_authorize_attachment_while_editing` — the allowance covers the new-submission path only.
- `test_foreign_attachment_still_rejected_on_new_submission` — the allowance is scoped to the submitter's actual saved value.
- `test_empty_saved_user_logo_does_not_authorize_foreign_attachment` — empty meta resolves to `0` and authorises nothing.
- `test_guest_submission_rejects_foreign_attachment` — the allowance never fires for logged-out submitters.
- `test_saved_user_meta_outside_company_group_does_not_authorize_attachment` — the `company` group guard, which had no coverage at all.
- `test_rejection_message_names_the_field_and_is_actionable` — locks in the message change.

Full class passes (19 tests). Full suite passes (615 tests; the 3 skips are the geocode tests needing a live API key). `phpcs` and Psalm clean.

Still uncovered, noted for follow-up: the draft-save path with a *valid* saved logo, and an end-to-end test of the priming chain (edit a listing with an admin-owned logo, assert the user meta is written, then submit a new listing). The two halves of that chain are currently tested separately and joined by a hand-written `update_user_meta()`.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 068ca646868a03bfca9aea1bdf33da72b22656ee <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/07/wp-job-manager-zip-3082-068ca646.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/07/3082-068ca646)             |

<!-- /wpjm:plugin-zip -->
