### PR TITLE
Prevent unauthorized job draft resumes

### DIFF
--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -308,8 +308,8 @@ class WP_Job_Manager {
 		}
 
 		$job_id         = $has_job_id ? absint( $_COOKIE[ $job_id_cookie ] ) : 0;
-		$submitting_key = $has_job_key ? wp_unslash( $_COOKIE[ $job_key_cookie ] ) : '';
-		$job = $job_id ? get_post( $job_id ) : null;
+		$submitting_key = $has_job_key ? sanitize_text_field( wp_unslash( $_COOKIE[ $job_key_cookie ] ) ) : '';
+		$job            = $job_id ? get_post( $job_id ) : null;
 
 		if (
 			! $job instanceof WP_Post

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -307,8 +307,9 @@ class WP_Job_Manager {
 			return;
 		}
 
-		$job_id         = $has_job_id ? absint( $_COOKIE[ $job_id_cookie ] ) : 0;
-		$submitting_key = $has_job_key ? sanitize_text_field( wp_unslash( $_COOKIE[ $job_key_cookie ] ) ) : '';
+		$job_id = $has_job_id ? absint( $_COOKIE[ $job_id_cookie ] ) : 0;
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- The submitting key is a bearer credential and must be compared verbatim.
+		$submitting_key = $has_job_key ? wp_unslash( $_COOKIE[ $job_key_cookie ] ) : '';
 		$job            = $job_id ? get_post( $job_id ) : null;
 
 		if (

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -305,12 +305,19 @@ class WP_Job_Manager {
 			'httponly' => true,
 			'samesite' => 'Lax',
 		];
+		$headers_sent   = headers_sent();
 
 		if ( isset( $_COOKIE['wp-job-manager-submitting-job-id'] ) ) {
-			setcookie( 'wp-job-manager-submitting-job-id', '', $cookie_options );
+			if ( ! $headers_sent ) {
+				setcookie( 'wp-job-manager-submitting-job-id', '', $cookie_options );
+			}
+			unset( $_COOKIE['wp-job-manager-submitting-job-id'] );
 		}
 		if ( isset( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
-			setcookie( 'wp-job-manager-submitting-job-key', '', $cookie_options );
+			if ( ! $headers_sent ) {
+				setcookie( 'wp-job-manager-submitting-job-key', '', $cookie_options );
+			}
+			unset( $_COOKIE['wp-job-manager-submitting-job-key'] );
 		}
 	}
 

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -133,6 +133,7 @@ class WP_Job_Manager {
 		add_action( 'admin_init', [ $this, 'updater' ] );
 		add_action( 'admin_init', [ $this, 'add_privacy_policy_content' ] );
 		add_action( 'wp_logout', [ $this, 'cleanup_job_posting_cookies' ] );
+		add_action( 'init', [ $this, 'validate_job_posting_cookies' ], 1 );
 		add_action( 'init', [ 'WP_Job_Manager_Email_Notifications', 'init' ] );
 		add_action( 'rest_api_init', [ $this, 'rest_init' ] );
 		add_action( 'plugins_loaded', [ $this, 'include_admin_files' ] );
@@ -294,6 +295,33 @@ class WP_Job_Manager {
 	}
 
 	/**
+	 * Validates job posting cookies before headers are sent.
+	 */
+	public function validate_job_posting_cookies() {
+		$job_id_cookie  = 'wp-job-manager-submitting-job-id';
+		$job_key_cookie = 'wp-job-manager-submitting-job-key';
+		$has_job_id     = ! empty( $_COOKIE[ $job_id_cookie ] );
+		$has_job_key    = ! empty( $_COOKIE[ $job_key_cookie ] );
+
+		if ( ! $has_job_id && ! $has_job_key ) {
+			return;
+		}
+
+		$job_id         = $has_job_id ? absint( $_COOKIE[ $job_id_cookie ] ) : 0;
+		$submitting_key = $has_job_key ? wp_unslash( $_COOKIE[ $job_key_cookie ] ) : '';
+		$job = $job_id ? get_post( $job_id ) : null;
+
+		if (
+			! $job instanceof WP_Post
+			|| WP_Job_Manager_Post_Types::PT_LISTING !== $job->post_type
+			|| ! in_array( get_post_status( $job ), [ 'preview', 'pending_payment' ], true )
+			|| get_post_meta( $job_id, '_submitting_key', true ) !== $submitting_key
+		) {
+			$this->cleanup_job_posting_cookies();
+		}
+	}
+
+	/**
 	 * Cleanup job posting cookies.
 	 */
 	public function cleanup_job_posting_cookies() {
@@ -305,18 +333,12 @@ class WP_Job_Manager {
 			'httponly' => true,
 			'samesite' => 'Lax',
 		];
-		$headers_sent   = headers_sent();
-
 		if ( isset( $_COOKIE['wp-job-manager-submitting-job-id'] ) ) {
-			if ( ! $headers_sent ) {
-				setcookie( 'wp-job-manager-submitting-job-id', '', $cookie_options );
-			}
+			setcookie( 'wp-job-manager-submitting-job-id', '', $cookie_options );
 			unset( $_COOKIE['wp-job-manager-submitting-job-id'] );
 		}
 		if ( isset( $_COOKIE['wp-job-manager-submitting-job-key'] ) ) {
-			if ( ! $headers_sent ) {
-				setcookie( 'wp-job-manager-submitting-job-key', '', $cookie_options );
-			}
+			setcookie( 'wp-job-manager-submitting-job-key', '', $cookie_options );
 			unset( $_COOKIE['wp-job-manager-submitting-job-key'] );
 		}
 	}

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -300,8 +300,8 @@ class WP_Job_Manager {
 	public function validate_job_posting_cookies() {
 		$job_id_cookie  = 'wp-job-manager-submitting-job-id';
 		$job_key_cookie = 'wp-job-manager-submitting-job-key';
-		$has_job_id     = ! empty( $_COOKIE[ $job_id_cookie ] );
-		$has_job_key    = ! empty( $_COOKIE[ $job_key_cookie ] );
+		$has_job_id     = isset( $_COOKIE[ $job_id_cookie ] );
+		$has_job_key    = isset( $_COOKIE[ $job_key_cookie ] );
 
 		if ( ! $has_job_id && ! $has_job_key ) {
 			return;

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -158,18 +158,23 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			&& ! empty( $_COOKIE['wp-job-manager-submitting-job-key'] )
 			&& empty( $this->job_id )
 		) {
-			$job_id     = absint( $_COOKIE['wp-job-manager-submitting-job-id'] );
-			$job_status = get_post_status( $job_id );
+			$job_id         = absint( $_COOKIE['wp-job-manager-submitting-job-id'] );
+			$job            = get_post( $job_id );
+			$job_status     = $job instanceof WP_Post ? get_post_status( $job ) : false;
+			$submitting_key = get_post_meta( $job_id, '_submitting_key', true );
 
 			if (
 				(
 					'preview' === $job_status
 					|| 'pending_payment' === $job_status
 				)
-				&& get_post_meta( $job_id, '_submitting_key', true ) === $_COOKIE['wp-job-manager-submitting-job-key']
+				&& $submitting_key === $_COOKIE['wp-job-manager-submitting-job-key']
+				&& $this->visitor_can_resume_job( $job )
 			) {
 				$this->job_id      = $job_id;
-				$this->resume_edit = get_post_meta( $job_id, '_submitting_key', true );
+				$this->resume_edit = $submitting_key;
+			} else {
+				WPJM()->cleanup_job_posting_cookies();
 			}
 		}
 
@@ -186,6 +191,24 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 				$this->step   = 0;
 			}
 		}
+	}
+
+	/**
+	 * Checks whether the current visitor can resume a job listing.
+	 *
+	 * @param WP_Post|null $job Job listing post.
+	 * @return bool
+	 */
+	private function visitor_can_resume_job( $job ) {
+		if ( ! $job instanceof WP_Post || WP_Job_Manager_Post_Types::PT_LISTING !== $job->post_type ) {
+			return false;
+		}
+
+		if ( is_user_logged_in() ) {
+			return job_manager_user_can_edit_job( $job->ID );
+		}
+
+		return 0 === (int) $job->post_author;
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -173,8 +173,6 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			) {
 				$this->job_id      = $job_id;
 				$this->resume_edit = $submitting_key;
-			} else {
-				WPJM()->cleanup_job_posting_cookies();
 			}
 		}
 
@@ -204,11 +202,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			return false;
 		}
 
