### PR TITLE
Fix a @deprecated version placeholder that never got substituted

### DIFF
--- a/includes/admin/class-wp-job-manager-admin-notices.php
+++ b/includes/admin/class-wp-job-manager-admin-notices.php
@@ -439,7 +439,7 @@ class WP_Job_Manager_Admin_Notices {
 	 *
 	 * @param array $additional_screens Screen IDs to also show a notice on.
 	 *
-	 * @deprecated $$next_version$$ Removed. See WP_Job_Manager\Admin\Notices_Conditions_Checker::check instead.
+	 * @deprecated 2.0.0 Removed. See WP_Job_Manager\Admin\Notices_Conditions_Checker::check instead.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
### Changes Proposed in this Pull Request

The docblock on `is_admin_on_standard_job_manager_screen()` used `$$next_version$$` with an underscore. `scripts/replace-next-version-tag.sh` only matches the hyphenated `$$next-version$$`, so this one has been skipped on every release since 2.0.0 and the raw token ships in the source.

I wrote the real version in rather than correcting the underscore to a hyphen. Correcting the spelling would have let the release script stamp it with whatever version is next, claiming a deprecation that did not happen in that release. The `_deprecated_function()` call in the same method already says `'2.0.0'`, and the deprecation went in on 2023-10-16, ahead of the 2.0.0 tag on 2023-11-17.

Comment only, no behaviour change. It was the only malformed instance in the tree; the other 21 placeholders use the correct spelling.

### Testing Instructions

* `grep -rn '\$\$next_version\$\$' --include='*.php' .` returns nothing.
* `grep -rn '\$\$next-version\$\$' --include='*.php' .` still finds the legitimate placeholders, which the release script will substitute as usual.

<!-- Add changelog entries meant for end-users. Leave empty to skip changelog. -->
### Release Notes

*


<!-- wpjm:plugin-zip -->
----

| Plugin build for 6f8208dcfddd18c13e3ea699b96f5e7965da59bd <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/08/wp-job-manager-zip-3095-6f8208dc.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/08/3095-6f8208dc)             |

<!-- /wpjm:plugin-zip -->
