### PR TITLE
fix: emit JSON-LD with JSON escapes instead of HTML entities

### DIFF
--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -1831,7 +1831,11 @@ class WP_Job_Manager_Post_Types {
 		$structured_data = wpjm_get_job_listing_structured_data();
 		if ( ! empty( $structured_data ) ) {
 			echo '<!-- WP Job Manager Structured Data -->' . "\r\n";
-			echo '<script type="application/ld+json">' . wpjm_esc_json( wp_json_encode( $structured_data ), true ) . '</script>';
+			// Script-element content is raw text: HTML entities are never decoded there, so
+			// the payload must use JSON escapes (< etc.), not HTML entities. The HEX
+			// flags escape <, >, &, ' and " so the JSON cannot close the script element.
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The JSON_HEX_* flags escape the payload for the script element.
+			echo '<script type="application/ld+json">' . wp_json_encode( $structured_data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ) . '</script>';
 		}
 	}
 

--- a/tests/php/tests/includes/test_class.job-title-entity-decoding.php
+++ b/tests/php/tests/includes/test_class.job-title-entity-decoding.php
@@ -3,10 +3,11 @@
  * Tests that a job listing title is HTML-entity decoded before it is placed
  * into a plain-text context (email subjects, the plain-text email body).
  *
- * The JSON-LD structured data has the same defect but is not fixed here: the
- * emitted `<script type="application/ld+json">` block is re-escaped by
- * `wpjm_esc_json()` with `$double_encode = true`, so decoding the title alone
- * does not change what the consumer reads. See #3027.
+ * The JSON-LD structured data had the same defect, fixed separately in #3027:
+ * the emitted `<script type="application/ld+json">` block is now JSON-escaped
+ * (`wp_json_encode()` with the `JSON_HEX_*` flags) instead of HTML-escaped, so
+ * the payload round-trips; what the title itself contains is still governed by
+ * the storage/filter pipeline covered here.
  *
  * WordPress core hooks `wp_filter_kses()` onto `title_save_pre` for any user
  * without the `unfiltered_html` capability, so a listing submitted by a guest,

--- a/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
+++ b/tests/php/tests/includes/test_class.wp-job-manager-post-types.php
@@ -982,12 +982,64 @@ class WP_Test_WP_Job_Manager_Post_Types extends WPJM_BaseTest {
 			$jobs->the_post();
 			$post            = get_post();
 			$structured_data = wpjm_get_job_listing_structured_data( $post );
-			$json_data       = wpjm_esc_json( wp_json_encode( $structured_data ), true );
+			$json_data       = wp_json_encode( $structured_data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 			ob_start();
 			$instance->output_structured_data();
 			$result = ob_get_clean();
 			$this->assertStringContainsString( '<script type="application/ld+json">', $result );
 			$this->assertStringContainsString( $json_data, $result );
+		}
+	}
+
+	/**
+	 * The JSON-LD payload must round-trip: a consumer parsing the script content
+	 * gets exactly the structured data back. HTML-escaping the JSON corrupts it,
+	 * because script content is raw text and entities are never decoded there.
+	 *
+	 * @since $$next-version$$
+	 * @covers WP_Job_Manager_Post_Types::output_structured_data
+	 */
+	public function test_output_structured_data_round_trips_without_html_entities() {
+		global $wp_query;
+		$instance = WP_Job_Manager_Post_Types::instance();
+
+		$this->login_as_admin();
+		kses_remove_filters();
+		$job_id = $this->factory->job_listing->create(
+			[
+				'post_title'   => 'Events & Marketing coordinator',
+				'post_content' => '<p>Sales & partnerships role.</p>',
+				'meta_input'   => [ '_company_name' => 'Acme & Co' ],
+			]
+		);
+		kses_init_filters();
+
+		$wp_query = new WP_Query(
+			[
+				'p'         => $job_id,
+				'post_type' => \WP_Job_Manager_Post_Types::PT_LISTING,
+			]
+		);
+		$this->assertEquals( 1, $wp_query->post_count );
+
+		while ( $wp_query->have_posts() ) {
+			$wp_query->the_post();
+			$structured_data = wpjm_get_job_listing_structured_data( get_post() );
+
+			ob_start();
+			$instance->output_structured_data();
+			$result = ob_get_clean();
+
+			$this->assertSame( 1, preg_match( '#<script type="application/ld\+json">(.*)</script>#s', $result, $matches ) );
+			$payload = $matches[1];
+
+			$this->assertStringNotContainsString( '<', $payload, 'JSON_HEX_TAG keeps the payload unable to close the script element.' );
+			$this->assertStringNotContainsString( '&', $payload, 'No HTML entities are baked into the payload.' );
+
+			$decoded = json_decode( $payload, true );
+			$this->assertSame( $structured_data, $decoded, 'A JSON-LD consumer reads back exactly the structured data.' );
+			$this->assertSame( 'Acme & Co', $decoded['hiringOrganization']['name'], 'An ampersand survives emission as a plain ampersand.' );
+			$this->assertStringContainsString( '<p>', $decoded['description'], 'Description HTML survives as HTML, not entities.' );
 		}
 	}
 

