### PR TITLE
Indicate WordPress 7.1 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mikejolley, automattic, adamkheckler, alexsanford1, annezazu, cena, chaselivingston, csonnek, davor.altman, donnapep, donncha, drawmyface, erania-pinnera, fjorgemota, jacobshere, jakeom, jeherve, jenhooks, jgs, jonryan, kraftbj, lamdayap, lschuyler, macmanx, nancythanki, orangesareorange, rachelsquirrel, renathoc, ryanc413, richardmtl, scarstocea
 Tags: jobs, careers, company, hiring, job board
 Requires at least: 6.4
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 2.4.6
 License: GPLv3

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.4
- * Tested up to: 7.0
+ * Tested up to: 7.1
  * Requires PHP: 7.4
  * Text Domain: wp-job-manager
  * Domain Path: /languages/


### PR DESCRIPTION
Bumps `Tested up to` from 7.0 to 7.1 in `readme.txt` and the `wp-job-manager.php` plugin header, following the pattern of #3015.

The same change has already been committed directly to WordPress.org SVN (`trunk` and `tags/2.4.6`) so the plugin directory listing is updated; this PR keeps the repo in sync so the next release doesn't regress it.

Note: the readme diff includes whitespace-only cleanup of changelog lines applied automatically by the lint-staged pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wpjm:plugin-zip -->
----

| Plugin build for b6396ab5e7d8c6185a4900a45ff5088a364166d6 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/08/wp-job-manager-zip-3097-b6396ab5.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/08/3097-b6396ab5)             |

<!-- /wpjm:plugin-zip -->
