### PR TITLE
Clear unusable attachment values before re-rendering the submit form

### DIFF
--- a/includes/forms/class-wp-job-manager-form-submit-job.php
+++ b/includes/forms/class-wp-job-manager-form-submit-job.php
@@ -727,6 +727,10 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 			// Get posted values.
 			$values = $this->get_posted_fields();
 
+			// Keep an attachment the submitter may not use out of the re-rendered form, so a
+			// validation failure cannot echo a foreign attachment's file URL back to them.
+			$this->scrub_unusable_attachment_field_values();
+
 			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Input is used safely. Nonce checked below when possible.
 			$input_create_account_username        = isset( $_POST['create_account_username'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_username'] ) ) : false;
 			$input_create_account_password        = isset( $_POST['create_account_password'] ) ? sanitize_text_field( wp_unslash( $_POST['create_account_password'] ) ) : false;
@@ -998,14 +1002,7 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 						// stale saved value, fail silently at the sink — set_post_thumbnail()
 						// ignores a dead ID — and then be written straight back to the saved value,
 						// so the listing would publish with no logo and never self-heal.
-						$is_usable = 'attachment' === get_post_type( $attachment_id )
-							&& (
-								$this->is_attachment_authorized_for_current_user( $attachment_id )
-								|| $this->is_existing_listing_attachment( $attachment_id, $key )
-								|| $this->is_saved_user_attachment( $attachment_id, $group_key, $key )
-							);
-
-						if ( ! $is_usable ) {
+						if ( ! $this->is_usable_attachment( $attachment_id, $group_key, $key ) ) {
 							// Tell the submitter how to recover. The rejected value is one the form
 							// offered them (a saved logo), so "invalid" alone leaves them stuck.
 							return new WP_Error(
@@ -1023,6 +1020,64 @@ class WP_Job_Manager_Form_Submit_Job extends WP_Job_Manager_Form {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Whether the current user may reference the given attachment ID in a file field,
+	 * either because they own it / can edit it or because the form legitimately offered
+	 * it back to them (an existing listing attachment or a saved company value). Gated on
+	 * the attachment still existing.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $group_key     Field group key.
+	 * @param string $key           Field key.
+	 * @return bool
+	 */
+	protected function is_usable_attachment( $attachment_id, $group_key, $key ) {
+		return 'attachment' === get_post_type( $attachment_id )
+			&& (
+				$this->is_attachment_authorized_for_current_user( $attachment_id )
+				|| $this->is_existing_listing_attachment( $attachment_id, $key )
+				|| $this->is_saved_user_attachment( $attachment_id, $group_key, $key )
+			);
+	}
+
+	/**
+	 * Blanks file-field values the current user may not use before the form is
+	 * re-rendered.
+	 *
+	 * A validation failure re-renders the submit form with the posted values, and
+	 * templates/form-fields/uploaded-file-html.php resolves a numeric file value to its
+	 * attachment URL with no authorization check. A submitter could therefore post a
+	 * foreign attachment ID as `current_<field>`, have validation refuse it, and read the
+	 * refused attachment's file URL back from the re-rendered form — reaching media that
+	 * WordPress itself withholds (e.g. an attachment parented to a private post). Dropping
+	 * the unusable value from the rendered field state closes that path while leaving the
+	 * validation message intact (it reads the untouched $values).
+	 *
+	 * @since $$next-version$$
+	 */
+	protected function scrub_unusable_attachment_field_values() {
+		foreach ( $this->fields as $group_key => $group_fields ) {
+			foreach ( $group_fields as $key => $field ) {
+				if ( 'file' !== $field['type'] || ! isset( $field['value'] ) ) {
+					continue;
+				}
+
+				$is_array = is_array( $field['value'] );
+				$values   = $is_array ? $field['value'] : [ $field['value'] ];
+
+				foreach ( $values as $index => $value ) {
+					if ( is_numeric( $value ) && absint( $value ) && ! $this->is_usable_attachment( absint( $value ), $group_key, $key ) ) {
+						unset( $values[ $index ] );
+					}
+				}
+
+				$this->fields[ $group_key ][ $key ]['value'] = $is_array ? array_values( $values ) : ( reset( $values ) ?: '' );
+			}
+		}
 	}
 
 	/**

--- a/tests/php/tests/security/test_class.submit-job-attachment-url-disclosure.php
+++ b/tests/php/tests/security/test_class.submit-job-attachment-url-disclosure.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Regression test: the job submission form must not echo a refused attachment's URL back
+ * to the submitter.
+ *
+ * validate_attachment_ownership() refuses a numeric file value the submitter may not use,
+ * but the form is then re-rendered with the posted values and
+ * templates/form-fields/uploaded-file-html.php resolves a numeric value to its attachment
+ * URL with no authorization check. A low-privilege user could therefore post a foreign
+ * attachment ID as `current_company_logo`, have it refused, and read the file URL back
+ * from the re-rendered form — reaching media WordPress itself withholds. The rendered
+ * field value for an unusable attachment must be blanked.
+ *
+ * @package wp-job-manager
+ */
+class Tests_Submit_Job_Attachment_URL_Disclosure extends WPJM_BaseTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/abstracts/abstract-wp-job-manager-form.php';
+		include_once JOB_MANAGER_PLUGIN_DIR . '/includes/forms/class-wp-job-manager-form-submit-job.php';
+	}
+
+	/**
+	 * Sets the company_logo field's rendered value and runs the scrub, returning the value
+	 * left for the template.
+	 *
+	 * @param mixed $value Value to place on the field before scrubbing.
+	 * @return mixed
+	 */
+	private function scrub_company_logo_value( $value ) {
+		$form = WP_Job_Manager_Form_Submit_Job::instance();
+		$form->init_fields();
+
+		$fields_prop = ( new ReflectionClass( $form ) )->getProperty( 'fields' );
+		$fields_prop->setAccessible( true );
+		$fields                                   = $fields_prop->getValue( $form );
+		$fields['company']['company_logo']['value'] = $value;
+		$fields_prop->setValue( $form, $fields );
+
+		$scrub = new ReflectionMethod( $form, 'scrub_unusable_attachment_field_values' );
+		$scrub->setAccessible( true );
+		$scrub->invoke( $form );
+
+		return $fields_prop->getValue( $form )['company']['company_logo']['value'];
+	}
+
+	/**
+	 * A foreign attachment ID posted into the logo field is blanked before re-render, so
+	 * its URL is never resolved by the template.
+	 */
+	public function test_foreign_attachment_id_is_scrubbed_from_render_value() {
+		$owner   = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$private = $this->factory->post->create( [ 'post_status' => 'private', 'post_author' => $owner ] );
+		$foreign = $this->factory->attachment->create_object(
+			'private-memo.png',
+			$private,
+			[ 'post_mime_type' => 'image/png', 'post_author' => $owner ]
+		);
+
+		// A low-privilege submitter who does not own the attachment.
+		$attacker = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $attacker );
+
+		$this->assertSame(
+			'',
+			$this->scrub_company_logo_value( (string) $foreign ),
+			'A foreign attachment ID must be blanked from the re-rendered field value.'
+		);
+	}
+
+	/**
+	 * Control: an attachment the submitter owns survives the scrub, so the normal
+	 * round-trip of a just-uploaded logo keeps working.
+	 */
+	public function test_owned_attachment_id_survives_scrub() {
+		$user = $this->factory->user->create( [ 'role' => 'employer' ] );
+		wp_set_current_user( $user );
+
+		$owned = $this->factory->attachment->create_object(
+			'my-logo.png',
+			0,
+			[ 'post_mime_type' => 'image/png', 'post_author' => $user ]
+		);
+
+		$this->assertSame(
+			(string) $owned,
+			(string) $this->scrub_company_logo_value( (string) $owned ),
+			'An attachment the submitter owns must survive the scrub.'
+		);
+	}
+
+	/**
+	 * Control: a plain (non-numeric) value such as an uploaded file URL is left untouched.
+	 */
+	public function test_non_numeric_value_is_untouched() {
+		$url = 'http://example.org/wp-content/uploads/2026/08/logo.png';
+
+		$this->assertSame(
+			$url,
+			$this->scrub_company_logo_value( $url ),
+			'A non-numeric file value must be left untouched.'
+		);
+	}
+}


### PR DESCRIPTION
When a file field references an attachment the current user may not use, blank its value before the submission form is re-rendered, so the re-render does not resolve it. Factors the usability check shared with `validate_attachment_ownership()` into `is_usable_attachment()`. Adds a regression test.

<!-- wpjm:plugin-zip -->
----

| Plugin build for be14a3a09664d3a6ea4f620b2263e0bde92e719d <a href="#"><img width=600></a> |
| ------------------------------------------------------------ |
| 📦 [Download plugin zip](https://wpjobmanager.com/wp-content/uploads/2026/09/wp-job-manager-zip-3109-be14a3a0.zip)                       |
| ▶️ [Open in playground](https://wpjobmanager.com/playground/?core=2026/09/3109-be14a3a0)             |

<!-- /wpjm:plugin-zip -->
