### PR TITLE
fix(logo): add optional alt text for company logo on front-end job submission

### DIFF
--- a/includes/forms/class-wp-job-manager-form-edit-job.php
+++ b/includes/forms/class-wp-job-manager-form-edit-job.php
@@ -119,6 +119,9 @@ class WP_Job_Manager_Form_Edit_Job extends WP_Job_Manager_Form_Submit_Job {
 					} elseif ( 'company_logo' === $key ) {
 						$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_thumbnail_id( $job->ID ) : get_post_meta( $job->ID, '_' . $key, true );
 
+					} elseif ( 'company_logo_alt' === $key ) {
+						$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_meta( get_post_thumbnail_id( $job->ID ), '_wp_attachment_image_alt', true ) : '';
+
 					} elseif ( ! empty( $field['taxonomy'] ) ) {
 						$this->fields[ $group_key ][ $key ]['value'] = wp_get_object_terms( $job->ID, $field['taxonomy'], [ 'fields' => 'ids' ] );
 

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -320,14 +320,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 					],
 				],
 				'company' => [
-					'company_name'    => [
+					'company_name'     => [
 						'label'       => __( 'Company name', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => true,
 						'placeholder' => __( 'Enter the name of the company', 'wp-job-manager' ),
 						'priority'    => 1,
 					],
-					'company_website' => [
+					'company_website'  => [
 						'label'       => __( 'Website', 'wp-job-manager' ),
 						'type'        => 'text',
 						'sanitizer'   => 'url',
@@ -335,7 +335,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'http://', 'wp-job-manager' ),
 						'priority'    => 2,
 					],
-					'company_tagline' => [
+					'company_tagline'  => [
 						'label'       => __( 'Tagline', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
@@ -343,7 +343,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'maxlength'   => 64,
 						'priority'    => 3,
 					],
-					'company_video'   => [
+					'company_video'    => [
 						'label'       => __( 'Video', 'wp-job-manager' ),
 						'type'        => 'text',
 						'sanitizer'   => 'url',
@@ -351,14 +351,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						'placeholder' => __( 'A link to a video about your company', 'wp-job-manager' ),
 						'priority'    => 4,
 					],
-					'company_twitter' => [
+					'company_twitter'  => [
 						'label'       => __( 'X / Twitter username', 'wp-job-manager' ),
 						'type'        => 'text',
 						'required'    => false,
 						'placeholder' => __( '@yourcompany', 'wp-job-manager' ),
 						'priority'    => 5,
 					],
-					'company_logo'    => [
+					'company_logo'     => [
 						'label'              => __( 'Logo', 'wp-job-manager' ),
 						'type'               => 'file',
 						'required'           => false,
@@ -378,6 +378,14 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 								'webp' => 'image/webp',
 							]
 						),
+					],
+					'company_logo_alt' => [
+						'label'       => __( 'Logo alt text', 'wp-job-manager' ),
+						'type'        => 'text',
+						'required'    => false,
+						'placeholder' => __( 'Describe the logo for screen readers and search engines', 'wp-job-manager' ),
+						'priority'    => 7,
+						'description' => __( 'Optional. Used when the logo is shown on the site.', 'wp-job-manager' ),
 					],
 				],
 			]
@@ -670,6 +678,9 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 							break;
 						case 'company_logo':
 							$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_thumbnail_id( $job->ID ) : get_post_meta( $job->ID, '_' . $key, true );
+							break;
+						case 'company_logo_alt':
+							$this->fields[ $group_key ][ $key ]['value'] = has_post_thumbnail( $job->ID ) ? get_post_meta( get_post_thumbnail_id( $job->ID ), '_wp_attachment_image_alt', true ) : '';
 							break;
 						default:
 							$this->fields[ $group_key ][ $key ]['value'] = get_post_meta( $job->ID, '_' . $key, true );
@@ -1066,10 +1077,11 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	/**
 	 * Creates a file attachment.
 	 *
-	 * @param  string $attachment_url
+	 * @param string $attachment_url
+	 * @param string $alt_text       Optional alt text to store on the attachment.
 	 * @return int attachment id.
 	 */
-	protected function create_attachment( $attachment_url ) {
+	protected function create_attachment( $attachment_url, $alt_text = '' ) {
 		include_once ABSPATH . 'wp-admin/includes/image.php';
 		include_once ABSPATH . 'wp-admin/includes/media.php';
 
@@ -1119,6 +1131,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		// same logo being uploaded on every submission.
 		$reusable_id = $this->find_reusable_attachment( $attachment_url );
 		if ( $reusable_id ) {
+			$this->set_attachment_alt_text( $reusable_id, $alt_text );
 			return $reusable_id;
 		}
 
@@ -1142,11 +1155,36 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			if ( $hash ) {
 				update_post_meta( $attachment_id, self::ATTACHMENT_HASH_META_KEY, $hash );
 			}
+			$this->set_attachment_alt_text( $attachment_id, $alt_text );
 			wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $attachment_url ) );
 			return $attachment_id;
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Stores alt text on an image attachment using WordPress's standard field.
+	 *
+	 * Only writes when alt text is provided. An existing value is never
+	 * overwritten, so a re-upload of the same logo cannot clobber alt text a
+	 * previous submission set.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $alt_text      Alt text to store.
+	 */
+	protected function set_attachment_alt_text( $attachment_id, $alt_text ) {
+		$alt_text = sanitize_text_field( $alt_text );
+		if ( '' === $alt_text ) {
+			return;
+		}
+
+		$existing = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		if ( '' === trim( (string) $existing ) ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+		}
 	}
 
 	/**
@@ -1215,11 +1253,13 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 					// Company logo is a featured image.
 				} elseif ( 'company_logo' === $key ) {
-					$attachment_id = is_numeric( $values[ $group_key ][ $key ] ) ? absint( $values[ $group_key ][ $key ] ) : $this->create_attachment( $values[ $group_key ][ $key ] );
+					$alt_text      = isset( $values[ $group_key ]['company_logo_alt'] ) ? $values[ $group_key ]['company_logo_alt'] : '';
+					$attachment_id = is_numeric( $values[ $group_key ][ $key ] ) ? absint( $values[ $group_key ][ $key ] ) : $this->create_attachment( $values[ $group_key ][ $key ], $alt_text );
 					if ( empty( $attachment_id ) ) {
 						delete_post_thumbnail( $this->job_id );
 					} else {
 						set_post_thumbnail( $this->job_id, $attachment_id );
+						$this->set_attachment_alt_text( $attachment_id, $alt_text );
 					}
 					update_user_meta( get_current_user_id(), '_company_logo', $attachment_id );
 

--- a/templates/content-summary-job_listing.php
+++ b/templates/content-summary-job_listing.php
@@ -34,7 +34,7 @@ if ( post_password_required( $post ) || ! job_manager_user_can_view_job_listing(
 	<?php } ?>
 
 	<?php if ( $logo = get_the_company_logo() ) : ?>
-		<img src="<?php echo esc_url( $logo ); ?>" alt="<?php the_company_name(); ?>" title="<?php the_company_name(); ?> - <?php the_company_tagline(); ?>" />
+		<img src="<?php echo esc_url( $logo ); ?>" alt="<?php echo esc_attr( get_the_company_logo_alt() ); ?>" title="<?php the_company_name(); ?> - <?php the_company_tagline(); ?>" />
 	<?php endif; ?>
 
 	<div class="job_summary_content">

--- a/templates/form-fields/uploaded-file-html.php
+++ b/templates/form-fields/uploaded-file-html.php
@@ -24,8 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$image_src = $value;
 	}
 	$extension = ! empty( $extension ) ? $extension : substr( strrchr( $image_src, '.' ), 1 );
-	if ( 'image' === wp_ext2type( $extension ) ) : ?>
-		<span class="job-manager-uploaded-file-preview"><img src="<?php echo esc_url( $image_src ); ?>" /> <a class="job-manager-remove-uploaded-file" href="#">[<?php _e( 'remove', 'wp-job-manager' ); ?>]</a></span>
+	if ( 'image' === wp_ext2type( $extension ) ) :
+		$preview_alt = is_numeric( $value ) ? get_post_meta( absint( $value ), '_wp_attachment_image_alt', true ) : ''; ?>
+		<span class="job-manager-uploaded-file-preview"><img src="<?php echo esc_url( $image_src ); ?>" alt="<?php echo esc_attr( $preview_alt ); ?>" /> <a class="job-manager-remove-uploaded-file" href="#">[<?php _e( 'remove', 'wp-job-manager' ); ?>]</a></span>
 	<?php else : ?>
 		<span class="job-manager-uploaded-file-name"><code><?php echo esc_html( basename( $image_src ) ); ?></code> <a class="job-manager-remove-uploaded-file" href="#">[<?php _e( 'remove', 'wp-job-manager' ); ?>]</a></span>
 	<?php endif; ?>

--- a/tests/php/tests/includes/test_class.submit-job-logo-alt.php
+++ b/tests/php/tests/includes/test_class.submit-job-logo-alt.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Tests that the company_logo_alt field persists alt text to the attachment
+ * during front-end job submission.
+ *
+ * @package wp-job-manager
+ */
+class WP_Test_Submit_Job_Logo_Alt extends WPJM_BaseTest {
+
+	/**
+	 * Filtered uploads base URL.
+	 *
+	 * @var string
+	 */
+	private $base_url = 'http://example.org/wp-content/uploads';
+
+	/**
+	 * Filtered uploads base directory.
+	 *
+	 * @var string
+	 */
+	private $base_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+
+		$this->base_dir = trailingslashit( get_temp_dir() ) . 'wpjm-uploads-' . uniqid();
+		wp_mkdir_p( $this->base_dir );
+
+		add_filter( 'upload_dir', [ $this, 'filter_upload_dir' ] );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'upload_dir', [ $this, 'filter_upload_dir' ] );
+
+		unset( $_POST, $_REQUEST );
+		$_POST    = [];
+		$_REQUEST = [];
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Points wp_upload_dir() at our deterministic base URL / directory.
+	 *
+	 * @param array $dirs Upload directory data.
+	 * @return array
+	 */
+	public function filter_upload_dir( $dirs ) {
+		$dirs['baseurl'] = $this->base_url;
+		$dirs['basedir'] = $this->base_dir;
+		$dirs['url']     = $this->base_url;
+		$dirs['path']    = $this->base_dir;
+		return $dirs;
+	}
+
+	/**
+	 * Writes a minimal valid PNG into the uploads base dir and returns its URL.
+	 *
+	 * @param string $filename File name to create.
+	 * @return string Public URL of the created file.
+	 */
+	private function write_local_image( $filename ) {
+		$png = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC' );
+		file_put_contents( trailingslashit( $this->base_dir ) . $filename, $png );
+		return trailingslashit( $this->base_url ) . $filename;
+	}
+
+	/**
+	 * Invokes the form's protected create_attachment().
+	 *
+	 * @param string $attachment_url Value to pass to create_attachment().
+	 * @param string $alt_text       Alt text to store.
+	 * @return int Attachment ID.
+	 */
+	private function create_attachment( $attachment_url, $alt_text = '' ) {
+		$form   = WP_Job_Manager_Form_Submit_Job::instance();
+		$method = new ReflectionMethod( $form, 'create_attachment' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $form, $attachment_url, $alt_text );
+	}
+
+	/**
+	 * Invokes the form's protected set_attachment_alt_text().
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $alt_text      Alt text to store.
+	 */
+	private function set_attachment_alt_text( $attachment_id, $alt_text ) {
+		$form   = WP_Job_Manager_Form_Submit_Job::instance();
+		$method = new ReflectionMethod( $form, 'set_attachment_alt_text' );
+		$method->setAccessible( true );
+
+		$method->invoke( $form, $attachment_id, $alt_text );
+	}
+
+	/**
+	 * Creating an attachment with alt text sets _wp_attachment_image_alt.
+	 */
+	public function test_attachment_created_with_alt_text() {
+		$local_url = $this->write_local_image( 'alt-upload.png' );
+
+		$attachment_id = $this->create_attachment( $local_url, 'Alt text for logo' );
+
+		$this->assertGreaterThan( 0, $attachment_id, 'Attachment must be created.' );
+		$this->assertSame(
+			'Alt text for logo',
+			get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			'_wp_attachment_image_alt must be set to the provided alt text.'
+		);
+	}
+
+	/**
+	 * Creating an attachment with empty alt text does not set meta or excerpt.
+	 */
+	public function test_attachment_created_without_alt_text() {
+		$local_url = $this->write_local_image( 'no-alt-upload.png' );
+
+		$attachment_id = $this->create_attachment( $local_url, '' );
+
+		$this->assertGreaterThan( 0, $attachment_id, 'Attachment must be created.' );
+		$this->assertSame(
+			'',
+			get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			'_wp_attachment_image_alt must be empty when no alt text is provided.'
+		);
+	}
+
+	/**
+	 * A reusable attachment (same hash) does not overwrite a previously saved alt.
+	 */
+	public function test_reusable_attachment_does_not_overwrite_alt() {
+		// Reuse only applies to a logged-in user's own attachments.
+		$this->login_as_employer();
+
+		$local_url = $this->write_local_image( 'reusable-alt.png' );
+
+		// First upload with alt.
+		$attachment_id = $this->create_attachment( $local_url, 'First alt' );
+		$this->assertGreaterThan( 0, $attachment_id );
+
+		$this->assertSame(
+			'First alt',
+			get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			'First alt must be set.'
+		);
+
+		// Second upload of the same file with a different alt — must not overwrite.
+		$attachment_id_2 = $this->create_attachment( $local_url, 'Second alt' );
+
+		// Expect the same attachment reused.
+		$this->assertEquals( $attachment_id, $attachment_id_2, 'Same file must reuse the existing attachment.' );
+		$this->assertSame(
+			'First alt',
+			get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			'Reuse must not overwrite the existing alt text.'
+		);
+	}
+
+	/**
+	 * set_attachment_alt_text with empty alt is a no-op.
+	 */
+	public function test_set_alt_text_noop_when_empty() {
+		$attachment_id = $this->factory->attachment->create(
+			[
+				'post_title'   => 'test.png',
+				'post_content' => '',
+				'post_excerpt' => '',
+				'post_mime_type' => 'image/png',
+			]
+		);
+
+		$this->set_attachment_alt_text( $attachment_id, '' );
+
+		$this->assertSame(
+			'',
+			get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			'Setting empty alt must not create meta.'
+		);
+	}
+
+	/**
+	 * set_attachment_alt_text with blank string is also a no-op.
+	 */
+	public function test_set_alt_text_noop_when_whitespace() {
+		$attachment_id = $this->factory->attachment->create(
+			[
+				'post_title'   => 'test.png',
+				'post_content' => '',
+				'post_excerpt' => '',
+				'post_mime_type' => 'image/png',
+			]
+		);
+
+		$this->set_attachment_alt_text( $attachment_id, '   ' );
+
+		$this->assertSame(
+			'',
+			get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			'Whitespace-only alt must not create meta.'
+		);
+	}
+
+	/**
+	 * get_the_company_logo_alt returns the existing alt text from the attachment.
+	 */
+	public function test_get_the_company_logo_alt_from_attachment() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'  => \WP_Job_Manager_Post_Types::PT_LISTING,
+				'post_title' => 'Test Job',
+			]
+		);
+
+		$attachment_id = $this->write_local_image_no_attachment( 'logo.png' );
+
+		// Manually set alt and attach thumbnail.
+		update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'Custom logo alt' );
+		set_post_thumbnail( $post_id, $attachment_id );
+
+		$this->assertSame(
+			'Custom logo alt',
+			get_the_company_logo_alt( get_post( $post_id ) ),
+			'get_the_company_logo_alt must return the attachment alt text.'
+		);
+	}
+
+	/**
+	 * Writes a local PNG and returns an attachment ID for it.
+	 *
+	 * @param string $filename File name.
+	 * @return int Attachment ID.
+	 */
+	private function write_local_image_no_attachment( $filename ) {
+		$url = $this->write_local_image( $filename );
+		return $this->create_attachment( $url, '' );
+	}
+}

