### PR TITLE
fix: store scheduled listing dates in site timezone

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -406,9 +406,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		if ( get_option( 'job_manager_enable_scheduled_listings' ) ) {
 			$this->fields['job']['job_schedule_listing'] = [
 				'label'       => __( 'Scheduled Date', 'wp-job-manager' ),
-				'description' => __( 'Optionally set the date when this listing will be published.', 'wp-job-manager' ),
+				'description' => __( 'Optionally set the date and time when this listing will be published.', 'wp-job-manager' ),
 				'type'        => 'date',
 				'required'    => false,
+				'enable_time' => true,
 				'placeholder' => '',
 				'priority'    => '6.5',
 			];
@@ -1370,44 +1371,98 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @return bool True when the scheduled date is a valid future date, false otherwise.
 	 */
 	public static function apply_scheduled_date( array &$job_data, string $scheduled_date ): bool {
-		$maybe_formatted_date = self::maybe_format_future_datetime( $scheduled_date );
+		$scheduled_datetime = self::format_scheduled_datetime( $scheduled_date );
 
-		if ( false === $maybe_formatted_date ) {
+		if ( false === $scheduled_datetime ) {
 			$job_data['post_date']     = current_time( 'mysql' );
 			$job_data['post_date_gmt'] = current_time( 'mysql', 1 );
 
 			return false;
 		}
 
-		$job_data['post_date']     = $maybe_formatted_date;
-		$job_data['post_date_gmt'] = $maybe_formatted_date;
+		$job_data['post_date']     = $scheduled_datetime['local'];
+		$job_data['post_date_gmt'] = $scheduled_datetime['gmt'];
 
 		return true;
 	}
 
 	/**
-	 * Checks that a string is a valid future datetime. Formats datetime for post date.
+	 * Parses a scheduled date in the site timezone and returns the local and GMT datetime strings.
 	 *
-	 * @param string $maybe_date_string The date to format.
+	 * The input is treated as a wall-clock time in the site's timezone. The local value is stored
+	 * in post_date and the GMT value is the matching UTC instant. Both are required so scheduled
+	 * listings publish at the expected local time regardless of the site timezone.
 	 *
-	 * @return false|mixed
+	 * @since $$next-version$$
+	 *
+	 * @param string $scheduled_date The scheduled date.
+	 *
+	 * @return array{local: string, gmt: string}|false The local and GMT datetime, or false when invalid.
 	 */
-	private static function maybe_format_future_datetime( string $maybe_date_string ) {
-		if ( empty( $maybe_date_string ) ) {
+	private static function format_scheduled_datetime( string $scheduled_date ) {
+		if ( empty( $scheduled_date ) ) {
 			return false;
 		}
 
-		$time = strtotime( $maybe_date_string );
-		if ( false === $time ) {
+		$date_parts = explode( ' ', $scheduled_date );
+		if ( ! isset( $date_parts[0] ) ) {
 			return false;
 		}
 
-		if ( $time < time() ) {
+		$local_datetime = DateTimeImmutable::createFromFormat( 'Y-m-d', $date_parts[0], wp_timezone() );
+		if ( false === $local_datetime || $local_datetime->format( 'Y-m-d' ) !== $date_parts[0] ) {
 			return false;
 		}
 
-		$fmt = 'Y-m-d H:i:s';
-		return wp_date( $fmt, $time );
+		// Set the time explicitly. createFromFormat leaves unspecified time parts at the
+		// current time, so a date-only value would otherwise inherit "now" instead of midnight.
+		$local_datetime = $local_datetime->setTime( 0, 0, 0 );
+
+		if ( isset( $date_parts[1] ) && preg_match( '/^(\d{1,2}):(\d{2})/', $date_parts[1], $time_matches ) ) {
+			$hours   = (int) $time_matches[1];
+			$minutes = (int) $time_matches[2];
+
+			// Guard against out-of-range times, which would throw on newer PHP versions.
+			if ( $hours > 23 || $minutes > 59 ) {
+				return false;
+			}
+
+			$local_datetime = $local_datetime->setTime( $hours, $minutes, 0 );
+		}
+
+		if ( $local_datetime->getTimestamp() < time() ) {
+			return false;
+		}
+
+		return [
+			'local' => $local_datetime->format( 'Y-m-d H:i:s' ),
+			'gmt'   => $local_datetime->setTimezone( new DateTimeZone( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
+		];
+	}
+
+	/**
+	 * Gets the value for a date field, appending an optional time component when enabled.
+	 *
+	 * @param string $key   The field key.
+	 * @param array  $field The field configuration.
+	 *
+	 * @return string The posted date, optionally including the time.
+	 */
+	protected function get_posted_date_field( $key, $field ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in submit handler.
+		$posted_date = isset( $_POST[ $key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) : '';
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in submit handler.
+		if ( ! empty( $field['enable_time'] ) && isset( $_POST[ $key . '-time' ] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in submit handler.
+			$posted_time = sanitize_text_field( wp_unslash( $_POST[ $key . '-time' ] ) );
+
+			if ( ! empty( $posted_time ) ) {
+				$posted_date .= ' ' . $posted_time;
+			}
+		}
+
+		return $posted_date;
 	}
 
 	/**

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1393,41 +1393,27 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * in post_date and the GMT value is the matching UTC instant. Both are required so scheduled
 	 * listings publish at the expected local time regardless of the site timezone.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.7
 	 *
 	 * @param string $scheduled_date The scheduled date.
 	 *
 	 * @return array{local: string, gmt: string}|false The local and GMT datetime, or false when invalid.
 	 */
 	private static function format_scheduled_datetime( string $scheduled_date ) {
-		if ( empty( $scheduled_date ) ) {
+		$scheduled_date = trim( $scheduled_date );
+
+		// An empty string parses as the current time, so reject it before parsing.
+		if ( '' === $scheduled_date ) {
 			return false;
 		}
 
-		$date_parts = explode( ' ', $scheduled_date );
-		if ( ! isset( $date_parts[0] ) ) {
+		try {
+			// Any strtotime-parseable value is accepted. Without JavaScript the datepicker
+			// input posts its display text ("August 31, 2028"), not the ISO value the
+			// JS-created hidden field would carry. A date with no time part starts at midnight.
+			$local_datetime = new DateTimeImmutable( $scheduled_date, wp_timezone() );
+		} catch ( Exception $e ) {
 			return false;
-		}
-
-		$local_datetime = DateTimeImmutable::createFromFormat( 'Y-m-d', $date_parts[0], wp_timezone() );
-		if ( false === $local_datetime || $local_datetime->format( 'Y-m-d' ) !== $date_parts[0] ) {
-			return false;
-		}
-
-		// Set the time explicitly. createFromFormat leaves unspecified time parts at the
-		// current time, so a date-only value would otherwise inherit "now" instead of midnight.
-		$local_datetime = $local_datetime->setTime( 0, 0, 0 );
-
-		if ( isset( $date_parts[1] ) && preg_match( '/^(\d{1,2}):(\d{2})/', $date_parts[1], $time_matches ) ) {
-			$hours   = (int) $time_matches[1];
-			$minutes = (int) $time_matches[2];
-
-			// Guard against out-of-range times, which would throw on newer PHP versions.
-			if ( $hours > 23 || $minutes > 59 ) {
-				return false;
-			}
-
-			$local_datetime = $local_datetime->setTime( $hours, $minutes, 0 );
 		}
 
 		if ( $local_datetime->getTimestamp() < time() ) {
@@ -1449,20 +1435,24 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * @return string The posted date, optionally including the time.
 	 */
 	protected function get_posted_date_field( $key, $field ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in submit handler.
-		$posted_date = isset( $_POST[ $key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) : '';
+		// Read the date through the shared handler so the before_sanitize callback still
+		// runs. That callback sets the field's `empty` flag, which required-field validation
+		// depends on.
+		$posted_value = $this->get_posted_field( $key, $field );
+		$posted_date  = is_string( $posted_value ) ? $posted_value : '';
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in submit handler.
-		if ( ! empty( $field['enable_time'] ) && isset( $_POST[ $key . '-time' ] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in submit handler.
-			$posted_time = sanitize_text_field( wp_unslash( $_POST[ $key . '-time' ] ) );
-
-			if ( ! empty( $posted_time ) ) {
-				$posted_date .= ' ' . $posted_time;
-			}
+		if ( '' === $posted_date || empty( $field['enable_time'] ) ) {
+			return $posted_date;
 		}
 
-		return $posted_date;
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in submit handler.
+		$posted_time = isset( $_POST[ $key . '-time' ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key . '-time' ] ) ) : '';
+
+		if ( '' === $posted_time ) {
+			return $posted_date;
+		}
+
+		return $posted_date . ' ' . $posted_time;
 	}
 
 	/**

--- a/templates/form-fields/date-field.php
+++ b/templates/form-fields/date-field.php
@@ -22,13 +22,16 @@ wp_enqueue_style( 'jquery-ui' );
 <?php
 $field_date_value = isset( $field['value'] ) ? $field['value'] : '';
 $field_time_value = '';
-if ( strpos( $field_date_value, ' ' ) ) {
-	$field_time_value = substr( strrchr( $field_date_value, ' ' ), 1, 5 );
-	$field_date_value = substr( $field_date_value, 0, 10 );
+
+// Split the stored value only for fields that opted into a time input, and only on a
+// real trailing time. Other date fields keep whatever value they were given.
+if ( ! empty( $field['enable_time'] ) && preg_match( '/^(.*\S)[ T](\d{1,2}):(\d{2})(?::\d{2})?$/', $field_date_value, $field_value_parts ) ) {
+	$field_date_value = $field_value_parts[1];
+	$field_time_value = sprintf( '%02d:%02d', (int) $field_value_parts[2], (int) $field_value_parts[3] );
 }
 ?>
 <input type="text" class="input-date job-manager-datepicker" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>"<?php if ( isset( $field['autocomplete'] ) && false === $field['autocomplete'] ) { echo ' autocomplete="off"'; } ?> id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" value="<?php echo esc_attr( $field_date_value ); ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
 <?php if ( ! empty( $field['enable_time'] ) ) : ?>
-<input type="time" class="input-time" name="<?php echo esc_attr( ( isset( $field['name'] ) ? $field['name'] : $key ) . '-time' ); ?>" value="<?php echo esc_attr( $field_time_value ); ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
+<input type="time" class="input-time" name="<?php echo esc_attr( ( isset( $field['name'] ) ? $field['name'] : $key ) . '-time' ); ?>" value="<?php echo esc_attr( $field_time_value ); ?>" />
 <?php endif; ?>
 <?php if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>

--- a/templates/form-fields/date-field.php
+++ b/templates/form-fields/date-field.php
@@ -19,5 +19,16 @@ wp_enqueue_script( 'wp-job-manager-datepicker' );
 wp_enqueue_style( 'jquery-ui' );
 
 ?>
-<input type="text" class="input-date job-manager-datepicker" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>"<?php if ( isset( $field['autocomplete'] ) && false === $field['autocomplete'] ) { echo ' autocomplete="off"'; } ?> id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" value="<?php echo isset( $field['value'] ) ? esc_attr( $field['value'] ) : ''; ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
+<?php
+$field_date_value = isset( $field['value'] ) ? $field['value'] : '';
+$field_time_value = '';
+if ( strpos( $field_date_value, ' ' ) ) {
+	$field_time_value = substr( strrchr( $field_date_value, ' ' ), 1, 5 );
+	$field_date_value = substr( $field_date_value, 0, 10 );
+}
+?>
+<input type="text" class="input-date job-manager-datepicker" name="<?php echo esc_attr( isset( $field['name'] ) ? $field['name'] : $key ); ?>"<?php if ( isset( $field['autocomplete'] ) && false === $field['autocomplete'] ) { echo ' autocomplete="off"'; } ?> id="<?php echo esc_attr( $key ); ?>" placeholder="<?php echo empty( $field['placeholder'] ) ? '' : esc_attr( $field['placeholder'] ); ?>" value="<?php echo esc_attr( $field_date_value ); ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
+<?php if ( ! empty( $field['enable_time'] ) ) : ?>
+<input type="time" class="input-time" name="<?php echo esc_attr( ( isset( $field['name'] ) ? $field['name'] : $key ) . '-time' ); ?>" value="<?php echo esc_attr( $field_time_value ); ?>" <?php if ( ! empty( $field['required'] ) ) echo 'required'; ?> />
+<?php endif; ?>
 <?php if ( ! empty( $field['description'] ) ) : ?><small class="description"><?php echo wp_kses_post( $field['description'] ); ?></small><?php endif; ?>

--- a/tests/php/tests/includes/test_class.wp-job-manager-form-submit-job.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-form-submit-job.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Tests for scheduled job listing date handling.
+ *
+ * @group forms
+ */
+class WP_Test_Job_Manager_Form_Submit_Job extends \WPJM_BaseTest {
+
+	/**
+	 * @var string Original timezone_string option, restored in tearDown.
+	 */
+	private $original_timezone;
+
+	/**
+	 * @var string Original gmt_offset option, restored in tearDown.
+	 */
+	private $original_gmt_offset;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->original_timezone   = get_option( 'timezone_string' );
+		$this->original_gmt_offset = get_option( 'gmt_offset' );
+	}
+
+	public function tearDown(): void {
+		update_option( 'timezone_string', $this->original_timezone );
+		update_option( 'gmt_offset', $this->original_gmt_offset );
+		parent::tearDown();
+	}
+
+	/**
+	 * Set the site timezone the way WP Settings > General does.
+	 *
+	 * @param string $timezone_string Olson timezone identifier, or '' for a manual offset.
+	 * @param float  $gmt_offset      Offset in hours, used only when $timezone_string is ''.
+	 */
+	private function set_site_timezone( $timezone_string, $gmt_offset ) {
+		update_option( 'timezone_string', $timezone_string );
+		update_option( 'gmt_offset', $gmt_offset );
+	}
+
+	public function test_scheduled_date_stores_local_and_gmt_in_utc_timezone() {
+		$this->set_site_timezone( 'UTC', 0 );
+
+		$job_data = [];
+		$result   = WP_Job_Manager_Form_Submit_Job::apply_scheduled_date( $job_data, '2030-01-02' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( '2030-01-02 00:00:00', $job_data['post_date'] );
+		$this->assertSame( '2030-01-02 00:00:00', $job_data['post_date_gmt'] );
+	}
+
+	public function test_scheduled_date_stores_local_and_gmt_in_non_utc_timezone() {
+		$this->set_site_timezone( 'Australia/Sydney', 0 );
+
+		// Australia/Sydney is UTC+11 in January (daylight saving time).
+		$job_data = [];
+		$result   = WP_Job_Manager_Form_Submit_Job::apply_scheduled_date( $job_data, '2030-01-02' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( '2030-01-02 00:00:00', $job_data['post_date'] );
+		$this->assertSame( '2030-01-01 13:00:00', $job_data['post_date_gmt'] );
+	}
+
+	public function test_scheduled_date_gmt_honors_manual_fractional_offset() {
+		// Manual offset (no Olson name), as with a UTC+5:30 site. The GMT projection
+		// must reflect the offset even though post_date itself is the local wall clock.
+		$this->set_site_timezone( '', 5.5 );
+
+		$job_data = [];
+		$result   = WP_Job_Manager_Form_Submit_Job::apply_scheduled_date( $job_data, '2030-01-02' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( '2030-01-02 00:00:00', $job_data['post_date'] );
+		$this->assertSame( '2030-01-01 18:30:00', $job_data['post_date_gmt'] );
+	}
+
+	public function test_scheduled_date_preserves_time_with_time_input() {
+		$this->set_site_timezone( 'UTC', 0 );
+
+		$job_data = [];
+		$result   = WP_Job_Manager_Form_Submit_Job::apply_scheduled_date( $job_data, '2030-01-02 09:30' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( '2030-01-02 09:30:00', $job_data['post_date'] );
+		$this->assertSame( '2030-01-02 09:30:00', $job_data['post_date_gmt'] );
+	}
+
+	public function test_scheduled_date_falls_back_to_now_when_time_is_invalid() {
+		$this->assert_fallback_to_now_for( '2030-01-02 25:99' );
+	}
+
+	public function test_scheduled_date_falls_back_to_now_when_in_the_past() {
+		$this->set_site_timezone( 'UTC', 0 );
+
+		$this->assert_fallback_to_now_for( '2000-01-01' );
+	}
+
+	public function test_scheduled_date_falls_back_to_now_when_empty() {
+		$this->assert_fallback_to_now_for( '' );
+	}
+
+	public function test_scheduled_date_falls_back_to_now_when_invalid() {
+		$this->assert_fallback_to_now_for( 'not-a-date' );
+	}
+
+	/**
+	 * Assert apply_scheduled_date falls back to the current time for a given input.
+	 *
+	 * The method sets post_date from a current_time() call, so a second read (also
+	 * current_time) could cross a second boundary and flake. Compare against a range
+	 * instead of requiring an exact match.
+	 *
+	 * @param string $scheduled_date The scheduled date input.
+	 */
+	private function assert_fallback_to_now_for( $scheduled_date ) {
+		$start    = time();
+		$job_data = [];
+		$result   = WP_Job_Manager_Form_Submit_Job::apply_scheduled_date( $job_data, $scheduled_date );
+		$end      = time() + 1;
+
+		$this->assertFalse( $result );
+		$this->assertTrue(
+			$job_data['post_date'] >= current_time( 'mysql', 0, $start ) && $job_data['post_date'] <= current_time( 'mysql', 0, $end ),
+			'post_date is not within the expected time window.'
+		);
+		$this->assertTrue(
+			$job_data['post_date_gmt'] >= current_time( 'mysql', 1, $start ) && $job_data['post_date_gmt'] <= current_time( 'mysql', 1, $end ),
+			'post_date_gmt is not within the expected time window.'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #2879

### Changes Proposed in this Pull Request

Scheduled job listings stored the same value in `post_date` and `post_date_gmt`, so on a non-UTC site the job published at the wrong wall-clock time (a UTC+11 site showed 11 AM instead of midnight). The scheduled date was also parsed with bare `strtotime()`, which assumes UTC and re-rendered the offset only in the local field.

This change parses the scheduled date in the site timezone and writes distinct local and GMT values:

- `format_scheduled_datetime()` replaces the old `maybe_format_future_datetime()` logic. The date is parsed with `DateTimeImmutable::createFromFormat( 'Y-m-d', ..., wp_timezone() )`, the time component is set explicitly, and the GMT value is computed by re-projecting the local instant onto UTC. Past, empty or invalid values fall back to the current time, matching the previous behavior.
- `apply_scheduled_date()` now writes `post_date` (site local) and `post_date_gmt` (UTC) from that pair instead of duplicating one string into both columns.
- The scheduled date field gained an optional HTML5 time input. A job can now be scheduled at an exact time, not just midnight. It only renders for the scheduled listing field, so existing date fields and submit-form integrations are unchanged unless they opt in.
- A new `get_posted_date_field()` handler merges the date and (optional) time inputs on submit.

### Testing Instructions

Environment: WordPress 6.4+, PHP 7.4+. Enable scheduled listings in WPJM settings, then set the site timezone to `Australia/Sydney` (UTC+11 in January/summer, UTC+10 in winter).

1. Submit a job and set the scheduled date to tomorrow, leaving the time empty. Expected: `post_date` is the local midnight (`00:00:00`), and `post_date_gmt` is the matching UTC instant (for Sydney in summer that is one day earlier at `13:00:00`). Before the fix `post_date` was 11 AM and both columns held the same value.
2. Submit another job with both a date and a time, for example tomorrow at 09:30. Expected: `post_date` stores `09:30:00`, not midnight.
3. Switch the site timezone to UTC and submit a job with a scheduled date. Expected: `post_date` equals `post_date_gmt`.
4. Set a manual fractional offset (for example UTC+5:30) and submit a job with a scheduled date. Expected: `post_date_gmt` is the correct projection (a `2030-01-02 00:00` local job stores `2030-01-01 18:30:00`).
5. Edit a scheduled job that has a time set. Expected: the date input shows only the date and the time input shows only the time, both pre-filled.
6. Submit a job with a past date, and one with the field left empty. Expected: the job publishes immediately in both cases.

Automated coverage: new `tests/php/tests/includes/test_class.wp-job-manager-form-submit-job.php` with 8 tests and 24 assertions covering UTC, UTC+11, fractional manual offset, explicit time, past date, empty, invalid, and invalid-time fallback paths.

### Release Notes

Fix scheduled job listings publishing at the wrong time on non-UTC sites, and allow scheduling at an exact time.

### New or Updated Hooks and Templates

No new or updated actions or filters. The `date` field template gains an optional time input only when a field sets `enable_time`; the scheduled listing field is the only current user of it.

### Deprecated Code

No code is deprecated. The private `maybe_format_future_datetime()` method was replaced by `format_scheduled_datetime()` within the same class.

### Screenshot / Video

No screenshot: this is a backend date/time storage fix. The only visible change is an optional time input next to the scheduled date field.