-		if ( is_user_logged_in() ) {
-			return job_manager_user_can_edit_job( $job->ID );
+		if ( 0 === (int) $job->post_author ) {
+			return true;
 		}
 
-		return 0 === (int) $job->post_author;
+		return is_user_logged_in() && job_manager_user_can_edit_job( $job->ID );
 	}
 
 	/**

--- a/tests/php/tests/includes/test_class.submit-job-resume-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-resume-ownership.php
@@ -365,4 +365,15 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 
 		$this->assert_resume_cookies_cleared();
 	}
+
+	/**
+	 * An empty resume cookie pair is removed during early validation.
+	 */
+	public function test_empty_resume_cookie_pair_is_cleared() {
+		$this->set_resume_cookies( 0, '' );
+
+		WPJM()->validate_job_posting_cookies();
+
+		$this->assert_resume_cookies_cleared();
+	}
 }

--- a/tests/php/tests/includes/test_class.submit-job-resume-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-resume-ownership.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Tests that stale submission cookies cannot resume another user's job draft.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
+
+	const JOB_ID_COOKIE  = 'wp-job-manager-submitting-job-id';
+	const JOB_KEY_COOKIE = 'wp-job-manager-submitting-job-key';
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+
+		$_GET     = [];
+		$_POST    = [];
+		$_REQUEST = [];
+		unset( $_COOKIE[ self::JOB_ID_COOKIE ], $_COOKIE[ self::JOB_KEY_COOKIE ] );
+		delete_option( 'job_manager_paid_listings_flow' );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_paid_listings_flow' );
+		unset( $_COOKIE[ self::JOB_ID_COOKIE ], $_COOKIE[ self::JOB_KEY_COOKIE ] );
+		$_GET     = [];
+		$_POST    = [];
+		$_REQUEST = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * @return array[] Paid-listings flow values.
+	 */
+	public function paid_listings_flows() {
+		return [
+			'default flow'      => [ '' ],
+			'before-submit flow' => [ 'before' ],
+		];
+	}
+
+	/**
+	 * Creates a resumable job listing.
+	 *
+	 * @param int    $author_id Author user ID, or 0 for a guest submission.
+	 * @param string $status    Job status.
+	 * @return array{0: int, 1: string} Job ID and submitting key.
+	 */
+	private function create_resumable_job( $author_id, $status = 'preview' ) {
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_author' => $author_id,
+				'post_status' => $status,
+			]
+		);
+		$key    = 'resume-key-' . $job_id;
+
+		update_post_meta( $job_id, '_submitting_key', $key );
+
+		return [ $job_id, $key ];
+	}
+
+	/**
+	 * Instantiates the submit form with resume cookies set.
+	 *
+	 * @param int    $job_id Job listing ID.
+	 * @param string $key    Submitting key.
+	 * @param string $flow   Paid-listings flow option.
+	 * @return WP_Job_Manager_Form_Submit_Job
+	 */
+	private function load_form_from_cookie( $job_id, $key, $flow = '' ) {
+		if ( '' === $flow ) {
+			delete_option( 'job_manager_paid_listings_flow' );
+		} else {
+			update_option( 'job_manager_paid_listings_flow', $flow );
+		}
+
+		$_COOKIE[ self::JOB_ID_COOKIE ]  = (string) $job_id;
+		$_COOKIE[ self::JOB_KEY_COOKIE ] = $key;
+
+		return new WP_Job_Manager_Form_Submit_Job();
+	}
+
+	/**
+	 * Asserts that rejected resume cookies were removed from the current request.
+	 */
+	private function assert_resume_cookies_cleared() {
+		$this->assertArrayNotHasKey( self::JOB_ID_COOKIE, $_COOKIE );
+		$this->assertArrayNotHasKey( self::JOB_KEY_COOKIE, $_COOKIE );
+	}
+
+	/**
+	 * An owner can resume their own preview listing.
+	 *
+	 * @dataProvider paid_listings_flows
+	 * @param string $flow Paid-listings flow option.
+	 */
+	public function test_logged_in_user_can_resume_own_listing( $flow ) {
+		$this->login_as_employer();
+		[ $job_id, $key ] = $this->create_resumable_job( get_current_user_id() );
+
+		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
+
+		$this->assertSame( $job_id, $form->get_job_id() );
+		$this->assertArrayHasKey( self::JOB_ID_COOKIE, $_COOKIE );
+		$this->assertArrayHasKey( self::JOB_KEY_COOKIE, $_COOKIE );
+	}
+
+	/**
+	 * A different logged-in user cannot resume another user's preview listing.
+	 *
+	 * @dataProvider paid_listings_flows
+	 * @param string $flow Paid-listings flow option.
+	 */
+	public function test_logged_in_user_cannot_resume_another_users_listing( $flow ) {
+		$this->login_as_employer();
+		[ $job_id, $key ] = $this->create_resumable_job( get_current_user_id() );
+
+		$this->login_as_employer_b();
+		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
+
+		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_cleared();
+	}
+
+	/**
+	 * A guest can resume a guest-authored preview listing when the key matches.
+	 *
+	 * @dataProvider paid_listings_flows
+	 * @param string $flow Paid-listings flow option.
+	 */
+	public function test_guest_can_resume_guest_listing( $flow ) {
+		$this->logout();
+		[ $job_id, $key ] = $this->create_resumable_job( 0 );
+
+		$this->assertSame( 0, (int) get_post_field( 'post_author', $job_id ) );
+
+		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
+
+		$this->assertSame( $job_id, $form->get_job_id() );
+		$this->assertArrayHasKey( self::JOB_ID_COOKIE, $_COOKIE );
+		$this->assertArrayHasKey( self::JOB_KEY_COOKIE, $_COOKIE );
+	}
+
+	/**
+	 * A guest cannot resume a listing authored by a registered user.
+	 *
+	 * @dataProvider paid_listings_flows
+	 * @param string $flow Paid-listings flow option.
+	 */
+	public function test_guest_cannot_resume_registered_users_listing( $flow ) {
+		$this->login_as_employer();
+		[ $job_id, $key ] = $this->create_resumable_job( get_current_user_id() );
+
+		$this->logout();
+		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
+
+		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_cleared();
+	}
+
+	/**
+	 * The ownership check also applies to pending-payment resumes.
+	 */
+	public function test_logged_in_user_can_resume_own_pending_payment_listing() {
+		$this->login_as_employer();
+		[ $job_id, $key ] = $this->create_resumable_job( get_current_user_id(), 'pending_payment' );
+
+		$allow_pending_payment = static function ( $statuses ) {
+			$statuses[] = 'pending_payment';
+			return $statuses;
+		};
+		add_filter( 'job_manager_valid_submit_job_statuses', $allow_pending_payment );
+
+		try {
+			$form = $this->load_form_from_cookie( $job_id, $key, 'before' );
+			$this->assertSame( $job_id, $form->get_job_id() );
+		} finally {
+			remove_filter( 'job_manager_valid_submit_job_statuses', $allow_pending_payment );
+		}
+	}
+
+	/**
+	 * An incorrect submitting key is rejected and removed.
+	 */
+	public function test_incorrect_submitting_key_is_rejected_and_cookies_are_cleared() {
+		$this->logout();
+		[ $job_id ] = $this->create_resumable_job( 0 );
+
+		$form = $this->load_form_from_cookie( $job_id, 'incorrect-key' );
+
+		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_cleared();
+	}
+
+	/**
+	 * A non-resumable job status is rejected and removed.
+	 */
+	public function test_non_resumable_status_is_rejected_and_cookies_are_cleared() {
+		$this->logout();
+		[ $job_id, $key ] = $this->create_resumable_job( 0, 'draft' );
+
+		$form = $this->load_form_from_cookie( $job_id, $key );
+
+		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_cleared();
+	}
+
+	/**
+	 * Missing jobs are rejected without leaving a stale-cookie loop.
+	 */
+	public function test_missing_job_is_rejected_and_cookies_are_cleared() {
+		$this->logout();
+		$form = $this->load_form_from_cookie( 99999999, 'missing-key' );
+
+		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_cleared();
+	}
+
+	/**
+	 * A matching key on a different post type cannot be used as a resume target.
+	 */
+	public function test_non_job_post_is_rejected_and_cookies_are_cleared() {
+		$this->logout();
+		$post_id = $this->factory->post->create(
+			[
+				'post_author' => 0,
+				'post_status' => 'preview',
+			]
+		);
+		$key     = 'resume-key-' . $post_id;
+		update_post_meta( $post_id, '_submitting_key', $key );
+
+		$form = $this->load_form_from_cookie( $post_id, $key );
+
+		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_cleared();
+	}
+}

