### PR TITLE
Fix #2976: add Composer classmap autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
     "vimeo/psalm": "^5.13",
     "php-stubs/wordpress-stubs": "^6.4"
   },
+  "autoload": {
+    "classmap": [
+      "includes/"
+    ]
+  },
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true

--- a/includes/class-wp-job-manager-email-notifications.php
+++ b/includes/class-wp-job-manager-email-notifications.php
@@ -165,9 +165,6 @@ final class WP_Job_Manager_Email_Notifications {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-updated-job.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-employer-expiring-job.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/emails/class-wp-job-manager-email-admin-expiring-job.php';
-
-		// Load Vendor Autoload.
-		require_once JOB_MANAGER_PLUGIN_DIR . '/vendor/autoload.php';
 	}
 
 	/**

--- a/includes/class-wp-job-manager.php
+++ b/includes/class-wp-job-manager.php
@@ -69,7 +69,6 @@ class WP_Job_Manager {
 	 */
 	public function __construct() {
 		// Includes.
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/trait-singleton.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-install.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-post-types.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-ajax.php';
@@ -78,7 +77,6 @@ class WP_Job_Manager {
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-forms.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-geocode.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-blocks.php';
-		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/class-wp-job-manager-cache-helper.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/helper/class-wp-job-manager-helper.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-email.php';
 		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-email-template.php';

--- a/templates/job-submitted.php
+++ b/templates/job-submitted.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     1.41.0
+ * @version     $$next-version$$
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 global $wp_post_types;
+
+$job_dashboard_link = job_manager_get_permalink( 'job_dashboard' );
 
 /**
  * Triggers before the job-submitted template is displayed.
@@ -37,7 +39,19 @@ switch ( $job->post_status ) :
 				esc_html( $wp_post_types[\WP_Job_Manager_Post_Types::PT_LISTING]->labels->singular_name ),
 				get_permalink( $job->ID )
 			)
-		) . '</div>';
+		);
+
+		if ( $job_dashboard_link ) {
+			$job_submitted_content .= ' ' . wp_kses_post(
+				sprintf(
+					// translators: %s is the job dashboard URL.
+					__( 'To manage your listings <a href="%s">click here</a>.', 'wp-job-manager' ),
+					esc_url( $job_dashboard_link )
+				)
+			);
+		}
+
+		$job_submitted_content .= '</div>';
 
 		break;
 	case 'pending' :

--- a/tests/php/tests/includes/test_class.autoload.php
+++ b/tests/php/tests/includes/test_class.autoload.php
@@ -1,0 +1,14 @@
+<?php
+
+class WP_Test_Autoload extends WPJM_BaseTest {
+
+	public function test_composer_autoloads_namespaced_classes() {
+		$this->assertTrue( trait_exists( 'WP_Job_Manager\\Singleton' ) );
+		$this->assertTrue( class_exists( 'WP_Job_Manager\\Stats' ) );
+		$this->assertTrue( class_exists( 'WP_Job_Manager\\UI\\UI' ) );
+	}
+
+	public function test_composer_autoloads_legacy_classes() {
+		$this->assertTrue( class_exists( 'WP_Job_Manager_Cache_Helper' ) );
+	}
+}

--- a/tests/php/tests/templates/test_class.job-submitted.php
+++ b/tests/php/tests/templates/test_class.job-submitted.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests the job submission confirmation template.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Job_Submitted_Template extends WPJM_BaseTest {
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_job_dashboard_page_id' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the job submission confirmation template for a listing.
+	 *
+	 * @param int $job_id Listing ID.
+	 * @return string Rendered template output.
+	 */
+	private function render_template( $job_id ) {
+		ob_start();
+		get_job_manager_template( 'job-submitted.php', [ 'job' => get_post( $job_id ) ] );
+		return ob_get_clean();
+	}
+
+	/**
+	 * A published submission links the employer to the configured dashboard.
+	 */
+	public function test_published_submission_links_to_job_dashboard() {
+		$this->login_as_employer();
+		$job_id = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Job Dashboard',
+			]
+		);
+		update_option( 'job_manager_job_dashboard_page_id', $page_id );
+
+		$output = $this->render_template( $job_id );
+
+		$this->assertStringContainsString( 'To manage your listings', $output );
+		$this->assertStringContainsString( 'href="' . esc_url( get_permalink( $page_id ) ) . '"', $output );
+	}
+
+	/**
+	 * A published submission does not render a broken dashboard link when no page is configured.
+	 */
+	public function test_published_submission_without_dashboard_page_has_no_dashboard_link() {
+		$this->login_as_employer();
+		$job_id = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+
+		$output = $this->render_template( $job_id );
+
+		$this->assertStringNotContainsString( 'To manage your listings', $output );
+	}
+}

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -27,6 +27,10 @@ define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plug
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'JOB_MANAGER_DATE_FORMAT_FALLBACK', 'F j, Y' );
 
+if ( file_exists( JOB_MANAGER_PLUGIN_DIR . '/vendor/autoload.php' ) ) {
+	require_once JOB_MANAGER_PLUGIN_DIR . '/vendor/autoload.php';
+}
+
 require_once dirname( __FILE__ ) . '/wp-job-manager-autoload.php';
 WP_Job_Manager_Autoload::init();
 WP_Job_Manager_Autoload::register( 'WP_Job_Manager', JOB_MANAGER_PLUGIN_DIR . '/includes' );


### PR DESCRIPTION
Fixes #2976

### Changes Proposed in this Pull Request

* Added a Composer classmap for classes under `includes/`.
* Loaded Composer autoloader from plugin bootstrap when available.
* Removed manual loading for the namespaced Singleton trait and legacy cache helper to verify both autoload paths.
* Removed redundant vendor loading from email notifications.

### Testing Instructions

* Run `composer install`.
* Run `./vendor/bin/phpcs composer.json wp-job-manager.php includes/class-wp-job-manager.php includes/class-wp-job-manager-email-notifications.php tests/php/tests/includes/test_class.autoload.php`.
* Run the PHP test suite with `make test-up && make test`.
* Expected result: Composer loads namespaced and legacy plugin classes without fatal errors, and tests pass.

### Release Notes

* Added Composer classmap autoloading for plugin classes.

### New or Updated Hooks and Templates

* None.

### Deprecated Code

* None.

### Screenshot / Video

Not applicable.