### PR TITLE
Apply the View Job Capability to sitemaps

### DIFF
--- a/includes/3rd-party/jetpack.php
+++ b/includes/3rd-party/jetpack.php
@@ -21,6 +21,12 @@ function wpjm_jetpack_skip_filled_job_listings( $skip_post, $post ) {
 		return true;
 	}
 
+	// Keep listings restricted by the View Job Capability out of the Jetpack sitemap: it is
+	// crawled anonymously, and an anonymous requester cannot satisfy a configured capability.
+	if ( ! job_manager_user_can_view_job_listing( $post->ID ) ) {
+		return true;
+	}
+
 	return $skip_post;
 }
 add_action( 'jetpack_sitemap_skip_post', 'wpjm_jetpack_skip_filled_job_listings', 10, 2 );

--- a/includes/3rd-party/yoast.php
+++ b/includes/3rd-party/yoast.php
@@ -24,6 +24,12 @@ function wpjm_yoast_skip_filled_job_listings( $url, $type, $post ) {
 		return false;
 	}
 
+	// Keep listings restricted by the View Job Capability out of the Yoast sitemap: it is
+	// crawled anonymously, and an anonymous requester cannot satisfy a configured capability.
+	if ( ! job_manager_user_can_view_job_listing( $post->ID ) ) {
+		return false;
+	}
+
 	return $url;
 }
 add_action( 'wpseo_sitemap_entry', 'wpjm_yoast_skip_filled_job_listings', 10, 3 );

