### PR TITLE
fix: match primary column th in Job Listings admin table styles

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -530,11 +530,12 @@ a.wpjm-activate-license-link:active {
 		width: 20%;
 	}
 
-	// Core renders the primary column as a `th` row header rather than a `td`
-	// (see WP_List_Table::single_row_columns()). `job_position` is registered as
-	// the primary column via the `list_table_primary_column` filter, so match both
-	// element types: `td` for older core, `tbody th` for current. Scoped to `tbody`
-	// so these body-cell styles do not leak onto the header cell above.
+	// `job_position` is registered as the primary column via the
+	// `list_table_primary_column` filter, and core renders the primary column as a
+	// `th` row header rather than a `td` (see WP_List_Table::single_row_columns()).
+	// Match both: `td` for older core, `th` for current. The `th` branch is scoped
+	// to `tbody` so it does not also hit the `thead`/`tfoot` column header, which
+	// keeps its own `th.column-job_position` rule above.
 	td.column-job_position,
 	tbody th.column-job_position {
 		width: 20%;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -530,7 +530,13 @@ a.wpjm-activate-license-link:active {
 		width: 20%;
 	}
 
-	td.column-job_position {
+	// Core renders the primary column as a `th` row header rather than a `td`
+	// (see WP_List_Table::single_row_columns()). `job_position` is registered as
+	// the primary column via the `list_table_primary_column` filter, so match both
+	// element types: `td` for older core, `tbody th` for current. Scoped to `tbody`
+	// so these body-cell styles do not leak onto the header cell above.
+	td.column-job_position,
+	tbody th.column-job_position {
 		width: 20%;
 		height: 34px;
 


### PR DESCRIPTION
Fixes #3098

### Changes Proposed in this Pull Request

WordPress 7.1 changed `WP_List_Table::single_row_columns()` to render the primary column as a `<th scope="row">` row header rather than a `<td>`:

```php
$is_primary = ( $primary === $column_name );
$tag        = $is_primary ? 'th' : 'td';
$scope      = $is_primary ? ' scope="row"' : '';
```

WP Job Manager registers `job_position` as the primary column via the `list_table_primary_column` filter, so that cell is now a `<th>`. The styles for it in `assets/css/admin.scss` were scoped under `td.column-job_position` and stopped matching entirely.

The visible symptom is the company logo: `the_company_logo()` emits the image with no width/height attributes, so with the rule dead it falls back to its intrinsic size (512x512 for the bundled placeholder, 150x150 for an uploaded logo) instead of the intended 32x32 thumbnail. The rest of the block was also inactive: column width, the `position: relative` anchor, the bold job title and company spacing.

This widens the selector to match both element types.

Only this one selector is affected. The other `td.column-*` rules (`featured_job`, `filled`, `job_status`) are not the primary column, so they remain `<td>`. Nothing in JS or PHP assumes `td` for this column.

### Backward compatibility

The `td` branch is kept, so this is additive:

- Compiled `td.`-prefixed selectors are byte-identical to trunk (verified by building both and diffing the output). WP 6.4 through 7.0 are unchanged.
- `tbody th.column-job_position` matches nothing when the primary column is a `td`, so the new branch is inert on older core.
- No modern selector syntax is used. A comma-separated list is dropped wholesale if any one selector fails to parse, so `:where(td, th)` was deliberately avoided.
- Scoped to `tbody` so body-cell styles do not leak onto the header or footer header cells, which keep the existing `th.column-job_position` width rule.

### Screenshots
Before:
<img width="2328" height="1956" alt="image" src="https://github.com/user-attachments/assets/4885b7c0-de57-426c-8cb7-ad26c37a1467" />

After:
<img width="2226" height="1524" alt="image" src="https://github.com/user-attachments/assets/61fcbe1e-3da0-483c-b642-0301c726bdb6" />

### Testing Instructions

Verified end to end on WordPress 7.1 via `wp-env`, with the plugin loaded from this branch and the stylesheet served through the normal enqueue path (not injected).

1. On WordPress 7.1, go to **Job Listings** in wp-admin with at least one listing that has no company logo.
2. Before this change: the placeholder renders at 512x512 under the job title and inflates every row; a listing with an uploaded logo renders at 150x150.
3. After this change: a 32x32 circular thumbnail sits at the right of the Position column, row height returns to normal, and the job title is bold again.
4. Confirm the header row is unchanged.
5. On WordPress 6.4 to 7.0, confirm the column renders exactly as before.

### Release Notes

Fix company logo rendering at full size in the Job Listings admin table on WordPress 7.1.

### New or Updated Hooks and Templates

None.

### Deprecated Code

None.



<!-- wpjm:plugin-zip -->
----

| Plugin build for e09a61ae5111aab7d97d46da0745b5cf8eac873f <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/08/wp-job-manager-zip-3099-e09a61ae.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/08/3099-e09a61ae)             |

<!-- /wpjm:plugin-zip -->


