### PR TITLE
Release WP Job Manager 2.4.6

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1335,7 +1335,7 @@ class WP_Job_Manager_Post_Types {
 	 * front-end submission's preview -> publish transition — must fall back to the
 	 * server-side calculated expiry.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 *
 	 * @param WP_Post $post The job listing being saved.
 	 *

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -22,7 +22,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * upload, used to reuse the uploader's existing identical attachment instead
 	 * of creating a duplicate on every submission.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 *
 	 * @var string
 	 */
@@ -964,7 +964,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * draft save cannot bind another user's attachment (e.g. as a company logo / featured image)
 	 * — the draft path skips validate_fields() and would otherwise reach the sink unchecked.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 *
 	 * @param array $values Submitted input values.
 	 * @return bool|WP_Error True when all referenced attachments are authorized, WP_Error otherwise.
@@ -1065,7 +1065,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * or replaced the logo on their behalf. This is not an arbitrary foreign ID:
 	 * it is the value already bound to a listing the user is authorized to edit.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 *
 	 * @param int    $attachment_id Attachment post ID.
 	 * @param string $key           Field key (e.g. 'company_logo').
@@ -1100,7 +1100,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * even when they did not author it — e.g. a site admin uploaded or replaced the
 	 * logo on their listing. It is server-side state, not a request-supplied ID.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 *
 	 * @param int    $attachment_id Attachment post ID.
 	 * @param string $group_key     Field group. Only 'company' is pre-populated from user meta.
@@ -1221,7 +1221,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 	 * always gets a fresh attachment, and one user's upload can never be bound to
 	 * another user's attachment, preserving the attachment-ownership boundary.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 *
 	 * @param string $file_path Absolute path to the uploaded file.
 	 * @return int Attachment ID to reuse, or 0 when none matches.

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 2.4.5\n"
+"Project-Id-Version: WP Job Manager 2.4.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-01T15:59:46+00:00\n"
+"POT-Creation-Date: 2026-08-19T15:01:39+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: wp-job-manager\n"
@@ -485,8 +485,8 @@ msgstr ""
 
 #: includes/admin/class-wp-job-manager-cpt.php:499
 #: includes/class-wp-job-manager-email-notifications.php:274
-#: includes/class-wp-job-manager-post-types.php:1885
-#: includes/forms/class-wp-job-manager-form-submit-job.php:241
+#: includes/class-wp-job-manager-post-types.php:1917
+#: includes/forms/class-wp-job-manager-form-submit-job.php:252
 #: includes/widgets/class-wp-job-manager-widget-recent-jobs.php:46
 #: templates/job-filters.php:35
 #: templates/job-filters.php:36
@@ -583,19 +583,19 @@ msgid "Job listing archive page"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:108
-#: includes/class-wp-job-manager-post-types.php:1566
+#: includes/class-wp-job-manager-post-types.php:1598
 msgctxt "Job permalink - resave permalinks after changing this"
 msgid "job"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:117
-#: includes/class-wp-job-manager-post-types.php:1567
+#: includes/class-wp-job-manager-post-types.php:1599
 msgctxt "Job category slug - resave permalinks after changing this"
 msgid "job-category"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-permalink-settings.php:126
-#: includes/class-wp-job-manager-post-types.php:1568
+#: includes/class-wp-job-manager-post-types.php:1600
 msgctxt "Job type slug - resave permalinks after changing this"
 msgid "job-type"
 msgstr ""
@@ -874,8 +874,8 @@ msgid "This allows users to select more than one type when submitting a job. The
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:279
-#: includes/class-wp-job-manager-post-types.php:1978
-#: includes/forms/class-wp-job-manager-form-submit-job.php:249
+#: includes/class-wp-job-manager-post-types.php:2010
+#: includes/forms/class-wp-job-manager-form-submit-job.php:260
 msgid "Remote Position"
 msgstr ""
 
@@ -888,8 +888,8 @@ msgid "This lets users select if the listing is a remote position when submittin
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:289
-#: includes/class-wp-job-manager-post-types.php:1987
-#: includes/forms/class-wp-job-manager-form-submit-job.php:288
+#: includes/class-wp-job-manager-post-types.php:2019
+#: includes/forms/class-wp-job-manager-form-submit-job.php:299
 msgid "Salary"
 msgstr ""
 
@@ -902,8 +902,8 @@ msgid "This lets users add a salary when submitting a job."
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:299
-#: includes/class-wp-job-manager-post-types.php:1997
-#: includes/forms/class-wp-job-manager-form-submit-job.php:295
+#: includes/class-wp-job-manager-post-types.php:2029
+#: includes/forms/class-wp-job-manager-form-submit-job.php:306
 msgid "Salary Currency"
 msgstr ""
 
@@ -928,14 +928,14 @@ msgid "Sets the default currency used by salaries"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:313
-#: includes/class-wp-job-manager-post-types.php:2000
-#: includes/forms/class-wp-job-manager-form-submit-job.php:223
+#: includes/class-wp-job-manager-post-types.php:2032
+#: includes/forms/class-wp-job-manager-form-submit-job.php:234
 msgid "e.g. USD"
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:320
-#: includes/class-wp-job-manager-post-types.php:2008
-#: includes/forms/class-wp-job-manager-form-submit-job.php:303
+#: includes/class-wp-job-manager-post-types.php:2040
+#: includes/forms/class-wp-job-manager-form-submit-job.php:314
 msgid "Salary Unit"
 msgstr ""
 
@@ -1786,27 +1786,27 @@ msgid "Company Logo"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:52
-#: includes/class-wp-job-manager-post-types.php:1904
+#: includes/class-wp-job-manager-post-types.php:1936
 msgid "Company Name"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:53
-#: includes/class-wp-job-manager-post-types.php:1912
+#: includes/class-wp-job-manager-post-types.php:1944
 msgid "Company Website"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:54
-#: includes/class-wp-job-manager-post-types.php:1921
+#: includes/class-wp-job-manager-post-types.php:1953
 msgid "Company Tagline"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:55
-#: includes/class-wp-job-manager-post-types.php:1929
+#: includes/class-wp-job-manager-post-types.php:1961
 msgid "Company X / Twitter"
 msgstr ""
 
 #: includes/class-wp-job-manager-data-exporter.php:56
-#: includes/class-wp-job-manager-post-types.php:1937
+#: includes/class-wp-job-manager-post-types.php:1969
 msgid "Company Video"
 msgstr ""
 
@@ -1850,18 +1850,18 @@ msgstr ""
 
 #: includes/class-wp-job-manager-email-notifications.php:283
 #: includes/class-wp-job-manager-post-types.php:351
-#: includes/forms/class-wp-job-manager-form-submit-job.php:256
+#: includes/forms/class-wp-job-manager-form-submit-job.php:267
 msgid "Job type"
 msgstr ""
 
 #: includes/class-wp-job-manager-email-notifications.php:293
 #: includes/class-wp-job-manager-post-types.php:287
-#: includes/forms/class-wp-job-manager-form-submit-job.php:265
+#: includes/forms/class-wp-job-manager-form-submit-job.php:276
 msgid "Job category"
 msgstr ""
 
 #: includes/class-wp-job-manager-email-notifications.php:302
-#: includes/forms/class-wp-job-manager-form-submit-job.php:313
+#: includes/forms/class-wp-job-manager-form-submit-job.php:324
 msgid "Company name"
 msgstr ""
 
@@ -1897,16 +1897,16 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: includes/class-wp-job-manager-geocode.php:234
+#: includes/class-wp-job-manager-geocode.php:233
 msgid "No results found"
 msgstr ""
 
-#: includes/class-wp-job-manager-geocode.php:237
+#: includes/class-wp-job-manager-geocode.php:236
 msgid "Query limit reached"
 msgstr ""
 
-#: includes/class-wp-job-manager-geocode.php:241
-#: includes/class-wp-job-manager-geocode.php:244
+#: includes/class-wp-job-manager-geocode.php:240
+#: includes/class-wp-job-manager-geocode.php:243
 msgid "Geocoding error"
 msgstr ""
 
@@ -2056,7 +2056,7 @@ msgid "This is where you can create and manage %s."
 msgstr ""
 
 #: includes/class-wp-job-manager-post-types.php:525
-#: wp-job-manager-functions.php:558
+#: wp-job-manager-functions.php:588
 msgctxt "post status"
 msgid "Expired"
 msgstr ""
@@ -2070,7 +2070,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: includes/class-wp-job-manager-post-types.php:538
-#: wp-job-manager-functions.php:559
+#: wp-job-manager-functions.php:589
 msgctxt "post status"
 msgid "Preview"
 msgstr ""
@@ -2087,111 +2087,111 @@ msgstr[1] ""
 msgid "This is where guest user data is stored."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1550
+#: includes/class-wp-job-manager-post-types.php:1582
 msgctxt "Post type archive slug - resave permalinks after changing this"
 msgid "jobs"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1867
-#: includes/forms/class-wp-job-manager-form-submit-job.php:210
+#: includes/class-wp-job-manager-post-types.php:1899
+#: includes/forms/class-wp-job-manager-form-submit-job.php:221
 msgid "Application email/URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1868
-#: includes/forms/class-wp-job-manager-form-submit-job.php:211
+#: includes/class-wp-job-manager-post-types.php:1900
+#: includes/forms/class-wp-job-manager-form-submit-job.php:222
 msgid "Enter an email address or website URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1871
-#: includes/forms/class-wp-job-manager-form-submit-job.php:200
+#: includes/class-wp-job-manager-post-types.php:1903
+#: includes/forms/class-wp-job-manager-form-submit-job.php:211
 msgid "Application email"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1872
-#: includes/forms/class-wp-job-manager-form-submit-job.php:201
+#: includes/class-wp-job-manager-post-types.php:1904
+#: includes/forms/class-wp-job-manager-form-submit-job.php:212
 msgid "you@example.com"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1874
-#: includes/forms/class-wp-job-manager-form-submit-job.php:205
+#: includes/class-wp-job-manager-post-types.php:1906
+#: includes/forms/class-wp-job-manager-form-submit-job.php:216
 msgid "Application URL"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1875
-#: includes/forms/class-wp-job-manager-form-submit-job.php:206
+#: includes/class-wp-job-manager-post-types.php:1907
+#: includes/forms/class-wp-job-manager-form-submit-job.php:217
 msgid "https://"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1878
+#: includes/class-wp-job-manager-post-types.php:1910
 msgid "Job listing expires at the end of the day."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1880
+#: includes/class-wp-job-manager-post-types.php:1912
 msgid "Job listing expires at the start of the day."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1886
-#: includes/forms/class-wp-job-manager-form-submit-job.php:245
+#: includes/class-wp-job-manager-post-types.php:1918
+#: includes/forms/class-wp-job-manager-form-submit-job.php:256
 msgid "e.g. \"London\""
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1887
+#: includes/class-wp-job-manager-post-types.php:1919
 msgid "Leave this blank if the location is not important."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1896
+#: includes/class-wp-job-manager-post-types.php:1928
 msgid "This field is required for the \"application\" area to appear beneath the listing."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1922
+#: includes/class-wp-job-manager-post-types.php:1954
 msgid "Brief description about the company"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1938
+#: includes/class-wp-job-manager-post-types.php:1970
 msgid "URL to the company video"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1947
+#: includes/class-wp-job-manager-post-types.php:1979
 msgid "Position Filled"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1953
+#: includes/class-wp-job-manager-post-types.php:1985
 msgid "Filled listings will no longer accept applications."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1956
+#: includes/class-wp-job-manager-post-types.php:1988
 msgid "Featured Listing"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1958
+#: includes/class-wp-job-manager-post-types.php:1990
 msgid "Featured listings will be sticky during searches, and can be styled differently."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1966
+#: includes/class-wp-job-manager-post-types.php:1998
 msgid "Listing Expiry Date"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1979
-#: includes/forms/class-wp-job-manager-form-submit-job.php:250
+#: includes/class-wp-job-manager-post-types.php:2011
+#: includes/forms/class-wp-job-manager-form-submit-job.php:261
 msgid "Select if this is a remote position."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1989
-#: includes/forms/class-wp-job-manager-form-submit-job.php:291
+#: includes/class-wp-job-manager-post-types.php:2021
+#: includes/forms/class-wp-job-manager-form-submit-job.php:302
 msgid "e.g. 20000"
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:1991
+#: includes/class-wp-job-manager-post-types.php:2023
 msgid "Add a salary field, this field is optional."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:2002
-#: includes/forms/class-wp-job-manager-form-submit-job.php:227
+#: includes/class-wp-job-manager-post-types.php:2034
+#: includes/forms/class-wp-job-manager-form-submit-job.php:238
 msgid "Add a salary currency, this field is optional. Leave it empty to use the default salary currency."
 msgstr ""
 
-#: includes/class-wp-job-manager-post-types.php:2013
-#: includes/forms/class-wp-job-manager-form-submit-job.php:306
+#: includes/class-wp-job-manager-post-types.php:2045
+#: includes/forms/class-wp-job-manager-form-submit-job.php:317
 msgid "Add a salary period unit, this field is optional. Leave it empty to use the default salary unit, if one is defined."
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 
 #. translators: Placeholder %d is the number of files to that users are limited to.
 #: includes/class-wp-job-manager.php:590
-#: includes/forms/class-wp-job-manager-form-submit-job.php:534
+#: includes/forms/class-wp-job-manager-form-submit-job.php:546
 #, php-format
 msgid "You are only allowed to upload a maximum of %d files."
 msgstr ""
@@ -2276,7 +2276,7 @@ msgid "Send a notice to the site administrator when a new job is submitted on th
 msgstr ""
 
 #. translators: Placeholder %s is the job listing post title.
-#: includes/emails/class-wp-job-manager-email-admin-new-job.php:63
+#: includes/emails/class-wp-job-manager-email-admin-new-job.php:66
 #, php-format
 msgid "New Job Listing Submitted: %s"
 msgstr ""
@@ -2290,7 +2290,7 @@ msgid "Send a notice to the site administrator when a job is updated on the fron
 msgstr ""
 
 #. translators: Placeholder %s is the job listing post title.
-#: includes/emails/class-wp-job-manager-email-admin-updated-job.php:63
+#: includes/emails/class-wp-job-manager-email-admin-updated-job.php:66
 #, php-format
 msgid "Job Listing Updated: %s"
 msgstr ""
@@ -2304,16 +2304,16 @@ msgid "Send notices to employers before a job listing expires."
 msgstr ""
 
 #. translators: Placeholder %s is the job listing post title.
-#: includes/emails/class-wp-job-manager-email-employer-expiring-job.php:79
+#: includes/emails/class-wp-job-manager-email-employer-expiring-job.php:82
 #, php-format
 msgid "Job Listing Expiring: %s"
 msgstr ""
 
-#: includes/emails/class-wp-job-manager-email-employer-expiring-job.php:132
+#: includes/emails/class-wp-job-manager-email-employer-expiring-job.php:135
 msgid "Notice Period"
 msgstr ""
 
-#: includes/emails/class-wp-job-manager-email-employer-expiring-job.php:134
+#: includes/emails/class-wp-job-manager-email-employer-expiring-job.php:137
 msgid "days"
 msgstr ""
 
@@ -2329,185 +2329,190 @@ msgstr ""
 msgid "Submit changes for approval"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:195
+#: includes/forms/class-wp-job-manager-form-edit-job.php:205
 msgid "Your changes have been saved."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:201
+#: includes/forms/class-wp-job-manager-form-edit-job.php:211
 msgid "View &rarr;"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-edit-job.php:203
+#: includes/forms/class-wp-job-manager-form-edit-job.php:213
 msgid "Your changes have been submitted and your listing will be visible again once approved."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:98
+#: includes/forms/class-wp-job-manager-form-submit-job.php:109
 msgid "Submit Details"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:104
-#: includes/forms/class-wp-job-manager-form-submit-job.php:700
+#: includes/forms/class-wp-job-manager-form-submit-job.php:115
+#: includes/forms/class-wp-job-manager-form-submit-job.php:712
 #: templates/job-preview.php:32
 msgid "Preview"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:110
+#: includes/forms/class-wp-job-manager-form-submit-job.php:121
 msgid "Done"
 msgstr ""
 
 #. translators: %s is the default salary currency code (e.g. USD).
-#: includes/forms/class-wp-job-manager-form-submit-job.php:226
+#: includes/forms/class-wp-job-manager-form-submit-job.php:237
 #, php-format
 msgid "Add a salary currency, this field is optional. Leave it empty to use the default salary currency (%s)."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:234
+#: includes/forms/class-wp-job-manager-form-submit-job.php:245
 msgid "Job Title"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:242
+#: includes/forms/class-wp-job-manager-form-submit-job.php:253
 msgid "Leave this blank if the location is not important"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:259
+#: includes/forms/class-wp-job-manager-form-submit-job.php:270
 msgid "Choose job type&hellip;"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:274
+#: includes/forms/class-wp-job-manager-form-submit-job.php:285
 msgid "Description"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:316
+#: includes/forms/class-wp-job-manager-form-submit-job.php:327
 msgid "Enter the name of the company"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:320
+#: includes/forms/class-wp-job-manager-form-submit-job.php:331
 #: templates/content-single-job_listing-company.php:31
 msgid "Website"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:324
+#: includes/forms/class-wp-job-manager-form-submit-job.php:335
 msgid "http://"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:328
+#: includes/forms/class-wp-job-manager-form-submit-job.php:339
 msgid "Tagline"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:331
+#: includes/forms/class-wp-job-manager-form-submit-job.php:342
 msgid "Briefly describe your company"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:336
+#: includes/forms/class-wp-job-manager-form-submit-job.php:347
 msgid "Video"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:340
+#: includes/forms/class-wp-job-manager-form-submit-job.php:351
 msgid "A link to a video about your company"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:344
+#: includes/forms/class-wp-job-manager-form-submit-job.php:355
 msgid "X / Twitter username"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:347
+#: includes/forms/class-wp-job-manager-form-submit-job.php:358
 msgid "@yourcompany"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:351
+#: includes/forms/class-wp-job-manager-form-submit-job.php:362
 msgid "Logo"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:358
+#: includes/forms/class-wp-job-manager-form-submit-job.php:369
 msgid "Square format recommended (1:1 ratio)."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:397
+#: includes/forms/class-wp-job-manager-form-submit-job.php:408
 msgid "Scheduled Date"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:398
+#: includes/forms/class-wp-job-manager-form-submit-job.php:409
 msgid "Optionally set the date when this listing will be published."
 msgstr ""
 
 #. translators: Placeholder %s is the label for the required field.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:451
+#: includes/forms/class-wp-job-manager-form-submit-job.php:467
 #, php-format
 msgid "%s is a required field"
 msgstr ""
 
 #. translators: Placeholder %s is the field label that is did not validate.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:462
+#: includes/forms/class-wp-job-manager-form-submit-job.php:478
 #, php-format
 msgid "%s is invalid"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:492
+#: includes/forms/class-wp-job-manager-form-submit-job.php:508
 msgid "Invalid image path."
 msgstr ""
 
 #. translators: Placeholder %1$s is field label; %2$s is the file mime type; %3$s is the allowed mime-types.
 #. translators: %1$s is the file field label; %2$s is the file type; %3$s is the list of allowed file types.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:503
-#: wp-job-manager-functions.php:1622
+#: includes/forms/class-wp-job-manager-form-submit-job.php:519
+#: wp-job-manager-functions.php:1652
 #, php-format
 msgid "\"%1$s\" (filetype %2$s) needs to be one of the following file types: %3$s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:511
-#: includes/forms/class-wp-job-manager-form-submit-job.php:517
+#: includes/forms/class-wp-job-manager-form-submit-job.php:529
 msgid "Invalid attachment provided."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:563
+#: includes/forms/class-wp-job-manager-form-submit-job.php:575
 msgid "Please enter a valid application email address"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:568
+#: includes/forms/class-wp-job-manager-form-submit-job.php:580
 msgid "Please enter a valid application URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:574
+#: includes/forms/class-wp-job-manager-form-submit-job.php:586
 msgid "Please enter a valid application email address or URL"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:759
+#: includes/forms/class-wp-job-manager-form-submit-job.php:777
 msgid "Please enter a username."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:763
+#: includes/forms/class-wp-job-manager-form-submit-job.php:781
 msgid "Please enter a password."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:767
+#: includes/forms/class-wp-job-manager-form-submit-job.php:785
 msgid "Please enter your email address."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:773
+#: includes/forms/class-wp-job-manager-form-submit-job.php:791
 msgid "Passwords must match."
 msgstr ""
 
 #. translators: Placeholder %s is the password hint.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:779
+#: includes/forms/class-wp-job-manager-form-submit-job.php:797
 #, php-format
 msgid "Invalid Password: %s"
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:781
+#: includes/forms/class-wp-job-manager-form-submit-job.php:799
 msgid "Password is not valid."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:813
+#: includes/forms/class-wp-job-manager-form-submit-job.php:831
 msgid "You must be signed in to post a new listing."
 msgstr ""
 
 #. translators: placeholder is the URL to the job dashboard page.
-#: includes/forms/class-wp-job-manager-form-submit-job.php:839
+#: includes/forms/class-wp-job-manager-form-submit-job.php:857
 #, php-format
 msgid "Draft was saved. Job listing drafts can be resumed from the <a href=\"%s\">job dashboard</a>."
 msgstr ""
 
-#: includes/forms/class-wp-job-manager-form-submit-job.php:1207
+#. translators: Placeholder %s is the label of the file field, e.g. "Company Logo".
+#: includes/forms/class-wp-job-manager-form-submit-job.php:1015
+#, php-format
+msgid "The saved file for \"%s\" is no longer available to use. Please upload it again, or remove it, and resubmit."
+msgstr ""
+
+#: includes/forms/class-wp-job-manager-form-submit-job.php:1440
 msgid "You have reached the listing limit for your account and cannot publish this listing."
 msgstr ""
 
@@ -2685,12 +2690,12 @@ msgstr ""
 msgid "No plugins are activated that have licenses managed by WP Job Manager."
 msgstr ""
 
-#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:249
-#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:275
+#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:250
+#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:276
 msgid "The promoted job was not found"
 msgstr ""
 
-#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:280
+#: includes/promoted-jobs/class-wp-job-manager-promoted-jobs-api.php:283
 msgid "Sorry, you are not allowed to view this job."
 msgstr ""
 
@@ -2852,7 +2857,7 @@ msgstr ""
 msgid "Applications have closed"
 msgstr ""
 
-#: templates/content-single-job_listing.php:24
+#: templates/content-single-job_listing.php:28
 msgid "This listing has expired."
 msgstr ""
 
@@ -2976,18 +2981,18 @@ msgstr ""
 msgid "Visit the job listing dashboard (%s) to manage the listing."
 msgstr ""
 
-#: templates/form-fields/file-field.php:63
+#: templates/form-fields/file-field.php:66
 #, php-format
 msgid "Maximum file size: %s."
 msgstr ""
 
 #: templates/form-fields/multiselect-field.php:20
-#: wp-job-manager-functions.php:1361
+#: wp-job-manager-functions.php:1391
 msgid "No results match"
 msgstr ""
 
 #: templates/form-fields/multiselect-field.php:20
-#: wp-job-manager-functions.php:1362
+#: wp-job-manager-functions.php:1392
 msgid "Select Some Options"
 msgstr ""
 
@@ -3118,124 +3123,124 @@ msgstr ""
 msgid "%1$s submitted successfully."
 msgstr ""
 
-#: wp-job-manager-functions.php:557
+#: wp-job-manager-functions.php:587
 msgctxt "post status"
 msgid "Draft"
 msgstr ""
 
-#: wp-job-manager-functions.php:560
+#: wp-job-manager-functions.php:590
 msgctxt "post status"
 msgid "Pending approval"
 msgstr ""
 
-#: wp-job-manager-functions.php:561
+#: wp-job-manager-functions.php:591
 msgctxt "post status"
 msgid "Pending payment"
 msgstr ""
 
-#: wp-job-manager-functions.php:562
+#: wp-job-manager-functions.php:592
 msgctxt "post status"
 msgid "Active"
 msgstr ""
 
-#: wp-job-manager-functions.php:563
+#: wp-job-manager-functions.php:593
 msgctxt "post status"
 msgid "Scheduled"
 msgstr ""
 
-#: wp-job-manager-functions.php:684
+#: wp-job-manager-functions.php:714
 msgid "Reset"
 msgstr ""
 
-#: wp-job-manager-functions.php:688
+#: wp-job-manager-functions.php:718
 msgid "RSS"
 msgstr ""
 
-#: wp-job-manager-functions.php:798
+#: wp-job-manager-functions.php:828
 msgid "Invalid email address."
 msgstr ""
 
-#: wp-job-manager-functions.php:806
+#: wp-job-manager-functions.php:836
 msgid "Your email address isn&#8217;t correct."
 msgstr ""
 
-#: wp-job-manager-functions.php:810
+#: wp-job-manager-functions.php:840
 msgid "This email is already registered, please choose another one."
 msgstr ""
 
-#: wp-job-manager-functions.php:1121
+#: wp-job-manager-functions.php:1151
 msgid "Full Time"
 msgstr ""
 
-#: wp-job-manager-functions.php:1122
+#: wp-job-manager-functions.php:1152
 msgid "Part Time"
 msgstr ""
 
-#: wp-job-manager-functions.php:1123
+#: wp-job-manager-functions.php:1153
 msgid "Contractor"
 msgstr ""
 
-#: wp-job-manager-functions.php:1124
+#: wp-job-manager-functions.php:1154
 msgid "Temporary"
 msgstr ""
 
-#: wp-job-manager-functions.php:1125
+#: wp-job-manager-functions.php:1155
 msgid "Intern"
 msgstr ""
 
-#: wp-job-manager-functions.php:1126
+#: wp-job-manager-functions.php:1156
 msgid "Volunteer"
 msgstr ""
 
-#: wp-job-manager-functions.php:1127
+#: wp-job-manager-functions.php:1157
 msgid "Per Diem"
 msgstr ""
 
-#: wp-job-manager-functions.php:1128
+#: wp-job-manager-functions.php:1158
 msgid "Other"
 msgstr ""
 
-#: wp-job-manager-functions.php:1195
+#: wp-job-manager-functions.php:1225
 msgid "Passwords must be at least 8 characters long."
 msgstr ""
 
-#: wp-job-manager-functions.php:1360
+#: wp-job-manager-functions.php:1390
 msgid "Choose a category&hellip;"
 msgstr ""
 
 #. translators: %s is the maximum allowed file size.
-#: wp-job-manager-functions.php:1609
+#: wp-job-manager-functions.php:1639
 #, php-format
 msgid "The company logo exceeds the maximum allowed file size of %s."
 msgstr ""
 
 #. translators: %s is the list of allowed file types.
-#: wp-job-manager-functions.php:1625
+#: wp-job-manager-functions.php:1655
 #, php-format
 msgid "Uploaded files need to be one of the following file types: %s"
 msgstr ""
 
-#: wp-job-manager-functions.php:1925
+#: wp-job-manager-functions.php:1994
 msgid "--"
 msgstr ""
 
-#: wp-job-manager-functions.php:1926
+#: wp-job-manager-functions.php:1995
 msgid "Year"
 msgstr ""
 
-#: wp-job-manager-functions.php:1927
+#: wp-job-manager-functions.php:1996
 msgid "Month"
 msgstr ""
 
-#: wp-job-manager-functions.php:1928
+#: wp-job-manager-functions.php:1997
 msgid "Week"
 msgstr ""
 
-#: wp-job-manager-functions.php:1929
+#: wp-job-manager-functions.php:1998
 msgid "Day"
 msgstr ""
 
-#: wp-job-manager-functions.php:1930
+#: wp-job-manager-functions.php:1999
 msgid "Hour"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: jobs, careers, company, hiring, job board
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.4.5
+Stable tag: 2.4.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/templates/emails/plain/email-job-details.php
+++ b/templates/emails/plain/email-job-details.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     $$next-version$$
+ * @version     2.4.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/form-fields/file-field.php
+++ b/templates/form-fields/file-field.php
@@ -8,7 +8,7 @@
  * @author      Automattic
  * @package     wp-job-manager
  * @category    Template
- * @version     $$next-version$$
+ * @version     2.4.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/tests/php/tests/test_class.wp-job-manager-functions.php
+++ b/tests/php/tests/test_class.wp-job-manager-functions.php
@@ -352,7 +352,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * the historical behavior (children included) and let a callback override it so
 	 * that a single parent category selection can match its exact term only.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_include_category_children_filter() {
@@ -425,7 +425,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * the expanded set contains duplicates, WP_Tax_Query rejects the clause as
 	 * "inexistent_terms", and the query matches nothing at all.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 * @covers ::get_job_listings
 	 */
 	public function test_get_job_listings_include_category_children_filter_in_and_mode() {
@@ -1443,7 +1443,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 * @covers ::job_manager_get_accept_file_types
 	 */
 	public function test_get_accept_file_types_prefixes_extensions_with_a_dot() {
@@ -1462,7 +1462,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	/**
 	 * Pipe-separated extension groups, as used by job_manager_get_allowed_mime_types(), are split into one token each.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 * @covers ::job_manager_get_accept_file_types
 	 */
 	public function test_get_accept_file_types_splits_pipe_separated_groups() {
@@ -1478,7 +1478,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 * @covers ::job_manager_get_accept_file_types
 	 */
 	public function test_get_accept_file_types_deduplicates_and_normalizes_leading_dots() {
@@ -1497,7 +1497,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	 * Fields may pass a plain list of mime types, or a mime-type-keyed map, instead of an extension-keyed map. The
 	 * `accept` attribute takes mime types too, so pass them through rather than emitting nonsense like `.0`.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 * @covers ::job_manager_get_accept_file_types
 	 */
 	public function test_get_accept_file_types_passes_through_mime_types() {
@@ -1506,7 +1506,7 @@ class WP_Test_WP_Job_Manager_Functions extends WPJM_BaseTest {
 	}
 
 	/**
-	 * @since $$next-version$$
+	 * @since 2.4.6
 	 * @covers ::job_manager_get_accept_file_types
 	 */
 	public function test_get_accept_file_types_empty_when_nothing_is_allowed() {

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -177,7 +177,7 @@ if ( ! function_exists( 'get_job_listings' ) ) :
 			 * it; if one selected term is an ancestor of another, the clause is
 			 * discarded entirely and the query returns nothing.
 			 *
-			 * @since $$next-version$$
+			 * @since 2.4.6
 			 *
 			 * @param bool   $include_children  Whether to include child terms of the selected categories.
 			 * @param string $operator          The tax query operator in use (`IN` or `AND`).
@@ -1727,7 +1727,7 @@ function job_manager_get_allowed_mime_types( $field = '' ) {
  * list of mime types, or a map keyed by mime type; those are emitted as mime type tokens, which `accept` also
  * accepts.
  *
- * @since $$next-version$$
+ * @since 2.4.6
  *
  * @param array $allowed_mime_types Array of allowed file extensions and mime types.
  * @return string Comma-separated list of `accept` tokens, empty when nothing is allowed.

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 2.4.5
+ * Version: 2.4.6
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.4
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define constants.
-define( 'JOB_MANAGER_VERSION', '2.4.5' );
+define( 'JOB_MANAGER_VERSION', '2.4.6' );
 define( 'JOB_MANAGER_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'JOB_MANAGER_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'JOB_MANAGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## WP Job Manager 2.4.6

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---

* Allow reusing a submitter's saved company logo on a new listing (#3082)
* Allow reusing a listing's existing logo on edit when authored by another user (#3060)
* Fix notice dismiss button colliding with core styles (#3036)
* Fix unreadable notice-banner button text on Settings (#3029)
* Decode HTML entities in plain-text job title contexts (#3026)
* Indicate WordPress 7.0 compatibility (#3015)
* Verify the TLS certificate on the geocoding request (#3014)
* Exclude password-protected listings from the promoted jobs feed (#3012)
* Only accept a manual listing expiry from the gated admin edit (#3011)
* Prevent the edit-job form from creating a new listing for an unauthorized or logged-out request.

* Enforce company-logo attachment ownership when saving a job listing as a draft.

* Apply the post-password check to the `[job]` and `[job_apply]` shortcodes.
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org


<!-- wpjm:plugin-zip -->
----

| Plugin build for 2736beb99b5e70bd4f6485a42ba31bf145947a03 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/08/wp-job-manager-zip-3096-2736beb9.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/08/3096-2736beb9)             |

<!-- /wpjm:plugin-zip -->