--- a/wp-job-manager-template.php
+++ b/wp-job-manager-template.php
@@ -883,19 +883,43 @@ function the_company_logo( $size = 'thumbnail', $default = null, $post = null ) 
 	$logo = get_the_company_logo( $post, $size );
 
 	if ( has_post_thumbnail( $post ) ) {
-		echo '<img class="company_logo" src="' . esc_url( $logo ) . '" alt="' . esc_attr( get_the_company_name( $post ) ) . '" />';
+		echo '<img class="company_logo" src="' . esc_url( $logo ) . '" alt="' . esc_attr( get_the_company_logo_alt( $post ) ) . '" />';
 
 		// Before 1.24.0, logo URLs were stored in post meta.
 	} elseif ( ! empty( $logo ) && ( strstr( $logo, 'http' ) || file_exists( $logo ) ) ) {
 		if ( 'full' !== $size ) {
 			$logo = job_manager_get_resized_image( $logo, $size );
 		}
-		echo '<img class="company_logo" src="' . esc_url( $logo ) . '" alt="' . esc_attr( get_the_company_name( $post ) ) . '" />';
+		echo '<img class="company_logo" src="' . esc_url( $logo ) . '" alt="' . esc_attr( get_the_company_logo_alt( $post ) ) . '" />';
 	} elseif ( $default ) {
-		echo '<img class="company_logo" src="' . esc_url( $default ) . '" alt="' . esc_attr( get_the_company_name( $post ) ) . '" />';
+		echo '<img class="company_logo" src="' . esc_url( $default ) . '" alt="' . esc_attr( get_the_company_logo_alt( $post ) ) . '" />';
 	} else {
-		echo '<img class="company_logo" src="' . esc_url( apply_filters( 'job_manager_default_company_logo', JOB_MANAGER_PLUGIN_URL . '/assets/images/company.png' ) ) . '" alt="' . esc_attr( get_the_company_name( $post ) ) . '" />';
+		echo '<img class="company_logo" src="' . esc_url( apply_filters( 'job_manager_default_company_logo', JOB_MANAGER_PLUGIN_URL . '/assets/images/company.png' ) ) . '" alt="' . esc_attr( get_the_company_logo_alt( $post ) ) . '" />';
 	}