--- a/tests/php/tests/includes/test_class.submit-job-resume-ownership.php
+++ b/tests/php/tests/includes/test_class.submit-job-resume-ownership.php
@@ -62,6 +62,33 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 	}
 
 	/**
+	 * Sets the resume cookies for a job listing.
+	 *
+	 * @param int    $job_id Job listing ID.
+	 * @param string $key    Submitting key.
+	 */
+	private function set_resume_cookies( $job_id, $key ) {
+		$_COOKIE[ self::JOB_ID_COOKIE ]  = (string) $job_id;
+		$_COOKIE[ self::JOB_KEY_COOKIE ] = $key;
+	}
+
+	/**
+	 * Instantiates the submit form.
+	 *
+	 * @param string $flow Paid-listings flow option.
+	 * @return WP_Job_Manager_Form_Submit_Job
+	 */
+	private function load_form( $flow = '' ) {
+		if ( '' === $flow ) {
+			delete_option( 'job_manager_paid_listings_flow' );
+		} else {
+			update_option( 'job_manager_paid_listings_flow', $flow );
+		}
+
+		return new WP_Job_Manager_Form_Submit_Job();
+	}
+
+	/**
 	 * Instantiates the submit form with resume cookies set.
 	 *
 	 * @param int    $job_id Job listing ID.
@@ -70,20 +97,24 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 	 * @return WP_Job_Manager_Form_Submit_Job
 	 */
 	private function load_form_from_cookie( $job_id, $key, $flow = '' ) {
-		if ( '' === $flow ) {
-			delete_option( 'job_manager_paid_listings_flow' );
-		} else {
-			update_option( 'job_manager_paid_listings_flow', $flow );
-		}
+		$this->set_resume_cookies( $job_id, $key );
 
-		$_COOKIE[ self::JOB_ID_COOKIE ]  = (string) $job_id;
-		$_COOKIE[ self::JOB_KEY_COOKIE ] = $key;
-
-		return new WP_Job_Manager_Form_Submit_Job();
+		return $this->load_form( $flow );
 	}
 
 	/**
-	 * Asserts that rejected resume cookies were removed from the current request.
+	 * Asserts that the expected resume cookies remain available to the request.
+	 *
+	 * @param int    $job_id Job listing ID.
+	 * @param string $key    Submitting key.
+	 */
+	private function assert_resume_cookies_preserved( $job_id, $key ) {
+		$this->assertSame( (string) $job_id, $_COOKIE[ self::JOB_ID_COOKIE ] );
+		$this->assertSame( $key, $_COOKIE[ self::JOB_KEY_COOKIE ] );
+	}
+
+	/**
+	 * Asserts that stale resume cookies were removed from the current request.
 	 */
 	private function assert_resume_cookies_cleared() {
 		$this->assertArrayNotHasKey( self::JOB_ID_COOKIE, $_COOKIE );
@@ -103,8 +134,7 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
 
 		$this->assertSame( $job_id, $form->get_job_id() );
-		$this->assertArrayHasKey( self::JOB_ID_COOKIE, $_COOKIE );
-		$this->assertArrayHasKey( self::JOB_KEY_COOKIE, $_COOKIE );
+		$this->assert_resume_cookies_preserved( $job_id, $key );
 	}
 
 	/**
@@ -118,10 +148,17 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 		[ $job_id, $key ] = $this->create_resumable_job( get_current_user_id() );
 
 		$this->login_as_employer_b();
-		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
+		$this->set_resume_cookies( $job_id, $key );
+		WPJM()->validate_job_posting_cookies();
+		$form = $this->load_form( $flow );
 
 		$this->assertSame( 0, $form->get_job_id() );
-		$this->assert_resume_cookies_cleared();
+		$this->assert_resume_cookies_preserved( $job_id, $key );
+
+		$this->login_as_employer();
+		$form = $this->load_form( $flow );
+
+		$this->assertSame( $job_id, $form->get_job_id() );
 	}
 
 	/**
@@ -139,8 +176,50 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
 
 		$this->assertSame( $job_id, $form->get_job_id() );
-		$this->assertArrayHasKey( self::JOB_ID_COOKIE, $_COOKIE );
-		$this->assertArrayHasKey( self::JOB_KEY_COOKIE, $_COOKIE );
+		$this->assert_resume_cookies_preserved( $job_id, $key );
+	}
+
+	/**
+	 * A guest-authored listing can be resumed after the guest logs in.
+	 *
+	 * @dataProvider paid_listings_flows
+	 * @param string $flow Paid-listings flow option.
+	 */
+	public function test_guest_can_log_in_and_resume_guest_listing( $flow ) {
+		$this->logout();
+		[ $job_id, $key ] = $this->create_resumable_job( 0 );
+		$this->set_resume_cookies( $job_id, $key );
+
+		$this->login_as_employer();
+		WPJM()->validate_job_posting_cookies();
+		$form = $this->load_form( $flow );
+
+		$this->assertSame( $job_id, $form->get_job_id() );
+		$this->assert_resume_cookies_preserved( $job_id, $key );
+	}
+
+	/**
+	 * A registered user's listing remains resumable after their session expires.
+	 *
+	 * @dataProvider paid_listings_flows
+	 * @param string $flow Paid-listings flow option.
+	 */
+	public function test_user_can_resume_listing_after_session_expires_and_is_restored( $flow ) {
+		$this->login_as_employer();
+		[ $job_id, $key ] = $this->create_resumable_job( get_current_user_id() );
+		$this->set_resume_cookies( $job_id, $key );
+
+		$this->login_as( 0 );
+		WPJM()->validate_job_posting_cookies();
+		$form = $this->load_form( $flow );
+
+		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_preserved( $job_id, $key );
+
+		$this->login_as_employer();
+		$form = $this->load_form( $flow );
+
+		$this->assertSame( $job_id, $form->get_job_id() );
 	}
 
 	/**
@@ -154,10 +233,12 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 		[ $job_id, $key ] = $this->create_resumable_job( get_current_user_id() );
 
 		$this->logout();
-		$form = $this->load_form_from_cookie( $job_id, $key, $flow );
+		$this->set_resume_cookies( $job_id, $key );
+		WPJM()->validate_job_posting_cookies();
+		$form = $this->load_form( $flow );
 
 		$this->assertSame( 0, $form->get_job_id() );
-		$this->assert_resume_cookies_cleared();
+		$this->assert_resume_cookies_preserved( $job_id, $key );
 	}
 
 	/**
@@ -182,28 +263,50 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 	}
 
 	/**
-	 * An incorrect submitting key is rejected and removed.
+	 * Cookie validation runs after post types and before submitted forms are loaded.
+	 */
+	public function test_cookie_validation_runs_on_early_init() {
+		$this->assertSame( 0, has_action( 'init', [ WPJM()->post_types, 'register_post_types' ] ) );
+		$this->assertSame( 1, has_action( 'init', [ WPJM(), 'validate_job_posting_cookies' ] ) );
+		$this->assertSame( 10, has_action( 'init', [ WPJM()->forms, 'load_posted_form' ] ) );
+	}
+
+	/**
+	 * An incorrect submitting key is rejected and removed during early validation.
 	 */
 	public function test_incorrect_submitting_key_is_rejected_and_cookies_are_cleared() {
+		$this->logout();
+		[ $job_id ] = $this->create_resumable_job( 0 );
+		$this->set_resume_cookies( $job_id, 'incorrect-key' );
+
+		WPJM()->validate_job_posting_cookies();
+
+		$this->assert_resume_cookies_cleared();
+	}
+
+	/**
+	 * The form still rejects an invalid key if early validation did not run.
+	 */
+	public function test_form_rejects_incorrect_submitting_key_without_clearing_cookies() {
 		$this->logout();
 		[ $job_id ] = $this->create_resumable_job( 0 );
 
 		$form = $this->load_form_from_cookie( $job_id, 'incorrect-key' );
 
 		$this->assertSame( 0, $form->get_job_id() );
-		$this->assert_resume_cookies_cleared();
+		$this->assert_resume_cookies_preserved( $job_id, 'incorrect-key' );
 	}
 
 	/**
-	 * A non-resumable job status is rejected and removed.
+	 * A non-resumable job status is rejected and removed during early validation.
 	 */
 	public function test_non_resumable_status_is_rejected_and_cookies_are_cleared() {
 		$this->logout();
 		[ $job_id, $key ] = $this->create_resumable_job( 0, 'draft' );
+		$this->set_resume_cookies( $job_id, $key );
 
-		$form = $this->load_form_from_cookie( $job_id, $key );
+		WPJM()->validate_job_posting_cookies();
 
-		$this->assertSame( 0, $form->get_job_id() );
 		$this->assert_resume_cookies_cleared();
 	}
 