--- a/includes/class-wp-job-manager-post-types.php
+++ b/includes/class-wp-job-manager-post-types.php
@@ -184,6 +184,7 @@ class WP_Job_Manager_Post_Types {
 		add_action( 'wp_head', [ $this, 'noindex_expired_filled_job_listings' ], 0 );
 		add_action( 'wp_footer', [ $this, 'output_structured_data' ] );
 		add_filter( 'wp_sitemaps_posts_query_args', [ $this, 'sitemaps_maybe_hide_filled' ], 10, 2 );
+		add_filter( 'wp_sitemaps_post_types', [ $this, 'sitemaps_maybe_hide_restricted_post_type' ] );
 
 		add_filter( 'the_job_description', 'wptexturize' );
 		add_filter( 'the_job_description', 'convert_smilies' );
@@ -1790,6 +1791,31 @@ class WP_Job_Manager_Post_Types {
 		];
 
 		return $query_args;
+	}
+
+	/**
+	 * Excludes job listings from the core sitemap when the View Job Capability restricts
+	 * who may view listings.
+	 *
+	 * The sitemap is generated for anonymous crawlers, which can never satisfy a configured
+	 * view capability, so an enumerated listing there discloses the existence — and, once
+	 * followed, the metadata — of listings the operator made non-public. Drop the whole post
+	 * type from the sitemap index in that case, the way {@see self::viewer_denied_by_view_cap()}
+	 * gates the search and REST-search surfaces.
+	 *
+	 * @access private
+	 * @since $$next-version$$
+	 *
+	 * @param array $post_types Post type objects keyed by name.
+	 *
+	 * @return array
+	 */
+	public function sitemaps_maybe_hide_restricted_post_type( $post_types ) {
+		if ( isset( $post_types[ self::PT_LISTING ] ) && self::viewer_denied_by_view_cap() ) {
+			unset( $post_types[ self::PT_LISTING ] );
+		}
+
+		return $post_types;
 	}
 
 	/**

--- a/tests/php/tests/security/test_class.sitemap-view-capability.php
+++ b/tests/php/tests/security/test_class.sitemap-view-capability.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Regression test: view-capability-restricted job listings must not be enumerated in
+ * public XML sitemaps.
+ *
+ * The core WordPress sitemap and the Yoast/Jetpack integrations filtered only for filled
+ * positions and omitted the `job_manager_view_job_listing_capability` gate, so a board an
+ * operator restricted to certain roles was still enumerated (and, once followed, its
+ * metadata disclosed) to anonymous crawlers. Sitemaps are generated for anonymous
+ * requesters, who can never satisfy a configured view capability.
+ *
+ * @package wp-job-manager
+ */
+class Tests_Sitemap_View_Capability extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->reregister_post_type();
+	}
+
+	public function tearDown(): void {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Restricts viewing listing details to administrators.
+	 */
+	private function restrict_viewing_to_admins() {
+		update_option( 'job_manager_view_job_listing_capability', [ 'manage_options' ] );
+	}
+
+	/**
+	 * The core sitemap post-type list as WordPress passes it: public post-type objects
+	 * keyed by name.
+	 *
+	 * @return array
+	 */
+	private function sitemap_post_types() {
+		return get_post_types( [ 'public' => true ], 'objects' );
+	}
+
+	/**
+	 * When the View Job Capability restricts an anonymous viewer, job listings are dropped
+	 * from the core sitemap entirely.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::sitemaps_maybe_hide_restricted_post_type
+	 */
+	public function test_restricted_listings_are_removed_from_core_sitemap_for_anonymous() {
+		$this->restrict_viewing_to_admins();
+		$this->logout();
+
+		$filtered = WP_Job_Manager_Post_Types::instance()->sitemaps_maybe_hide_restricted_post_type( $this->sitemap_post_types() );
+
+		$this->assertArrayNotHasKey(
+			\WP_Job_Manager_Post_Types::PT_LISTING,
+			$filtered,
+			'Restricted job listings must not appear in the core sitemap for a denied viewer.'
+		);
+	}
+
+	/**
+	 * Control: with no view capability configured, job listings stay in the sitemap.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::sitemaps_maybe_hide_restricted_post_type
+	 */
+	public function test_listings_remain_in_core_sitemap_when_unrestricted() {
+		delete_option( 'job_manager_view_job_listing_capability' );
+		$this->logout();
+
+		$filtered = WP_Job_Manager_Post_Types::instance()->sitemaps_maybe_hide_restricted_post_type( $this->sitemap_post_types() );
+
+		$this->assertArrayHasKey(
+			\WP_Job_Manager_Post_Types::PT_LISTING,
+			$filtered,
+			'With no view capability configured, job listings must remain in the sitemap.'
+		);
+	}
+
+	/**
+	 * Positive control: a viewer who satisfies the capability keeps job listings in the
+	 * sitemap, so the gate does not over-block.
+	 *
+	 * @covers WP_Job_Manager_Post_Types::sitemaps_maybe_hide_restricted_post_type
+	 */
+	public function test_listings_remain_in_core_sitemap_for_capable_viewer() {
+		$this->restrict_viewing_to_admins();
+		$this->login_as_admin();
+
+		$filtered = WP_Job_Manager_Post_Types::instance()->sitemaps_maybe_hide_restricted_post_type( $this->sitemap_post_types() );
+
+		$this->assertArrayHasKey(
+			\WP_Job_Manager_Post_Types::PT_LISTING,
+			$filtered,
+			'A capable viewer must still see job listings in the sitemap.'
+		);
+	}
+
+	/**
+	 * The Yoast per-entry filter drops a restricted listing for an anonymous crawler and
+	 * keeps it otherwise.
+	 */
+	public function test_yoast_entry_is_skipped_for_restricted_listing() {
+		require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/yoast.php';
+
+		$job_id = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+		$post   = get_post( $job_id );
+		$url    = [ 'loc' => get_permalink( $job_id ) ];
+
+		$this->restrict_viewing_to_admins();
+		$this->logout();
+		$this->assertFalse(
+			wpjm_yoast_skip_filled_job_listings( $url, 'post', $post ),
+			'Yoast must skip a view-restricted listing for a denied crawler.'
+		);
+
+		delete_option( 'job_manager_view_job_listing_capability' );
+		$this->assertSame(
+			$url,
+			wpjm_yoast_skip_filled_job_listings( $url, 'post', $post ),
+			'Yoast must keep the listing when unrestricted.'
+		);
+	}
+
+	/**
+	 * The Jetpack per-post filter skips a restricted listing for an anonymous crawler and
+	 * keeps it otherwise.
+	 */
+	public function test_jetpack_post_is_skipped_for_restricted_listing() {
+		require_once JOB_MANAGER_PLUGIN_DIR . '/includes/3rd-party/jetpack.php';
+
+		$job_id = $this->factory->job_listing->create( [ 'post_status' => 'publish' ] );
+		$post   = get_post( $job_id );
+
+		$this->restrict_viewing_to_admins();
+		$this->logout();
+		$this->assertTrue(
+			wpjm_jetpack_skip_filled_job_listings( false, $post ),
+			'Jetpack must skip a view-restricted listing for a denied crawler.'
+		);
+
+		delete_option( 'job_manager_view_job_listing_capability' );
+		$this->assertFalse(
+			wpjm_jetpack_skip_filled_job_listings( false, $post ),
+			'Jetpack must keep the listing when unrestricted.'
+		);
+	}
+}


### PR DESCRIPTION
Exclude job listings from the core WordPress sitemap and the Yoast and Jetpack sitemap integrations when the View Job Capability restricts viewing. Adds a regression test.

The AIOSEO integration is left unchanged: it hooks the pre-4.0 `aiosp_sitemap_post_filter`, which does not fire in AIOSEO 5.x, so its existing filled-position filter is already inert there. Reviving it needs the current hook and belongs in a separate change.

<!-- wpjm:plugin-zip -->
----

| Plugin build for dfff1089f66dc2c1ec68fad2316d2cbeddf2a47b <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/09/wp-job-manager-zip-3107-dfff1089.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/09/3107-dfff1089)             |

<!-- /wpjm:plugin-zip -->
