### PR TITLE
Restrict frontend logo attachments to the uploads directory

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -328,8 +328,6 @@
     <UndefinedConstant>
       <code>COOKIEPATH</code>
       <code>COOKIE_DOMAIN</code>
-      <code>WP_CONTENT_DIR</code>
-      <code>WP_CONTENT_URL</code>
     </UndefinedConstant>
     <UndefinedPropertyFetch>
       <code><![CDATA[$term->slug]]></code>

--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -1155,25 +1155,23 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 
 		$attachment_url = sprintf( '%s://%s%s', $scheme, $host, $path );
 
-		$local_dirs     = [ $upload_dir['basedir'], WP_CONTENT_DIR, ABSPATH ];
-		$attachment_url = str_replace( [ $upload_dir['baseurl'], WP_CONTENT_URL, site_url( '/' ) ], $local_dirs, $attachment_url );
+		// A frontend upload always resolves to a file inside the uploads directory, so map
+		// only the uploads URL to its path and require the result to sit under it. Mapping
+		// WP_CONTENT_URL or site_url() as well would let a crafted URL such as
+		// site_url( '/wp-config.php' ) resolve to a path at the WordPress root that still
+		// passes a containment check against ABSPATH; that path is then stored verbatim in
+		// `_wp_attached_file`, relocating core's attachment-deletion fence out of
+		// wp-content/uploads and letting an arbitrary in-tree file be deleted with the
+		// attachment. Anything that does not map into the uploads directory — a remote
+		// origin, a scheme-relative //host/... URL, or an in-tree path elsewhere on disk —
+		// is not one of our uploads and is refused.
+		$uploads_basedir = trailingslashit( $upload_dir['basedir'] );
+		$attachment_url  = str_replace( trailingslashit( $upload_dir['baseurl'] ), $uploads_basedir, $attachment_url );
 		if ( empty( $attachment_url ) || ! is_string( $attachment_url ) ) {
 			return 0;
 		}
 
-		// Only attach files that resolve to a path under one of this site's own
-		// directories. After the mapping above a genuine upload becomes a local
-		// filesystem path; anything still pointing at a remote origin (including
-		// scheme-relative //host/... URLs) or at an arbitrary path elsewhere on
-		// disk is not one of our uploads, so we do not turn it into an attachment.
-		$is_local = false;
-		foreach ( array_filter( $local_dirs ) as $base ) {
-			if ( 0 === strpos( $attachment_url, trailingslashit( $base ) ) ) {
-				$is_local = true;
-				break;
-			}
-		}
-		if ( ! $is_local ) {
+		if ( 0 !== strpos( $attachment_url, $uploads_basedir ) ) {
 			return 0;
 		}
 

--- a/tests/php/tests/includes/test_class.submit-job-attachment-local.php
+++ b/tests/php/tests/includes/test_class.submit-job-attachment-local.php
@@ -163,4 +163,55 @@ class WP_Test_Submit_Job_Attachment_Local extends WPJM_BaseTest {
 			'The created post must be an attachment.'
 		);
 	}
+
+	/**
+	 * A site-root URL that maps onto ABSPATH (e.g. wp-config.php) must not be attached.
+	 * The stored `_wp_attached_file` would otherwise hold an absolute path outside the
+	 * uploads directory, relocating core's attachment-deletion fence to the WordPress root.
+	 */
+	public function test_site_root_url_is_not_attached() {
+		$before = count( get_posts( [ 'post_type' => 'attachment', 'fields' => 'ids', 'numberposts' => -1 ] ) );
+
+		$this->assertSame(
+			0,
+			$this->create_attachment( site_url( '/wp-config.php' ) ),
+			'A URL resolving to the WordPress root must not be turned into an attachment.'
+		);
+
+		$after = count( get_posts( [ 'post_type' => 'attachment', 'fields' => 'ids', 'numberposts' => -1 ] ) );
+		$this->assertSame( $before, $after, 'No attachment post should be created for a site-root URL.' );
+	}
+
+	/**
+	 * A wp-content URL outside the uploads directory (e.g. a theme file) must not be
+	 * attached: legitimate frontend uploads live only under the uploads directory.
+	 */
+	public function test_wp_content_url_outside_uploads_is_not_attached() {
+		$this->assertSame(
+			0,
+			$this->create_attachment( content_url( '/themes/twentytwentythree/style.css' ) ),
+			'A wp-content URL outside the uploads directory must not be attached.'
+		);
+	}
+
+	/**
+	 * The stored attachment path of an accepted upload stays inside the uploads directory,
+	 * so core's deletion fence remains pinned there.
+	 */
+	public function test_attached_file_path_is_confined_to_uploads() {
+		$local_url     = $this->write_local_image( 'confined-logo.png' );
+		$attachment_id = $this->create_attachment( $local_url );
+
+		$this->assertGreaterThan( 0, $attachment_id );
+
+		$stored_path = get_post_meta( $attachment_id, '_wp_attached_file', true );
+		$this->assertNotEmpty( $stored_path );
+
+		$absolute = path_is_absolute( $stored_path ) ? $stored_path : trailingslashit( $this->base_dir ) . $stored_path;
+		$this->assertStringStartsWith(
+			trailingslashit( $this->base_dir ),
+			$absolute,
+			'The stored attachment path must resolve inside the uploads directory.'
+		);
+	}
 }


### PR DESCRIPTION
`create_attachment()` mapped a submitted URL onto `ABSPATH` and `WP_CONTENT_DIR` as well as the uploads directory. Map only the uploads URL and require the resolved path to sit under the uploads directory, so a frontend file value can only ever resolve to a file there. Adds regression tests.


<!-- wpjm:plugin-zip -->
----

| Plugin build for 9e0b733077c76bdf1b55408b141f3b0e58e72613 <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/09/wp-job-manager-zip-3108-9e0b7330.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/09/3108-9e0b7330)             |

<!-- /wpjm:plugin-zip -->