--- a/wp-job-manager-functions.php
+++ b/wp-job-manager-functions.php
@@ -1878,13 +1878,20 @@ function job_manager_duplicate_listing( $post_id ) {
 /**
  * Escape JSON for use on HTML or attribute text nodes.
  *
+ * Do not use for `<script>` element content: script content is raw text, so HTML
+ * entities are never decoded there and end up baked into the payload. Use
+ * `wp_json_encode()` with the `JSON_HEX_*` flags instead.
+ *
  * @since 1.32.2
+ * @deprecated $$next-version$$
  *
  * @param string $json JSON to escape.
  * @param bool   $html True if escaping for HTML text node, false for attributes. Determines how quotes are handled.
  * @return string Escaped JSON.
  */
 function wpjm_esc_json( $json, $html = false ) {
+	_deprecated_function( __FUNCTION__, '$$next-version$$', 'wp_json_encode' );
+
 	return _wp_specialchars(
 		$json,
 		$html ? ENT_NOQUOTES : ENT_QUOTES, // Escape quotes in attribute nodes only.


### PR DESCRIPTION
## What

Fixes #3027. The JobPosting structured data was run through `wpjm_esc_json()` (HTML entity escaping) before being echoed into its `<script type="application/ld+json">` block. Script-element content is raw text per the HTML spec — character references are never decoded there — so the escaping was baked into the payload: consumers read `Events &amp;amp; Marketing` titles and `&amp;lt;p&amp;gt;`-riddled descriptions.

## Fix

Encode with `wp_json_encode( $data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT )`, per the issue's proposal. The dangerous characters become JSON unicode escapes (`<` etc.), which JSON parsers decode back to the original characters — and the payload still cannot contain a literal `</script>`, so the security property is preserved at the right layer.

`wpjm_esc_json()` had exactly one caller (this one) and is deprecated with a pointer to the right approach; its phpcs `customEscapingFunctions` entry is left in place for back-compat.

## Tests

- New `test_output_structured_data_round_trips_without_html_entities`: extracts the emitted payload and asserts (a) it contains no literal `<` or `&`, (b) `json_decode` returns exactly the structured data array, (c) an ampersand in the company name survives as a plain ampersand, (d) description HTML survives as HTML.
- The existing `test_output_structured_data` expectation updated from the old (tautological) escaping to the new encoding.
- Full suite green locally: 616 tests, 3 known geocode skips.

Note: what the *title itself* contains (`&#038;` from the `the_title` filter chain) is upstream of emission and tracked by #3026's work — this PR makes emission faithful to whatever the structured data contains.




<!-- wpjm:plugin-zip -->
----

| Plugin build for 317eb454de905e2d049bed3031ebfadc9343318e <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/08/wp-job-manager-zip-3101-317eb454.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/08/3101-317eb454)             |

<!-- /wpjm:plugin-zip -->