+}
+
+/**
+ * Gets the alt text for a job's company logo.
+ *
+ * Reads alt text stored on the logo attachment and falls back to the company
+ * name when none is set, so existing listings without alt text keep working.
+ *
+ * @since $$next-version$$
+ * @param int|WP_Post $post (default: null).
+ * @return string Alt text for the company logo.
+ */
+function get_the_company_logo_alt( $post = null ) {
+	$post = get_post( $post );
+	$alt  = get_the_company_name( $post );
+
+	if ( $post && has_post_thumbnail( $post->ID ) ) {
+		$attachment_alt = get_post_meta( get_post_thumbnail_id( $post->ID ), '_wp_attachment_image_alt', true );
+		if ( '' !== trim( (string) $attachment_alt ) ) {
+			$alt = $attachment_alt;
+		}
+	}
+
+	return apply_filters( 'job_manager_company_logo_alt', $alt, $post );
 }
 
 /**


### PR DESCRIPTION
Fixes #2899

### Changes Proposed in this Pull Request

Adds a company_logo_alt text field to the front-end job submission form and the edit form, giving submitters an optional way to describe their logo for screen readers and search engines.

Alt text is stored on the logo attachment using WordPress's standard `_wp_attachment_image_alt` post meta, so it shows up in the media library and works with existing tooling. The rendered alt comes from a new `get_the_company_logo_alt()` helper, used by `the_company_logo()` and the job summary template. When no alt is set, it falls back to the company name, so existing listings keep their current behavior.

Reuse is handled carefully. When the same logo file is uploaded again (matched by attachment hash), a previously saved alt is never overwritten, so a later re-upload cannot clobber alt text set by an earlier submission.

### Testing Instructions

1. Set up a fresh WordPress install with Job Manager, and enable job submission through the settings.
2. Submit a new job, upload a company logo, and fill in the new "Logo alt text" field (for example `ACME logo`).
3. After the job is published, view the job listing page and the job summary. The logo img should render `alt="ACME logo"`.
4. Edit the job and confirm the alt text field is pre-filled with the saved value.
5. Submit another job with a logo but leave the alt field blank. The logo should fall back to the company name as alt, and no alt meta should be written.
6. Upload the same logo file again for a different listing, this time with a different alt. Confirm the original job's alt text is not changed.

### Release Notes

* Added optional alt text for company logos submitted on the front-end job form.

### New or Updated Hooks and Templates
<!-- Add notes for developers on hook/template changes. Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

* New filter `job_manager_company_logo_alt` on the alt text used for a job's company logo. Accepts the alt string and the post object, and returns the alt string to use. Lets themes and plugins override the value without touching the database.

### Deprecated Code

None.

### Screenshot / Video

None. Front-end form change only; no visual assets to attach.