### PR TITLE
Fix primary action button overflow on dashboard

### DIFF
--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -138,8 +138,10 @@
 	white-space: nowrap;
 	min-width: 0; /* allow the button to shrink below its text width */
 	overflow: hidden;
+	text-overflow: ellipsis;
 
 	span {
+		display: block; /* text-overflow does not apply to inline boxes */
 		min-width: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/assets/css/job-dashboard.scss
+++ b/assets/css/job-dashboard.scss
@@ -136,6 +136,14 @@
 .jm-dashboard-action--primary {
 	flex-basis: fit-content;
 	white-space: nowrap;
+	min-width: 0; /* allow the button to shrink below its text width */
+	overflow: hidden;
+
+	span {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 }
 
 .jm-dashboard-action:where(:not(:hover):not(:focus)) {


### PR DESCRIPTION
Fixes #2946
Closes #2829

### Changes Proposed in this Pull Request

The primary action button on the front-end Job Dashboard (Continue Submission, Mark filled, etc.) is an outline button with `white-space: nowrap` and `flex-basis: fit-content`. At narrow container widths the Actions column shrinks, but the button cannot shrink with it, so it overflows to the left and overlaps the Views and Date columns. Because the button has no background fill, the text behind it bleeds through and the row looks broken.

This happens on both table variants: the small table at around 640px (#2946) and the large table at around 930px (#2829).

The fix lets the button shrink below its text width and truncates the inner label span with an ellipsis:

```scss
.jm-dashboard-action--primary {
	flex-basis: fit-content;
	white-space: nowrap;
	min-width: 0; /* allow the button to shrink below its text width */
	overflow: hidden;
	text-overflow: ellipsis;

	span {
		display: block; /* text-overflow does not apply to inline boxes */
		min-width: 0;
		overflow: hidden;
		text-overflow: ellipsis;
	}
}
```

The `span` needs `display: block`. `.jm-dashboard-action` sets `display: block` on the anchor and `job-dashboard.css` loads after `ui.css`, so the anchor is not the flex box `.jm-ui-button--outline` declares. That makes the inner `span` a non-replaced inline box, and CSS does not apply `overflow` or `text-overflow` to inline boxes. The `text-overflow` on the anchor is a fallback if a theme forces the span back to inline.

No PHP or template changes. The `<span>` wrapping the label already exists in `UI_Elements::button()`. The full action stays available in the three-dot overflow menu, which is built from the same `$job_actions` array, so truncating the standalone button never removes access to it.

This works for both table variants with a single rule, so no per-variant breakpoint is needed. The mobile layout (where the Actions column already wraps onto its own line) is not affected.

### Testing Instructions

1. Set up a Job Dashboard with at least one draft job (Continue Submission button) and one active job (Mark filled button).
2. Open the dashboard and narrow the browser window.
3. Small table (up to 4 columns): at around 640px container width, confirm the primary action button no longer overlaps the Views or Date columns. The label clips with an ellipsis.
4. Large table (5 or more columns): at around 930px container width, confirm the same behaviour (this is the #2829 case).
5. Open the three-dot overflow menu and confirm the full action is still listed and works.
6. Shrink to mobile width (under 540px small table, under 780px large table) and confirm no regression.

### Release Notes

* Fixed: the primary action button on the Job Dashboard no longer overlaps neighbouring columns at narrow widths. Long labels are truncated with an ellipsis, and the full action remains in the overflow menu.

### New or Updated Hooks and Templates

*

### Deprecated Code

*

### Screenshot / Video