### PR TITLE
Fix guest upload of WPJM whitelisted mime types

### DIFF
--- a/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-ajax.php
@@ -426,6 +426,72 @@ class WP_Test_WP_Job_Manager_Ajax extends WPJM_BaseTest {
 		$this->assertCount( 0, $result['_jobs'] );
 	}
 
+	/**
+	 * Regression: a guest (logged-out) visitor whose site restricts `upload_mimes` for non-logged-in
+	 * users must still be able to upload a file type that WPJM whitelists. WP core's
+	 * `wp_check_filetype_and_ext()` ignores the `mimes` override passed to `wp_handle_upload()` and
+	 * calls `get_allowed_mime_types()` for the current user instead, so WPJM's upload path
+	 * short-circuits this by merging its own allow-list into the per-user map only for the duration
+	 * of the upload.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::job_manager_upload_file
+	 */
+	public function test_upload_file_guest_with_restricted_upload_mimes() {
+		wp_set_current_user( 0 );
+
+		$pdf_file = DIR_TESTDATA . '/images/test-alpha.pdf';
+
+		// Make a copy of this file as it gets moved during the file upload.
+		$tmp_name = wp_tempnam( $pdf_file );
+		copy( $pdf_file, $tmp_name );
+
+		// Build a $file array as `job_manager_upload_file()` expects it, with a valid type already set.
+		$file = [
+			'name'     => 'test-alpha.pdf',
+			'type'     => 'application/pdf',
+			'tmp_name' => $tmp_name,
+			'error'    => 0,
+			'size'     => filesize( $pdf_file ),
+		];
+		$this->assertFileExists( $tmp_name );
+
+		// Site-level hardening pattern: per-user `upload_mimes` restricts guests to images only.
+		// WPJM's own allow-list (which still includes PDF by default) is the source of truth.
+		$guest_mimes_filter = function ( $mimes, $user ) {
+			if ( ! $user || ! user_can( $user, 'unfiltered_html' ) ) {
+				return [
+					'jpg|jpeg|jpe' => 'image/jpeg',
+					'png'          => 'image/png',
+				];
+			}
+			return $mimes;
+		};
+		// Bypass the `is_uploaded_file()` test that `wp_handle_upload()` runs in non-HTTP contexts,
+		// while keeping any `mimes` override that the production code passes through.
+		$upload_overrides_filter = function ( $overrides ) {
+			$overrides['action'] = 'test-wpjm-upload';
+			return $overrides;
+		};
+
+		add_filter( 'upload_mimes', $guest_mimes_filter, 10, 2 );
+		add_filter( 'submit_job_wp_handle_upload_overrides', $upload_overrides_filter );
+
+		$result = job_manager_upload_file( $file, [ 'file_key' => 'application' ] );
+
+		remove_filter( 'submit_job_wp_handle_upload_overrides', $upload_overrides_filter );
+		remove_filter( 'upload_mimes', $guest_mimes_filter, 10 );
+
+		$this->assertNotWPError( $result, 'Guest PDF upload should succeed when WPJM whitelists PDF, even with a per-user restrictive upload_mimes filter.' );
+		$this->assertIsObject( $result );
+		$this->assertObjectHasProperty( 'url', $result );
+		$this->assertObjectHasProperty( 'file', $result );
+		$this->assertFileExists( $result->file );
+
+		// Cleanup.
+		@unlink( $result->file );
+	}
+
 	private function set_up_job_listing_search_request() {
 		$_REQUEST['search_location']   = null;
 		$_REQUEST['search_keywords']   = null;

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1611,6 +1611,14 @@ function job_manager_upload_file( $file, $args = [] ) {
 		$allowed_mime_types = $args['allowed_mime_types'];
 	}
 
+	// While a WPJM upload is in progress, treat WPJM's allow-list as authoritative. WordPress core
+	// runs `get_allowed_mime_types()` (per current user) inside `wp_check_filetype_and_ext()` after
+	// `wp_handle_upload()` has been called, and a site that hardens `upload_mimes` for non-logged-in
+	// visitors will reject files WPJM itself accepted. Merging WPJM's list into the per-user list
+	// only for the duration of this call keeps the two checks consistent without relaxing the
+	// site's broader upload policy.
+	add_filter( 'upload_mimes', '_job_manager_extend_upload_mimes' );
+
 	/**
 	 * Filter file configuration before upload
 	 *
@@ -1626,13 +1634,11 @@ function job_manager_upload_file( $file, $args = [] ) {
 	$file = apply_filters( 'job_manager_upload_file_pre_upload', $file, $args, $allowed_mime_types );
 
 	if ( is_wp_error( $file ) ) {
-		return $file;
-	}
-
-	if ( 'company_logo' === $args['file_key'] ) {
+		$result = $file;
+	} elseif ( 'company_logo' === $args['file_key'] ) {
 		$max_size = job_manager_get_company_logo_max_size();
 		if ( $file['size'] > $max_size ) {
-			return new WP_Error(
+			$result = new WP_Error(
 				'upload',
 				sprintf(
 					// translators: %s is the maximum allowed file size.
@@ -1643,21 +1649,32 @@ function job_manager_upload_file( $file, $args = [] ) {
 		}
 	}
 
-	if ( ! in_array( $file['type'], $allowed_mime_types, true ) ) {
+	if ( ! isset( $result ) && ! in_array( $file['type'], $allowed_mime_types, true ) ) {
 		// Replace pipe separating similar extensions (e.g. jpeg|jpg) to comma to match the list separator.
 		$allowed_file_extensions = implode( ', ', str_replace( '|', ', ', array_keys( $allowed_mime_types ) ) );
 
 		if ( $args['file_label'] ) {
 			// translators: %1$s is the file field label; %2$s is the file type; %3$s is the list of allowed file types.
-			return new WP_Error( 'upload', sprintf( __( '"%1$s" (filetype %2$s) needs to be one of the following file types: %3$s', 'wp-job-manager' ), $args['file_label'], $file['type'], $allowed_file_extensions ) );
+			$result = new WP_Error( 'upload', sprintf( __( '"%1$s" (filetype %2$s) needs to be one of the following file types: %3$s', 'wp-job-manager' ), $args['file_label'], $file['type'], $allowed_file_extensions ) );
 		} else {
 			// translators: %s is the list of allowed file types.
-			return new WP_Error( 'upload', sprintf( __( 'Uploaded files need to be one of the following file types: %s', 'wp-job-manager' ), $allowed_file_extensions ) );
+			$result = new WP_Error( 'upload', sprintf( __( 'Uploaded files need to be one of the following file types: %s', 'wp-job-manager' ), $allowed_file_extensions ) );
 		}
-	} else {
-		$upload = wp_handle_upload( $file, apply_filters( 'submit_job_wp_handle_upload_overrides', [ 'test_form' => false ] ) );
+	}
+
+	if ( ! isset( $result ) ) {
+		$upload = wp_handle_upload(
+			$file,
+			apply_filters(
+				'submit_job_wp_handle_upload_overrides',
+				[
+					'test_form' => false,
+					'mimes'     => $allowed_mime_types,
+				]
+			)
+		);
 		if ( ! empty( $upload['error'] ) ) {
-			return new WP_Error( 'upload', $upload['error'] );
+			$result = new WP_Error( 'upload', $upload['error'] );
 		} else {
 			$uploaded_file->url       = $upload['url'];
 			$uploaded_file->file      = $upload['file'];
@@ -1665,13 +1682,15 @@ function job_manager_upload_file( $file, $args = [] ) {
 			$uploaded_file->type      = $upload['type'];
 			$uploaded_file->size      = $file['size'];
 			$uploaded_file->extension = substr( strrchr( $uploaded_file->name, '.' ), 1 );
+			$result                   = $uploaded_file;
 		}
 	}
 
+	remove_filter( 'upload_mimes', '_job_manager_extend_upload_mimes' );
 	$job_manager_upload         = false;
 	$job_manager_uploading_file = '';
 
-	return $uploaded_file;
+	return $result;
 }
 
 /**
@@ -1717,6 +1736,37 @@ function job_manager_get_allowed_mime_types( $field = '' ) {
 	 * @param string $field The field key for the upload.
 	 */
 	return apply_filters( 'job_manager_mime_types', $allowed_mime_types, $field );
+}
+
+/**
+ * Merges WPJM's allow-list into the per-user mime map while a WPJM upload is in progress.
+ *
+ * WP core's `wp_check_filetype_and_ext()` consults `get_allowed_mime_types()` for the current
+ * user when deciding whether a real-MIME match is acceptable, and ignores the `mimes` override
+ * passed via `wp_handle_upload()`. Without this filter, a site that hardens `upload_mimes` for
+ * non-logged-in visitors would reject files WPJM itself accepted. Scoped to the duration of
+ * `job_manager_upload_file()` via `$job_manager_uploading_file` so unrelated uploads keep their
+ * site-restricted list.
+ *
+ * @since $$next-version$$
+ *
+ * @param array $mimes Per-user mime map, keyed by pipe-separated extensions.
+ * @return array Possibly extended mime map.
+ */
+function _job_manager_extend_upload_mimes( $mimes ) {
+	global $job_manager_upload, $job_manager_uploading_file;
+
+	if ( empty( $job_manager_upload ) ) {
+		return $mimes;
+	}
+
+	$wpjm_mimes = job_manager_get_allowed_mime_types( $job_manager_uploading_file );
+
+	if ( ! is_array( $wpjm_mimes ) ) {
+		return $mimes;
+	}
+
+	return array_merge( $mimes, $wpjm_mimes );
 }
 
 /**


### PR DESCRIPTION
Fixes #2887

### Changes Proposed in this Pull Request

* Install a scoped `upload_mimes` filter inside `job_manager_upload_file()` that merges WPJM's resolved allow-list into the per-user mime map only for the duration of the upload. The filter is gated on the existing `$job_manager_upload` global, so unrelated uploads keep the site's per-user list.
* Restructure `job_manager_upload_file()` so the scoped filter is removed on every exit path (early `WP_Error` returns, size check, mime-mismatch, the upload itself).
* Pass `mimes => $allowed_mime_types` through the existing `submit_job_wp_handle_upload_overrides` filter for any third-party code that reads the override map.
* Add `_job_manager_extend_upload_mimes()` helper, guarded by `$job_manager_upload` and resolving the field-specific WPJM allow-list.
* Add a regression test `test_upload_file_guest_with_restricted_upload_mimes` covering the exact failure path: a guest user uploading a PDF on a site whose `upload_mimes` filter restricts guests to images only.

### Testing Instructions

* Run `npm run lint:php` — must pass clean.
* Run `WP_TESTS_DIR=/var/folders/j_/fymn2lbj2fgc618ggmjndbq80000gn/T/wordpress-tests-lib ./vendor/bin/phpunit --filter test_upload` — the new test must pass alongside the three existing `test_upload_file*` tests.
* Manual reproduction: on a WP install with WPJM, add this mu-plugin and log out:

  ```php
  add_filter( 'upload_mimes', function ( $mimes ) {
      if ( ! is_user_logged_in() ) {
          return [ 'jpg|jpeg|jpe' => 'image/jpeg', 'png' => 'image/png' ];
      }
      return $mimes;
  } );
  add_filter( 'job_manager_user_can_upload_file_via_ajax', '__return_true' );
  add_filter( 'job_manager_mime_types', function ( $types ) {
      $types['pdf'] = 'application/pdf';
      return $types;
  } );
  ```

  On the application form, upload a `.pdf` as a guest. Before the fix the upload fails with "You are not allowed to upload this file type."; after the fix the upload succeeds. Logged-in uploads and disallowed types (e.g. `.exe`) must still behave as before.

### Release Notes

* Allow guest users to upload file types that WPJM whitelists via `job_manager_mime_types`, even when a site has tightened the per-user `upload_mimes` filter for logged-out visitors.

### New or Updated Hooks and Templates

* No new or updated hooks. The internal `_job_manager_extend_upload_mimes()` is a private helper and is not part of the public API.

### Deprecated Code

* None.

### Screenshot / Video