@@ -212,9 +315,10 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 	 */
 	public function test_missing_job_is_rejected_and_cookies_are_cleared() {
 		$this->logout();
-		$form = $this->load_form_from_cookie( 99999999, 'missing-key' );
+		$this->set_resume_cookies( 99999999, 'missing-key' );
 
-		$this->assertSame( 0, $form->get_job_id() );
+		WPJM()->validate_job_posting_cookies();
+
 		$this->assert_resume_cookies_cleared();
 	}
 
@@ -231,10 +335,34 @@ class WP_Test_Submit_Job_Resume_Ownership extends WPJM_BaseTest {
 		);
 		$key     = 'resume-key-' . $post_id;
 		update_post_meta( $post_id, '_submitting_key', $key );
+		$this->set_resume_cookies( $post_id, $key );
 
-		$form = $this->load_form_from_cookie( $post_id, $key );
+		WPJM()->validate_job_posting_cookies();
 
-		$this->assertSame( 0, $form->get_job_id() );
+		$this->assert_resume_cookies_cleared();
+	}
+
+	/**
+	 * @return array[] Incomplete cookie pairs.
+	 */
+	public function incomplete_resume_cookie_pairs() {
+		return [
+			'missing job ID' => [ [ self::JOB_KEY_COOKIE => 'resume-key' ] ],
+			'missing key'    => [ [ self::JOB_ID_COOKIE => '123' ] ],
+		];
+	}
+
+	/**
+	 * An incomplete resume cookie pair is removed during early validation.
+	 *
+	 * @dataProvider incomplete_resume_cookie_pairs
+	 * @param array $cookies Resume cookies for the request.
+	 */
+	public function test_incomplete_resume_cookie_pair_is_cleared( $cookies ) {
+		$_COOKIE = array_merge( $_COOKIE, $cookies );
+
+		WPJM()->validate_job_posting_cookies();
+
 		$this->assert_resume_cookies_cleared();
 	}
 }


