### PR TITLE
fix: show an error when a job dashboard duplicate fails

### DIFF
--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -484,7 +484,8 @@ class Job_Dashboard_Shortcode {
 						exit;
 					}
 
-					break;
+					// translators: Placeholder %s is the job listing title.
+					throw new \Exception( sprintf( __( 'Could not duplicate %s', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) );
 				case 'relist':
 				case 'renew':
 				case 'continue':

--- a/includes/class-job-dashboard-shortcode.php
+++ b/includes/class-job-dashboard-shortcode.php
@@ -436,6 +436,8 @@ class Job_Dashboard_Shortcode {
 				throw new \Exception( __( 'Invalid ID', 'wp-job-manager' ) );
 			}
 
+			$action_failed = false;
+
 			switch ( $action ) {
 				case 'mark_filled':
 					// Check status.
@@ -477,15 +479,24 @@ class Job_Dashboard_Shortcode {
 						throw new \Exception( __( 'Missing submission page.', 'wp-job-manager' ) );
 					}
 
-					$new_job_id = job_manager_duplicate_listing( $job_id );
+					$new_job_id = job_manager_duplicate_listing( $job_id, true );
 
-					if ( $new_job_id ) {
+					if ( ! is_wp_error( $new_job_id ) && $new_job_id ) {
 						wp_safe_redirect( add_query_arg( [ 'job_id' => absint( $new_job_id ) ], job_manager_get_permalink( 'submit_job_form' ) ) );
 						exit;
 					}
 
-					// translators: Placeholder %s is the job listing title.
-					throw new \Exception( sprintf( __( 'Could not duplicate %s', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ) );
+					// Message.
+					$action_failed               = true;
+					$this->job_dashboard_message = Notice::error(
+						[
+							// translators: Placeholder %s is the job listing title.
+							'title'   => sprintf( __( 'Could not duplicate %s', 'wp-job-manager' ), wpjm_get_the_job_title( $job ) ),
+							'message' => __( 'The copy could not be saved. Please try again. If this keeps happening, contact the site administrator.', 'wp-job-manager' ),
+						]
+					);
+
+					break;
 				case 'relist':
 				case 'renew':
 				case 'continue':
@@ -522,7 +533,7 @@ class Job_Dashboard_Shortcode {
 			 * @param int    $job_id The ID for the job that's been altered.
 			 */
 			$success_message = apply_filters( 'job_manager_job_dashboard_success_message', '', $action, $job_id );
-			if ( $success_message ) {
+			if ( $success_message && ! $action_failed ) {
 				$this->job_dashboard_message = Notice::success( $success_message );
 			}
 		} catch ( \Exception $e ) {

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -1566,4 +1566,76 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 		$this->assertSame( '0', get_post_meta( $new_id, '_featured', true ) );
 		$this->assertEquals( [ 'onsite' ], wp_get_post_terms( $new_id, 'job_listing_type', [ 'fields' => 'slugs' ] ) );
 	}
+
+	/**
+	 * An empty ID keeps returning 0 for callers that do not opt into WP_Error.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::job_manager_duplicate_listing
+	 */
+	public function test_duplicate_listing_returns_zero_for_empty_id() {
+		$this->assertSame( 0, job_manager_duplicate_listing( 0 ) );
+	}
+
+	/**
+	 * An empty ID returns a WP_Error when the caller asks for one.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::job_manager_duplicate_listing
+	 */
+	public function test_duplicate_listing_returns_wp_error_for_empty_id() {
+		$result = job_manager_duplicate_listing( 0, true );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'job_manager_duplicate_listing_missing_id', $result->get_error_code() );
+	}
+
+	/**
+	 * A post that is not a job listing fails with a distinct error code.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::job_manager_duplicate_listing
+	 */
+	public function test_duplicate_listing_rejects_other_post_types() {
+		$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
+
+		$this->assertSame( 0, job_manager_duplicate_listing( $post_id ) );
+
+		$result = job_manager_duplicate_listing( $post_id, true );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'job_manager_duplicate_listing_invalid_listing', $result->get_error_code() );
+	}
+
+	/**
+	 * A failed insert stops the duplicate instead of assigning terms against object ID 0.
+	 *
+	 * @since $$next-version$$
+	 * @covers ::job_manager_duplicate_listing
+	 */
+	public function test_duplicate_listing_returns_wp_error_when_the_insert_fails() {
+		global $wpdb;
+
+		$job_id = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+		wp_set_object_terms( $job_id, [ 'remote' ], 'job_listing_type' );
+
+		$listings_before = wp_count_posts( \WP_Job_Manager_Post_Types::PT_LISTING );
+
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+		$result = job_manager_duplicate_listing( $job_id, true );
+		remove_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'empty_content', $result->get_error_code() );
+		$this->assertEquals(
+			$listings_before,
+			wp_count_posts( \WP_Job_Manager_Post_Types::PT_LISTING ),
+			'A failed duplicate should not create a job listing.'
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Checking for the orphan rows the old fall-through used to write.
+		$orphan_terms = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->term_relationships} WHERE object_id = 0" );
+
+		$this->assertSame( 0, $orphan_terms, 'A failed duplicate should not assign terms against object ID 0.' );
+	}
 }

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -1512,4 +1512,58 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	public function test_get_accept_file_types_empty_when_nothing_is_allowed() {
 		$this->assertSame( '', job_manager_get_accept_file_types( [] ) );
 	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::job_manager_duplicate_listing
+	 */
+	public function test_duplicate_listing_from_publish_creates_preview_copy() {
+		$job_id    = $this->factory->job_listing->create( [
+			'post_title'  => 'Senior Developer',
+			'post_content' => 'Great job.',
+			'post_status' => 'publish',
+		] );
+		wp_set_object_terms( $job_id, [ 'remote' ], 'job_listing_type' );
+		update_post_meta( $job_id, '_filled', 1 );
+		update_post_meta( $job_id, '_featured', 1 );
+		update_post_meta( $job_id, '_application', 'jobs@example.com' );
+
+		$new_id = job_manager_duplicate_listing( $job_id );
+
+		$this->assertNotEquals( 0, $new_id, 'Duplicate should return a nonzero post ID.' );
+		$this->assertEquals( 'preview', get_post_status( $new_id ) );
+		$this->assertEquals( 'Senior Developer', get_the_title( $new_id ) );
+		$this->assertEquals( 'Great job.', get_post_field( 'post_content', $new_id ) );
+		$this->assertEquals( 'jobs@example.com', get_post_meta( $new_id, '_application', true ) );
+		$this->assertSame( '0', get_post_meta( $new_id, '_filled', true ) );
+		$this->assertSame( '0', get_post_meta( $new_id, '_featured', true ) );
+		$this->assertEquals( [ 'remote' ], wp_get_post_terms( $new_id, 'job_listing_type', [ 'fields' => 'slugs' ] ) );
+	}
+
+	/**
+	 * @since $$next-version$$
+	 * @covers ::job_manager_duplicate_listing
+	 */
+	public function test_duplicate_listing_from_expired_creates_preview_copy() {
+		$job_id = $this->factory->job_listing->create( [
+			'post_title'   => 'Expired Role',
+			'post_content' => 'Still useful.',
+			'post_status'  => 'expired',
+		] );
+		wp_set_object_terms( $job_id, [ 'onsite' ], 'job_listing_type' );
+		update_post_meta( $job_id, '_filled', 1 );
+		update_post_meta( $job_id, '_featured', 1 );
+		update_post_meta( $job_id, '_application', 'apply@example.com' );
+
+		$new_id = job_manager_duplicate_listing( $job_id );
+
+		$this->assertNotEquals( 0, $new_id, 'Duplicate should return a nonzero post ID.' );
+		$this->assertEquals( 'preview', get_post_status( $new_id ) );
+		$this->assertEquals( 'Expired Role', get_the_title( $new_id ) );
+		$this->assertEquals( 'Still useful.', get_post_field( 'post_content', $new_id ) );
+		$this->assertEquals( 'apply@example.com', get_post_meta( $new_id, '_application', true ) );
+		$this->assertSame( '0', get_post_meta( $new_id, '_filled', true ) );
+		$this->assertSame( '0', get_post_meta( $new_id, '_featured', true ) );
+		$this->assertEquals( [ 'onsite' ], wp_get_post_terms( $new_id, 'job_listing_type', [ 'fields' => 'slugs' ] ) );
+	}
 }

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1795,19 +1795,26 @@ function calculate_job_expiry( $job_id, $return_datetime = false, $from_timestam
  * Duplicates a listing.
  *
  * @since 1.25.0
- * @param  int $post_id
- * @return int 0 on fail or the post ID.
+ * @since $$next-version$$ Added the $wp_error parameter.
+ *
+ * @param  int  $post_id  ID of the listing to duplicate.
+ * @param  bool $wp_error Optional. Return a WP_Error on failure instead of 0. Default false.
+ * @return int|WP_Error The new post ID, or 0 on fail. A WP_Error on fail when $wp_error is true.
  */
-function job_manager_duplicate_listing( $post_id ) {
+function job_manager_duplicate_listing( $post_id, $wp_error = false ) {
 	global $wpdb;
 
 	if ( empty( $post_id ) ) {
-		return 0;
+		return $wp_error
+			? new WP_Error( 'job_manager_duplicate_listing_missing_id', __( 'No job listing was selected to duplicate.', 'wp-job-manager' ) )
+			: 0;
 	}
 
 	$post = get_post( $post_id );
 	if ( ! $post || \WP_Job_Manager_Post_Types::PT_LISTING !== $post->post_type ) {
-		return 0;
+		return $wp_error
+			? new WP_Error( 'job_manager_duplicate_listing_invalid_listing', __( 'The job listing to duplicate could not be found.', 'wp-job-manager' ) )
+			: 0;
 	}
 
 	/**
@@ -1828,8 +1835,13 @@ function job_manager_duplicate_listing( $post_id ) {
 			'post_type'      => $post->post_type,
 			'to_ping'        => $post->to_ping,
 			'menu_order'     => $post->menu_order,
-		]
+		],
+		true
 	);
+
+	if ( is_wp_error( $new_post_id ) ) {
+		return $wp_error ? $new_post_id : 0;
+	}
 
 	/**
 	 * Copy taxonomies.


### PR DESCRIPTION
Fixes #2884

### Changes Proposed in this Pull Request

The "Duplicate" action in the employer job dashboard already worked for listings in any status, including active (publish) and expired. The only real defect was a silent failure: when `job_manager_duplicate_listing()` returned 0, the handler fell through with no message and just reloaded the dashboard, which looked like the button did nothing.

This change makes that failure visible and actionable:

- `job_manager_duplicate_listing()` gains an optional `$wp_error` parameter. When it is `true` the function returns a `WP_Error` describing the failure instead of a bare `0`, so callers can tell a missing ID, a non-listing post, and a failed insert apart. The default stays `false` and still returns `0`, so the documented return contract is unchanged for existing callers.
- The internal `wp_insert_post()` call now passes `$wp_error = true` and bails out as soon as the insert fails. Previously the return value was never checked, so a failed insert let the function carry on and call `wp_set_object_terms( 0, ... )`, which writes orphan `term_relationships` rows against object ID 0. (The `update_post_meta( 0, ... )` calls on the same path were already no-ops, since `update_metadata()` bails on a falsy object ID.)
- The job dashboard now shows an error notice with a title and a next step when duplication fails, matching the error pattern used by the other dashboard actions (`mark_filled`, `mark_not_filled`, `relist`, `renew`):

  > **Could not duplicate {job title}**
  > The copy could not be saved. Please try again. If this keeps happening, contact the site administrator.

  The underlying `WP_Error` message is deliberately not shown to the employer, because WordPress core embeds `$wpdb->last_error` in its `db_insert_error` message and this notice renders on a public-facing page.

- The `job_manager_job_dashboard_success_message` filter is now skipped when the action failed. Without that guard a third-party filter returning text for the `duplicate` action would overwrite the error notice with a success notice.

A pre-existing test gap was also covered with regression tests against `job_manager_duplicate_listing()`.

### Testing Instructions

Install this branch on a test site.

Success path:

1. On the employer job dashboard (`[job_dashboard]` shortcode), open a row for an active (published) job.
2. Click "Duplicate". Confirm you are redirected to the submission page with the form pre-filled.
3. Repeat the same on a row for an expired job. Same pre-filled form, same redirect.
4. Repeat on a draft row to confirm draft duplication still works.

Failure path (this is what the PR adds). Force the underlying post insert to fail by dropping this into a mu-plugin:

```php
<?php
add_filter( 'wp_insert_post_empty_content', '__return_true' );
```

1. With the filter active, click "Duplicate" on any job in the dashboard.
2. Confirm the dashboard reloads showing the error notice titled "Could not duplicate {job title}", instead of doing nothing.
3. Remove the mu-plugin and confirm "Duplicate" works normally again.

Automated checks:

- PHPUnit: 613 tests, 2199 assertions, all pass (3 geocode tests skipped, they need a Google API key). Six tests cover `job_manager_duplicate_listing()`: duplicating from `publish` and from `expired` source statuses, the `0` return for an empty ID and for a non-listing post type, the matching `WP_Error` codes when `$wp_error` is `true`, and a forced insert failure asserting no listing is created and no term row is written against object ID 0. The last one was confirmed to fail without the early bail.
- `./vendor/bin/phpcs`: clean on both changed source files.

### Known limitation

The dashboard notice is carried across the redirect by `set_transient()`. On a site with no persistent object cache that is a `wp_options` write, so on a site whose database writes are failing the notice itself can fail to persist and the employer would still land on a clean dashboard with no feedback. That is a property of the existing dashboard notice mechanism, shared by every other action, and is not something this PR changes.

### Release Notes

Duplicating a job listing now shows an error notice explaining what to do next when the action fails, instead of silently reloading the dashboard.

### New or Updated Hooks and Templates

None. `job_manager_duplicate_listing()` gains an optional `$wp_error` parameter; the default behaviour and return type are unchanged.

### Deprecated Code

None.

### Screenshot / Video

No visible UI change on the success path. The error notice only appears on the previously silent failure case.