### PR DESCRIPTION
Fixes #1936

The resume cookie path checked the listing status and submitting key, but not whether the current visitor could edit the listing. On a shared device, a stale cookie could therefore resume another account's unfinished submission.

### Changes Proposed in this Pull Request

* Validate the submission cookie pair on `init` at priority 1, after job post types register and before submitted forms load.
* Clear cookies only when they are incomplete or reference an invalid ID, missing or non-job post, unsupported status, or mismatched submitting key.
* Ignore valid but currently unauthorized resumes without deleting their cookies, allowing an expired session to resume after the owner logs in again.
* Allow a valid guest-authored draft to resume after the visitor logs in; registered-user drafts still require `job_manager_user_can_edit_job()`.
* Retain status, key, post-type, and ownership checks in the submit form as defense in depth.
* Add regression coverage for both paid-listings flows, authentication transitions, ownership boundaries, and stale cookie variants.

### Testing Instructions

* `vendor/bin/phpunit --filter WP_Test_Submit_Job_Resume_Ownership` - 22 tests, 63 assertions.
* `vendor/bin/phpunit` - 629 tests, 2,236 assertions, with the 3 existing live-geocode tests skipped because no API key was configured.
* `vendor/bin/phpcs includes/class-wp-job-manager.php includes/forms/class-wp-job-manager-form-submit-job.php tests/php/tests/includes/test_class.submit-job-resume-ownership.php`.
* `php -l` on all three changed PHP files.
* Sent a real wp-env page request with an invalid job ID/key cookie pair and confirmed that the response included clearing `Set-Cookie` headers for both cookies before its redirect.

### Release Notes

* Prevent a job submission preview from being resumed by a different account on the same device without discarding a valid draft when authentication changes.
